### PR TITLE
Fix #14: StackOverflowError on app install

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1735,12 +1735,12 @@ def validateAction(action) {
 
 def findDevice(deviceId) {
     if (!deviceId) return null
-    return selectedDevices?.find { it.id.toString() == deviceId.toString() }
+    return settings.selectedDevices?.find { it.id.toString() == deviceId.toString() }
 }
 
 // Expose devices to child apps
 def getSelectedDevices() {
-    return selectedDevices
+    return settings.selectedDevices
 }
 
 // Allow child apps to find devices


### PR DESCRIPTION
Fixes #14

The StackOverflowError was caused by infinite recursion in the Groovy property accessor pattern:

1. `getSelectedDevices()` returns `selectedDevices`
2. Groovy interprets `selectedDevices` as a property access, calling `getSelectedDevices()`
3. This creates infinite recursion → StackOverflowError

The fix changes `findDevice()` to use `settings.selectedDevices` instead of the bare `selectedDevices` reference, which directly accesses the settings map and avoids the recursive property accessor call.