### PR TITLE
v0.4.0 - Hub Admin Read/Write tools with Hub Security support

### DIFF
--- a/hubitat-mcp-rule.groovy
+++ b/hubitat-mcp-rule.groovy
@@ -3,6 +3,8 @@
  *
  * Individual automation rule with isolated settings.
  * Each rule is a separate child app instance.
+ *
+ * Version: 0.4.0
  */
 
 definition(

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,12 +1,12 @@
 {
     "packageName": "MCP Rule Server",
     "author": "kingpanther13",
-    "version": "0.3.3",
+    "version": "0.4.0",
     "minimumHEVersion": "2.3.0",
-    "dateReleased": "2026-01-29",
+    "dateReleased": "2026-01-31",
     "documentationLink": "https://github.com/kingpanther13/Hubitat-local-MCP-server/blob/main/README.md",
     "communityLink": "",
-    "releaseNotes": "v0.3.3 - Multi-device trigger support and validation fixes:\n\n- Added multi-device trigger support: device_event triggers now accept deviceIds array with matchMode (any/all)\n- Fixed duration trigger key mismatch in cancellation path for multi-device triggers\n- Fixed checkDurationTrigger to handle multi-device triggers (checks all/any devices based on matchMode)\n- Added missing value validation for device_was condition when operator is specified\n- Fixed missing typed updateSetting for illuminance and power condition loading",
+    "releaseNotes": "v0.4.0 - Hub Admin Read/Write Tools with Hub Security support:\n\nNEW FEATURES:\n- Hub Admin Read Tools (6 new tools): get_hub_details, list_hub_apps, list_hub_drivers, get_zwave_details, get_zigbee_details, get_hub_health\n- Hub Admin Write Tools (4 new tools): create_hub_backup, reboot_hub, shutdown_hub, zwave_repair\n- Hub Security authentication support (works with and without Hub Security enabled)\n- UI toggles: Enable/disable Hub Admin Read and Write access independently\n- Mandatory backup enforcement: Write tools require a recent backup before execution\n- Robust safety prompts: Write tool descriptions mandate backup + user confirmation\n\nHUB ADMIN READ TOOLS:\n- get_hub_details: Extended hub info (firmware, model, memory, temperature, database size, radio info)\n- list_hub_apps: List all installed apps on the hub via internal API\n- list_hub_drivers: List all installed drivers on the hub via internal API\n- get_zwave_details: Z-Wave radio info, firmware, device table\n- get_zigbee_details: Zigbee radio info, channel, PAN ID, device details\n- get_hub_health: Health metrics with warnings for low memory, high temp, large database\n\nHUB ADMIN WRITE TOOLS:\n- create_hub_backup: Create hub database backup (MUST be called before any other write tool)\n- reboot_hub: Reboot the hub (requires backup + user confirmation)\n- shutdown_hub: Shut down the hub (requires backup + user confirmation + warns about manual restart)\n- zwave_repair: Start Z-Wave network repair (requires backup + user confirmation)\n\nSAFETY FEATURES:\n- Hub Admin Read and Write are both OFF by default\n- Write tools check for a backup created within the last hour\n- Write tool descriptions contain mandatory pre-flight checklists\n- Write tools require explicit confirm=true parameter\n- Hub Security cookie caching with 30-minute expiry\n- Graceful fallbacks when internal API endpoints are unavailable\n\nTotal MCP tools: 44 (was 34 in v0.3.0)",
     "apps": [
         {
             "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",


### PR DESCRIPTION
NEW FEATURES:
- 6 Hub Admin Read tools: get_hub_details, list_hub_apps, list_hub_drivers, get_zwave_details, get_zigbee_details, get_hub_health
- 4 Hub Admin Write tools: create_hub_backup, reboot_hub, shutdown_hub, zwave_repair
- Hub Security authentication support with cookie caching
- UI toggles to enable/disable Hub Admin Read and Write independently
- Mandatory backup enforcement before any write operation
- Safety prompts and confirm parameter on all write tools

Total MCP tools: 44 (was 34 in v0.3.0)