### PR TITLE
Fix sandbox ClassExpression error — use class name strings instead of…

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3022,7 +3022,8 @@ def hubInternalGet(String path, Map query = null, int timeout = 30) {
     def responseText = null
     try {
         httpGet(params) { resp ->
-            if (resp.data instanceof java.io.Reader || resp.data instanceof java.io.InputStream) {
+            def dataClassName = resp.data?.getClass()?.name ?: ""
+            if (dataClassName.contains("Reader") || dataClassName.contains("InputStream")) {
                 // textParser: true returns a Reader/InputStream — read it fully
                 responseText = resp.data.text
             } else {
@@ -3105,7 +3106,8 @@ def hubInternalPostForm(String path, Map body, int timeout = 420) {
     try {
         httpPost(params) { resp ->
             def responseData = resp.data
-            if (responseData instanceof java.io.Reader || responseData instanceof java.io.InputStream) {
+            def rdClassName = responseData?.getClass()?.name ?: ""
+            if (rdClassName.contains("Reader") || rdClassName.contains("InputStream")) {
                 // textParser: true returns a Reader/InputStream — read it fully
                 responseData = responseData.text
             }


### PR DESCRIPTION
… instanceof

Hubitat Groovy sandbox blocks `instanceof java.io.Reader` and `instanceof java.io.InputStream` (ClassExpression not allowed). Replaced with `.getClass().name.contains("Reader")` checks which achieve the same detection without referencing restricted classes.

https://claude.ai/code/session_013FtCmYQwgnNF6Ri7nwSX1r