### PR TITLE
v0.4.5 — Chunked reading, resave mode, sourceFile mode for large sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ This Hubitat app exposes an MCP server that allows AI assistants (like Claude) t
 - **Query system state** - Get device status, hub info, modes, variables, HSM status
 - **Administer the hub** - View hub health, manage apps/drivers, create backups, and more
 
+**New in v0.4.5:**
+- **Chunked reading** — `get_app_source`, `get_driver_source`, and `read_file` support `offset`/`length` for reading large sources in segments
+- **Smart large-source handling** — sources over 64KB are auto-saved to File Manager, enabling cloud-free updates
+- **`resave` mode** — re-save current source entirely on-hub (no cloud round-trip needed)
+- **`sourceFile` mode** — read source from a File Manager file (bypasses 64KB cloud limit)
+
 **New in v0.4.4:**
 - **Critical bug fixes** from live testing — InputStreamReader handling, delete response parsing, list_files reliability
 - **Backup chain prevention** — deleting backup files no longer creates infinite backup-of-backup chains
@@ -668,6 +674,12 @@ The response includes `total`, `hasMore`, and `nextOffset` to help with paginati
 
 ## Version History
 
+- **v0.4.5** - Smart large-file handling (59 tools)
+  - Chunked reading for `get_app_source`, `get_driver_source`, `read_file` via `offset`/`length` parameters
+  - Large sources (>64KB) auto-saved to File Manager as `mcp-source-{type}-{id}.groovy`
+  - New `resave` mode for `update_app_code`/`update_driver_code` — re-saves current source entirely on-hub, no cloud round-trip
+  - New `sourceFile` mode — reads source from File Manager file, bypasses 64KB cloud response limit
+  - Refactored get/update source tools into shared `toolGetItemSource`/`toolUpdateItemCode` helpers
 - **v0.4.4** - Fix bugs found during live Claude.ai testing (59 tools)
   - **CRITICAL**: Fixed `hubInternalGet`/`hubInternalPostForm` not reading `InputStreamReader` — `textParser: true` returns a Reader/InputStream that must be read with `.text`, not `.toString()`
   - **MAJOR**: Fixed `list_files` returning empty array — rewritten with multi-endpoint fallback and multi-format parsing (JSON list, JSON object, HTML href extraction)

--- a/hubitat-mcp-rule.groovy
+++ b/hubitat-mcp-rule.groovy
@@ -4,7 +4,7 @@
  * Individual automation rule with isolated settings.
  * Each rule is a separate child app instance.
  *
- * Version: 0.4.4
+ * Version: 0.4.5
  */
 
 definition(

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,12 +1,12 @@
 {
     "packageName": "MCP Rule Server",
     "author": "kingpanther13",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "minimumHEVersion": "2.3.0",
     "dateReleased": "2026-02-01",
     "documentationLink": "https://github.com/kingpanther13/Hubitat-local-MCP-server/blob/main/README.md",
     "communityLink": "",
-    "releaseNotes": "v0.4.4 - Fix bugs found during live testing:\n\n- CRITICAL: Fix hubInternalGet/hubInternalPostForm not reading InputStreamReader (textParser:true returns Reader, must call .text)\n- MAJOR: Fix delete_app/delete_driver status parsing to handle both boolean and string 'true'\n- MAJOR: Fix list_files returning empty array (rewritten with multi-endpoint fallback)\n- DESIGN: Prevent infinite backup chain when deleting backup files\n- Add debug logging for delete responses and file manager operations\n\nv0.4.3 - Comprehensive bug fixes + item backup & file manager tools (59 tools)",
+    "releaseNotes": "v0.4.5 - Smart large-file handling:\n\n- Chunked reading for get_app_source, get_driver_source, and read_file (offset/length params)\n- Large sources auto-saved to File Manager for cloud-free updates\n- New 'resave' mode: re-save current source entirely on-hub (no cloud round-trip)\n- New 'sourceFile' mode: read source from File Manager file (bypasses 64KB cloud limit)\n- Refactored get/update tools into shared helpers\n\nv0.4.4 - Fix bugs from live testing (InputStreamReader, delete status, backup chain)\nv0.4.3 - Comprehensive bug fixes + item backup & file manager tools (59 tools)",
     "apps": [
         {
             "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",


### PR DESCRIPTION
- get_app_source, get_driver_source: chunked reading via offset/length params; large sources (>64KB) auto-saved to File Manager as mcp-source-{type}-{id}.groovy for cloud-free updates
- read_file: chunked reading via offset/length params (no more "too large for response" — just read in segments)
- update_app_code, update_driver_code: three modes — source (direct), sourceFile (from File Manager), resave (on-hub only)
- Refactored into shared toolGetItemSource/toolUpdateItemCode helpers

https://claude.ai/code/session_013FtCmYQwgnNF6Ri7nwSX1r