### PR TITLE
Fix get_hub_logs ordering (return most recent first); add server-side deviceId/appId scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Source code is automatically backed up before any modify/delete operation.
 
 | Tool | Description |
 |------|-------------|
-| `get_hub_logs` | Hub log entries with level/source filtering |
+| `get_hub_logs` | Hub log entries (most recent first) with level/source filters and server-side deviceId/appId scoping |
 | `get_device_history` | Up to 7 days of device event history |
 | `get_debug_logs` | Retrieve MCP debug log entries |
 | `clear_debug_logs` | Clear all MCP debug logs |

--- a/SKILL.md
+++ b/SKILL.md
@@ -491,6 +491,7 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 | `/hub/backupDB` with query `fileName=latest` | Creates fresh backup and returns .lzf binary |
 | `/hub/fileManager/json` | Lists all files in File Manager (JSON array: name, size, date) |
 | `/hub2/roomsList` | List of rooms as JSON (alternative to `getRooms()` SDK method) |
+| `/logs/past/json` | Hub log buffer as JSON array of tab-delimited strings (chronological order, oldest first — reverse client-side for newest-first). Accepts optional `?type=dev&id=<deviceId>` or `?type=app&id=<appId>` to scope server-side to a single source. |
 
 **Write endpoints (POST):**
 | Path | Body | Purpose |

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -268,8 +268,10 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 - Higher values (100+) may cause delays on busy devices
 
 **get_hub_logs:**
+- Returns most recent entries first
 - Default 100 entries, max 500
 - Use level and source filters to narrow results
+- For single-device or single-app logs, pass `deviceId` or `appId` — this is a server-side scope filter (mutually exclusive) and is much cheaper than post-filtering the full buffer
 
 **get_device_history:**
 - Up to 7 days of history

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -153,7 +153,7 @@ For complete safety protocols and tool-specific requirements, see [safety-guide.
 Core tool: `get_device_events` (always visible)
 
 Via `manage_logs` gateway (6 tools):
-- `get_hub_logs` - Hub log entries, most recent first (filter by level/source, scope to deviceId/appId)
+- `get_hub_logs` - Hub log entries, most recent first (filter by level/source, or scope server-side to a single `deviceId` / `appId` — mutually exclusive)
 - `get_device_history` - Device event history (up to 7 days)
 - `get_debug_logs` / `clear_debug_logs` - MCP-specific debug logs
 - `set_log_level` - Set MCP log level

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -153,7 +153,7 @@ For complete safety protocols and tool-specific requirements, see [safety-guide.
 Core tool: `get_device_events` (always visible)
 
 Via `manage_logs` gateway (6 tools):
-- `get_hub_logs` - Hub log entries (filter by level and source)
+- `get_hub_logs` - Hub log entries, most recent first (filter by level/source, scope to deviceId/appId)
 - `get_device_history` - Device event history (up to 7 days)
 - `get_debug_logs` / `clear_debug_logs` - MCP-specific debug logs
 - `set_log_level` - Set MCP log level

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -140,7 +140,7 @@ Hub and MCP log access and configuration.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
-| `get_hub_logs` | Hub log entries. Default 100, max 500. Use filters. | Hub Admin Read |
+| `get_hub_logs` | Hub log entries, most recent first. Default 100, max 500. Filter by level/source, or scope to a single `deviceId` / `appId` (server-side). | Hub Admin Read |
 | `get_device_history` | Up to 7 days of device event history. | Hub Admin Read |
 | `get_debug_logs` | Retrieve MCP debug log entries. Filter by level. | None |
 | `clear_debug_logs` | Clear all MCP debug logs. | None |

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1120,7 +1120,7 @@ Verify rule after creation.""",
                     source: [type: "string", description: "Filter by source/app name (case-insensitive substring match against the log entry)"],
                     deviceId: [type: "string", description: "Scope to a single device's log entries (server-side filter, mutually exclusive with appId)"],
                     appId: [type: "string", description: "Scope to a single app's log entries (server-side filter, mutually exclusive with deviceId)"],
-                    limit: [type: "integer", description: "Max entries to return (newest first). Default: 100, max: 500.", default: 100]
+                    limit: [type: "integer", description: "Max entries to return. Default: 100, max: 500.", default: 100]
                 ]
             ]
         ],
@@ -5064,20 +5064,34 @@ def toolGetHubLogs(args) {
     def limit = Math.min(args.limit ?: 100, maxLimit)
     def levelFilter = args.level
     def sourceFilter = args.source
-    def deviceIdFilter = args.deviceId?.toString()
-    def appIdFilter = args.appId?.toString()
+    def deviceIdFilter = args.deviceId?.toString()?.trim()
+    def appIdFilter = args.appId?.toString()?.trim()
+
+    if (deviceIdFilter && appIdFilter) {
+        throw new IllegalArgumentException("deviceId and appId are mutually exclusive: set only one")
+    }
 
     // Server-side scoping: the hub's /logs/past/json endpoint accepts ?type=dev&id=<N>
     // or ?type=app&id=<N> to filter at the source (same mechanism the UI's device- and
     // app-specific log pages use). Much cheaper than returning the whole buffer and
-    // filtering client-side when the caller only wants one device/app.
+    // filtering client-side when the caller only wants one device/app. The level and
+    // source filters plus the limit below still apply client-side on top of the scoped
+    // result; they are not replaced by deviceId/appId.
+    //
+    // Both ids must be validated before the HTTP call. The hub returns 200 OK with an
+    // empty array for unknown or non-numeric ids, which would otherwise be indistinguishable
+    // from a real device that simply has no log entries.
     def query = null
-    if (deviceIdFilter && appIdFilter) {
-        throw new IllegalArgumentException("deviceId and appId are mutually exclusive — set only one")
-    }
     if (deviceIdFilter) {
+        def device = findDevice(deviceIdFilter)
+        if (!device) {
+            throw new IllegalArgumentException("Device not found: ${deviceIdFilter}")
+        }
         query = [type: "dev", id: deviceIdFilter]
     } else if (appIdFilter) {
+        if (!appIdFilter.isInteger()) {
+            throw new IllegalArgumentException("appId must be numeric: ${appIdFilter}")
+        }
         query = [type: "app", id: appIdFilter]
     }
 
@@ -5109,8 +5123,12 @@ def toolGetHubLogs(args) {
 
     // Hub returns chronological order (oldest-first). Callers overwhelmingly want
     // the most recent N entries — reverse so the limit trims the tail of the buffer
-    // rather than the head. Matches what the official Hubitat Vue UI does client-side
-    // on its "Past Logs" page (reverses the fetch result before rendering).
+    // rather than the head. Guard against non-List parse results (a String or Map
+    // from the newline-split fallback or a firmware variant) since List.reverse()
+    // only makes sense on the array case.
+    if (!(logArray instanceof List)) {
+        return [logs: [], error: "Unexpected log format from hub", count: 0]
+    }
     logArray = logArray.reverse()
 
     def totalParsed = logArray.size()

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -551,7 +551,7 @@ def getGatewayConfig() {
                 get_logging_status: "Get logging system status and capacity"
             ],
             searchHints: [
-                get_hub_logs: "errors warnings messages trace syslog output print",
+                get_hub_logs: "errors warnings messages trace syslog output print recent latest newest device app scope",
                 get_device_history: "events timeline past activity what happened sensor",
                 get_performance_stats: "slow cpu busy resource usage hog bottleneck",
                 get_hub_jobs: "scheduled cron timer recurring what is running next automation",

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -541,7 +541,7 @@ def getGatewayConfig() {
             description: "System logs, performance stats, and log settings: hub logs, device/app performance stats, scheduled jobs, device event history, MCP debug logs, and log level configuration.",
             tools: ["get_hub_logs", "get_device_history", "get_performance_stats", "get_hub_jobs", "get_debug_logs", "clear_debug_logs", "set_log_level", "get_logging_status"],
             summaries: [
-                get_hub_logs: "Get Hubitat system logs. Args: level (debug/info/warn/error), source, limit",
+                get_hub_logs: "Get Hubitat system logs, most recent first. Args: level (debug/info/warn/error), source (substring), deviceId or appId (server-side scope), limit",
                 get_device_history: "Get device event history (up to 7 days). Args: deviceId, hours, attribute",
                 get_performance_stats: "Get device/app performance stats (count, % busy, total ms, state size, events, large state flag). Args: type (device/app/both), sortBy (pct/count/stateSize/totalMs/name), limit",
                 get_hub_jobs: "Get scheduled jobs, running jobs, and hub actions",
@@ -1112,13 +1112,15 @@ Verify rule after creation.""",
         ],
         [
             name: "get_hub_logs",
-            description: "Get Hubitat system logs. Filter by level/source. Default 100 entries, max 500. Requires Hub Admin Read.",
+            description: "Get Hubitat system logs, most recent first. Filter by level, source substring, or scope server-side to a single device or app. Default 100 entries, max 500. Requires Hub Admin Read.",
             inputSchema: [
                 type: "object",
                 properties: [
                     level: [type: "string", description: "Filter by log level: trace, debug, info, warn, error. Default: all levels.", enum: ["trace", "debug", "info", "warn", "error"]],
-                    source: [type: "string", description: "Filter by source/app name (case-insensitive substring match)"],
-                    limit: [type: "integer", description: "Max entries to return. Default: 100, max: 500.", default: 100]
+                    source: [type: "string", description: "Filter by source/app name (case-insensitive substring match against the log entry)"],
+                    deviceId: [type: "string", description: "Scope to a single device's log entries (server-side filter, mutually exclusive with appId)"],
+                    appId: [type: "string", description: "Scope to a single app's log entries (server-side filter, mutually exclusive with deviceId)"],
+                    limit: [type: "integer", description: "Max entries to return (newest first). Default: 100, max: 500.", default: 100]
                 ]
             ]
         ],
@@ -5062,12 +5064,28 @@ def toolGetHubLogs(args) {
     def limit = Math.min(args.limit ?: 100, maxLimit)
     def levelFilter = args.level
     def sourceFilter = args.source
+    def deviceIdFilter = args.deviceId?.toString()
+    def appIdFilter = args.appId?.toString()
 
-    mcpLog("info", "monitoring", "Fetching hub logs (level=${levelFilter}, source=${sourceFilter}, limit=${limit})")
+    // Server-side scoping: the hub's /logs/past/json endpoint accepts ?type=dev&id=<N>
+    // or ?type=app&id=<N> to filter at the source (same mechanism the UI's device- and
+    // app-specific log pages use). Much cheaper than returning the whole buffer and
+    // filtering client-side when the caller only wants one device/app.
+    def query = null
+    if (deviceIdFilter && appIdFilter) {
+        throw new IllegalArgumentException("deviceId and appId are mutually exclusive — set only one")
+    }
+    if (deviceIdFilter) {
+        query = [type: "dev", id: deviceIdFilter]
+    } else if (appIdFilter) {
+        query = [type: "app", id: appIdFilter]
+    }
+
+    mcpLog("info", "monitoring", "Fetching hub logs (level=${levelFilter}, source=${sourceFilter}, deviceId=${deviceIdFilter}, appId=${appIdFilter}, limit=${limit})")
 
     def responseText = null
     try {
-        responseText = hubInternalGet("/logs/past/json", null, 30)
+        responseText = hubInternalGet("/logs/past/json", query, 30)
     } catch (Exception e) {
         mcpLog("error", "monitoring", "Failed to fetch hub logs: ${e.message}")
         return [logs: [], error: "Failed to fetch hub logs: ${e.message}", count: 0]
@@ -5088,6 +5106,12 @@ def toolGetHubLogs(args) {
         mcpLog("debug", "monitoring", "Hub logs response not JSON, falling back to line-split: ${e.message}")
         logArray = responseText.split("\n").toList()
     }
+
+    // Hub returns chronological order (oldest-first). Callers overwhelmingly want
+    // the most recent N entries — reverse so the limit trims the tail of the buffer
+    // rather than the head. Matches what the official Hubitat Vue UI does client-side
+    // on its "Past Logs" page (reverses the fetch result before rendering).
+    logArray = logArray.reverse()
 
     def totalParsed = logArray.size()
     for (logEntry in logArray) {


### PR DESCRIPTION
## Summary

Two related changes to `get_hub_logs` in the `manage_logs` gateway:

1. **Bug fix — return most recent entries first.** The hub's `/logs/past/json` returns log entries in chronological order (oldest first), so `get_hub_logs(limit=50)` previously returned the 50 **oldest** entries in the buffer — callers couldn't see anything current. The Hubitat Vue UI's Past Logs page does the right thing client-side (`e.reverse()` before rendering); now `toolGetHubLogs` matches that.

2. **Enhancement — server-side `deviceId` / `appId` scope filter.** The hub's log endpoint accepts `?type=dev&id=<N>` and `?type=app&id=<N>` to narrow the response to a single source (this is what the Hubitat device-log and app-log UI pages use). Wired up as two new optional, mutually-exclusive args. On a representative prod hub, `deviceId=<id>` cut the parsed log count from ~17,800 → ~1,300 — about 93% less payload for a call that only wanted one device's logs. The existing `source` substring filter still works and still runs client-side.

## Repro before fix

```
call: get_hub_logs(limit=5)
returns: entries from 2026-04-17 15:09:28 (~30 hours old at call time)
```

## After fix

```
call: get_hub_logs(limit=5)
returns: entries from 2026-04-19 02:01:01 (seconds old)

call: get_hub_logs(deviceId=1075, limit=5)
returns: 5 newest entries for device 1075, totalParsed=1299 (vs 17865 unfiltered)

call: get_hub_logs(deviceId=1075, appId=953)
returns: JSON-RPC -32602 Invalid params: "deviceId and appId are mutually exclusive — set only one"
```

## Changes

- `hubitat-mcp-server.groovy:toolGetHubLogs` — reverse `logArray` once after parsing so the filter/limit loop trims from the oldest end. Accept `deviceId` / `appId` args, pass through to `hubInternalGet` as a query map (`[type: "dev", id: ...]` / `[type: "app", id: ...]`), reject when both are set.
- Tool `description` + `inputSchema` updated to reflect "most recent first" and the new args
- `manage_logs` gateway summary + searchHints updated
- `SKILL.md` Hub Internal API Endpoints Reference gains a row for `/logs/past/json` documenting the chronological-order quirk and the `type=dev|app` + `id=` query params
- Tool-reference touch-ups in `README.md`, `TOOL_GUIDE.md`, `agent-skill/hubitat-mcp/SKILL.md`, `agent-skill/hubitat-mcp/tool-reference.md`

## Scope (intentionally narrow)

- No new tool, no gateway-count shift, no schema change to other tools
- No version bump — leaving that for your release cut
- No `packageManifest.json` change
- Sandbox lint clean; tested on a live hub (firmware 2.4.4.156) with default/level-filtered/deviceId-scoped/appId-scoped/mutual-exclusion cases all green

## Test plan (for reviewer)

- Call `manage_logs(tool="get_hub_logs", args={"limit": 5})` and confirm the first entry's timestamp is within the last few seconds (prior behavior: entry from hours-to-days ago, depending on buffer size)
- Call with `{"deviceId": "<any device id>"}` and confirm the response contains only that device's entries
- Call with both `deviceId` and `appId` and confirm the JSON-RPC `-32602 Invalid params` error
- Existing level/source filter semantics unchanged
