### PR TITLE
fix: release workflow pushes the version tag explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,5 +72,9 @@ jobs:
           git commit \
             -m "chore(release): ${NEW_VERSION}" \
             -m "Co-authored-by: ${PR_AUTHOR} <${PR_AUTHOR_ID}+${PR_AUTHOR}@users.noreply.github.com>"
-          git tag "v${NEW_VERSION}"
-          git push origin main --follow-tags
+          # Use annotated tag + explicit tag push. --follow-tags silently skips
+          # lightweight tags, so the previous 'git tag ... && git push --follow-tags'
+          # form left the tag unpushed on v0.9.3's first run.
+          git tag -a "v${NEW_VERSION}" -m "Release ${NEW_VERSION}"
+          git push origin main
+          git push origin "v${NEW_VERSION}"

--- a/README.md
+++ b/README.md
@@ -1570,6 +1570,7 @@ MIT License - see [LICENSE](LICENSE)
 - Inspired by the [Home Assistant MCP](https://github.com/homeassistant-ai/ha-mcp/)
 - Thanks to the Hubitat community for documentation and examples
 - [@ashwinma14](https://github.com/ashwinma14) - Fix for StackOverflowError on app install ([#15](https://github.com/kingpanther13/Hubitat-local-MCP-server/pull/15))
+- [@level99](https://github.com/level99) - Enriched `list_devices` summary + server-side `filter` arg ([#63](https://github.com/kingpanther13/Hubitat-local-MCP-server/pull/63)) and `get_hub_logs` ordering fix + `deviceId`/`appId` server-side scope ([#64](https://github.com/kingpanther13/Hubitat-local-MCP-server/pull/64))
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary

The v0.9.3 release workflow succeeded on bumping versions and committing, but left the \`v0.9.3\` tag unpushed. Root cause: \`git tag\` without \`-a\` creates a lightweight tag, and \`git push --follow-tags\` only follows **annotated** tags. Main got the \`chore(release)\` commit but no tag ref on the remote.

I retroactively tagged \`v0.9.3\` on \`f5f5ae4\` after the fact to unblock further releases. This PR prevents the issue recurring.

## Fix

- Create the tag with \`git tag -a -m \"Release X.Y.Z\"\` (annotated)
- Push the tag with an explicit \`git push origin vX.Y.Z\` step instead of relying on \`--follow-tags\`

## Not labeled

Intentionally **no** \`release:*\` label on this PR — merging just lands the workflow fix without bumping the version. The next labeled PR will exercise the corrected tag-push path and produce \`v0.9.4\`.