### PR TITLE
chore: drop unused json import in sandbox_lint.py

### DIFF
--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -13,7 +13,6 @@ Outputs GitHub Actions annotations when running in CI.
 import re
 import sys
 import os
-import json
 from pathlib import Path
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Removes the unused \`import json\` in \`tests/sandbox_lint.py\`. Pyright flagged it; the module is never referenced (the lines that mention 'json' are string literals for the \`packageManifest.json\` filename, not calls to the \`json\` module). \`sandbox_lint.py\` runs clean without it.

Dual purpose:
1. Minor housekeeping.
2. Exercises the fixed release workflow from #67 — this PR carries \`release:patch\`, so merging should produce \`v0.9.4\` and (this time) push the tag to origin.