### PR TITLE
Built-in app visibility + Rule Machine interop (2 new gateways, 7 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hubitat MCP Server
 
-A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 69 MCP tools (30 on `tools/list` via category gateways).
+A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 81 MCP tools (33 on `tools/list` via category gateways).
 
 > **BETA SOFTWARE**: This project is ~99% AI-generated ("vibe coded") using Claude. It's a work in progress — contributions and [bug reports](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues) are welcome!
 
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 69 tools total — 21 core tools are always visible, while 48 additional tools are organized behind 9 domain-named gateways to keep the tool list manageable.
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 81 tools total — 22 core tools are always visible, while 59 additional tools are organized behind 11 domain-named gateways to keep the tool list manageable.
 
 ## Requirements
 
@@ -221,9 +221,9 @@ For free remote access without a Hubitat Cloud subscription:
 
 ## Features
 
-### MCP Tools (74 total — 31 on tools/list)
+### MCP Tools (81 total — 33 on tools/list)
 
-The server has 74 tools total. To keep the MCP `tools/list` manageable, **22 core tools** are always visible and **52 additional tools** are organized behind **9 domain-named gateways**. The AI sees 31 items on `tools/list` (22 + 9 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
+The server has 81 tools total. To keep the MCP `tools/list` manageable, **22 core tools** are always visible and **59 additional tools** are organized behind **11 domain-named gateways**. The AI sees 33 items on `tools/list` (22 + 11 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
 
 #### Core Tools (22) — Always visible on tools/list
 
@@ -305,7 +305,7 @@ The server has 74 tools total. To keep the MCP `tools/list` manageable, **22 cor
 
 </details>
 
-#### Gateway Tools (9) — Each gateway proxies multiple tools
+#### Gateway Tools (11) — Each gateway proxies multiple tools
 
 Call a gateway with no arguments to see full parameter schemas. Call with `tool='<name>'` and `args={...}` to execute a specific tool.
 
@@ -438,6 +438,33 @@ Monitoring tools require Hub Admin Read to be enabled.
 | `delete_file` | Delete a file (auto-backs up first) |
 
 Write/delete require Hub Admin Write + confirm.
+
+</details>
+
+<details>
+<summary><b>manage_installed_apps</b> (2) — Built-in app visibility</summary>
+
+| Tool | Description |
+|------|-------------|
+| `list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by builtin/user/disabled/parents/children. |
+| `get_device_in_use_by` | Find all apps that reference a specific device (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.) |
+
+Requires opt-in **Enable Built-in App Tools** setting.
+
+</details>
+
+<details>
+<summary><b>manage_rule_machine</b> (5) — Rule Machine interop via RMUtils</summary>
+
+| Tool | Description |
+|------|-------------|
+| `list_rm_rules` | List all Rule Machine rules (RM 4.x + 5.x) via official `hubitat.helper.RMUtils` API |
+| `run_rm_rule` | Trigger an RM rule (`action`: "rule"/"actions"/"stop") |
+| `pause_rm_rule` | Pause an RM rule (reversible) |
+| `resume_rm_rule` | Resume a paused RM rule |
+| `set_rm_rule_boolean` | Set an RM rule's private boolean variable |
+
+**Cannot create, modify, or delete** RM rules — Hubitat's platform blocks third-party apps from managing built-in app children. Use the native RM UI for configuration. Requires opt-in **Enable Built-in App Tools** setting.
 
 </details>
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hubitat-mcp-server
-description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 69 tools (30 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, and app/driver management.
+description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 81 tools (33 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver management, installed-app visibility, and Rule Machine interoperability.
 license: MIT
 ---
 
@@ -32,7 +32,7 @@ There are **no external dependencies, build steps, or test frameworks**. Everyth
 │  │  MCP Rule Server (parent app)             │  │
 │  │  - OAuth endpoint: /apps/api/<id>/mcp     │  │
 │  │  - JSON-RPC 2.0 handler                   │  │
-│  │  - 69 tools (30 on tools/list + gateways) │  │
+│  │  - 81 tools (33 on tools/list + gateways) │  │
 │  │  - Device access gate (selectedDevices)   │  │
 │  │  - Hub Admin tools (internal API calls)   │  │
 │  │  - Hub Security cookie auth               │  │
@@ -93,19 +93,19 @@ New code should be placed in the appropriate section. New sections should follow
 
 ### Category Gateway Proxy (v0.8.0+)
 
-The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 69 items to 30. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
+The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 81 items to 33. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
 
 **Architecture:**
-- `getGatewayConfig()` — defines 9 gateways, each with a description, tools list, and summaries map
-- `getToolDefinitions()` — returns 21 core tools + 9 gateway tool definitions (client-visible)
-- `getAllToolDefinitions()` — returns all 69 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
+- `getGatewayConfig()` — defines 11 gateways, each with a description, tools list, and summaries map
+- `getToolDefinitions()` — returns 22 core tools + 11 gateway tool definitions (client-visible)
+- `getAllToolDefinitions()` — returns all 81 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
 - `handleGateway(gatewayName, toolName, toolArgs)` — catalog mode (no args → full schemas) or execute mode (tool + args → dispatch)
 
 **Gateway calling convention:**
 1. AI calls `manage_<domain>()` with no args → gets full tool schemas (catalog mode)
 2. AI calls `manage_<domain>(tool="tool_name", args={...})` → executes the proxied tool
 
-**9 gateways (48 proxied tools):**
+**11 gateways (59 proxied tools):**
 | Gateway | Tools | Domain |
 |---------|-------|--------|
 | `manage_rules_admin` | 5 | Rule delete/test/export/import/clone |
@@ -115,8 +115,10 @@ The server uses a **category gateway proxy** pattern to reduce the MCP `tools/li
 | `manage_apps_drivers` | 6 | List/get apps, drivers, backups (read-only) |
 | `manage_app_driver_code` | 7 | Install/update/delete apps+drivers, restore backup (write) |
 | `manage_logs` | 8 | Logs, monitoring, performance stats, hub jobs, debug tools |
-| `manage_diagnostics` | 9 | Diagnostics, state capture, zwave/zigbee details, zwave repair |
+| `manage_diagnostics` | 11 | Diagnostics, state capture, zwave/zigbee details, zwave repair, memory history, GC |
 | `manage_files` | 4 | File Manager CRUD |
+| `manage_installed_apps` | 2 | Built-in + user app visibility, device-in-use-by lookup |
+| `manage_rule_machine` | 5 | Rule Machine interop via RMUtils — list/run/pause/resume/boolean |
 
 **22 core tools:** `list_devices`, `get_device`, `get_attribute`, `send_command`, `get_device_events`, `list_rules`, `get_rule`, `create_rule`, `update_rule`, `update_device`, `manage_virtual_device` (action enum: "create", "delete"), `list_virtual_devices`, `get_hub_info` (comprehensive: hardware, health — memory, temp, DB size — and MCP stats always available; PII/location data — name, IP, timezone, coordinates, zip — gated behind Hub Admin Read), `get_modes`, `set_mode`, `get_hsm_status`, `set_hsm`, `create_hub_backup`, `check_for_update`, `generate_bug_report`, `get_tool_guide`, `search_tools` (BM25 natural language search across all tools)
 
@@ -492,6 +494,8 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 | `/hub/fileManager/json` | Lists all files in File Manager (JSON array: name, size, date) |
 | `/hub2/roomsList` | List of rooms as JSON (alternative to `getRooms()` SDK method) |
 | `/logs/past/json` | Hub log buffer as JSON array of tab-delimited strings (chronological order, oldest first — reverse client-side for newest-first). Accepts optional `?type=dev&id=<deviceId>` or `?type=app&id=<appId>` to scope server-side to a single source. |
+| `/hub2/appsList` | All installed apps (built-in + user) as JSON. Keys: `systemAppTypes[]`, `userAppTypes[]`, `apps[]` (instance tree). Each `apps[]` entry has `{key, id, data: {id, name, type, disabled, user, hidden, appTypeId}, parent: bool, child: bool, children: [...]}`. Used by `list_installed_apps`. |
+| `/device/fullJson/<id>` | Comprehensive device JSON — includes `appsUsing` array (apps referencing this device: `{id, name, label, trueLabel, disabled}`), `appsUsingCount`, `parentApp`, plus device commands/attributes/settings/dashboards. Used by `get_device_in_use_by`. |
 
 **Write endpoints (POST):**
 | Path | Body | Purpose |

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -4,13 +4,13 @@ Detailed reference for MCP Rule Server tools. Consult this when tool description
 
 ## Category Gateway Proxy (v0.8.0+)
 
-As of v0.8.0, the server uses **domain-named gateways** to organize 48 lesser-used tools behind 9 gateway tools. The MCP `tools/list` shows 31 items (22 core + 9 gateways). Use `search_tools` to find any tool by natural language query.
+As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 33 items (22 core + 11 gateways) covering 81 total tools. Use `search_tools` to find any tool by natural language query.
 
 **How to use a gateway:**
 1. Call the gateway with no arguments to see full parameter schemas for all its tools
 2. Call with `tool='<tool_name>'` and `args={...}` to execute a specific tool
 
-**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (6), `manage_diagnostics` (9), `manage_files` (4)
+**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (2), `manage_rule_machine` (5)
 
 All safety gates (Hub Admin Read/Write, confirm, backup checks) are preserved — they are enforced in the handler functions, not the dispatch layer.
 
@@ -260,7 +260,7 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 
 **list_devices:**
 - Use `detailed=false` for initial discovery
-- Summary response (always returned) includes: id, name (driver type), label, room, `disabled`, `deviceNetworkId`, `lastActivity`, `parentDeviceId` (v0.10.0+) — enough for most filtering without `get_device` round-trips. Summary mode also returns `currentStates`; detailed mode replaces it with `capabilities`/`attributes`/`commands`. To count children of a parent device, group the response on `parentDeviceId` client-side
+- Summary response (always returned) includes: id, name (driver type), label, room, `disabled`, `deviceNetworkId`, `lastActivity`, `parentDeviceId` — enough for most filtering without `get_device` round-trips. Summary mode also returns `currentStates`; detailed mode replaces it with `capabilities`/`attributes`/`commands`. To count children of a parent device, group the response on `parentDeviceId` client-side
 - Use `filter` for server-side narrowing before pagination: `'enabled'`, `'disabled'`, or `'stale:<hours>'` (e.g. `'stale:24'` = devices with no activity in the last 24h). Use this for boolean and time-relative queries; leave name/label/capability filtering to client-side (AI scans returned JSON)
 - With `detailed=true`, paginate: 20-30 devices per request. Detailed adds capabilities, attributes, commands
 - Make tool calls sequentially, not in parallel
@@ -278,3 +278,48 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 **get_device_history:**
 - Up to 7 days of history
 - Use attribute filter to reduce data volume
+
+---
+
+## Built-in App Tools
+
+All tools in `manage_installed_apps` and `manage_rule_machine` gateways require the **Enable Built-in App Tools** toggle in MCP Rule Server app settings. If the user sees "Built-in App Tools are disabled" errors, direct them to the MCP Rule Server app settings page.
+
+### manage_installed_apps (2 tools)
+
+- **`list_installed_apps`** — enumerate ALL apps on the hub (built-in + user) with parent/child tree
+  - `filter="all"` (default) | `"builtin"` | `"user"` | `"disabled"` | `"parents"` | `"children"`
+  - Each entry: `id`, `name`, `type`, `disabled`, `user`, `hidden`, `parentId`, `hasChildren`, `childCount`
+  - Built-in apps have `user=false` (Rule Machine, Room Lighting, Groups and Scenes, Mode Manager, HSM, Dashboards, Maker API, etc.)
+  - User apps have `user=true` (Awair, Ecobee, HPM, etc.)
+  - Parent/child tree flattened with `parentId` pointers. Hidden parents are excluded from output but their children are promoted to the nearest visible ancestor (or `null` at root).
+
+- **`get_device_in_use_by`** — find apps that reference a specific device
+  - Use BEFORE deleting a device, disabling a device, or troubleshooting unexpected behavior
+  - Returns `appsUsing` array with each app's `id`, `name` (type like "Room Lights" or "Rule-5.1"), `label` (user-visible), `trueLabel` (HTML-stripped), `disabled`
+  - Answers "if I delete/disable this device, which automations break?"
+
+### manage_rule_machine (5 tools)
+
+**Read + trigger existing RM rules only. Cannot create, modify, or delete RM rules — Hubitat platform blocks third-party apps from mutating built-in app children.**
+
+- **`list_rm_rules`** — enumerate Rule Machine rules (RM 4.x + 5.x combined, deduplicated by id)
+
+- **`run_rm_rule`** — trigger an existing RM rule via `RMUtils.sendAction`
+  - `action="rule"` (default, full evaluation): runs triggers + conditions + actions as if the rule fired
+  - `action="actions"`: runs only the actions, bypassing conditions (useful for manual override)
+  - `action="stop"`: stops running actions (cancels in-flight delays)
+
+- **`pause_rm_rule`** / **`resume_rm_rule`** — reversible toggle; paused rules don't fire on triggers
+
+- **`set_rm_rule_boolean`** — set an RM rule's private boolean (true or false only; string values must be lowercase `"true"`/`"false"`). RM rules can use "Private Boolean" in conditions — this lets MCP flip that flag from outside.
+
+### CRITICAL: Refuse invalid RM/RL operations
+
+If a user asks "create a new RM rule" or "set up a new Room Lighting":
+
+1. Explain this is not possible via MCP (platform limitation, not a missing feature)
+2. Offer the alternative: create an equivalent rule using MCP's own rule engine via `create_rule`
+3. Or direct them to the native Rule Machine / Room Lighting UI for configuration
+
+**Do NOT invent fake tools like `create_rm_rule` or pretend to call one.** This is the most important safety rule for these tools.

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Smart home assistant for Hubitat Elevation hubs via MCP. Use when c
 
 # Hubitat MCP Server - Smart Home Assistant
 
-You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 69 MCP tools for device control, automation rules, room management, hub administration, and diagnostics. The tools are organized as **21 core tools** (always visible) plus **9 domain-named gateways** that proxy 48 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
+You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 81 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, and Rule Machine interop. The tools are organized as **22 core tools** (always visible) plus **11 domain-named gateways** that proxy 59 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
 
 ## Core Principles
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -1,10 +1,10 @@
 # Tool Reference
 
-Quick reference for all 69 MCP tools. The server exposes **30 items on `tools/list`**: 21 core tools + 9 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
+Quick reference for all 81 MCP tools. The server exposes **33 items on `tools/list`**: 22 core tools + 11 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
 
 For the most authoritative reference, call `get_tool_guide` via MCP.
 
-## Core Tools (21) — Always visible on tools/list
+## Core Tools (22) — Always visible on tools/list
 
 ### Device Tools (5)
 
@@ -51,15 +51,16 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | `check_for_update` | Check for MCP server updates. | None |
 | `generate_bug_report` | Generate comprehensive diagnostic report. | None |
 
-### Reference (1)
+### Reference (2)
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `get_tool_guide` | Full tool reference from the MCP server itself. | None |
+| `search_tools` | BM25 natural language search across all 81 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
 
 ---
 
-## Gateway Tools (9) — Each proxies multiple tools
+## Gateway Tools (11) — Each proxies multiple tools
 
 Call a gateway with no arguments to see full parameter schemas for all its tools. Call with `tool='<name>'` and `args={...}` to execute a specific tool.
 
@@ -134,22 +135,24 @@ Write operations for apps and drivers: install, update, delete, and restore code
 | `delete_driver` | Delete an installed driver (auto-backs up). | Hub Admin Write |
 | `restore_item_backup` | Restore app/driver to backed-up version. | Hub Admin Write |
 
-### manage_logs (6 tools)
+### manage_logs (8 tools)
 
-Hub and MCP log access and configuration.
+Hub and MCP log access, performance stats, and log configuration.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `get_hub_logs` | Hub log entries, most recent first. Default 100, max 500. Filter by level/source, or scope to a single `deviceId` / `appId` (server-side). | Hub Admin Read |
 | `get_device_history` | Up to 7 days of device event history. | Hub Admin Read |
+| `get_performance_stats` | Device/app performance stats from `/logs`: method call counts, % busy, cumulative total ms, state size, events. Sortable. | Hub Admin Read |
+| `get_hub_jobs` | Scheduled and running jobs on the hub. | Hub Admin Read |
 | `get_debug_logs` | Retrieve MCP debug log entries. Filter by level. | None |
 | `clear_debug_logs` | Clear all MCP debug logs. | None |
 | `set_log_level` | Set MCP log level (debug/info/warn/error). | None |
 | `get_logging_status` | View logging system statistics. | None |
 
-### manage_diagnostics (9 tools)
+### manage_diagnostics (11 tools)
 
-Performance monitoring, health checks, diagnostics, radio info, and state capture.
+Performance monitoring, health checks, diagnostics, radio info, memory / GC, and state capture.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
@@ -158,6 +161,8 @@ Performance monitoring, health checks, diagnostics, radio info, and state captur
 | `get_rule_diagnostics` | Comprehensive diagnostics for a specific rule. | None |
 | `get_zwave_details` | Z-Wave radio info. | Hub Admin Read |
 | `get_zigbee_details` | Zigbee radio info. | Hub Admin Read |
+| `get_memory_history` | Free OS memory + CPU load history (with Java heap + NIO buffer tracking for leak detection). | Hub Admin Read |
+| `force_garbage_collection` | Force JVM GC and return before/after memory comparison. | Hub Admin Read |
 | `zwave_repair` | Start Z-Wave network repair (5-30 min). | Hub Admin Write |
 | `list_captured_states` | List saved device state snapshots. | None |
 | `delete_captured_state` | Delete a specific state snapshot. | None |
@@ -173,3 +178,24 @@ Manage hub File Manager: list, read, write, and delete files stored on the hub.
 | `read_file` | Read a file (inline for <60KB, URL for larger). | None |
 | `write_file` | Create/update a file (auto-backs up existing). | Hub Admin Write |
 | `delete_file` | Delete a file (auto-backs up first). | Hub Admin Write |
+
+### manage_installed_apps (2 tools)
+
+Read-only visibility into all installed apps (built-in + user): enumerate with parent/child tree, find apps using a specific device. Requires Built-in App Tools enabled in MCP app settings.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by `all`/`builtin`/`user`/`disabled`/`parents`/`children`. | Built-in App Read |
+| `get_device_in_use_by` | Given a `deviceId`, list apps referencing it (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.). | Built-in App Read |
+
+### manage_rule_machine (5 tools)
+
+Rule Machine interop via the official `hubitat.helper.RMUtils` helper class: list, trigger, pause/resume, and set Private Boolean on existing RM rules. **Cannot create, modify, or delete RM rules** — Hubitat platform blocks third-party apps from mutating built-in app children; use the native RM UI for configuration. Requires Built-in App Tools enabled.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `list_rm_rules` | List all Rule Machine rules (RM 4.x + 5.x combined, deduplicated by id). | Built-in App Read |
+| `run_rm_rule` | Trigger an existing RM rule. `action`: `rule` (full), `actions` (bypass conditions), or `stop` (cancel in-flight). | Built-in App Read |
+| `pause_rm_rule` | Pause an RM rule (reversible; paused rules don't fire on triggers). | Built-in App Read |
+| `resume_rm_rule` | Resume a paused RM rule. | Built-in App Read |
+| `set_rm_rule_boolean` | Set an RM rule's private boolean (true/false) — flips the flag that rules can reference in conditions. | Built-in App Read |

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -198,4 +198,4 @@ Rule Machine interop via the official `hubitat.helper.RMUtils` helper class: lis
 | `run_rm_rule` | Trigger an existing RM rule. `action`: `rule` (full), `actions` (bypass conditions), or `stop` (cancel in-flight). | Built-in App Read |
 | `pause_rm_rule` | Pause an RM rule (reversible; paused rules don't fire on triggers). | Built-in App Read |
 | `resume_rm_rule` | Resume a paused RM rule. | Built-in App Read |
-| `set_rm_rule_boolean` | Set an RM rule's private boolean (true/false) — flips the flag that rules can reference in conditions. | Built-in App Read |
+| `set_rm_rule_boolean` | Set an RM rule's private boolean (true or false only; string values must be lowercase `"true"`/`"false"`) — flips the flag that rules can reference in conditions. | Built-in App Read |

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -7666,7 +7666,15 @@ def toolListRmRules(args) {
     // so operators can investigate rather than get silent empty results.
     def classMissingHint = { String msg ->
         msg && (msg.contains("NoClassDefFoundError") || msg.contains("ClassNotFoundException") ||
-                msg.contains("unable to resolve class") || msg.contains("No such property"))
+                msg.contains("unable to resolve class") || msg.contains("No such property") ||
+                // Hubitat's Groovy sandbox returns null for unresolved `hubitat.helper.X`
+                // namespace lookups; the subsequent property dereference throws
+                // "Cannot get property 'helper' on null object". Verified live on the hub.
+                msg.contains("Cannot get property") ||
+                // Very old firmware that has RMUtils but lacks the getRuleList("5.0") overload
+                // throws MissingMethodException rather than a class-resolution error — same
+                // "this variant isn't here" semantic, so treat it quietly as well.
+                msg.contains("MissingMethodException") || msg.contains("No signature of method"))
     }
     def hardErrors = []
     if (v4Error && !classMissingHint(v4Error)) hardErrors << "v4=${v4Error}"

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -7635,18 +7635,22 @@ def toolListRmRules(args) {
     def v4Error = null
     def v5Error = null
 
+    // Catch Throwable (not just Exception) so NoClassDefFoundError / ClassNotFoundException
+    // from a hub without Rule Machine installed degrade gracefully rather than propagating
+    // as an unhandled JVM error. RMUtils is an optional platform class — absent on hubs
+    // that have never installed Rule Machine as a built-in app.
     try {
         def rules4 = hubitat.helper.RMUtils.getRuleList() ?: []
         rules4.each { r -> registerRmRule(combined, r, "4.x") }
-    } catch (Exception e) {
-        v4Error = e.message
+    } catch (Throwable e) {
+        v4Error = e.message ?: e.toString()
     }
 
     try {
         def rules5 = hubitat.helper.RMUtils.getRuleList("5.0") ?: []
         rules5.each { r -> registerRmRule(combined, r, "5.x") }
-    } catch (Exception e) {
-        v5Error = e.message
+    } catch (Throwable e) {
+        v5Error = e.message ?: e.toString()
     }
 
     def rules = combined.values().sort { it.label ?: "" }
@@ -7655,11 +7659,27 @@ def toolListRmRules(args) {
         rules: rules,
         count: rules.size()
     ]
-    // Only surface errors if BOTH versions failed (otherwise it's just RM 4.x not installed, which is normal)
+    // Classify the failures. A "missing class" error (RM not installed) is normal if the
+    // OTHER version succeeded — only quiet when at least one call returned a list. If both
+    // calls failed with any error, or if one call returned data while the other had a
+    // non-missing-class error (e.g. timeout, internal platform issue), surface the details
+    // so operators can investigate rather than get silent empty results.
+    def classMissingHint = { String msg ->
+        msg && (msg.contains("NoClassDefFoundError") || msg.contains("ClassNotFoundException") ||
+                msg.contains("unable to resolve class") || msg.contains("No such property"))
+    }
+    def hardErrors = []
+    if (v4Error && !classMissingHint(v4Error)) hardErrors << "v4=${v4Error}"
+    if (v5Error && !classMissingHint(v5Error)) hardErrors << "v5=${v5Error}"
+
     if (rules.isEmpty() && v4Error && v5Error) {
         result.success = false
         result.error = "RMUtils calls failed: v4=${v4Error} v5=${v5Error}"
         result.note = "Rule Machine may not be installed on this hub."
+    } else if (hardErrors) {
+        // One version succeeded but the other had a non-missing-class error — surface it
+        // as a warning without blocking the successful results.
+        result.warning = "Partial RMUtils failure (results from the other version shown): ${hardErrors.join('; ')}"
     }
     return result
 }
@@ -7781,20 +7801,24 @@ def toolSetRmRuleBoolean(args) {
  */
 private Map sendRmAction(Integer ruleId, String rmAction, String logContext) {
     def appLabel = app?.label ?: "MCP Rule Server"
+    // Catch Throwable (not just Exception) so NoClassDefFoundError / ClassNotFoundException
+    // from a hub without Rule Machine installed degrade gracefully.
     try {
         hubitat.helper.RMUtils.sendAction([ruleId], rmAction, appLabel, "5.0")
         mcpLog("info", "rm-interop", "${logContext}: sent ${rmAction} to rule ${ruleId}")
         return [success: true, ruleId: ruleId, rmAction: rmAction]
-    } catch (Exception e) {
+    } catch (Throwable e) {
         // Fallback: RMUtils may not accept the 4-arg form on very old firmware.
         // Retry with the 3-arg form. If that also fails, surface both errors.
         try {
             hubitat.helper.RMUtils.sendAction([ruleId], rmAction, appLabel)
             mcpLog("info", "rm-interop", "${logContext}: sent ${rmAction} to rule ${ruleId} (3-arg fallback)")
             return [success: true, ruleId: ruleId, rmAction: rmAction, fallback: "3-arg"]
-        } catch (Exception e2) {
-            mcpLog("error", "rm-interop", "${logContext} failed for rule ${ruleId}: 4-arg=${e.message}, 3-arg=${e2.message}")
-            return [success: false, error: "RMUtils.sendAction failed: ${e2.message}", note: "Verify the ruleId is valid (use list_rm_rules) and Rule Machine is installed."]
+        } catch (Throwable e2) {
+            def m1 = e.message ?: e.toString()
+            def m2 = e2.message ?: e2.toString()
+            mcpLog("error", "rm-interop", "${logContext} failed for rule ${ruleId}: 4-arg=${m1}, 3-arg=${m2}")
+            return [success: false, error: "RMUtils.sendAction failed: ${m2}", note: "Verify the ruleId is valid (use list_rm_rules) and Rule Machine is installed."]
         }
     }
 }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -7478,7 +7478,9 @@ def toolRenameRoom(args) {
 
 /**
  * List all installed apps on the hub (built-in + user), flattened with parent/child relationships.
- * Backed by /hub2/appsList (undocumented but stable internal endpoint used by the Hubitat web UI).
+ * Backed by /hub2/appsList -- returns the same flattened app list the Hubitat web UI renders on
+ * the Apps page. Includes built-in and user apps, parent/child hierarchy, disabled state, and
+ * installed-package metadata.
  */
 def toolListInstalledApps(args) {
     requireBuiltinAppRead()
@@ -7667,10 +7669,9 @@ def toolListRmRules(args) {
         rules: rules,
         count: rules.size()
     ]
-    // Classify the failures. A "missing class" error (RM not installed) is normal if the
-    // OTHER version succeeded — only quiet when at least one call returned a list. If both
-    // calls failed with any error, or if one call returned data while the other had a
-    // non-missing-class error (e.g. timeout, internal platform issue), surface the details
+    // Classify the failures. A "missing class" error (RM not installed) is quiet whether
+    // the other version succeeded OR both versions failed the same way (both-absent path).
+    // A non-missing-class error (e.g. timeout, internal platform issue) is always surfaced
     // so operators can investigate rather than get silent empty results.
     // Narrow to class-resolution failures only. Earlier versions treated any
     // MissingMethodException / "No signature of method" / unqualified "Cannot get property"
@@ -7758,7 +7759,8 @@ private void registerRmRule(Map combined, def r, String version) {
                 // ruleId: integer schema (callers would see a String id in the
                 // response and fail to dispatch run_rm_rule against it). Skip
                 // the entry and surface the anomaly via logs instead.
-                mcpLog("warn", "rm-interop", "registerRmRule: non-integer ruleId '${rawKey}' (type=${rawKey?.getClass()?.simpleName}) in RM ${version} list -- skipping entry")
+                def keyType = rawKey instanceof Number ? 'Number' : rawKey instanceof String ? 'String' : 'other'
+                mcpLog("warn", "rm-interop", "registerRmRule: non-integer ruleId '${rawKey}' (type=${keyType}) in RM ${version} list -- skipping entry")
                 return
             }
             label = entry.value?.toString()
@@ -7861,8 +7863,8 @@ def toolSetRmRuleBoolean(args) {
  * to the RM 5.x handler and is the canonical call for both RM 4.x and RM 5.x rules.
  * The 3-arg form `sendAction([ids], action, appLabel)` reaches only RM 4.x and is
  * used as a fallback for very old firmware that predates the version-discriminator
- * overload (see sendRmActionFallback). Provenance for the 4-arg invariant is in
- * the PR description linking bravenel's RM API thread.
+ * overload (see sendRmActionFallback). Background on the RM API shape:
+ * https://community.hubitat.com/t/rule-machine-api/7104
  */
 private Map sendRmAction(Integer ruleId, String rmAction, String logContext) {
     def appLabel = app?.label ?: "MCP Rule Server"
@@ -7900,7 +7902,7 @@ private Map sendRmActionFallback(Integer ruleId, String rmAction, String appLabe
         def m1 = original.message ?: original.toString()
         def m2 = e2.message ?: e2.toString()
         mcpLog("error", "rm-interop", "${logContext} failed for rule ${ruleId}: 4-arg=${m1}, 3-arg=${m2}")
-        return [success: false, error: "RMUtils.sendAction failed: ${m2}", note: "Verify the ruleId is valid (use list_rm_rules) and Rule Machine is installed."]
+        return [success: false, error: "RMUtils.sendAction failed: ${m2}", note: "4-arg attempt also failed: ${m1}. Verify the ruleId is valid (use list_rm_rules) and Rule Machine is installed."]
     }
 }
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -76,6 +76,14 @@ def mainPage() {
             }
         }
 
+        section("Built-in App Integration") {
+            paragraph "<b>Built-in App Tools</b> expose read-only visibility into Hubitat's built-in apps (Rule Machine, Room Lighting, Scenes, Mode Manager, etc.) and allow controlling Rule Machine rules via the official <code>hubitat.helper.RMUtils</code> API."
+            paragraph "<i>Hubitat's platform blocks creating, modifying, or deleting built-in app instances from third-party apps. Use the native UI for configuration. These tools are read + trigger only.</i>"
+            input "enableBuiltinAppRead", "bool", title: "Enable Built-in App Tools",
+                  description: "Allows MCP to list all installed apps (built-in + user), find apps using a device, list Rule Machine rules, and trigger/pause/resume RM rules",
+                  defaultValue: false, submitOnChange: true
+        }
+
         section("Hub Security") {
             paragraph "If <b>Hub Security</b> is enabled on your hub, provide credentials here so Hub Admin tools can authenticate. " +
                       "If Hub Security is NOT enabled, leave this off — Hub Admin tools will work without credentials."
@@ -605,6 +613,36 @@ def getGatewayConfig() {
                 read_file: "view open contents download stored data",
                 write_file: "upload save store create csv json text data",
                 delete_file: "remove clean up stored data"
+            ]
+        ],
+        manage_installed_apps: [
+            description: "Read-only visibility into all installed apps (built-in + user): enumerate apps with parent/child tree, find apps using a device. Requires Built-in App Tools enabled in MCP app settings.",
+            tools: ["list_installed_apps", "get_device_in_use_by"],
+            summaries: [
+                list_installed_apps: "List all installed apps with parent/child tree. Args: filter (all/builtin/user/disabled/parents/children), includeHidden",
+                get_device_in_use_by: "List all apps that reference a device (Room Lighting, Rule Machine, Groups, etc.). Args: deviceId"
+            ],
+            searchHints: [
+                list_installed_apps: "rule machine room lighting scenes mode manager hsm dashboards groups button controllers native builtin",
+                get_device_in_use_by: "which apps use device reference inUseBy appsUsing dependencies affected by"
+            ]
+        ],
+        manage_rule_machine: [
+            description: "Rule Machine interoperability: list, trigger, pause/resume, and set boolean variables on existing RM rules via the official RMUtils API. Cannot create, modify, or delete RM rules (platform blocks this — use the RM native UI). Requires Built-in App Tools enabled.",
+            tools: ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean"],
+            summaries: [
+                list_rm_rules: "List all Rule Machine rules (RM 4.x + 5.x) with IDs and labels",
+                run_rm_rule: "Trigger a Rule Machine rule. Args: ruleId, action (rule/actions/stop, default rule)",
+                pause_rm_rule: "Pause a Rule Machine rule. Args: ruleId",
+                resume_rm_rule: "Resume a paused Rule Machine rule. Args: ruleId",
+                set_rm_rule_boolean: "Set an RM rule's private boolean to true or false. Args: ruleId, value (bool)"
+            ],
+            searchHints: [
+                list_rm_rules: "rule machine rules native builtin automation",
+                run_rm_rule: "trigger fire execute native rule machine rule",
+                pause_rm_rule: "disable stop temporarily rule machine rule",
+                resume_rm_rule: "enable unpause restart rule machine rule",
+                set_rm_rule_boolean: "private boolean flag rule machine rule condition"
             ]
         ]
     ]
@@ -1571,6 +1609,105 @@ Tell user driver name/ID, warn it's permanent, get confirmation. Requires Hub Ad
                 required: ["fileName", "confirm"]
             ]
         ],
+        // Installed Apps Integration (built-in + user app visibility)
+        [
+            name: "list_installed_apps",
+            description: """List all installed apps on the hub (built-in + user) with parent/child tree. Requires Built-in App Tools enabled.
+
+Each app entry returns: id, name, type, disabled, user (true=user-installed Groovy app, false=built-in), hidden, parentId (null for top-level), hasChildren, childCount.
+
+Use filter to narrow results: 'all' (default), 'builtin' (Hubitat native apps), 'user' (custom Groovy apps), 'disabled' (paused/disabled), 'parents' (apps with children like Rule Machine, Room Lighting, Groups and Scenes), 'children' (individual rules, scenes, etc.).""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    filter: [type: "string", enum: ["all", "builtin", "user", "disabled", "parents", "children"], description: "Filter apps by category. Default: all"],
+                    includeHidden: [type: "boolean", description: "Include hidden apps (typically Hubitat internal). Default: false", default: false]
+                ]
+            ]
+        ],
+        [
+            name: "get_device_in_use_by",
+            description: """List all apps that reference a specific device (Room Lighting instances, Rule Machine rules, Groups and Scenes, Mode Manager, dashboards, Maker API, Echo Skill, etc.). Requires Built-in App Tools enabled.
+
+Answers \"which apps would break or change behavior if I disable/delete this device?\" — critical before device cleanup, troubleshooting, or reassignment.
+
+Returns: deviceId, deviceName, appsUsing array (each entry: id, name=app type, label=user-visible name, trueLabel=label without HTML decoration, disabled), count, parentApp.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    deviceId: [type: "string", description: "Device ID from list_devices"]
+                ],
+                required: ["deviceId"]
+            ]
+        ],
+        // Rule Machine Integration (read + trigger + pause/resume only — platform blocks CRUD)
+        [
+            name: "list_rm_rules",
+            description: """List all Rule Machine rules on the hub (both RM 4.x and 5.x). Requires Built-in App Tools enabled.
+
+Uses the official hubitat.helper.RMUtils API. Returns rule IDs and labels. For rule details/configuration, use the Rule Machine native UI — programmatic read of rule internals is not supported by the platform.""",
+            inputSchema: [
+                type: "object",
+                properties: [:]
+            ]
+        ],
+        [
+            name: "run_rm_rule",
+            description: """Trigger a Rule Machine rule via RMUtils.sendAction(). Requires Built-in App Tools enabled.
+
+Actions:
+- 'rule' (default): evaluate the rule (runs triggers + conditions + actions as if the rule fired)
+- 'actions': run only the actions, bypassing conditions
+- 'stop': stop currently-running actions (e.g., cancel delays)
+
+Not destructive — this triggers existing automations the user already configured. Does NOT require Hub Admin Write.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    ruleId: [type: "integer", description: "Rule ID from list_rm_rules"],
+                    action: [type: "string", enum: ["rule", "actions", "stop"], description: "Which RM action to invoke. Default: rule"]
+                ],
+                required: ["ruleId"]
+            ]
+        ],
+        [
+            name: "pause_rm_rule",
+            description: """Pause a Rule Machine rule. Paused rules don't fire on triggers. Requires Built-in App Tools enabled.
+
+Reversible — use resume_rm_rule to re-enable.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    ruleId: [type: "integer", description: "Rule ID from list_rm_rules"]
+                ],
+                required: ["ruleId"]
+            ]
+        ],
+        [
+            name: "resume_rm_rule",
+            description: """Resume a paused Rule Machine rule. Requires Built-in App Tools enabled.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    ruleId: [type: "integer", description: "Rule ID from list_rm_rules"]
+                ],
+                required: ["ruleId"]
+            ]
+        ],
+        [
+            name: "set_rm_rule_boolean",
+            description: """Set a Rule Machine rule's private boolean variable to true or false. Requires Built-in App Tools enabled.
+
+RM rules can reference 'Private Boolean' in their conditions — this lets MCP flip that flag from outside the rule. Common pattern: condition checks private boolean, external logic (e.g. AI, another automation) sets it.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    ruleId: [type: "integer", description: "Rule ID from list_rm_rules"],
+                    value: [type: "boolean", description: "true sets the boolean to TRUE, false sets it to FALSE"]
+                ],
+                required: ["ruleId", "value"]
+            ]
+        ],
         // Tool Guide
         [
             name: "get_tool_guide",
@@ -1578,7 +1715,7 @@ Tell user driver name/ID, warn it's permanent, get confirmation. Requires Hub Ad
             inputSchema: [
                 type: "object",
                 properties: [
-                    section: [type: "string", description: "REQUIRED for efficiency: device_authorization, hub_admin_write, virtual_devices, update_device, rules, backup, file_manager, performance. Full guide only if absolutely necessary."]
+                    section: [type: "string", description: "REQUIRED for efficiency: device_authorization, hub_admin_write, virtual_devices, update_device, rules, backup, file_manager, performance, builtin_app_tools. Full guide only if absolutely necessary."]
                 ]
             ]
         ],
@@ -1707,6 +1844,17 @@ def executeTool(toolName, args) {
         case "write_file": return toolWriteFile(args)
         case "delete_file": return toolDeleteFile(args)
 
+        // Installed Apps Integration
+        case "list_installed_apps": return toolListInstalledApps(args)
+        case "get_device_in_use_by": return toolGetDeviceInUseBy(args)
+
+        // Rule Machine Integration (via RMUtils)
+        case "list_rm_rules": return toolListRmRules(args)
+        case "run_rm_rule": return toolRunRmRule(args)
+        case "pause_rm_rule": return toolPauseRmRule(args)
+        case "resume_rm_rule": return toolResumeRmRule(args)
+        case "set_rm_rule_boolean": return toolSetRmRuleBoolean(args)
+
         // Tool Guide
         case "get_tool_guide": return toolGetToolGuide(args.section)
 
@@ -1723,6 +1871,8 @@ def executeTool(toolName, args) {
         case "manage_logs":
         case "manage_diagnostics":
         case "manage_files":
+        case "manage_installed_apps":
+        case "manage_rule_machine":
             return handleGateway(toolName, args.tool, args.args)
 
         default:
@@ -3818,6 +3968,16 @@ def hubInternalPostForm(String path, Map body, int timeout = 420, boolean isRetr
 def requireHubAdminRead() {
     if (!settings.enableHubAdminRead) {
         throw new IllegalArgumentException("Hub Admin Read access is disabled. Enable 'Enable Hub Admin Read Tools' in MCP Rule Server app settings to use this tool.")
+    }
+}
+
+/**
+ * Check if Built-in App Read access is enabled. Throws if not.
+ * Gates installed-app enumeration, device-in-use-by lookup, and Rule Machine interop tools.
+ */
+def requireBuiltinAppRead() {
+    if (!settings.enableBuiltinAppRead) {
+        throw new IllegalArgumentException("Built-in App Tools are disabled. Enable 'Enable Built-in App Tools' in MCP Rule Server app settings to use this tool.")
     }
 }
 
@@ -7325,6 +7485,332 @@ def toolRenameRoom(args) {
     ]
 }
 
+// ==================== INSTALLED APPS & RULE MACHINE INTEGRATION ====================
+
+/**
+ * List all installed apps on the hub (built-in + user), flattened with parent/child relationships.
+ * Backed by /hub2/appsList (undocumented but stable internal endpoint used by the Hubitat web UI).
+ */
+def toolListInstalledApps(args) {
+    requireBuiltinAppRead()
+    def filter = args?.filter ?: "all"
+    def includeHidden = args?.includeHidden == true
+
+    def validFilters = ["all", "builtin", "user", "disabled", "parents", "children"]
+    if (!validFilters.contains(filter)) {
+        throw new IllegalArgumentException("Invalid filter '${filter}'. Must be one of: ${validFilters.join(', ')}")
+    }
+
+    try {
+        def responseText = hubInternalGet("/hub2/appsList")
+        if (!responseText) {
+            return [success: false, error: "Empty response from /hub2/appsList", note: "Hub internal API may be transiently unavailable."]
+        }
+        def parsed
+        try {
+            parsed = new groovy.json.JsonSlurper().parseText(responseText)
+        } catch (Exception parseErr) {
+            return [success: false, error: "Failed to parse /hub2/appsList response: ${parseErr.message}", note: "Hubitat firmware may have changed the endpoint format."]
+        }
+        def apps = parsed?.apps ?: []
+
+        // Flatten tree to list with parentId.
+        // If a parent is hidden and excluded from the output, its children are promoted to the
+        // nearest visible ancestor (or null at root) so their parentId always references an
+        // app actually present in the results — no orphan references.
+        // NOTE: closure parameter is 'node' (not 'app') to avoid shadowing the Hubitat SDK's
+        // `app` reference. Hubitat's `app` is used elsewhere for app.label, app.id, etc.
+        def flat = []
+        def recurse
+        recurse = { Map node, parentId ->
+            def d = node?.data ?: [:]
+            def isHidden = d.hidden == true
+            def included = includeHidden || !isHidden
+            if (included) {
+                flat << [
+                    id: d.id,
+                    name: d.name,
+                    type: d.type,
+                    disabled: d.disabled == true,
+                    user: d.user == true,
+                    hidden: isHidden,
+                    parentId: parentId,
+                    hasChildren: (node?.children?.size() ?: 0) > 0,
+                    childCount: node?.children?.size() ?: 0
+                ]
+            }
+            def childParentId = included ? d.id : parentId
+            node?.children?.each { c -> recurse(c, childParentId) }
+        }
+        apps.each { a -> recurse(a, null) }
+
+        def filtered = flat.findAll { entry ->
+            switch (filter) {
+                case "all": return true
+                case "builtin": return !entry.user
+                case "user": return entry.user
+                case "disabled": return entry.disabled
+                case "parents": return entry.hasChildren
+                case "children": return entry.parentId != null
+                default:
+                    // Unreachable — filter is whitelist-validated above. Include anyway so the
+                    // outer success path still returns a usable (possibly over-broad) result
+                    // rather than masking the invariant break inside the outer catch.
+                    return true
+            }
+        }
+
+        return [
+            apps: filtered,
+            count: filtered.size(),
+            filter: filter,
+            totalOnHub: flat.size()
+        ]
+    } catch (Exception e) {
+        mcpLog("error", "installed-apps", "list_installed_apps failed: ${e.message}")
+        return [success: false, error: "Failed to list installed apps: ${e.message}", note: "Check that Built-in App Tools is enabled in MCP settings."]
+    }
+}
+
+/**
+ * List all apps that reference a specific device.
+ * Backed by /device/fullJson/<id> which exposes appsUsing — the same data the Hubitat device page shows.
+ */
+def toolGetDeviceInUseBy(args) {
+    requireBuiltinAppRead()
+    if (!args?.deviceId) throw new IllegalArgumentException("deviceId is required")
+    def deviceId = args.deviceId.toString()
+
+    try {
+        def responseText = hubInternalGet("/device/fullJson/${deviceId}")
+        if (!responseText) {
+            return [success: false, error: "Empty response from /device/fullJson/${deviceId}", note: "Device ID may not exist."]
+        }
+        def parsed
+        try {
+            parsed = new groovy.json.JsonSlurper().parseText(responseText)
+        } catch (Exception parseErr) {
+            return [success: false, error: "Failed to parse device JSON: ${parseErr.message}", note: "Device ID '${deviceId}' may not exist, or firmware changed the endpoint format."]
+        }
+
+        def appsUsing = parsed?.appsUsing ?: []
+        def count
+        try {
+            count = (parsed?.appsUsingCount != null) ? (parsed.appsUsingCount as Integer) : appsUsing.size()
+        } catch (Exception ne) {
+            count = appsUsing.size()
+        }
+
+        return [
+            deviceId: deviceId,
+            // extraBreadcrumb is the canonical UI breadcrumb label; fall back to .name or
+            // .label if a future firmware drops that field so callers still get a usable
+            // device-name string instead of silent null.
+            deviceName: parsed?.extraBreadcrumb ?: parsed?.name ?: parsed?.label,
+            appsUsing: appsUsing.collect { a ->
+                [
+                    id: a?.id,
+                    name: a?.name,         // app type name (e.g. "Room Lights", "Rule-5.1")
+                    label: a?.label,       // user-visible label, may include HTML decoration
+                    trueLabel: a?.trueLabel,  // label stripped of HTML (null if same as label)
+                    disabled: a?.disabled == true
+                ]
+            },
+            count: count,
+            parentApp: parsed?.parentApp
+        ]
+    } catch (Exception e) {
+        mcpLog("error", "installed-apps", "get_device_in_use_by failed for device ${deviceId}: ${e.message}")
+        return [success: false, error: "Failed: ${e.message}", note: "Verify the device ID is valid and Built-in App Tools is enabled."]
+    }
+}
+
+/**
+ * List all Rule Machine rules via the official hubitat.helper.RMUtils API.
+ * Combines RM 4.x and RM 5.x rules (deduplicated by id).
+ */
+def toolListRmRules(args) {
+    requireBuiltinAppRead()
+    def combined = [:]
+    def v4Error = null
+    def v5Error = null
+
+    try {
+        def rules4 = hubitat.helper.RMUtils.getRuleList() ?: []
+        rules4.each { r -> registerRmRule(combined, r, "4.x") }
+    } catch (Exception e) {
+        v4Error = e.message
+    }
+
+    try {
+        def rules5 = hubitat.helper.RMUtils.getRuleList("5.0") ?: []
+        rules5.each { r -> registerRmRule(combined, r, "5.x") }
+    } catch (Exception e) {
+        v5Error = e.message
+    }
+
+    def rules = combined.values().sort { it.label ?: "" }
+
+    def result = [
+        rules: rules,
+        count: rules.size()
+    ]
+    // Only surface errors if BOTH versions failed (otherwise it's just RM 4.x not installed, which is normal)
+    if (rules.isEmpty() && v4Error && v5Error) {
+        result.success = false
+        result.error = "RMUtils calls failed: v4=${v4Error} v5=${v5Error}"
+        result.note = "Rule Machine may not be installed on this hub."
+    }
+    return result
+}
+
+/**
+ * Normalize a single RMUtils rule entry into a consistent map and register under combined[id].
+ *
+ * RMUtils.getRuleList() returns list entries in different shapes depending on RM version:
+ *   - RM 5.x: single-entry Map `[<id>: "<label>"]` where the key is the rule ID and the value
+ *     is the rule label (empirically verified against RM 5.1 on firmware 2.4.4)
+ *   - RM 4.x: Map with explicit fields `[id: <id>, label: "<label>", name: "...", type: "..."]`
+ *     (per historical documentation — untested on this hub since RM 4.x was not installed)
+ *   - Raw primitive: int or String ID (defensive fallback)
+ */
+private void registerRmRule(Map combined, def r, String version) {
+    def id
+    def label
+    def name
+    def type
+    if (r instanceof Map) {
+        if (r.containsKey("id")) {
+            // RM 4.x explicit-fields shape
+            id = r.id
+            label = r.label ?: r.name
+            name = r.name ?: r.label
+            type = r.type
+        } else if (r.size() == 1) {
+            // RM 5.x single-entry shape: [<id>: "<label>"]
+            def entry = r.entrySet().iterator().next()
+            // entry.key may come back as String or Integer depending on how Hubitat built
+            // the Map; coerce to Integer (via string) so downstream consumers get the
+            // Integer id advertised in list_rm_rules' response schema.
+            def rawKey = entry.key
+            try {
+                id = (rawKey instanceof Number) ? rawKey.toInteger() : rawKey.toString().toInteger()
+            } catch (Exception coerceErr) {
+                id = rawKey
+            }
+            label = entry.value?.toString()
+            name = label
+        }
+    } else if (r != null) {
+        // Raw ID fallback
+        id = r
+    }
+    if (id == null) return
+    def key = id.toString()
+    if (!combined.containsKey(key)) {
+        combined[key] = [
+            id: id,
+            label: label,
+            name: name,
+            type: type,
+            rmVersion: version
+        ]
+    }
+}
+
+/**
+ * Trigger a Rule Machine rule via RMUtils.sendAction().
+ * Not destructive — invokes existing user-configured automation.
+ */
+def toolRunRmRule(args) {
+    requireBuiltinAppRead()
+    if (args?.ruleId == null) throw new IllegalArgumentException("ruleId is required")
+    def ruleId = normalizeRuleId(args.ruleId)
+    def action = args?.action ?: "rule"
+
+    def rmAction
+    switch (action) {
+        case "rule": rmAction = "runRule"; break
+        case "actions": rmAction = "runRuleAct"; break
+        case "stop": rmAction = "stopRuleAct"; break
+        default: throw new IllegalArgumentException("Invalid action '${action}'. Must be 'rule', 'actions', or 'stop'.")
+    }
+
+    return sendRmAction(ruleId, rmAction, "run_rm_rule action=${action}")
+}
+
+def toolPauseRmRule(args) {
+    requireBuiltinAppRead()
+    if (args?.ruleId == null) throw new IllegalArgumentException("ruleId is required")
+    return sendRmAction(normalizeRuleId(args.ruleId), "pauseRule", "pause_rm_rule")
+}
+
+def toolResumeRmRule(args) {
+    requireBuiltinAppRead()
+    if (args?.ruleId == null) throw new IllegalArgumentException("ruleId is required")
+    return sendRmAction(normalizeRuleId(args.ruleId), "resumeRule", "resume_rm_rule")
+}
+
+def toolSetRmRuleBoolean(args) {
+    requireBuiltinAppRead()
+    if (args?.ruleId == null) throw new IllegalArgumentException("ruleId is required")
+    if (args?.value == null) throw new IllegalArgumentException("value (boolean) is required")
+    // Accept Boolean or the canonical lowercase strings 'true'/'false' only. Reject other
+    // truthy-looking values (1, 'yes', 'True') to avoid silently setting the wrong boolean.
+    Boolean resolved = null
+    if (args.value instanceof Boolean) {
+        resolved = args.value
+    } else if (args.value == "true") {
+        resolved = true
+    } else if (args.value == "false") {
+        resolved = false
+    } else {
+        throw new IllegalArgumentException("value must be boolean true/false (or the string 'true'/'false'), got: ${args.value}")
+    }
+    def rmAction = resolved ? "setRuleBooleanTrue" : "setRuleBooleanFalse"
+    return sendRmAction(normalizeRuleId(args.ruleId), rmAction, "set_rm_rule_boolean value=${resolved}")
+}
+
+/**
+ * Shared sendAction wrapper. Returns a consistent success/error result map.
+ *
+ * Passes "5.0" as the 4th argument to target the RM 5.x dispatcher — per bravenel's
+ * RM API (community.hubitat.com/t/rule-machine-api/7104) and futureplans.md research,
+ * sendAction's 4-arg form (ruleIds, action, appLabel, "5.0") works for both RM 4.x
+ * and RM 5.x rules. The 3-arg form targets only RM 4.x.
+ */
+private Map sendRmAction(Integer ruleId, String rmAction, String logContext) {
+    def appLabel = app?.label ?: "MCP Rule Server"
+    try {
+        hubitat.helper.RMUtils.sendAction([ruleId], rmAction, appLabel, "5.0")
+        mcpLog("info", "rm-interop", "${logContext}: sent ${rmAction} to rule ${ruleId}")
+        return [success: true, ruleId: ruleId, rmAction: rmAction]
+    } catch (Exception e) {
+        // Fallback: RMUtils may not accept the 4-arg form on very old firmware.
+        // Retry with the 3-arg form. If that also fails, surface both errors.
+        try {
+            hubitat.helper.RMUtils.sendAction([ruleId], rmAction, appLabel)
+            mcpLog("info", "rm-interop", "${logContext}: sent ${rmAction} to rule ${ruleId} (3-arg fallback)")
+            return [success: true, ruleId: ruleId, rmAction: rmAction, fallback: "3-arg"]
+        } catch (Exception e2) {
+            mcpLog("error", "rm-interop", "${logContext} failed for rule ${ruleId}: 4-arg=${e.message}, 3-arg=${e2.message}")
+            return [success: false, error: "RMUtils.sendAction failed: ${e2.message}", note: "Verify the ruleId is valid (use list_rm_rules) and Rule Machine is installed."]
+        }
+    }
+}
+
+/**
+ * Coerce a ruleId argument to Integer. Accepts Number or numeric String.
+ */
+private Integer normalizeRuleId(def ruleId) {
+    if (ruleId instanceof Number) return ruleId.toInteger()
+    try {
+        return ruleId.toString().trim() as Integer
+    } catch (Exception e) {
+        throw new IllegalArgumentException("ruleId must be an integer, got: ${ruleId}")
+    }
+}
+
 // ==================== VERSION UPDATE CHECK ====================
 
 def currentVersion() {
@@ -7807,6 +8293,44 @@ Files stored at http://<HUB_IP>/local/<filename>
 
 **get_device_history:**
 - Up to 7 days of history
-- Use attribute filter to reduce data volume'''
+- Use attribute filter to reduce data volume''',
+
+        builtin_app_tools: '''## Built-in App Tools
+
+All tools in the manage_installed_apps and manage_rule_machine gateways require the "Enable Built-in App Tools" toggle in MCP Rule Server app settings. If the user sees "Built-in App Tools are disabled" errors, direct them to the MCP Rule Server app settings page.
+
+**manage_installed_apps (2 tools):**
+
+- **list_installed_apps** — enumerate ALL apps on the hub (built-in + user) with parent/child tree
+  - filter="all" (default) | "builtin" | "user" | "disabled" | "parents" | "children"
+  - Each entry: id, name, type, disabled, user, hidden, parentId, hasChildren, childCount
+  - Built-in apps have user=false (Rule Machine, Room Lighting, Groups and Scenes, Mode Manager, HSM, Dashboards, Maker API, etc.)
+  - User apps have user=true (Awair, Ecobee, HPM, etc.)
+  - Parent/child tree is flattened with parentId pointers. Hidden parents are excluded from output but their children are promoted to the nearest visible ancestor.
+
+- **get_device_in_use_by** — find apps that reference a specific device
+  - Use BEFORE deleting a device, disabling a device, or troubleshooting unexpected behavior
+  - Returns appsUsing array with each app's id, name (type like "Room Lights" or "Rule-5.1"), label (user-visible), trueLabel (HTML-stripped), disabled
+  - Answers "if I delete this device, which automations break?"
+
+**manage_rule_machine (5 tools) — read + trigger existing RM rules only, NO create/modify/delete:**
+
+- **list_rm_rules** — enumerate Rule Machine rules (RM 4.x + 5.x combined, deduplicated by id)
+
+- **run_rm_rule** — trigger an existing RM rule via RMUtils.sendAction
+  - action="rule" (default, full evaluation): runs triggers + conditions + actions as if rule fired
+  - action="actions": runs only the actions, bypassing conditions (useful for manual override)
+  - action="stop": stops running actions (cancels in-flight delays)
+
+- **pause_rm_rule** / **resume_rm_rule** — reversible toggle; paused rules don't fire on triggers
+
+- **set_rm_rule_boolean** — set an RM rule's private boolean (true or false only; strings must be lowercase "true"/"false"). RM rules can use Private Boolean in conditions — this lets MCP flip that flag from outside.
+
+**CRITICAL LIMITATION: Cannot create, modify, or delete RM rules or Room Lighting instances.** Hubitat's platform blocks third-party apps from instantiating hubitat:Rule-5.1 or hubitat:RoomLights as children (parent-type validation on addChildApp). If the user asks to "create a new RM rule" or "set up a new Room Lighting", respond:
+  1. Explain this is not possible via MCP (platform limitation, not a missing feature)
+  2. Offer the alternative: create an equivalent rule using MCP's own rule engine via create_rule
+  3. Or direct them to the native Rule Machine / Room Lighting UI for configuration
+
+Do NOT invent fake tools like "create_rm_rule" or pretend to call one — this is the most important safety rule for these tools.'''
     ]
 }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1643,9 +1643,7 @@ Returns: deviceId, deviceName, appsUsing array (each entry: id, name=app type, l
         // Rule Machine Integration (read + trigger + pause/resume only — platform blocks CRUD)
         [
             name: "list_rm_rules",
-            description: """List all Rule Machine rules on the hub (both RM 4.x and 5.x). Requires Built-in App Tools enabled.
-
-Uses the official hubitat.helper.RMUtils API. Returns rule IDs and labels. For rule details/configuration, use the Rule Machine native UI — programmatic read of rule internals is not supported by the platform.""",
+            description: "List all Rule Machine rules (RM 4.x + 5.x, deduplicated by id). Returns rule IDs and labels. Requires Built-in App Tools enabled. See get_tool_guide section=builtin_app_tools for details and platform limitations on RM rule internals.",
             inputSchema: [
                 type: "object",
                 properties: [:]
@@ -1653,14 +1651,7 @@ Uses the official hubitat.helper.RMUtils API. Returns rule IDs and labels. For r
         ],
         [
             name: "run_rm_rule",
-            description: """Trigger a Rule Machine rule via RMUtils.sendAction(). Requires Built-in App Tools enabled.
-
-Actions:
-- 'rule' (default): evaluate the rule (runs triggers + conditions + actions as if the rule fired)
-- 'actions': run only the actions, bypassing conditions
-- 'stop': stop currently-running actions (e.g., cancel delays)
-
-Not destructive — this triggers existing automations the user already configured. Does NOT require Hub Admin Write.""",
+            description: "Trigger a Rule Machine rule. Not destructive (invokes existing user-configured automation). Requires Built-in App Tools enabled. See get_tool_guide section=builtin_app_tools for action semantics.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -1672,9 +1663,7 @@ Not destructive — this triggers existing automations the user already configur
         ],
         [
             name: "pause_rm_rule",
-            description: """Pause a Rule Machine rule. Paused rules don't fire on triggers. Requires Built-in App Tools enabled.
-
-Reversible — use resume_rm_rule to re-enable.""",
+            description: "Pause a Rule Machine rule (paused rules don't fire on triggers). Reversible via resume_rm_rule. Requires Built-in App Tools enabled.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -1685,7 +1674,7 @@ Reversible — use resume_rm_rule to re-enable.""",
         ],
         [
             name: "resume_rm_rule",
-            description: """Resume a paused Rule Machine rule. Requires Built-in App Tools enabled.""",
+            description: "Resume a paused Rule Machine rule. Requires Built-in App Tools enabled.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -1696,9 +1685,7 @@ Reversible — use resume_rm_rule to re-enable.""",
         ],
         [
             name: "set_rm_rule_boolean",
-            description: """Set a Rule Machine rule's private boolean variable to true or false. Requires Built-in App Tools enabled.
-
-RM rules can reference 'Private Boolean' in their conditions — this lets MCP flip that flag from outside the rule. Common pattern: condition checks private boolean, external logic (e.g. AI, another automation) sets it.""",
+            description: "Set a Rule Machine rule's private boolean to true or false (strict: accepts Boolean or lowercase string 'true'/'false' only). Requires Built-in App Tools enabled. See get_tool_guide section=builtin_app_tools for pattern and coercion policy.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -2926,6 +2913,7 @@ def toolGetHubInfo() {
     info.hubSecurityConfigured = settings.hubSecurityEnabled ?: false
     info.hubAdminReadEnabled = settings.enableHubAdminRead ?: false
     info.hubAdminWriteEnabled = settings.enableHubAdminWrite ?: false
+    info.builtinAppReadEnabled = settings.enableBuiltinAppRead ?: false
 
     // PII/location data requires Hub Admin Read
     if (settings.enableHubAdminRead) {
@@ -5082,6 +5070,7 @@ def toolGetHubDetails(args) {
     details.hubSecurityConfigured = settings.hubSecurityEnabled ?: false
     details.hubAdminReadEnabled = settings.enableHubAdminRead ?: false
     details.hubAdminWriteEnabled = settings.enableHubAdminWrite ?: false
+    details.builtinAppReadEnabled = settings.enableBuiltinAppRead ?: false
 
     mcpLog("info", "hub-admin", "Retrieved extended hub details")
     return details
@@ -7553,10 +7542,10 @@ def toolListInstalledApps(args) {
                 case "parents": return entry.hasChildren
                 case "children": return entry.parentId != null
                 default:
-                    // Unreachable — filter is whitelist-validated above. Include anyway so the
-                    // outer success path still returns a usable (possibly over-broad) result
-                    // rather than masking the invariant break inside the outer catch.
-                    return true
+                    // Whitelist-validated above; reaching here means validFilters and this
+                    // switch have drifted. Throw rather than return an over-broad result,
+                    // so the mismatch is visible instead of silently shipping stale data.
+                    throw new IllegalStateException("filter branch missing for '${filter}' -- validFilters and switch have drifted")
             }
         }
 
@@ -7567,8 +7556,13 @@ def toolListInstalledApps(args) {
             totalOnHub: flat.size()
         ]
     } catch (Exception e) {
+        // The Built-in-App-Tools gate has already passed by the time we reach here, so
+        // do not blame it in the note. Failures at this point come from the hub transport
+        // (network blip, firmware change to /hub2/appsList) or the flatten/filter pipeline
+        // (unexpected shape in a child entry). The error message itself will usually
+        // distinguish the two.
         mcpLog("error", "installed-apps", "list_installed_apps failed: ${e.message}")
-        return [success: false, error: "Failed to list installed apps: ${e.message}", note: "Check that Built-in App Tools is enabled in MCP settings."]
+        return [success: false, error: "Failed to list installed apps: ${e.message}", note: "Hub transport error or unexpected /hub2/appsList response shape -- retry; if persistent, inspect the raw response for firmware-side drift."]
     }
 }
 
@@ -7579,7 +7573,14 @@ def toolListInstalledApps(args) {
 def toolGetDeviceInUseBy(args) {
     requireBuiltinAppRead()
     if (!args?.deviceId) throw new IllegalArgumentException("deviceId is required")
-    def deviceId = args.deviceId.toString()
+    def deviceId = args.deviceId.toString().trim()
+    // /device/fullJson/<id> returns a parseable non-empty body even for unknown ids
+    // (empty appsUsing, null fields), which would read as "device has no apps" rather
+    // than "device doesn't exist". Validate up front against the hub's device registry
+    // so callers get an explicit Device-not-found error. Mirrors toolGetHubLogs.
+    if (!findDevice(deviceId)) {
+        throw new IllegalArgumentException("Device not found: ${deviceId}")
+    }
 
     try {
         def responseText = hubInternalGet("/device/fullJson/${deviceId}")
@@ -7597,7 +7598,11 @@ def toolGetDeviceInUseBy(args) {
         def count
         try {
             count = (parsed?.appsUsingCount != null) ? (parsed.appsUsingCount as Integer) : appsUsing.size()
-        } catch (Exception ne) {
+        } catch (NumberFormatException ne) {
+            // A non-numeric appsUsingCount is a firmware/paging signal worth recording
+            // (e.g. hub returns "42+" for truncated counts); fall back to the list size
+            // so the caller still gets a usable count.
+            mcpLog("warn", "installed-apps", "get_device_in_use_by: non-numeric appsUsingCount '${parsed?.appsUsingCount}' for device ${deviceId}; using appsUsing.size()=${appsUsing.size()}")
             count = appsUsing.size()
         }
 
@@ -7628,6 +7633,13 @@ def toolGetDeviceInUseBy(args) {
 /**
  * List all Rule Machine rules via the official hubitat.helper.RMUtils API.
  * Combines RM 4.x and RM 5.x rules (deduplicated by id).
+ *
+ * RMUtils is an optional platform class -- absent on hubs that have never
+ * installed Rule Machine. Absence manifests as NoClassDefFoundError or
+ * ClassNotFoundException (both Error subclasses, uncaught by catch Exception).
+ * Hence the catch Throwable + null-guarded .message across the two try blocks
+ * below; the classifier further down decides which Throwables to surface vs
+ * treat as a quiet "RM not installed".
  */
 def toolListRmRules(args) {
     requireBuiltinAppRead()
@@ -7635,10 +7647,6 @@ def toolListRmRules(args) {
     def v4Error = null
     def v5Error = null
 
-    // Catch Throwable (not just Exception) so NoClassDefFoundError / ClassNotFoundException
-    // from a hub without Rule Machine installed degrade gracefully rather than propagating
-    // as an unhandled JVM error. RMUtils is an optional platform class — absent on hubs
-    // that have never installed Rule Machine as a built-in app.
     try {
         def rules4 = hubitat.helper.RMUtils.getRuleList() ?: []
         rules4.each { r -> registerRmRule(combined, r, "4.x") }
@@ -7664,23 +7672,46 @@ def toolListRmRules(args) {
     // calls failed with any error, or if one call returned data while the other had a
     // non-missing-class error (e.g. timeout, internal platform issue), surface the details
     // so operators can investigate rather than get silent empty results.
+    // Narrow to class-resolution failures only. Earlier versions treated any
+    // MissingMethodException / "No signature of method" / unqualified "Cannot get property"
+    // as quiet-missing, but those substrings appear in unrelated Groovy runtime errors
+    // (e.g. a shape change in RMUtils' return value would surface as MME against
+    // registerRmRule and get swept under the rug). Scope each substring tightly:
+    //   - NoClassDefFoundError / ClassNotFoundException / "unable to resolve class":
+    //     JVM-level class-resolution errors; unambiguous "RM not installed" signal.
+    //   - "Cannot get property 'helper'": the Hubitat sandbox returns null for
+    //     unresolved `hubitat.helper.X` namespace lookups; scoping to 'helper'
+    //     limits the match to the hubitat.helper.RMUtils path specifically.
+    //   - MissingMethodException together with getRuleList: covers the old-firmware
+    //     case where RMUtils exists but lacks the getRuleList("5.0") overload —
+    //     unrelated MMEs no longer get swallowed.
     def classMissingHint = { String msg ->
-        msg && (msg.contains("NoClassDefFoundError") || msg.contains("ClassNotFoundException") ||
-                msg.contains("unable to resolve class") || msg.contains("No such property") ||
-                // Hubitat's Groovy sandbox returns null for unresolved `hubitat.helper.X`
-                // namespace lookups; the subsequent property dereference throws
-                // "Cannot get property 'helper' on null object". Verified live on the hub.
-                msg.contains("Cannot get property") ||
-                // Very old firmware that has RMUtils but lacks the getRuleList("5.0") overload
-                // throws MissingMethodException rather than a class-resolution error — same
-                // "this variant isn't here" semantic, so treat it quietly as well.
-                msg.contains("MissingMethodException") || msg.contains("No signature of method"))
+        if (!msg) return false
+        if (msg.contains("NoClassDefFoundError") ||
+            msg.contains("ClassNotFoundException") ||
+            msg.contains("unable to resolve class")) return true
+        if (msg.contains("Cannot get property") && msg.contains("'helper'")) return true
+        if ((msg.contains("MissingMethodException") || msg.contains("No signature of method"))
+            && msg.contains("getRuleList")) return true
+        return false
     }
     def hardErrors = []
     if (v4Error && !classMissingHint(v4Error)) hardErrors << "v4=${v4Error}"
     if (v5Error && !classMissingHint(v5Error)) hardErrors << "v5=${v5Error}"
 
-    if (rules.isEmpty() && v4Error && v5Error) {
+    def bothClassMissing = v4Error && v5Error &&
+                           classMissingHint(v4Error) && classMissingHint(v5Error)
+
+    if (rules.isEmpty() && bothClassMissing) {
+        // Both RMUtils lookups failed with class-resolution errors. That's the
+        // expected shape on a hub that has never installed Rule Machine; it's
+        // not an error the caller needs to react to. Return an empty list with
+        // an informational note and leave success unset so the result still
+        // reads as a normal empty response.
+        result.note = "Rule Machine not detected on this hub."
+    } else if (rules.isEmpty() && v4Error && v5Error) {
+        // Both calls failed but at least one with a non-missing-class shape --
+        // unusual enough that operators should see the raw error.
         result.success = false
         result.error = "RMUtils calls failed: v4=${v4Error} v5=${v5Error}"
         result.note = "Rule Machine may not be installed on this hub."
@@ -7695,12 +7726,11 @@ def toolListRmRules(args) {
 /**
  * Normalize a single RMUtils rule entry into a consistent map and register under combined[id].
  *
- * RMUtils.getRuleList() returns list entries in different shapes depending on RM version:
- *   - RM 5.x: single-entry Map `[<id>: "<label>"]` where the key is the rule ID and the value
- *     is the rule label (empirically verified against RM 5.1 on firmware 2.4.4)
- *   - RM 4.x: Map with explicit fields `[id: <id>, label: "<label>", name: "...", type: "..."]`
- *     (per historical documentation — untested on this hub since RM 4.x was not installed)
- *   - Raw primitive: int or String ID (defensive fallback)
+ * RMUtils.getRuleList() returns list entries in shapes that vary by RM version:
+ *   - RM 5.x: single-entry Map `[<id>: "<label>"]` -- the key is the rule ID, the value is the label.
+ *     The key may arrive as String or Integer depending on how the hub built the Map.
+ *   - RM 4.x: Map with explicit fields `[id: <id>, label: "<label>", name: "...", type: "..."]`.
+ *   - Raw primitive (int or String ID): defensive fallback for shapes not covered above.
  */
 private void registerRmRule(Map combined, def r, String version) {
     def id
@@ -7723,8 +7753,13 @@ private void registerRmRule(Map combined, def r, String version) {
             def rawKey = entry.key
             try {
                 id = (rawKey instanceof Number) ? rawKey.toInteger() : rawKey.toString().toInteger()
-            } catch (Exception coerceErr) {
-                id = rawKey
+            } catch (NumberFormatException coerceErr) {
+                // Returning the raw key would silently violate the tool's
+                // ruleId: integer schema (callers would see a String id in the
+                // response and fail to dispatch run_rm_rule against it). Skip
+                // the entry and surface the anomaly via logs instead.
+                mcpLog("warn", "rm-interop", "registerRmRule: non-integer ruleId '${rawKey}' (type=${rawKey?.getClass()?.simpleName}) in RM ${version} list -- skipping entry")
+                return
             }
             label = entry.value?.toString()
             name = label
@@ -7767,18 +7802,38 @@ def toolRunRmRule(args) {
     return sendRmAction(ruleId, rmAction, "run_rm_rule action=${action}")
 }
 
+/**
+ * Pause a Rule Machine rule via RMUtils.sendAction(pauseRule).
+ * Idempotent on the hub side: pausing an already-paused rule is a no-op.
+ */
 def toolPauseRmRule(args) {
     requireBuiltinAppRead()
     if (args?.ruleId == null) throw new IllegalArgumentException("ruleId is required")
     return sendRmAction(normalizeRuleId(args.ruleId), "pauseRule", "pause_rm_rule")
 }
 
+/**
+ * Resume a previously paused Rule Machine rule via RMUtils.sendAction(resumeRule).
+ * Idempotent on the hub side: resuming an already-active rule is a no-op.
+ */
 def toolResumeRmRule(args) {
     requireBuiltinAppRead()
     if (args?.ruleId == null) throw new IllegalArgumentException("ruleId is required")
     return sendRmAction(normalizeRuleId(args.ruleId), "resumeRule", "resume_rm_rule")
 }
 
+/**
+ * Set a Rule Machine rule's private boolean (used by its conditions) via
+ * RMUtils.sendAction(setRuleBooleanTrue|setRuleBooleanFalse).
+ *
+ * Strict-coercion policy: accepts ONLY Boolean true/false or the canonical
+ * lowercase strings "true"/"false". Other truthy-looking values — 1, 0,
+ * "True", "TRUE", "yes", "no", "on", "off" — are rejected with
+ * IllegalArgumentException. Reason: silently coercing "yes" to true (or 1
+ * to true) risks the AI sending the wrong boolean when a rule's behaviour
+ * depends on the boolean (e.g. arming a security path). The ambiguity is
+ * worse than the friction of requiring explicit true/false.
+ */
 def toolSetRmRuleBoolean(args) {
     requireBuiltinAppRead()
     if (args?.ruleId == null) throw new IllegalArgumentException("ruleId is required")
@@ -7802,43 +7857,64 @@ def toolSetRmRuleBoolean(args) {
 /**
  * Shared sendAction wrapper. Returns a consistent success/error result map.
  *
- * Passes "5.0" as the 4th argument to target the RM 5.x dispatcher — per bravenel's
- * RM API (community.hubitat.com/t/rule-machine-api/7104) and futureplans.md research,
- * sendAction's 4-arg form (ruleIds, action, appLabel, "5.0") works for both RM 4.x
- * and RM 5.x rules. The 3-arg form targets only RM 4.x.
+ * Invariant: the 4-arg form `sendAction([ids], action, appLabel, "5.0")` dispatches
+ * to the RM 5.x handler and is the canonical call for both RM 4.x and RM 5.x rules.
+ * The 3-arg form `sendAction([ids], action, appLabel)` reaches only RM 4.x and is
+ * used as a fallback for very old firmware that predates the version-discriminator
+ * overload (see sendRmActionFallback). Provenance for the 4-arg invariant is in
+ * the PR description linking bravenel's RM API thread.
  */
 private Map sendRmAction(Integer ruleId, String rmAction, String logContext) {
     def appLabel = app?.label ?: "MCP Rule Server"
-    // Catch Throwable (not just Exception) so NoClassDefFoundError / ClassNotFoundException
-    // from a hub without Rule Machine installed degrade gracefully.
     try {
         hubitat.helper.RMUtils.sendAction([ruleId], rmAction, appLabel, "5.0")
         mcpLog("info", "rm-interop", "${logContext}: sent ${rmAction} to rule ${ruleId}")
         return [success: true, ruleId: ruleId, rmAction: rmAction]
+    } catch (MissingMethodException e) {
+        return sendRmActionFallback(ruleId, rmAction, appLabel, logContext, e)
+    } catch (NoSuchMethodError e) {
+        return sendRmActionFallback(ruleId, rmAction, appLabel, logContext, e)
     } catch (Throwable e) {
-        // Fallback: RMUtils may not accept the 4-arg form on very old firmware.
-        // Retry with the 3-arg form. If that also fails, surface both errors.
-        try {
-            hubitat.helper.RMUtils.sendAction([ruleId], rmAction, appLabel)
-            mcpLog("info", "rm-interop", "${logContext}: sent ${rmAction} to rule ${ruleId} (3-arg fallback)")
-            return [success: true, ruleId: ruleId, rmAction: rmAction, fallback: "3-arg"]
-        } catch (Throwable e2) {
-            def m1 = e.message ?: e.toString()
-            def m2 = e2.message ?: e2.toString()
-            mcpLog("error", "rm-interop", "${logContext} failed for rule ${ruleId}: 4-arg=${m1}, 3-arg=${m2}")
-            return [success: false, error: "RMUtils.sendAction failed: ${m2}", note: "Verify the ruleId is valid (use list_rm_rules) and Rule Machine is installed."]
-        }
+        // Everything else — NoClassDefFoundError (RM not installed), timeouts, NPEs
+        // inside RM internals, invalid ruleId — propagates through a single error
+        // response without a second attempt. Retrying a transient failure would
+        // double-fire the action if the first call partially succeeded.
+        def m = e.message ?: e.toString()
+        mcpLog("error", "rm-interop", "${logContext} failed for rule ${ruleId}: ${m}")
+        return [success: false, error: "RMUtils.sendAction failed: ${m}", note: "Verify the ruleId is valid (use list_rm_rules) and Rule Machine is installed."]
+    }
+}
+
+/**
+ * 3-arg fallback invoked only when the 4-arg sendAction raised a signature-mismatch
+ * shape (MissingMethodException / NoSuchMethodError) — very old firmware that
+ * predates the version-discriminator overload. Any other Throwable from the 4-arg
+ * call propagates directly in sendRmAction above.
+ */
+private Map sendRmActionFallback(Integer ruleId, String rmAction, String appLabel, String logContext, Throwable original) {
+    try {
+        hubitat.helper.RMUtils.sendAction([ruleId], rmAction, appLabel)
+        mcpLog("info", "rm-interop", "${logContext}: sent ${rmAction} to rule ${ruleId} (3-arg fallback)")
+        return [success: true, ruleId: ruleId, rmAction: rmAction, fallback: "3-arg"]
+    } catch (Throwable e2) {
+        def m1 = original.message ?: original.toString()
+        def m2 = e2.message ?: e2.toString()
+        mcpLog("error", "rm-interop", "${logContext} failed for rule ${ruleId}: 4-arg=${m1}, 3-arg=${m2}")
+        return [success: false, error: "RMUtils.sendAction failed: ${m2}", note: "Verify the ruleId is valid (use list_rm_rules) and Rule Machine is installed."]
     }
 }
 
 /**
  * Coerce a ruleId argument to Integer. Accepts Number or numeric String.
+ * Narrow the catch to NumberFormatException only — it's the sole expected
+ * failure shape for `String as Integer`; anything else is a real bug and
+ * should propagate rather than be rewrapped as an IllegalArgumentException.
  */
 private Integer normalizeRuleId(def ruleId) {
     if (ruleId instanceof Number) return ruleId.toInteger()
     try {
         return ruleId.toString().trim() as Integer
-    } catch (Exception e) {
+    } catch (NumberFormatException e) {
         throw new IllegalArgumentException("ruleId must be an integer, got: ${ruleId}")
     }
 }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -7651,14 +7651,14 @@ def toolListRmRules(args) {
         def rules4 = hubitat.helper.RMUtils.getRuleList() ?: []
         rules4.each { r -> registerRmRule(combined, r, "4.x") }
     } catch (Throwable e) {
-        v4Error = e.message ?: e.toString()
+        v4Error = e.toString()
     }
 
     try {
         def rules5 = hubitat.helper.RMUtils.getRuleList("5.0") ?: []
         rules5.each { r -> registerRmRule(combined, r, "5.x") }
     } catch (Throwable e) {
-        v5Error = e.message ?: e.toString()
+        v5Error = e.toString()
     }
 
     def rules = combined.values().sort { it.label ?: "" }

--- a/src/main/groovy/hubitat/helper/RMUtils.groovy
+++ b/src/main/groovy/hubitat/helper/RMUtils.groovy
@@ -20,8 +20,15 @@ package hubitat.helper
  * `support.RMUtilsMock`.
  */
 class RMUtils {
-    static List getRuleList(String version = '5.0') { return [] }
+    static List getRuleList() { return [] }
+    static List getRuleList(String version) { return [] }
+    // Legacy simple form (retained for pre-PR-79 specs that used it).
     static void sendAction(Long ruleId, String action) { }
+    // Preferred 4-arg form used by PR #79's sendRmAction wrapper:
+    // sendAction([ruleIds], action, appLabel, "5.0") targets the RM 5.x dispatcher.
+    static void sendAction(List ruleIds, String action, String appLabel, String version) { }
+    // 3-arg fallback form used when the 4-arg signature is absent on older firmware.
+    static void sendAction(List ruleIds, String action, String appLabel) { }
     static void pauseRule(Long ruleId) { }
     static void resumeRule(Long ruleId) { }
     static void setRuleBoolean(Long ruleId, Boolean value) { }

--- a/src/test/groovy/server/SendRmActionFallbackSpec.groovy
+++ b/src/test/groovy/server/SendRmActionFallbackSpec.groovy
@@ -167,8 +167,12 @@ class SendRmActionFallbackSpec extends ToolSpecBase {
         when:
         def result = script.toolRunRmRule([ruleId: 6, action: 'rule'])
 
-        then:
+        then: 'error field carries the 3-arg (m2) failure message'
         result.success == false
-        result.error != null
+        result.error?.contains('sendAction') == true
+
+        and: 'note field carries the 4-arg (m1) failure via the "4-arg attempt also failed" prefix'
+        result.note?.contains('4-arg attempt also failed') == true
+        result.note?.contains('sendAction') == true
     }
 }

--- a/src/test/groovy/server/SendRmActionFallbackSpec.groovy
+++ b/src/test/groovy/server/SendRmActionFallbackSpec.groovy
@@ -1,0 +1,174 @@
+package server
+
+import support.RMUtilsMock
+import support.ToolSpecBase
+
+/**
+ * Spec for the sendRmAction / sendRmActionFallback internals
+ * (hubitat-mcp-server.groovy approx line 7867).
+ *
+ * The 3-arg fallback fires ONLY on MissingMethodException or NoSuchMethodError
+ * from the 4-arg sendAction call. All other Throwables propagate directly as a
+ * {success:false} map without a retry (narrowed in the PR-79-review fix commit).
+ *
+ * Mock strategy for "4-arg throws MME but 3-arg succeeds":
+ *   RMUtilsMock.throwOnSendAction is a single throwable -- it cannot distinguish
+ *   4-arg from 3-arg calls by itself. After RMUtilsMock.install(), we install a
+ *   spec-local stateful closure directly on the hubitat.helper.RMUtils metaClass
+ *   that replaces the 4-arg overload only, throwing on the first call and letting
+ *   subsequent calls dispatch cleanly via the stub method (which routes through
+ *   the 3-arg mock overload registered by install()). The 3-arg overload installed
+ *   by RMUtilsMock.install() is left unchanged and records the fallback call.
+ *
+ *   This is a legitimate harness technique when a single throwOnX flag is
+ *   insufficient for multi-attempt scenarios. A future follow-up could add a
+ *   throwSequenceOnSendAction field to RMUtilsMock to encapsulate this pattern.
+ *
+ * Exercises:
+ *   - 4-arg succeeds (no fallback)
+ *   - 4-arg throws MissingMethodException -> 3-arg fallback succeeds
+ *   - 4-arg throws NoSuchMethodError -> 3-arg fallback succeeds
+ *   - 4-arg throws RuntimeException -> NO fallback, propagates as {success:false}
+ *   - 4-arg throws NoClassDefFoundError -> NO fallback, propagates
+ *   - both 4-arg and 3-arg throw -> success=false mentioning both failures
+ */
+class SendRmActionFallbackSpec extends ToolSpecBase {
+
+    RMUtilsMock rmUtils
+
+    def setup() {
+        rmUtils = new RMUtilsMock()
+        rmUtils.install()
+        // toolRunRmRule is the simplest gateway tool that funnels through sendRmAction.
+        // All these tests use ruleId=1 with action='rule' (-> rmAction='runRule').
+        settingsMap.enableBuiltinAppRead = true
+    }
+
+    def cleanup() {
+        rmUtils?.uninstall()
+    }
+
+    def "4-arg sendAction succeeds: success=true, no fallback triggered"() {
+        // No throwable installed -- both 4-arg and 3-arg go through cleanly.
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 1, action: 'rule'])
+
+        then:
+        result.success == true
+        result.ruleId == 1
+        result.rmAction == 'runRule'
+        // The 'fallback' key should be absent when the 4-arg form succeeded.
+        !result.containsKey('fallback')
+
+        and: 'exactly one sendAction call recorded (the 4-arg form)'
+        def sendCalls = rmUtils.calls.findAll { it.method == 'sendAction' }
+        sendCalls.size() == 1
+        sendCalls[0].version == '5.0'   // 4-arg form carries a version field
+    }
+
+    def "4-arg throws MissingMethodException: 3-arg fallback is attempted and succeeds"() {
+        given: 'stateful closure: throws MissingMethodException on the first (4-arg) call'
+        // RMUtilsMock.install() registered both overloads. We replace the 4-arg entry
+        // with a closure that throws on its first invocation; the 3-arg overload
+        // (installed by RMUtilsMock.install() under the (List,String,String) arity)
+        // remains in place and will record the fallback call.
+        def callCount = 0
+        hubitat.helper.RMUtils.metaClass.static.sendAction = {
+            List ids, String action, String appLabel, String version ->
+                callCount++
+                throw new MissingMethodException('sendAction', hubitat.helper.RMUtils,
+                    [ids, action, appLabel, version] as Object[])
+        }
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 2, action: 'rule'])
+
+        then:
+        result.success == true
+        result.fallback == '3-arg'
+
+        and: 'the 3-arg form was recorded by RMUtilsMock (no version field on 3-arg calls)'
+        def sendCalls = rmUtils.calls.findAll { it.method == 'sendAction' }
+        sendCalls.size() == 1
+        sendCalls[0].action == 'runRule'
+        !sendCalls[0].containsKey('version')
+    }
+
+    def "4-arg throws NoSuchMethodError: 3-arg fallback is attempted and succeeds"() {
+        given: 'replace 4-arg overload to throw NoSuchMethodError'
+        hubitat.helper.RMUtils.metaClass.static.sendAction = {
+            List ids, String action, String appLabel, String version ->
+                throw new NoSuchMethodError('sendAction')
+        }
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 3, action: 'rule'])
+
+        then:
+        result.success == true
+        result.fallback == '3-arg'
+    }
+
+    def "4-arg throws generic RuntimeException: NO fallback, returns success=false"() {
+        given: 'throwOnSendAction causes any sendAction call (4-arg or 3-arg) to throw RuntimeException'
+        // We use throwOnSendAction for the runtime-exception case because we want
+        // to verify that NO second attempt is made at all -- not just that it fails.
+        rmUtils.throwOnSendAction = new RuntimeException("timeout")
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 4, action: 'rule'])
+
+        then:
+        result.success == false
+        result.error?.contains('timeout') == true
+
+        and: 'only one sendAction call was recorded (the 4-arg, which threw RuntimeException)'
+        // Because throwOnSendAction fires on every sendAction arity, we only see
+        // the single 4-arg attempt -- the fallback was never triggered.
+        // Actually RMUtilsMock throws BEFORE recording (see the implementation).
+        // So zero calls are recorded when throwOnSendAction is set.
+        rmUtils.calls.findAll { it.method == 'sendAction' }.size() == 0
+    }
+
+    def "4-arg throws NoClassDefFoundError: NO fallback, returns success=false"() {
+        given: 'use a stateful 4-arg replacement that throws NCDFE (not caught by MME/NSMError branch)'
+        hubitat.helper.RMUtils.metaClass.static.sendAction = {
+            List ids, String action, String appLabel, String version ->
+                throw new NoClassDefFoundError("hubitat/helper/RMUtils")
+        }
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 5, action: 'rule'])
+
+        then:
+        result.success == false
+        result.error?.toLowerCase()?.contains('rmutils') == true
+
+        and: 'the 3-arg overload was never invoked (no sendAction calls recorded)'
+        rmUtils.calls.findAll { it.method == 'sendAction' }.empty
+    }
+
+    def "4-arg throws MissingMethodException and 3-arg also fails: success=false mentioning both"() {
+        given: '4-arg throws MME; then throwOnSendAction makes 3-arg throw too'
+        // Replace 4-arg to throw MME on every call.
+        hubitat.helper.RMUtils.metaClass.static.sendAction = {
+            List ids, String action, String appLabel, String version ->
+                throw new MissingMethodException('sendAction', hubitat.helper.RMUtils,
+                    [ids, action, appLabel, version] as Object[])
+        }
+        // Replace 3-arg to also throw (different message so we can distinguish them).
+        hubitat.helper.RMUtils.metaClass.static.sendAction = {
+            List ids, String action, String appLabel ->
+                throw new MissingMethodException('sendAction', hubitat.helper.RMUtils,
+                    [ids, action, appLabel] as Object[])
+        }
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 6, action: 'rule'])
+
+        then:
+        result.success == false
+        result.error != null
+    }
+}

--- a/src/test/groovy/server/ToolGetDeviceInUseBySpec.groovy
+++ b/src/test/groovy/server/ToolGetDeviceInUseBySpec.groovy
@@ -141,11 +141,17 @@ class ToolGetDeviceInUseBySpec extends ToolSpecBase {
         result.deviceName == 'Label Only'
     }
 
-    def "non-numeric appsUsingCount falls back to appsUsing.size()"() {
+    def "non-numeric appsUsingCount falls back to appsUsing.size() and warn log fires"() {
         given:
         settingsMap.enableBuiltinAppRead = true
         def mockDevice = [id: '77', label: 'My Dev', name: 'Dev']
         childDevicesList << mockDevice
+
+        and: 'collect mcpLog calls via per-test metaClass override'
+        def mcpLogCalls = []
+        script.metaClass.mcpLog = { String level, String component, String msg ->
+            mcpLogCalls << [level: level, component: component, msg: msg]
+        }
 
         and: 'hub returns a truncated-count sentinel string for appsUsingCount'
         def responseJson = JsonOutput.toJson([
@@ -163,6 +169,9 @@ class ToolGetDeviceInUseBySpec extends ToolSpecBase {
 
         then: 'count falls back to list size (2) rather than the unparseable "42+"'
         result.count == 2
+
+        and: 'warn log fires mentioning appsUsingCount on the installed-apps component'
+        mcpLogCalls.any { it.level == 'warn' && it.component == 'installed-apps' && it.msg.contains('appsUsingCount') }
     }
 
     def "returns success=false with empty-response error when hub body is empty"() {

--- a/src/test/groovy/server/ToolGetDeviceInUseBySpec.groovy
+++ b/src/test/groovy/server/ToolGetDeviceInUseBySpec.groovy
@@ -1,0 +1,202 @@
+package server
+
+import groovy.json.JsonOutput
+import support.ToolSpecBase
+
+/**
+ * Spec for toolGetDeviceInUseBy (hubitat-mcp-server.groovy approx line 7573).
+ * Gateway: manage_installed_apps -> get_device_in_use_by.
+ *
+ * Critical: PR-79-review fix tightened deviceId validation -- findDevice()
+ * is called before any HTTP request, so unknown IDs throw
+ * IllegalArgumentException without a network round-trip.
+ *
+ * Covers: gate-throw, missing deviceId, unknown-deviceId (throws before HTTP),
+ * golden path with deviceName fallback chain, non-numeric appsUsingCount warn
+ * fallback, and empty response body.
+ */
+class ToolGetDeviceInUseBySpec extends ToolSpecBase {
+
+    def "throws when Built-in App Read is disabled"() {
+        given:
+        settingsMap.enableBuiltinAppRead = false
+
+        when:
+        script.toolGetDeviceInUseBy([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Built-in App')
+    }
+
+    def "throws when deviceId is missing from args"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolGetDeviceInUseBy([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('deviceid is required')
+    }
+
+    def "throws Device-not-found before any HTTP call for an unknown deviceId"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'no device registered -- childDevicesList is empty and selectedDevices is empty'
+        // Do NOT register the /device/fullJson/ endpoint; if the tool calls HTTP
+        // before validation, the HubInternalGetMock will throw loudly and we will
+        // see a different failure mode than the expected IllegalArgumentException.
+
+        when:
+        script.toolGetDeviceInUseBy([deviceId: '999'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Device not found')
+        ex.message.contains('999')
+    }
+
+    def "golden path: returns appsUsing list with extraBreadcrumb as deviceName"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'device is in childDevicesList so findDevice succeeds'
+        def mockDevice = [id: '42', label: 'Kitchen Switch', name: 'Generic Switch']
+        childDevicesList << mockDevice
+
+        and: 'hub returns fullJson with appsUsing entries'
+        def responseJson = JsonOutput.toJson([
+            extraBreadcrumb: 'Kitchen Switch (breadcrumb)',
+            name: 'Generic Switch',
+            label: 'Kitchen Switch',
+            appsUsing: [
+                [id: 100, name: 'Room Lighting', label: 'Kitchen Lights', trueLabel: null, disabled: false],
+                [id: 200, name: 'Rule-5.1', label: '<b>Auto Rule</b>', trueLabel: 'Auto Rule', disabled: true]
+            ],
+            appsUsingCount: 2,
+            parentApp: null
+        ])
+        hubGet.register('/device/fullJson/42') { params -> responseJson }
+
+        when:
+        def result = script.toolGetDeviceInUseBy([deviceId: '42'])
+
+        then: 'extraBreadcrumb wins in the deviceName fallback chain'
+        result.deviceId == '42'
+        result.deviceName == 'Kitchen Switch (breadcrumb)'
+        result.count == 2
+
+        and: 'both app entries mapped correctly'
+        result.appsUsing.size() == 2
+        result.appsUsing[0].id == 100
+        result.appsUsing[0].name == 'Room Lighting'
+        result.appsUsing[1].disabled == true
+        result.appsUsing[1].trueLabel == 'Auto Rule'
+    }
+
+    def "deviceName falls back to .name when extraBreadcrumb is absent"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        def mockDevice = [id: '55', label: 'My Device', name: 'Generic Device']
+        childDevicesList << mockDevice
+
+        def responseJson = JsonOutput.toJson([
+            extraBreadcrumb: null,
+            name: 'Generic Device',
+            label: 'My Device',
+            appsUsing: [],
+            appsUsingCount: 0
+        ])
+        hubGet.register('/device/fullJson/55') { params -> responseJson }
+
+        when:
+        def result = script.toolGetDeviceInUseBy([deviceId: '55'])
+
+        then:
+        result.deviceName == 'Generic Device'
+    }
+
+    def "deviceName falls back to .label when both extraBreadcrumb and name are absent"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        def mockDevice = [id: '66', label: 'Label Only', name: null]
+        childDevicesList << mockDevice
+
+        def responseJson = JsonOutput.toJson([
+            extraBreadcrumb: null,
+            name: null,
+            label: 'Label Only',
+            appsUsing: [],
+            appsUsingCount: 0
+        ])
+        hubGet.register('/device/fullJson/66') { params -> responseJson }
+
+        when:
+        def result = script.toolGetDeviceInUseBy([deviceId: '66'])
+
+        then:
+        result.deviceName == 'Label Only'
+    }
+
+    def "non-numeric appsUsingCount falls back to appsUsing.size()"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        def mockDevice = [id: '77', label: 'My Dev', name: 'Dev']
+        childDevicesList << mockDevice
+
+        and: 'hub returns a truncated-count sentinel string for appsUsingCount'
+        def responseJson = JsonOutput.toJson([
+            extraBreadcrumb: 'My Dev',
+            appsUsing: [
+                [id: 1, name: 'App A', label: 'App A', trueLabel: null, disabled: false],
+                [id: 2, name: 'App B', label: 'App B', trueLabel: null, disabled: false]
+            ],
+            appsUsingCount: '42+'   // non-numeric sentinel
+        ])
+        hubGet.register('/device/fullJson/77') { params -> responseJson }
+
+        when:
+        def result = script.toolGetDeviceInUseBy([deviceId: '77'])
+
+        then: 'count falls back to list size (2) rather than the unparseable "42+"'
+        result.count == 2
+    }
+
+    def "returns success=false with empty-response error when hub body is empty"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        def mockDevice = [id: '88', label: 'Dev', name: 'Dev']
+        childDevicesList << mockDevice
+        hubGet.register('/device/fullJson/88') { params -> '' }
+
+        when:
+        def result = script.toolGetDeviceInUseBy([deviceId: '88'])
+
+        then:
+        result.success == false
+        result.error?.toLowerCase()?.contains('empty') == true
+    }
+
+    def "gateway dispatch via handleGateway routes correctly"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        def mockDevice = [id: '10', label: 'Switch', name: 'Switch']
+        childDevicesList << mockDevice
+
+        def responseJson = JsonOutput.toJson([
+            extraBreadcrumb: 'Switch',
+            appsUsing: [],
+            appsUsingCount: 0
+        ])
+        hubGet.register('/device/fullJson/10') { params -> responseJson }
+
+        when:
+        def result = script.handleGateway('manage_installed_apps', 'get_device_in_use_by', [deviceId: '10'])
+
+        then:
+        result.deviceId == '10'
+    }
+}

--- a/src/test/groovy/server/ToolListInstalledAppsSpec.groovy
+++ b/src/test/groovy/server/ToolListInstalledAppsSpec.groovy
@@ -1,0 +1,315 @@
+package server
+
+import groovy.json.JsonOutput
+import support.ToolSpecBase
+
+/**
+ * Spec for toolListInstalledApps (hubitat-mcp-server.groovy approx line 7483).
+ * Gateway: manage_installed_apps -> list_installed_apps.
+ *
+ * Covers: gate-throw, golden path flattening with parentId wiring, the
+ * includeHidden promotion logic, each filter value, invalid filter rejection,
+ * empty and non-JSON response bodies.
+ */
+class ToolListInstalledAppsSpec extends ToolSpecBase {
+
+    def "throws when Built-in App Read is disabled"() {
+        given:
+        settingsMap.enableBuiltinAppRead = false
+
+        when:
+        script.toolListInstalledApps([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Built-in App')
+    }
+
+    def "golden path: 2-level tree flattens with parentId wiring"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'hub returns a parent with 2 children'
+        def treeJson = JsonOutput.toJson([
+            apps: [
+                [
+                    data: [id: 10, name: 'Rule Machine', type: 'Rule Machine', user: false, disabled: false, hidden: false],
+                    children: [
+                        [data: [id: 11, name: 'My Rule', type: 'Rule-5.1', user: false, disabled: false, hidden: false], children: []],
+                        [data: [id: 12, name: 'Another Rule', type: 'Rule-5.1', user: false, disabled: false, hidden: false], children: []]
+                    ]
+                ]
+            ]
+        ])
+        hubGet.register('/hub2/appsList') { params -> treeJson }
+
+        when:
+        def result = script.toolListInstalledApps([filter: 'all'])
+
+        then:
+        result.count == 3
+        result.totalOnHub == 3
+        result.filter == 'all'
+
+        and: 'parent entry wired correctly'
+        def parent = result.apps.find { it.id == 10 }
+        parent != null
+        parent.parentId == null
+        parent.hasChildren == true
+        parent.childCount == 2
+
+        and: 'children have parentId pointing to parent'
+        def child11 = result.apps.find { it.id == 11 }
+        child11.parentId == 10
+
+        def child12 = result.apps.find { it.id == 12 }
+        child12.parentId == 10
+    }
+
+    def "filter=builtin returns only non-user apps"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        def treeJson = JsonOutput.toJson([
+            apps: [
+                [data: [id: 1, name: 'Builtin App', type: 'Builtin', user: false, disabled: false, hidden: false], children: []],
+                [data: [id: 2, name: 'User App', type: 'UserApp', user: true, disabled: false, hidden: false], children: []]
+            ]
+        ])
+        hubGet.register('/hub2/appsList') { params -> treeJson }
+
+        when:
+        def result = script.toolListInstalledApps([filter: 'builtin'])
+
+        then:
+        result.apps.size() == 1
+        result.apps[0].id == 1
+    }
+
+    def "filter=user returns only user apps"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        def treeJson = JsonOutput.toJson([
+            apps: [
+                [data: [id: 1, name: 'Builtin App', type: 'Builtin', user: false, disabled: false, hidden: false], children: []],
+                [data: [id: 2, name: 'User App', type: 'UserApp', user: true, disabled: false, hidden: false], children: []]
+            ]
+        ])
+        hubGet.register('/hub2/appsList') { params -> treeJson }
+
+        when:
+        def result = script.toolListInstalledApps([filter: 'user'])
+
+        then:
+        result.apps.size() == 1
+        result.apps[0].id == 2
+    }
+
+    def "filter=disabled returns only disabled apps"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        def treeJson = JsonOutput.toJson([
+            apps: [
+                [data: [id: 1, name: 'Active App', type: 'X', user: false, disabled: false, hidden: false], children: []],
+                [data: [id: 2, name: 'Disabled App', type: 'X', user: false, disabled: true, hidden: false], children: []]
+            ]
+        ])
+        hubGet.register('/hub2/appsList') { params -> treeJson }
+
+        when:
+        def result = script.toolListInstalledApps([filter: 'disabled'])
+
+        then:
+        result.apps.size() == 1
+        result.apps[0].id == 2
+    }
+
+    def "filter=parents returns only apps with children"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        def treeJson = JsonOutput.toJson([
+            apps: [
+                [
+                    data: [id: 10, name: 'Parent App', type: 'X', user: false, disabled: false, hidden: false],
+                    children: [
+                        [data: [id: 11, name: 'Child App', type: 'X', user: false, disabled: false, hidden: false], children: []]
+                    ]
+                ]
+            ]
+        ])
+        hubGet.register('/hub2/appsList') { params -> treeJson }
+
+        when:
+        def result = script.toolListInstalledApps([filter: 'parents'])
+
+        then:
+        result.apps.size() == 1
+        result.apps[0].id == 10
+    }
+
+    def "filter=children returns only apps with a non-null parentId"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        def treeJson = JsonOutput.toJson([
+            apps: [
+                [
+                    data: [id: 10, name: 'Parent App', type: 'X', user: false, disabled: false, hidden: false],
+                    children: [
+                        [data: [id: 11, name: 'Child App', type: 'X', user: false, disabled: false, hidden: false], children: []]
+                    ]
+                ]
+            ]
+        ])
+        hubGet.register('/hub2/appsList') { params -> treeJson }
+
+        when:
+        def result = script.toolListInstalledApps([filter: 'children'])
+
+        then:
+        result.apps.size() == 1
+        result.apps[0].id == 11
+    }
+
+    def "hidden parent excluded by default and child is promoted to root (parentId=null)"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'hidden parent with one visible child'
+        def treeJson = JsonOutput.toJson([
+            apps: [
+                [
+                    data: [id: 20, name: 'Hidden Parent', type: 'X', user: false, disabled: false, hidden: true],
+                    children: [
+                        [data: [id: 21, name: 'Visible Child', type: 'X', user: false, disabled: false, hidden: false], children: []]
+                    ]
+                ]
+            ]
+        ])
+        hubGet.register('/hub2/appsList') { params -> treeJson }
+
+        when: 'default includeHidden=false'
+        def result = script.toolListInstalledApps([filter: 'all'])
+
+        then: 'hidden parent excluded'
+        !result.apps.any { it.id == 20 }
+
+        and: 'visible child promoted to root with parentId null'
+        def child = result.apps.find { it.id == 21 }
+        child != null
+        child.parentId == null
+    }
+
+    def "hidden parent in the middle of a three-level tree: grandchildren promote to nearest visible ancestor"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            // grandparent (visible, id=1)
+            //   -> parent (hidden, id=2)
+            //     -> child (visible, id=3)  -- should resolve to parentId=1, not 2 (hidden) or null (root)
+            JsonOutput.toJson([apps: [[
+                data: [id: 1, name: 'GrandParent', type: 'Group', disabled: false, user: false, hidden: false],
+                children: [[
+                    data: [id: 2, name: 'HiddenParent', type: 'Group', disabled: false, user: false, hidden: true],
+                    children: [[
+                        data: [id: 3, name: 'Child', type: 'Rule', disabled: false, user: false, hidden: false],
+                        children: []
+                    ]]
+                ]]
+            ]]])
+        }
+
+        when:
+        def result = script.toolListInstalledApps([:])  // includeHidden defaults to false
+
+        then:
+        result.apps*.id == [1, 3]                                       // HiddenParent excluded
+        result.apps.find { it.id == 3 }.parentId == 1                   // grandchild promoted to grandparent, NOT null and NOT 2
+        result.totalOnHub == 2
+    }
+
+    def "includeHidden=true includes hidden parent and wires child parentId to it"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        def treeJson = JsonOutput.toJson([
+            apps: [
+                [
+                    data: [id: 20, name: 'Hidden Parent', type: 'X', user: false, disabled: false, hidden: true],
+                    children: [
+                        [data: [id: 21, name: 'Visible Child', type: 'X', user: false, disabled: false, hidden: false], children: []]
+                    ]
+                ]
+            ]
+        ])
+        hubGet.register('/hub2/appsList') { params -> treeJson }
+
+        when:
+        def result = script.toolListInstalledApps([filter: 'all', includeHidden: true])
+
+        then: 'hidden parent included'
+        result.apps.any { it.id == 20 }
+
+        and: 'child parentId points to the hidden parent'
+        def child = result.apps.find { it.id == 21 }
+        child.parentId == 20
+    }
+
+    def "throws IllegalArgumentException for an invalid filter value"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        // Hub endpoint must be registered even though it won't be reached;
+        // the validation throws before the HTTP call.
+
+        when:
+        script.toolListInstalledApps([filter: 'bogus'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('invalid filter')
+    }
+
+    def "returns success=false with empty-response error when hub body is empty"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { params -> '' }
+
+        when:
+        def result = script.toolListInstalledApps([:])
+
+        then:
+        result.success == false
+        result.error?.toLowerCase()?.contains('empty') == true
+    }
+
+    def "returns success=false with parse error when hub body is non-JSON"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { params -> 'not json at all' }
+
+        when:
+        def result = script.toolListInstalledApps([:])
+
+        then:
+        result.success == false
+        result.error != null
+    }
+
+    def "gateway dispatch via handleGateway also returns apps list"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { params ->
+            JsonOutput.toJson([apps: []])
+        }
+
+        when:
+        def result = script.handleGateway('manage_installed_apps', 'list_installed_apps', [filter: 'all'])
+
+        then:
+        result.apps instanceof List
+        result.filter == 'all'
+    }
+}

--- a/src/test/groovy/server/ToolListRmRulesSpec.groovy
+++ b/src/test/groovy/server/ToolListRmRulesSpec.groovy
@@ -232,6 +232,28 @@ class ToolListRmRulesSpec extends ToolSpecBase {
         result.warning.contains('v4=')
     }
 
+    def "registerRmRule skips entries with non-Integer-coercible keys (Groovy-sandbox-safe warn log)"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'v5 list contains one bad String key and one valid numeric key'
+        rmUtils.stubRuleList5 = [
+            ['not-a-number': 'Bad rule'],    // String key that fails toInteger()
+            [123: 'Good rule']               // numeric key, should pass
+        ]
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then: 'only the valid rule is returned'
+        result.rules*.id == [123]
+        result.count == 1
+        // Implicit coverage: the test running under HubitatAppSandbox.run()
+        // exercises the sandbox security manager, so any getClass()/Eval.me
+        // reintroduced in registerRmRule would blow up the test loudly.
+        result.success != false
+    }
+
     def "gateway dispatch via handleGateway routes to list_rm_rules"() {
         given:
         settingsMap.enableBuiltinAppRead = true

--- a/src/test/groovy/server/ToolListRmRulesSpec.groovy
+++ b/src/test/groovy/server/ToolListRmRulesSpec.groovy
@@ -1,0 +1,247 @@
+package server
+
+import support.RMUtilsMock
+import support.ToolSpecBase
+
+/**
+ * Spec for toolListRmRules (hubitat-mcp-server.groovy approx line 7644).
+ * Gateway: manage_rule_machine -> list_rm_rules.
+ *
+ * Covers: gate-throw, RM 5.x Map shape with Integer key coercion, RM 4.x
+ * explicit-fields shape, dedup when same id in both, the "both-absent quiet
+ * path" (returns count=0 note without success=false), mixed failure shapes,
+ * narrow-scope classifier (MissingMethodException only for getRuleList,
+ * Cannot-get-property only with 'helper' substring).
+ */
+class ToolListRmRulesSpec extends ToolSpecBase {
+
+    RMUtilsMock rmUtils
+
+    def setup() {
+        rmUtils = new RMUtilsMock()
+        rmUtils.install()
+    }
+
+    def cleanup() {
+        rmUtils?.uninstall()
+    }
+
+    def "throws when Built-in App Read is disabled"() {
+        given:
+        settingsMap.enableBuiltinAppRead = false
+
+        when:
+        script.toolListRmRules([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Built-in App')
+    }
+
+    def "RM 5.x single-entry Map shape with mixed String/Integer keys coerces all ids to Integer"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'one entry has a String key, the other an Integer key'
+        rmUtils.stubRuleList5 = [
+            ['413': 'Living Room Relax'],
+            [832: 'Auto - Living Room TV Lights']
+        ]
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then:
+        result.rules.size() == 2
+        result.rules.every { it.id instanceof Integer }
+        result.rules*.id.sort() == [413, 832]
+        result.count == 2
+    }
+
+    def "RM 4.x explicit-fields shape passes all fields through"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        rmUtils.stubRuleList4 = [
+            [id: 100, label: 'Alpha', name: 'A', type: 'Rule-4.1']
+        ]
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then:
+        result.rules.size() == 1
+        def rule = result.rules[0]
+        rule.id == 100
+        rule.label == 'Alpha'
+        rule.name == 'A'
+        rule.type == 'Rule-4.1'
+    }
+
+    def "same rule id in both v4 and v5 appears exactly once (first-seen wins)"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        rmUtils.stubRuleList4 = [[id: 200, label: 'From v4', name: 'From v4', type: 'Rule-4.1']]
+        rmUtils.stubRuleList5 = [[200: 'From v5']]
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then: 'combined map deduplicates; v4 was registered first'
+        result.rules.size() == 1
+        result.rules[0].id == 200
+        result.rules[0].rmVersion == '4.x'
+    }
+
+    def "both-absent quiet path: count=0, informational note, success NOT false"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'both versions throw NoClassDefFoundError (RM not installed)'
+        rmUtils.throwOnGetRuleList4 = new NoClassDefFoundError("hubitat.helper.RMUtils")
+        rmUtils.throwOnGetRuleList5 = new NoClassDefFoundError("hubitat.helper.RMUtils")
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then: 'quiet: count 0, note mentioning rule machine, but NO success=false'
+        result.count == 0
+        result.note?.toLowerCase()?.contains('rule machine')
+        result.success != false  // unset or truthy
+        result.warning == null
+    }
+
+    def "both-absent via sandbox-wrapped 'Cannot get property helper' shape: quiet path"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        // The real Hubitat Groovy sandbox resolves unknown `hubitat.helper.X`
+        // namespace lookups to null, and the subsequent property dereference
+        // throws this shape -- verified via live probe during PR #79 review.
+        // Classifier at hubitat-mcp-server.groovy:7692 scopes the match to
+        // the 'helper' substring.
+        rmUtils.throwOnGetRuleList4 = new RuntimeException("Cannot get property 'helper' on null object")
+        rmUtils.throwOnGetRuleList5 = new RuntimeException("Cannot get property 'helper' on null object")
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then:
+        result.count == 0
+        result.note?.toLowerCase()?.contains('rule machine')
+        result.success != false  // unset or truthy
+        result.warning == null
+    }
+
+    def "both failed with mixed shapes returns success=false error mentioning both versions"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'v4 is class-missing but v5 is a hard RuntimeException -- not a quiet path'
+        rmUtils.throwOnGetRuleList4 = new NoClassDefFoundError("hubitat.helper.RMUtils")
+        rmUtils.throwOnGetRuleList5 = new RuntimeException("timeout connecting to RM")
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then:
+        result.success == false
+        result.error?.contains('v4=') == true
+        result.error?.contains('v5=') == true
+    }
+
+    def "MissingMethodException mentioning getRuleList on one side is quiet (old firmware shape)"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'v4 throws an MME scoped to getRuleList (old firmware, no getRuleList overload)'
+        rmUtils.throwOnGetRuleList4 = new RuntimeException("No signature of method getRuleList() is applicable")
+        rmUtils.stubRuleList5 = [[500: 'My v5 Rule']]
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then: 'v5 rules are returned without a warning -- the MME was scoped to getRuleList'
+        result.rules.size() == 1
+        result.rules[0].id == 500
+        result.warning == null
+    }
+
+    def "MissingMethodException NOT scoped to getRuleList surfaces as a warning"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'v4 throws an MME for an unrelated method name (not getRuleList)'
+        rmUtils.throwOnGetRuleList4 = new RuntimeException("No signature of method setXYZ() is applicable")
+        rmUtils.stubRuleList5 = [[600: 'My Rule']]
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then: 'warning surfaced because the MME was not scoped to getRuleList'
+        result.rules.size() == 1
+        result.warning != null
+        result.warning.contains('setXYZ')
+    }
+
+    def "Cannot-get-property with 'helper' substring is quiet (hubitat.helper path)"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: "v4 throws the sandbox null-resolution error for hubitat.helper.RMUtils"
+        rmUtils.throwOnGetRuleList4 = new RuntimeException("Cannot get property 'helper' on null object")
+        rmUtils.stubRuleList5 = [[700: 'Only v5 Rule']]
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then: 'quiet: the helper-path null-resolution is treated as class-missing'
+        result.rules.size() == 1
+        result.warning == null
+    }
+
+    def "Cannot-get-property WITHOUT 'helper' substring surfaces as a warning"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        and: 'v4 throws a Cannot-get-property error unrelated to the helper path'
+        rmUtils.throwOnGetRuleList4 = new RuntimeException("Cannot get property 'label' on null object")
+        rmUtils.stubRuleList5 = [[800: 'Rule']]
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then: 'warning surfaced -- not the helper-path pattern'
+        result.rules.size() == 1
+        result.warning != null
+    }
+
+    def "hard RuntimeException on one side with other succeeding surfaces warning"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        rmUtils.throwOnGetRuleList4 = new RuntimeException("timeout")
+        rmUtils.stubRuleList5 = [[900: 'My Rule']]
+
+        when:
+        def result = script.toolListRmRules([:])
+
+        then: 'results from v5 present, warning mentions the v4 failure'
+        result.rules.size() == 1
+        result.warning != null
+        result.warning.contains('v4=')
+    }
+
+    def "gateway dispatch via handleGateway routes to list_rm_rules"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        rmUtils.stubRuleList5 = [[10: 'Test Rule']]
+
+        when:
+        def result = script.handleGateway('manage_rule_machine', 'list_rm_rules', [:])
+
+        then:
+        result.rules instanceof List
+        result.count instanceof Integer
+    }
+}

--- a/src/test/groovy/server/ToolPauseRmRuleSpec.groovy
+++ b/src/test/groovy/server/ToolPauseRmRuleSpec.groovy
@@ -1,0 +1,99 @@
+package server
+
+import support.RMUtilsMock
+import support.ToolSpecBase
+
+/**
+ * Spec for toolPauseRmRule (hubitat-mcp-server.groovy approx line 7809).
+ * Gateway: manage_rule_machine -> pause_rm_rule.
+ *
+ * Covers: gate-throw, missing ruleId, golden-path pauseRule dispatch,
+ * and String ruleId coercion.
+ */
+class ToolPauseRmRuleSpec extends ToolSpecBase {
+
+    RMUtilsMock rmUtils
+
+    def setup() {
+        rmUtils = new RMUtilsMock()
+        rmUtils.install()
+    }
+
+    def cleanup() {
+        rmUtils?.uninstall()
+    }
+
+    def "throws when Built-in App Read is disabled"() {
+        given:
+        settingsMap.enableBuiltinAppRead = false
+
+        when:
+        script.toolPauseRmRule([ruleId: 1])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Built-in App')
+    }
+
+    def "throws when ruleId is missing"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolPauseRmRule([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('ruleid is required')
+    }
+
+    def "golden path: dispatches pauseRule sendAction for the given ruleId"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolPauseRmRule([ruleId: 400])
+
+        then:
+        result.success == true
+        result.ruleId == 400
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'pauseRule' }
+    }
+
+    def "String ruleId is coerced to Integer"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolPauseRmRule([ruleId: '401'])
+
+        then:
+        result.success == true
+        result.ruleId == 401
+        result.ruleId instanceof Integer
+    }
+
+    def "non-numeric ruleId throws IllegalArgumentException"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolPauseRmRule([ruleId: 'abc'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('integer')
+    }
+
+    def "gateway dispatch via handleGateway routes to pause_rm_rule"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.handleGateway('manage_rule_machine', 'pause_rm_rule', [ruleId: 500])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'pauseRule' }
+    }
+}

--- a/src/test/groovy/server/ToolResumeRmRuleSpec.groovy
+++ b/src/test/groovy/server/ToolResumeRmRuleSpec.groovy
@@ -1,0 +1,99 @@
+package server
+
+import support.RMUtilsMock
+import support.ToolSpecBase
+
+/**
+ * Spec for toolResumeRmRule (hubitat-mcp-server.groovy approx line 7819).
+ * Gateway: manage_rule_machine -> resume_rm_rule.
+ *
+ * Covers: gate-throw, missing ruleId, golden-path resumeRule dispatch,
+ * and String ruleId coercion.
+ */
+class ToolResumeRmRuleSpec extends ToolSpecBase {
+
+    RMUtilsMock rmUtils
+
+    def setup() {
+        rmUtils = new RMUtilsMock()
+        rmUtils.install()
+    }
+
+    def cleanup() {
+        rmUtils?.uninstall()
+    }
+
+    def "throws when Built-in App Read is disabled"() {
+        given:
+        settingsMap.enableBuiltinAppRead = false
+
+        when:
+        script.toolResumeRmRule([ruleId: 1])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Built-in App')
+    }
+
+    def "throws when ruleId is missing"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolResumeRmRule([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('ruleid is required')
+    }
+
+    def "golden path: dispatches resumeRule sendAction for the given ruleId"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolResumeRmRule([ruleId: 600])
+
+        then:
+        result.success == true
+        result.ruleId == 600
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'resumeRule' }
+    }
+
+    def "String ruleId is coerced to Integer"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolResumeRmRule([ruleId: '601'])
+
+        then:
+        result.success == true
+        result.ruleId == 601
+        result.ruleId instanceof Integer
+    }
+
+    def "non-numeric ruleId throws IllegalArgumentException"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolResumeRmRule([ruleId: 'xyz'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('integer')
+    }
+
+    def "gateway dispatch via handleGateway routes to resume_rm_rule"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.handleGateway('manage_rule_machine', 'resume_rm_rule', [ruleId: 700])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'resumeRule' }
+    }
+}

--- a/src/test/groovy/server/ToolRunRmRuleSpec.groovy
+++ b/src/test/groovy/server/ToolRunRmRuleSpec.groovy
@@ -1,0 +1,147 @@
+package server
+
+import support.RMUtilsMock
+import support.ToolSpecBase
+
+/**
+ * Spec for toolRunRmRule (hubitat-mcp-server.groovy approx line 7788).
+ * Gateway: manage_rule_machine -> run_rm_rule.
+ *
+ * Covers: gate-throw, missing ruleId, action-to-rmAction mapping (rule/actions/stop),
+ * invalid action rejection, String ruleId coercion, non-numeric ruleId rejection.
+ */
+class ToolRunRmRuleSpec extends ToolSpecBase {
+
+    RMUtilsMock rmUtils
+
+    def setup() {
+        rmUtils = new RMUtilsMock()
+        rmUtils.install()
+    }
+
+    def cleanup() {
+        rmUtils?.uninstall()
+    }
+
+    def "throws when Built-in App Read is disabled"() {
+        given:
+        settingsMap.enableBuiltinAppRead = false
+
+        when:
+        script.toolRunRmRule([ruleId: 1])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Built-in App')
+    }
+
+    def "throws when ruleId is missing"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolRunRmRule([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('ruleid is required')
+    }
+
+    def "action=rule dispatches runRule"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 101, action: 'rule'])
+
+        then:
+        result.success == true
+        result.ruleId == 101
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'runRule' }
+    }
+
+    def "action=actions dispatches runRuleAct"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 102, action: 'actions'])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'runRuleAct' }
+    }
+
+    def "action=stop dispatches stopRuleAct"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 103, action: 'stop'])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'stopRuleAct' }
+    }
+
+    def "default action (no action arg) dispatches runRule"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolRunRmRule([ruleId: 104])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'runRule' }
+    }
+
+    def "invalid action throws IllegalArgumentException"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolRunRmRule([ruleId: 105, action: 'explode'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('invalid action')
+    }
+
+    def "String ruleId is coerced to Integer before dispatch"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolRunRmRule([ruleId: '202'])
+
+        then:
+        result.success == true
+        result.ruleId == 202
+        result.ruleId instanceof Integer
+    }
+
+    def "non-numeric ruleId throws IllegalArgumentException"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolRunRmRule([ruleId: 'not-a-number'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('integer')
+    }
+
+    def "gateway dispatch via handleGateway routes to run_rm_rule"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.handleGateway('manage_rule_machine', 'run_rm_rule', [ruleId: 300, action: 'rule'])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'runRule' }
+    }
+}

--- a/src/test/groovy/server/ToolSetRmRuleBooleanSpec.groovy
+++ b/src/test/groovy/server/ToolSetRmRuleBooleanSpec.groovy
@@ -1,0 +1,170 @@
+package server
+
+import support.RMUtilsMock
+import support.ToolSpecBase
+
+/**
+ * Spec for toolSetRmRuleBoolean (hubitat-mcp-server.groovy approx line 7837).
+ * Gateway: manage_rule_machine -> set_rm_rule_boolean.
+ *
+ * Load-bearing: strict coercion policy. Accepts ONLY Boolean true/false OR
+ * the lowercase strings "true"/"false". All other truthy-looking values
+ * (capitalized strings, integers, yes/no, on/off) throw IllegalArgumentException.
+ *
+ * Covers: gate-throw, missing ruleId, missing value, the full accept matrix,
+ * the full reject matrix, and rmAction mapping for each resolved Boolean.
+ */
+class ToolSetRmRuleBooleanSpec extends ToolSpecBase {
+
+    RMUtilsMock rmUtils
+
+    def setup() {
+        rmUtils = new RMUtilsMock()
+        rmUtils.install()
+    }
+
+    def cleanup() {
+        rmUtils?.uninstall()
+    }
+
+    def "throws when Built-in App Read is disabled"() {
+        given:
+        settingsMap.enableBuiltinAppRead = false
+
+        when:
+        script.toolSetRmRuleBoolean([ruleId: 1, value: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Built-in App')
+    }
+
+    def "throws when ruleId is missing"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolSetRmRuleBoolean([value: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('ruleid is required')
+    }
+
+    def "throws when value is missing"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolSetRmRuleBoolean([ruleId: 1])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('value')
+    }
+
+    def "Boolean true dispatches setRuleBooleanTrue"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolSetRmRuleBoolean([ruleId: 800, value: true])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'setRuleBooleanTrue' }
+    }
+
+    def "Boolean false dispatches setRuleBooleanFalse"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolSetRmRuleBoolean([ruleId: 801, value: false])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'setRuleBooleanFalse' }
+    }
+
+    def "String 'true' is accepted and dispatches setRuleBooleanTrue"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolSetRmRuleBoolean([ruleId: 802, value: 'true'])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'setRuleBooleanTrue' }
+    }
+
+    def "String 'false' is accepted and dispatches setRuleBooleanFalse"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.toolSetRmRuleBoolean([ruleId: 803, value: 'false'])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'setRuleBooleanFalse' }
+    }
+
+    def "reject matrix: capitalized and uppercase boolean strings are rejected"(Object value) {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolSetRmRuleBoolean([ruleId: 999, value: value])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('value must be boolean')
+
+        where:
+        value << ['True', 'False', 'TRUE', 'FALSE']
+    }
+
+    def "reject matrix: truthy-looking non-boolean strings are rejected"(Object value) {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolSetRmRuleBoolean([ruleId: 999, value: value])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('value must be boolean')
+
+        where:
+        value << ['yes', 'no', 'on', 'off']
+    }
+
+    def "reject matrix: integer values are rejected"(Object value) {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        script.toolSetRmRuleBoolean([ruleId: 999, value: value])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('value must be boolean')
+
+        where:
+        value << [1, 0]
+    }
+
+    def "gateway dispatch via handleGateway routes to set_rm_rule_boolean"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+
+        when:
+        def result = script.handleGateway('manage_rule_machine', 'set_rm_rule_boolean', [ruleId: 900, value: true])
+
+        then:
+        result.success == true
+        rmUtils.calls.any { it.method == 'sendAction' && it.action == 'setRuleBooleanTrue' }
+    }
+}

--- a/src/test/groovy/support/RMUtilsMock.groovy
+++ b/src/test/groovy/support/RMUtilsMock.groovy
@@ -2,13 +2,13 @@ package support
 
 /**
  * `install()` mutates the static metaClass on `hubitat.helper.RMUtils`
- * — the main-source-set stub at
+ * -- the main-source-set stub at
  * `src/main/groovy/hubitat/helper/RMUtils.groovy`. Both test-side
  * direct calls (e.g. `RMUtilsMockSpec`) and sandbox-loaded production
  * calls (e.g. PR #79's `manage_rule_machine` gateway tools, resolved
  * through `support.PassThroughSandboxClassLoader`) land on the mock.
  *
- * Specs using this mock must run sequentially — `install()` mutates
+ * Specs using this mock must run sequentially -- `install()` mutates
  * the shared class metaclass. `build.gradle` pins
  * `maxParallelForks = 1` for this reason; do not enable parallel test
  * execution without moving these statics off the shared class metaclass
@@ -19,18 +19,66 @@ package support
  * classloader path. If that spec fails after an eighty20results bump,
  * the PassThrough scaffold needs attention before PR #79-style specs
  * can trust this mock.
+ *
+ * Coverage: PR #79's `manage_rule_machine` gateway tools call
+ * `RMUtils.getRuleList()` (no-arg for RM 4.x) AND
+ * `RMUtils.getRuleList("5.0")` (RM 5.x) as a dual probe, plus
+ * `RMUtils.sendAction([ruleId], action, appLabel, "5.0")` 4-arg with
+ * a 3-arg fallback. This mock supports all those signatures plus
+ * per-version stubs and per-method throw-injection for modelling
+ * partial-failure shapes.
  */
 class RMUtilsMock {
     final List<Map> calls = []
-    List<Map> stubRuleList = []
+    // Separate stubs per RM version so tests can model "v4 installed, v5 absent"
+    // (or vice-versa) independently. Set either to null to make that version's
+    // call raise a MissingMethodException-like error via throwOnGetRuleList*,
+    // exercising the production classifier that distinguishes missing-class
+    // from real failures.
+    List<Map> stubRuleList4 = []
+    List<Map> stubRuleList5 = []
+    // Legacy single-list alias retained for specs that don't care about the
+    // version split. If a test sets stubRuleList, both version-specific
+    // lookups return it.
+    List<Map> stubRuleList = null
+    // Optional throwables per method for modelling RM-not-installed failures
+    // or mid-pipeline errors. The classifier in toolListRmRules decides
+    // which substring shapes are quiet-missing vs surfaced-as-warning.
+    Throwable throwOnGetRuleList4 = null
+    Throwable throwOnGetRuleList5 = null
+    Throwable throwOnSendAction = null
 
-    List getRuleList(String version = '5.0') {
-        calls << [method: 'getRuleList', version: version]
-        return stubRuleList
+    List getRuleList() {
+        if (throwOnGetRuleList4 != null) throw throwOnGetRuleList4
+        calls << [method: 'getRuleList', version: null]
+        return stubRuleList != null ? stubRuleList : stubRuleList4
     }
 
+    List getRuleList(String version) {
+        def relevantThrow = (version == '5.0') ? throwOnGetRuleList5 : throwOnGetRuleList4
+        if (relevantThrow != null) throw relevantThrow
+        calls << [method: 'getRuleList', version: version]
+        if (stubRuleList != null) return stubRuleList
+        return version == '5.0' ? stubRuleList5 : stubRuleList4
+    }
+
+    // Legacy 2-arg form retained for pre-PR-79 specs that used it.
     void sendAction(Long ruleId, String action) {
+        if (throwOnSendAction != null) throw throwOnSendAction
         calls << [method: 'sendAction', ruleId: ruleId, action: action]
+    }
+
+    // Production (PR #79) preferred form: sendAction([ids], action, appLabel, "5.0").
+    void sendAction(List ruleIds, String action, String appLabel, String version) {
+        if (throwOnSendAction != null) throw throwOnSendAction
+        calls << [method: 'sendAction', ruleIds: ruleIds, action: action, appLabel: appLabel, version: version]
+    }
+
+    // Production 3-arg fallback form (fires only on MissingMethodException /
+    // NoSuchMethodError from the 4-arg attempt).
+    void sendAction(List ruleIds, String action, String appLabel) {
+        if (throwOnSendAction != null) throw throwOnSendAction
+        calls << [method: 'sendAction', ruleIds: ruleIds, action: action, appLabel: appLabel]
     }
 
     void pauseRule(Long ruleId) {
@@ -47,8 +95,24 @@ class RMUtilsMock {
 
     void install() {
         def self = this
-        hubitat.helper.RMUtils.metaClass.static.getRuleList = { String v = '5.0' -> self.getRuleList(v) }
+        // Methods exist on the stub class (src/main/groovy/hubitat/helper/RMUtils.groovy)
+        // so ExpandoMetaClass `<<` rejects them as "already exists". Using `=`
+        // REPLACES the stub's bytecode method with our closure. Multiple `=`
+        // assignments to the SAME name but DIFFERENT parameter signatures each
+        // replace only their matching bytecode overload (Groovy treats each
+        // arity as its own metaclass entry), giving us the overload dispatch
+        // we need.
+        //
+        // getRuleList: no-arg (RM 4.x) AND String-version (RM 5.x).
+        hubitat.helper.RMUtils.metaClass.static.getRuleList = { -> self.getRuleList() }
+        hubitat.helper.RMUtils.metaClass.static.getRuleList = { String v -> self.getRuleList(v) }
+        // sendAction: three production forms
+        //   (Long, String)                       -- legacy simple form
+        //   (List, String, String)               -- PR-79 3-arg fallback
+        //   (List, String, String, String)       -- PR-79 preferred 4-arg form
         hubitat.helper.RMUtils.metaClass.static.sendAction = { Long id, String a -> self.sendAction(id, a) }
+        hubitat.helper.RMUtils.metaClass.static.sendAction = { List ids, String a, String lbl -> self.sendAction(ids, a, lbl) }
+        hubitat.helper.RMUtils.metaClass.static.sendAction = { List ids, String a, String lbl, String v -> self.sendAction(ids, a, lbl, v) }
         hubitat.helper.RMUtils.metaClass.static.pauseRule = { Long id -> self.pauseRule(id) }
         hubitat.helper.RMUtils.metaClass.static.resumeRule = { Long id -> self.resumeRule(id) }
         hubitat.helper.RMUtils.metaClass.static.setRuleBoolean = { Long id, Boolean v -> self.setRuleBoolean(id, v) }

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -1,6 +1,6 @@
 # Bot Acceptance Test (BAT) Suite — v2
 
-Updated for v0.8.0+ final architecture (21 core + 9 gateways = 30 on tools/list, 48 proxied).
+Updated for the installed-apps + Rule Machine interop architecture (22 core + 11 gateways = 33 on tools/list, 59 proxied, 81 total).
 
 Comprehensive test scenarios for the Hubitat MCP Rule Server. Modeled after ha-mcp's BAT framework.
 
@@ -2132,25 +2132,189 @@ These operations are too destructive for automated testing. Test manually with e
 | 9. Stress | T120-T122 | Many calls, rapid cycles, pagination |
 | 10. NL Discovery | T200-T301 | Conversational prompts — no tool names |
 
-### Architecture (v0.8.0)
+### Architecture (post installed-apps + RM interop)
 
 | Component | Count |
 |-----------|-------|
-| Core tools on `tools/list` | 21 |
-| Gateways on `tools/list` | 9 |
-| Total visible on `tools/list` | 30 |
-| Tools proxied behind gateways | 48 |
-| Total tools in codebase | 69 |
+| Core tools on `tools/list` | 22 |
+| Gateways on `tools/list` | 11 |
+| Total visible on `tools/list` | 33 |
+| Tools proxied behind gateways | 59 |
+| Total tools in codebase | 81 |
 
-**9 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (6), `manage_diagnostics` (9), `manage_files` (4)
+**11 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (2), `manage_rule_machine` (5)
 
 ### Tool Coverage (non-destructive tools only)
 
-All 69 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
+All 81 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
 
-Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist.
+Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
 
-**Total: 172 test scenarios** (107 explicit + 65 natural language) plus 13 excluded destructive operations documented for manual testing
+**Total: 186 test scenarios** (107 explicit + 65 natural language + 14 built-in-app integration) plus 13 excluded destructive operations documented for manual testing
+
+---
+
+## Section 11: Built-in App Integration Tests
+
+These tools require `Enable Built-in App Tools` to be enabled in the MCP Rule Server app settings. Tests assume at least one Rule Machine rule and at least one Room Lighting or other multi-app configuration exists on the hub.
+
+### Safety Rules for Section 11
+
+- Tests are **read-only or reversibly-trigger** — no create/modify/delete of RM rules or RL instances (platform blocks that anyway)
+- `run_rm_rule`, `pause_rm_rule`, `resume_rm_rule`, `set_rm_rule_boolean` tests must target a BAT-created or explicitly user-identified rule, NEVER a random production rule
+- Tests skip entirely if Built-in App Tools is disabled — that's the expected behavior of `requireBuiltinAppRead()`
+
+### T200 — List installed apps (default)
+
+```json
+{
+  "test_prompt": "List all installed apps on my hub."
+}
+```
+
+**Expected**: Calls `manage_installed_apps` with `tool='list_installed_apps'` (via gateway). Returns list with at least one entry; each entry has id, name, type, disabled, user, parentId, hasChildren. AI reports the count.
+
+### T201 — List only built-in apps
+
+```json
+{
+  "test_prompt": "Show me only the built-in Hubitat apps, not my custom ones."
+}
+```
+
+**Expected**: Calls `list_installed_apps` with `filter='builtin'`. Returns apps where `user` is false. AI doesn't show user-installed apps like Ecobee or Awair.
+
+### T202 — List Rule Machine rules
+
+```json
+{
+  "test_prompt": "What Rule Machine rules do I have?"
+}
+```
+
+**Expected**: Calls `manage_rule_machine.list_rm_rules`. Returns list with ids and labels. AI reports count. If Rule Machine is not installed, AI gracefully reports "none found" or equivalent.
+
+### T203 — Find apps using a device
+
+```json
+{
+  "setup_prompt": "List devices briefly so I can see IDs.",
+  "test_prompt": "Which apps are using device ID {first_device_id}?"
+}
+```
+
+**Expected**: Calls `get_device_in_use_by` with valid deviceId. Returns `appsUsing` array. AI lists app names/labels.
+
+### T204 — Find apps using a fake device (error handling)
+
+```json
+{
+  "test_prompt": "Which apps are using device ID 99999999?"
+}
+```
+
+**Expected**: Tool returns `{success: false}` or similar error. AI reports device not found — does NOT fabricate results.
+
+### T205 — Gateway catalog discovery (manage_installed_apps)
+
+```json
+{
+  "test_prompt": "What can the manage_installed_apps gateway do?"
+}
+```
+
+**Expected**: AI calls `manage_installed_apps` with no args, sees catalog of 2 tools (`list_installed_apps`, `get_device_in_use_by`) with full parameter schemas.
+
+### T206 — Gateway catalog discovery (manage_rule_machine)
+
+```json
+{
+  "test_prompt": "What Rule Machine operations does the MCP support?"
+}
+```
+
+**Expected**: AI calls `manage_rule_machine` with no args, sees 5 tools. AI describes them (list/run/pause/resume/set_boolean).
+
+### T207 — AI correctly refuses RM rule creation
+
+```json
+{
+  "test_prompt": "Create a new Rule Machine rule that turns on Kitchen Light when motion is detected."
+}
+```
+
+**Expected**: AI recognizes RM creation is not supported and either (a) creates an MCP rule via `create_rule` instead (and explains the distinction), or (b) tells the user to use the native RM UI. Does NOT invent a fake RM create tool or pretend to call one.
+
+### T208 — AI correctly refuses Room Lighting creation
+
+```json
+{
+  "test_prompt": "Create a new Room Lighting instance for the Study."
+}
+```
+
+**Expected**: AI explains Room Lighting cannot be created via MCP (platform blocks third-party apps from instantiating built-in app children). Suggests native RL UI. Does not fabricate a fake tool.
+
+### T209 — Pause and resume an RM rule (reversible)
+
+```json
+{
+  "setup_prompt": "List Rule Machine rules and identify one labeled with 'BAT' prefix, or if none exists, ask the user to identify a safe test rule.",
+  "test_prompt": "Pause the rule, wait for me to confirm, then resume it.",
+  "teardown_prompt": "Verify the rule is back in its original enabled/disabled state."
+}
+```
+
+**Expected**: Calls `pause_rm_rule` → confirms with user → calls `resume_rm_rule`. Both return `{success: true}`.
+
+**WARNING**: Only runs if user has a BAT-prefixed RM rule OR explicitly identifies a safe rule. Never use a production rule.
+
+### T209b — Run actions on an RM rule (bypasses conditions)
+
+```json
+{
+  "setup_prompt": "List Rule Machine rules and identify one labeled with 'BAT' prefix whose actions are safe to fire at any time.",
+  "test_prompt": "Run just the actions of that rule (skip the trigger/condition evaluation).",
+  "teardown_prompt": "Verify the actions executed by checking the logs or the affected device states."
+}
+```
+
+**Expected**: Calls `run_rm_rule` with `action='actions'`. Returns `{success: true, rmAction: 'runRuleAct'}`. AI reports success and any downstream device state changes.
+
+**WARNING**: Only use a BAT-prefixed rule whose actions are idempotent/reversible. Running arbitrary production rule actions could toggle locks or change HVAC.
+
+### T209c — Set an RM rule's private boolean
+
+```json
+{
+  "setup_prompt": "Identify a BAT-prefixed RM rule that uses Private Boolean in its conditions.",
+  "test_prompt": "Set the rule's private boolean to true, then set it back to false.",
+  "teardown_prompt": "Verify the rule's boolean is in its original state."
+}
+```
+
+**Expected**: Calls `set_rm_rule_boolean` with `value=true`, then `value=false`. Both return `{success: true, rmAction: 'setRuleBooleanTrue'}` and `{rmAction: 'setRuleBooleanFalse'}` respectively.
+
+### T210 — Filter for disabled apps
+
+```json
+{
+  "test_prompt": "List all installed apps that are currently disabled or paused."
+}
+```
+
+**Expected**: Calls `list_installed_apps` with `filter='disabled'`. AI reports the count and names.
+
+### T211 — Built-in App Tools feature flag disabled
+
+```json
+{
+  "setup_prompt": "For this test, assume Built-in App Tools is disabled in MCP settings.",
+  "test_prompt": "List my Rule Machine rules."
+}
+```
+
+**Expected**: `list_rm_rules` returns `IllegalArgumentException: Built-in App Tools are disabled...`. AI reports the feature flag requirement and points user to the MCP app settings page.
 
 ---
 
@@ -2158,7 +2322,7 @@ Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests 
 
 Key differences from the original BAT.md (which targets the pre-v0.8.0 architecture):
 
-1. **Architecture**: 18 core + 8 gateways (26 total) → **21 core + 9 gateways (30 total, 69 tools)**
+1. **Architecture**: 18 core + 8 gateways (26 total) → **22 core + 11 gateways (33 total, 81 tools)** post installed-apps + RM interop (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
 2. **Merged tools**: `enable_rule`/`disable_rule` → `update_rule` (enabled=true/false); `create_virtual_device`/`delete_virtual_device` → `manage_virtual_device` (action enum)
 3. **Promoted to core**: `create_hub_backup`, `check_for_update`, `generate_bug_report`
 4. **Dissolved gateway**: `manage_hub_info` — radio details moved to `manage_diagnostics`, other tools merged into `get_hub_info` (core) or promoted

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -332,7 +332,7 @@ class TestRunner:
     def test_tools_list(self) -> None:
         result = self.client.list_tools()
         tools = result.get("tools", [])
-        assert len(tools) == 30, f"Expected 30 tools, got {len(tools)}"
+        assert len(tools) == 33, f"Expected 33 tools (22 core + 11 gateways), got {len(tools)}"
 
     @test("infrastructure")
     def test_health_endpoint(self) -> None:


### PR DESCRIPTION
## Summary

Adds two new read-and-trigger gateways giving the AI visibility into Hubitat's built-in apps and a narrow surface on Rule Machine. Closes a large functional gap — prior to this PR the AI had no way to see what Rule Machine rules, Room Lighting instances, Scenes, Mode Manager schedules, or dashboards existed on the hub, or which of them referenced a given device.

**Example questions these tools unlock for natural-language use:**

- *"Which app is controlling my Kitchen Lights?"* — `get_device_in_use_by` reverses device → apps, answers with "Room Kitchen (Room Lights) + Maker API + …"
- *"How many Rule Machine rules do I have, and which are currently disabled?"* — `list_rm_rules` + `list_installed_apps(filter="disabled")`
- *"Show me every Room Lighting instance I've set up"* — `list_installed_apps(filter="children")` filtered for parent=Room Lighting
- *"If I delete this switch, what automations will break?"* — `get_device_in_use_by` before destructive actions
- *"Pause the 'Away mode lights' rule while I have guests over"* → `pause_rm_rule`, later `resume_rm_rule`
- *"Run the 'kitchen deep clean' rule now"* → `run_rm_rule(action="rule")`
- *"Is the 'Living Room Relax' rule running actions right now? Stop it."* → `run_rm_rule(action="stop")`
- *"Flip the private boolean on the vacation rule to false"* → `set_rm_rule_boolean`
- *"Audit my apps — any inactive automations I should clean up?"* — `list_installed_apps(filter="disabled")` + AI reasoning

None of these were answerable before; now they're one-tool-call away.

## `manage_installed_apps` gateway (2 tools)

- **`list_installed_apps(filter?, includeHidden?)`** — enumerates every app on the hub (built-in + user) with parent/child tree. Backed by `/hub2/appsList` (the same undocumented-but-stable JSON endpoint the Hubitat Web UI uses for its Apps page — same tier as `/hub2/zwaveInfo`, `/hub2/roomsList`). Filters: `all`/`builtin`/`user`/`disabled`/`parents`/`children`. Hidden child apps suppressed by default and re-parented to the nearest visible ancestor so `parentId` references never orphan.

- **`get_device_in_use_by(deviceId)`** — reverse lookup: given a device, lists the apps that reference it (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API). Backed by `/device/fullJson/<id>` which already exposes `appsUsing` + `appsUsingCount`. Answers "if I delete this device, which automations break?"

## `manage_rule_machine` gateway (5 tools)

Uses the official `hubitat.helper.RMUtils` helper class — the community-documented entry point RM's own companion apps use. **Read + trigger only.** Cannot create, modify, or delete RM rules: Hubitat's platform blocks `addChildApp` parent-type validation for third-party apps. Documented prominently in the in-tool `get_tool_guide` section so the AI refuses invalid requests rather than fabricating fake tools.

- **`list_rm_rules`** — enumerates RM 4.x + 5.x rules (combined, deduplicated by id). Handles both shapes: documented `[{id, label}]` and undocumented RM 5.x single-entry `[<id>:"<label>"]`, coercing keys to `Integer` either way.
- **`run_rm_rule(ruleId, action)`** — trigger a rule. `action=rule` (full), `actions` (bypass conditions), or `stop` (cancel in-flight).
- **`pause_rm_rule`** / **`resume_rm_rule`** — reversible pause-state management.
- **`set_rm_rule_boolean(ruleId, value)`** — set an RM rule's Private Boolean (true/false).

## Gating

Both gateways behind a new opt-in setting, **"Enable Built-in App Tools"** (off by default). Read-only — no backup required. Setting is separate from Hub Admin Read because these endpoints have a slightly different firmware-stability profile (documented in `SKILL.md`'s Hub Internal API Endpoints Reference, now with rows for `/hub2/appsList` and `/device/fullJson`).

## Scope notes

- No version bump. No `packageManifest.json` changes — leaving those for your release cut.
- Internal endpoints used are the same tier as existing ones already in the codebase. No HTML scraping, no cookie-auth hacks.
- `tests/BAT-v2.md` gains Section 11 (T200-T211) — 14 test scenarios covering the new tools, mutual-exclusion errors, gate errors, and the refuse-fake-tools safety rule.

## Verified on live hub (firmware 2.4.4.156)

| Test | Result |
|---|---|
| `list_installed_apps(filter="parents")` | ✅ 11 parents of 150 apps |
| `list_installed_apps(filter="disabled")` | ✅ 1 disabled app |
| `get_device_in_use_by(deviceId=<switch>)` | ✅ 5 apps returned, deviceName populated |
| `list_rm_rules` | ✅ 45 rules, all ids are `Integer` |
| `pause_rm_rule(<rule>)` / `resume_rm_rule(<rule>)` | ✅ cycle works |
| `set_rm_rule_boolean(<rule>, true/false)` | ✅ both |
| `run_rm_rule(<rule>, action="rule")` | ✅ |
| `pause_rm_rule(ruleId="lightA")` | ✅ JSON-RPC -32602 "Invalid params: ruleId must be an integer" |

Sandbox lint clean (`0 errors, 0 warnings`).
