### PR TITLE
ci: silence Groovy 2.5 reflective warnings + run Gradle daemon on JDK 17

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,11 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '11'
+          # Gradle daemon runs on this JVM. Gradle 9 requires JDK 17+
+          # for the daemon itself; project targets JDK 11 via the
+          # toolchain block in build.gradle, which Gradle locates from
+          # the runner's pre-installed temurin-11.
+          java-version: '17'
       - uses: gradle/actions/setup-gradle@v4
       - name: Run unit tests
         run: ./gradlew test --info --warning-mode all

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: '11'
       - uses: gradle/actions/setup-gradle@v4
       - name: Run unit tests
-        run: ./gradlew test --info
+        run: ./gradlew test --info --warning-mode all
       - name: Upload test report on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/build.gradle
+++ b/build.gradle
@@ -52,10 +52,14 @@ test {
             '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
             '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
             '--add-opens=java.base/java.io=ALL-UNNAMED',
+            '--add-opens=java.base/java.math=ALL-UNNAMED',
             '--add-opens=java.base/java.net=ALL-UNNAMED',
             '--add-opens=java.base/java.nio=ALL-UNNAMED',
             '--add-opens=java.base/java.text=ALL-UNNAMED',
+            '--add-opens=java.base/java.time=ALL-UNNAMED',
             '--add-opens=java.base/java.util=ALL-UNNAMED',
+            '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
+            '--add-opens=java.base/java.util.regex=ALL-UNNAMED',
             '--add-opens=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED'
     testLogging {
         events 'passed', 'skipped', 'failed'

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ test {
             '--add-opens=java.base/java.io=ALL-UNNAMED',
             '--add-opens=java.base/java.net=ALL-UNNAMED',
             '--add-opens=java.base/java.nio=ALL-UNNAMED',
+            '--add-opens=java.base/java.text=ALL-UNNAMED',
             '--add-opens=java.base/java.util=ALL-UNNAMED',
             '--add-opens=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED'
     testLogging {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ test {
     // metaclass methods on hubitat.helper.RMUtils / .NetworkUtils — concurrent
     // specs installing and uninstalling these at the same time would race.
     maxParallelForks = 1
+    // Silence Groovy 2.5.23's reflective access to Object.finalize() under JDK
+    // 11+. We're pinned to Groovy 2.5 by hubitat_ci's compiled-against version;
+    // opening java.lang grants the access CachedClass needs without affecting
+    // behaviour. Remove if/when hubitat_ci moves to Groovy 4.
+    jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
     testLogging {
         events 'passed', 'skipped', 'failed'
         exceptionFormat 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,15 @@ test {
     // metaclass methods on hubitat.helper.RMUtils / .NetworkUtils — concurrent
     // specs installing and uninstalling these at the same time would race.
     maxParallelForks = 1
-    // Silence Groovy 2.5.23's reflective access to Object.finalize() under JDK
-    // 11+. We're pinned to Groovy 2.5 by hubitat_ci's compiled-against version;
-    // opening java.lang grants the access CachedClass needs without affecting
+    // Silence Groovy 2.5.23's reflective access under JDK 11+.
+    // We're pinned to Groovy 2.5 by hubitat_ci's compiled-against
+    // version; opening the relevant java.base packages grants the
+    // access CachedClass / CachedConstructor need without changing
     // behaviour. Remove if/when hubitat_ci moves to Groovy 4.
-    jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED'
+    //  - java.lang: CachedClass reflects on Object.finalize()
+    //  - java.io:   CachedConstructor reflects on File(String, File)
+    jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
+            '--add-opens=java.base/java.io=ALL-UNNAMED'
     testLogging {
         events 'passed', 'skipped', 'failed'
         exceptionFormat 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,8 @@ test {
             '--add-opens=java.base/java.io=ALL-UNNAMED',
             '--add-opens=java.base/java.net=ALL-UNNAMED',
             '--add-opens=java.base/java.nio=ALL-UNNAMED',
-            '--add-opens=java.base/java.util=ALL-UNNAMED'
+            '--add-opens=java.base/java.util=ALL-UNNAMED',
+            '--add-opens=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED'
     testLogging {
         events 'passed', 'skipped', 'failed'
         exceptionFormat 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ test {
             '--add-opens=java.base/java.util=ALL-UNNAMED',
             '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
             '--add-opens=java.base/java.util.regex=ALL-UNNAMED',
+            '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
             '--add-opens=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED'
     testLogging {
         events 'passed', 'skipped', 'failed'

--- a/build.gradle
+++ b/build.gradle
@@ -41,13 +41,19 @@ test {
     maxParallelForks = 1
     // Silence Groovy 2.5.23's reflective access under JDK 11+.
     // We're pinned to Groovy 2.5 by hubitat_ci's compiled-against
-    // version; opening the relevant java.base packages grants the
-    // access CachedClass / CachedConstructor need without changing
-    // behaviour. Remove if/when hubitat_ci moves to Groovy 4.
-    //  - java.lang: CachedClass reflects on Object.finalize()
-    //  - java.io:   CachedConstructor reflects on File(String, File)
+    // version; each --add-opens grants access to a java.base package
+    // that Groovy's CachedClass / CachedConstructor reflects into
+    // on initialization. Each suppression tends to reveal the next
+    // path the first time a spec exercises it — the set below covers
+    // the packages Groovy 2.5 is known to reach into. Add more as
+    // new warnings surface, or drop the whole block when hubitat_ci
+    // moves to Groovy 4.
     jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
-            '--add-opens=java.base/java.io=ALL-UNNAMED'
+            '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens=java.base/java.io=ALL-UNNAMED',
+            '--add-opens=java.base/java.net=ALL-UNNAMED',
+            '--add-opens=java.base/java.nio=ALL-UNNAMED',
+            '--add-opens=java.base/java.util=ALL-UNNAMED'
     testLogging {
         events 'passed', 'skipped', 'failed'
         exceptionFormat 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ test {
     // moves to Groovy 4.
     jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
             '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
             '--add-opens=java.base/java.io=ALL-UNNAMED',
             '--add-opens=java.base/java.net=ALL-UNNAMED',
             '--add-opens=java.base/java.nio=ALL-UNNAMED',


### PR DESCRIPTION
## Summary

Cleans up the noise in the Unit Tests CI log. Both warning categories
eliminated:

- **All Groovy 2.5 illegal reflective-access warnings** — silenced via
  a complete set of `--add-opens` JVM args on the test task. Groovy
  2.5.23 reflects into many JDK internals (java.lang, java.io,
  java.util, java.text, java.math, sun.util.calendar, xerces DOM, …)
  during its class-cache initialization; each package needs an
  explicit open under the JPMS module system. Each suppression tended
  to unmask the next one — the diagnostic `--warning-mode all` loop
  landed the full list in one PR instead of churning across many.

- **Gradle deprecation warning "Executing Gradle on JVM versions 16
  and lower has been deprecated"** — fixed by bumping `setup-java`'s
  `java-version` from `'11'` to `'17'` for the Gradle daemon.
  Project compilation and test execution remain on JDK 11 via the
  `toolchain` block in `build.gradle`; Gradle locates the runner's
  pre-installed temurin-11 via auto-detection. Verified in CI.

## Changes

- `build.gradle`: `test { jvmArgs ... }` with 14 `--add-opens` entries
  covering the java.base / java.xml packages Groovy 2.5 reflects into
  during spec loading. Removable if/when hubitat_ci upgrades to
  Groovy 4+.
- `.github/workflows/unit-tests.yml`:
  - `java-version: '11'` → `'17'` (daemon only; project stays on 11
    via toolchain).
  - Added `--warning-mode all` to `./gradlew test` as a forward-
    looking safeguard — identical output to default when no
    deprecations exist, itemises them immediately when new ones are
    introduced.

## Verification

Final CI run (2cdc5f3):
- Unit Tests: **success**, 0 reflective warnings, 0 Gradle
  deprecations in the log.
- Only non-test-code warning remaining is GitHub's Node.js 20
  deprecation notice for `actions/checkout@v4`, `actions/setup-java@v4`,
  and `gradle/actions/setup-gradle@v4` — upstream concern, resolves
  when those actions publish Node 24 releases.

## Out of scope

- Upgrading Groovy or hubitat_ci — Groovy 2.5 is pinned by
  `hubitat_ci:0.17`'s compiled-against version. The opens can be
  dropped when hubitat_ci ships a Groovy 4 build.
- Upgrading Gradle to 9.x — the daemon-JVM deprecation was the only
  Gradle 9 blocker surfaced; other Gradle 8.10 features may also be
  removed in 9, to triage separately.