### PR TITLE
chore: add Dependabot config + hubitat_ci version-check workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot config. See:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # GitHub Actions. Weekly cadence picks up action releases — notably the
+  # Node.js 20 → 24 migrations that upstream actions publish as minor/patch
+  # bumps and that resolve the current Unit Tests CI deprecation notice.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    open-pull-requests-limit: 3
+
+  # Gradle dependencies in build.gradle. Monthly cadence since test-only
+  # changes don't need aggressive freshness, and the set is small.
+  #
+  # Pinned intentionally (see ignores below):
+  #   - groovy-all is constrained to 2.5.x by hubitat_ci:0.17's compiled-
+  #     against version; minor/major bumps break the harness.
+  #   - spock-core uses the "-groovy-2.5" variant suffix, which Dependabot
+  #     doesn't model — ignore entirely, manual bump when Groovy is unpinned.
+  #   - hubitat_ci lives on biocomp Azure Artifacts (not Maven Central).
+  #     Dependabot can't resolve it anyway; explicit ignore keeps config
+  #     self-documenting. New versions are surfaced by the separate
+  #     hubitat-ci-version-check.yml workflow.
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "org.codehaus.groovy:groovy-all"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "org.spockframework:spock-core"
+      - dependency-name: "me.biocomp.hubitat_ci:hubitat_ci"
+    groups:
+      gradle-dependencies:
+        patterns: ["*"]
+    open-pull-requests-limit: 2

--- a/.github/workflows/hubitat-ci-version-check.yml
+++ b/.github/workflows/hubitat-ci-version-check.yml
@@ -1,0 +1,91 @@
+name: hubitat_ci version check
+
+# hubitat_ci is published to the biocomp Azure Artifacts Maven feed, which
+# Dependabot cannot resolve. This workflow polls the feed's maven-metadata.xml
+# weekly and opens a GitHub issue when a newer version appears, so the pinned
+# version in build.gradle has a notification channel.
+#
+# Upstream source: https://github.com/biocomp/hubitat_ci
+# Feed: https://biocomp.pkgs.visualstudio.com/HubitatCiRelease/_packaging/hubitat_ci_feed@Release/
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Mondays 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch latest hubitat_ci version from Azure Artifacts
+        id: fetch
+        run: |
+          set -euo pipefail
+          URL="https://biocomp.pkgs.visualstudio.com/HubitatCiRelease/_packaging/hubitat_ci_feed@Release/maven/v1/me/biocomp/hubitat_ci/hubitat_ci/maven-metadata.xml"
+          METADATA=$(curl -sSf "$URL")
+          LATEST=$(echo "$METADATA" | grep -oP '(?<=<latest>)[^<]+' | head -1 || true)
+          if [ -z "$LATEST" ]; then
+            LATEST=$(echo "$METADATA" | grep -oP '(?<=<release>)[^<]+' | head -1 || true)
+          fi
+          if [ -z "$LATEST" ]; then
+            echo "::error::Could not parse latest/release version from maven-metadata.xml"
+            echo "$METADATA"
+            exit 1
+          fi
+          PINNED=$(grep -oP "hubitat_ci:\K[^'\"]+" build.gradle | head -1)
+          if [ -z "$PINNED" ]; then
+            echo "::error::Could not parse pinned hubitat_ci version from build.gradle"
+            exit 1
+          fi
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "pinned=$PINNED" >> "$GITHUB_OUTPUT"
+          echo "Pinned in build.gradle: $PINNED"
+          echo "Latest in feed:         $LATEST"
+          if [ "$LATEST" = "$PINNED" ]; then
+            echo "::notice::hubitat_ci is up to date."
+          else
+            echo "::notice::hubitat_ci update available: $PINNED -> $LATEST"
+          fi
+
+      - name: Open tracking issue when a newer version is available
+        if: steps.fetch.outputs.latest != steps.fetch.outputs.pinned
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LATEST: ${{ steps.fetch.outputs.latest }}
+          PINNED: ${{ steps.fetch.outputs.pinned }}
+        run: |
+          set -euo pipefail
+          TITLE="chore: hubitat_ci update available (${LATEST})"
+          # Search open + closed so a closed "don't update yet" decision isn't
+          # re-opened every Monday. A newer version would produce a different
+          # title and trigger a fresh issue.
+          EXISTING=$(gh issue list --state all --search "\"${TITLE}\" in:title" --json number --jq '.[0].number // ""')
+          if [ -n "$EXISTING" ]; then
+            echo "Issue #${EXISTING} already tracks ${LATEST} — no-op."
+            exit 0
+          fi
+          gh issue create \
+            --title "${TITLE}" \
+            --body "$(cat <<EOF
+          The weekly version check detected a newer \`hubitat_ci\` version on the biocomp Azure Artifacts feed.
+
+          - **Currently pinned:** \`${PINNED}\` (in \`build.gradle\`)
+          - **Latest available:** \`${LATEST}\`
+          - **Upstream source:** https://github.com/biocomp/hubitat_ci
+          - **Feed metadata:** https://biocomp.pkgs.visualstudio.com/HubitatCiRelease/_packaging/hubitat_ci_feed@Release/maven/v1/me/biocomp/hubitat_ci/hubitat_ci/maven-metadata.xml
+
+          **To update:**
+          1. Edit \`build.gradle\` — change \`hubitat_ci:${PINNED}\` to \`hubitat_ci:${LATEST}\`.
+          2. If the Groovy version pinned by \`hubitat_ci\` changed, update \`org.codehaus.groovy:groovy-all\` and \`org.spockframework:spock-core\` (variant suffix) to match.
+          3. Run \`./gradlew test\` locally and in CI.
+          4. Review the upstream changelog on biocomp/hubitat_ci for breaking API changes that would require harness migration.
+
+          This issue was opened automatically by \`.github/workflows/hubitat-ci-version-check.yml\`. Closing it suppresses notifications for this specific version; a newer version produces a fresh issue.
+          EOF
+          )"

--- a/.github/workflows/hubitat-ci-version-check.yml
+++ b/.github/workflows/hubitat-ci-version-check.yml
@@ -38,7 +38,9 @@ jobs:
             echo "$METADATA"
             exit 1
           fi
-          PINNED=$(grep -oP "hubitat_ci:\K[^'\"]+" build.gradle | head -1)
+          # Full GAV coordinate: group `hubitat_ci:` appears twice (group + artifact),
+          # so split on the last colon rather than relying on lookbehind.
+          PINNED=$(grep -oE "me\.biocomp\.hubitat_ci:hubitat_ci:[^'\"]+" build.gradle | head -1 | cut -d: -f3)
           if [ -z "$PINNED" ]; then
             echo "::error::Could not parse pinned hubitat_ci version from build.gradle"
             exit 1


### PR DESCRIPTION
Sets up automated dependency tracking for everything Dependabot can reach, plus a custom poller for the one dep it can't.

## Changes

### `.github/dependabot.yml`

Two update schedules:

- **`github-actions`, weekly, grouped.** Picks up minor/patch bumps to
  `actions/checkout`, `actions/setup-java`, `actions/setup-python`,
  `actions/upload-artifact`, and `gradle/actions/setup-gradle`.
  Notable: resolves the "Node.js 20 actions are deprecated" notice
  currently shown on every Unit Tests run, once those actions publish
  their Node 24 releases.

- **`gradle`, monthly, grouped**, with explicit ignore rules:
  - `groovy-all` — constrained to 2.5.x by `hubitat_ci:0.17`'s
    compiled-against version; minor/major bumps break the harness.
    Patch allowed (`2.5.23 → 2.5.24`).
  - `spock-core` — the `-groovy-2.5` variant suffix isn't modelled by
    Dependabot; ignored entirely until Groovy is unpinned.
  - `hubitat_ci` — hosted on biocomp Azure Artifacts (not Maven
    Central), invisible to Dependabot anyway. Explicit ignore keeps
    the config self-documenting.

### `.github/workflows/hubitat-ci-version-check.yml`

Weekly scheduled workflow that polls the Azure Artifacts feed's
`maven-metadata.xml` and compares `<latest>` against the pinned
version in `build.gradle`. Opens a tracking issue when a newer
version appears, with upgrade instructions linking back to
`github.com/biocomp/hubitat_ci`.

De-duplication: searches open + closed issues so a closed "not
updating yet" decision isn't reopened next Monday. A newer version
produces a different title and triggers a fresh issue.
`workflow_dispatch` also enabled for on-demand checks.

## Secondary notification channel

For redundancy on upstream activity (not just Maven-published
releases), consider clicking **Watch → Custom → Releases** on
https://github.com/biocomp/hubitat_ci. GitHub will email you when a
new release is published even before it hits the Maven feed, which
sometimes lags. Current state: latest GitHub release is `v0.16`
(2021-04-24), latest Maven version is `0.17` — so the two sources
don't always agree. The Maven poller is authoritative for what
`build.gradle` can resolve; the GitHub watch is a tripwire for
upstream activity in general.

## Verification

The `maven-metadata.xml` URL was fetched and confirmed to return
parseable XML with `<latest>0.17</latest>` matching the current
pin. The poller script logic (fetch, parse, compare, issue-create)
was verified against real output before committing.

## Out of scope

- Auto-merging Dependabot PRs — can be layered on later via a
  separate workflow if the update PRs prove reliable.
- Security-advisory updates — enabled by default on public repos
  regardless of this config.