### PR TITLE
chore: migrate hubitat_ci to joelwetzel fork + Dependabot + version-check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot config. See:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # GitHub Actions. Weekly cadence picks up action releases — notably the
+  # Node.js 20 → 24 migrations that upstream actions publish as minor/patch
+  # bumps and that resolve the current Unit Tests CI deprecation notice.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    open-pull-requests-limit: 3
+
+  # Gradle dependencies in build.gradle. Monthly cadence since test-only
+  # changes don't need aggressive freshness, and the set is small.
+  #
+  # Pinned intentionally (see ignores below):
+  #   - groovy-all stays on 2.5.x — matches joelwetzel's compiled-against
+  #     version and is closest to Hubitat's runtime Groovy 2.4.
+  #   - spock-core uses the "-groovy-2.5" variant suffix, which Dependabot
+  #     doesn't model as a version coordinator; manual bump only.
+  #   - com.github.joelwetzel:hubitat_ci is served by JitPack and pinned to a
+  #     specific commit SHA (no upstream release tags). Dependabot can't see
+  #     JitPack SHAs as versions; the hubitat-ci-version-check.yml workflow
+  #     polls joelwetzel's master branch and opens tracking issues instead.
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "org.codehaus.groovy:groovy-all"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "org.spockframework:spock-core"
+      - dependency-name: "com.github.joelwetzel:hubitat_ci"
+    groups:
+      gradle-dependencies:
+        patterns: ["*"]
+    open-pull-requests-limit: 2

--- a/.github/workflows/hubitat-ci-version-check.yml
+++ b/.github/workflows/hubitat-ci-version-check.yml
@@ -30,13 +30,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Pinned coord from build.gradle — JitPack build-identifier shape is
-          # 'com.github.joelwetzel:hubitat_ci:master-<sha>-<build-number>'.
-          # Extract the <sha> portion for comparison against master HEAD.
-          COORD=$(grep -oE "com\.github\.joelwetzel:hubitat_ci:[^'\"]+" build.gradle | head -1 | cut -d: -f3)
-          PINNED=$(echo "$COORD" | sed -nE 's/^master-([a-f0-9]+)-[0-9]+$/\1/p')
+          # Pinned SHA from build.gradle — coordinate shape is
+          # 'com.github.joelwetzel:hubitat_ci:<short-sha>'.
+          PINNED=$(grep -oE "com\.github\.joelwetzel:hubitat_ci:[^'\"]+" build.gradle | head -1 | cut -d: -f3)
           if [ -z "$PINNED" ]; then
-            echo "::error::Could not parse pinned com.github.joelwetzel:hubitat_ci SHA from build.gradle (coord: $COORD)"
+            echo "::error::Could not parse pinned com.github.joelwetzel:hubitat_ci SHA from build.gradle"
             exit 1
           fi
 

--- a/.github/workflows/hubitat-ci-version-check.yml
+++ b/.github/workflows/hubitat-ci-version-check.yml
@@ -1,0 +1,106 @@
+name: hubitat_ci version check
+
+# joelwetzel/hubitat_ci is consumed from JitPack at a pinned master-branch
+# commit SHA (the fork doesn't cut releases/tags). This workflow polls
+# joelwetzel's master HEAD weekly and opens a tracking issue when commits
+# beyond our pinned SHA are available.
+#
+# Upstream: https://github.com/joelwetzel/hubitat_ci
+# Fork of:  https://github.com/biocomp/hubitat_ci
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Mondays 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare pinned commit against joelwetzel master HEAD
+        id: compare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Pinned SHA from build.gradle — coordinate shape is
+          # 'com.github.joelwetzel:hubitat_ci:<sha>'.
+          PINNED=$(grep -oE "com\.github\.joelwetzel:hubitat_ci:[^'\"]+" build.gradle | head -1 | cut -d: -f3)
+          if [ -z "$PINNED" ]; then
+            echo "::error::Could not parse pinned com.github.joelwetzel:hubitat_ci SHA from build.gradle"
+            exit 1
+          fi
+
+          # joelwetzel master HEAD. The default-branch commit SHA is the full
+          # 40-char form; we compare by startsWith to handle short-hash pins.
+          LATEST=$(gh api repos/joelwetzel/hubitat_ci/commits/master --jq .sha)
+          if [ -z "$LATEST" ]; then
+            echo "::error::Could not fetch joelwetzel/hubitat_ci master HEAD"
+            exit 1
+          fi
+
+          SHORT_LATEST=${LATEST:0:10}
+          echo "pinned=$PINNED"              >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST"              >> "$GITHUB_OUTPUT"
+          echo "short_latest=$SHORT_LATEST"  >> "$GITHUB_OUTPUT"
+          echo "Pinned in build.gradle: $PINNED"
+          echo "joelwetzel master HEAD: $LATEST"
+
+          if [[ "$LATEST" == "$PINNED"* ]]; then
+            echo "up_to_date=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::joelwetzel/hubitat_ci is up to date."
+          else
+            echo "up_to_date=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::joelwetzel/hubitat_ci update available: $PINNED -> $SHORT_LATEST"
+          fi
+
+      - name: Open tracking issue when new commits are available
+        if: steps.compare.outputs.up_to_date != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PINNED: ${{ steps.compare.outputs.pinned }}
+          LATEST: ${{ steps.compare.outputs.latest }}
+          SHORT_LATEST: ${{ steps.compare.outputs.short_latest }}
+        run: |
+          set -euo pipefail
+          TITLE="chore: joelwetzel/hubitat_ci update available (${SHORT_LATEST})"
+
+          EXISTING=$(gh issue list --state all --search "\"${TITLE}\" in:title" --json number --jq '.[0].number // ""')
+          if [ -n "$EXISTING" ]; then
+            echo "Issue #${EXISTING} already tracks ${SHORT_LATEST} — no-op."
+            exit 0
+          fi
+
+          COMMITS_SUMMARY=$(gh api "repos/joelwetzel/hubitat_ci/compare/${PINNED}...${LATEST}" \
+            --jq '.commits | map("- " + (.sha[0:10]) + " " + (.commit.message | split("\n")[0])) | .[0:20] | join("\n")' \
+            2>/dev/null || echo "(commit list unavailable — compare the two SHAs manually)")
+
+          BODY="The weekly version check detected new commits on \`joelwetzel/hubitat_ci\`'s master branch past our pinned SHA.
+
+          - **Currently pinned:** \`${PINNED}\` (in \`build.gradle\` via JitPack)
+          - **Latest master HEAD:** \`${LATEST}\`
+          - **Compare view:** https://github.com/joelwetzel/hubitat_ci/compare/${PINNED}...${LATEST}
+          - **Fork repo:** https://github.com/joelwetzel/hubitat_ci
+
+          ## Commits since pin (up to 20)
+
+          ${COMMITS_SUMMARY}
+
+          ## To update
+
+          1. Edit \`build.gradle\` — change \`com.github.joelwetzel:hubitat_ci:${PINNED}\` to \`com.github.joelwetzel:hubitat_ci:${SHORT_LATEST}\`.
+          2. Run \`./gradlew test\` locally or in CI. The harness may need adjustment if any API has moved (imports under \`me.biocomp.hubitat_ci.*\`).
+          3. Review the compare view above for any breaking changes.
+
+          This issue was opened automatically by \`.github/workflows/hubitat-ci-version-check.yml\`. Closing it suppresses notifications for this SHA; a newer HEAD triggers a fresh issue."
+
+          gh issue create \
+            --title "${TITLE}" \
+            --body "${BODY}"

--- a/.github/workflows/hubitat-ci-version-check.yml
+++ b/.github/workflows/hubitat-ci-version-check.yml
@@ -30,11 +30,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Pinned SHA from build.gradle — coordinate shape is
-          # 'com.github.joelwetzel:hubitat_ci:<sha>'.
-          PINNED=$(grep -oE "com\.github\.joelwetzel:hubitat_ci:[^'\"]+" build.gradle | head -1 | cut -d: -f3)
+          # Pinned coord from build.gradle — JitPack build-identifier shape is
+          # 'com.github.joelwetzel:hubitat_ci:master-<sha>-<build-number>'.
+          # Extract the <sha> portion for comparison against master HEAD.
+          COORD=$(grep -oE "com\.github\.joelwetzel:hubitat_ci:[^'\"]+" build.gradle | head -1 | cut -d: -f3)
+          PINNED=$(echo "$COORD" | sed -nE 's/^master-([a-f0-9]+)-[0-9]+$/\1/p')
           if [ -z "$PINNED" ]; then
-            echo "::error::Could not parse pinned com.github.joelwetzel:hubitat_ci SHA from build.gradle"
+            echo "::error::Could not parse pinned com.github.joelwetzel:hubitat_ci SHA from build.gradle (coord: $COORD)"
             exit 1
           fi
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,13 @@ dependencies {
     // Groovy, and is closest to Hubitat's runtime Groovy 2.4.
     testImplementation 'org.codehaus.groovy:groovy-all:2.5.23'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-2.5'
-    // joelwetzel/hubitat_ci pinned by JitPack's master-<sha>-<build> build
-    // identifier (reproducible, resolves instantly, avoids the read-timeout
-    // that 'master-SNAPSHOT' or a bare commit hash can trigger on first
-    // request). Bumped by tracking issues from
-    // .github/workflows/hubitat-ci-version-check.yml.
-    testImplementation 'com.github.joelwetzel:hubitat_ci:master-a62a351eed-1'
+    // joelwetzel/hubitat_ci pinned by commit SHA. JitPack's
+    // 'master-<sha>-<build>' form publishes the POM with version
+    // 'master-SNAPSHOT' (mismatch → Gradle rejects). The bare short-SHA
+    // form resolves cleanly once JitPack has built that commit — warmed
+    // via the api/builds endpoint before pushing. Bumped by tracking
+    // issues from .github/workflows/hubitat-ci-version-check.yml.
+    testImplementation 'com.github.joelwetzel:hubitat_ci:a62a351eed'
     // Required by Spock to Mock/Spy non-interface types (TestDevice, TestChildApp).
     // Spock 2.x can use either byte-buddy or cglib-nodep as its class-gen
     // backend; neither is a transitive dep of spock-core on the groovy-2.5 variant.

--- a/build.gradle
+++ b/build.gradle
@@ -4,27 +4,50 @@ plugins {
 
 repositories {
     mavenCentral()
-    // hubitat_ci is published to Azure Artifacts (publicly readable, no credentials needed).
-    // content { includeGroup } scopes the repo to just its group, which avoids
-    // dependency-confusion lookups against it for anything else (Gemini note).
+    // joelwetzel/hubitat_ci is an actively-maintained fork of biocomp/hubitat_ci
+    // (original upstream's last Maven publish: 2019). Consumed via JitPack —
+    // no auth, reproducible by commit SHA.
+    //
+    // Fork selection rationale (also considered eighty20results):
+    // - joelwetzel retains biocomp's public API exactly — drop-in for our
+    //   existing HarnessSpec, ToolSpecBase, and the ToolCreateRule /
+    //   ToolUpdateRule / RuleEngineSmoke specs that rely on addChildApp
+    //   and parent.findDevice method-missing dispatch.
+    // - eighty20results is on Groovy 3.0 (nice) but has substantive breaking
+    //   changes in the child-app handling path (requires a childAppResolver
+    //   closure, replaces parent's methodMissing, re-architects getChildApps)
+    //   that break three of our existing specs. Migration cost outweighs
+    //   the cosmetic benefit of dropping the --add-opens block, for now.
+    // - biocomp (the original) has been dormant on the Maven side since
+    //   2019 — staying on it blocks us from any of the Hubitat-runtime
+    //   compatibility fixes either fork has added since.
+    //
+    // joelwetzel also adds an integration-testing framework (time control,
+    // device fixtures, scheduler simulation) beyond biocomp's baseline,
+    // available if we want integration-style coverage later.
+    //
+    // Pinned by commit SHA since the fork doesn't cut release tags yet.
+    // Tracked by .github/workflows/hubitat-ci-version-check.yml.
     maven {
-        url 'https://biocomp.pkgs.visualstudio.com/HubitatCiRelease/_packaging/hubitat_ci_feed@Release/maven/v1'
+        url 'https://jitpack.io'
         content {
-            includeGroup 'me.biocomp.hubitat_ci'
+            includeGroup 'com.github.joelwetzel'
         }
     }
 }
 
 dependencies {
-    // groovy-all must match the version hubitat_ci was compiled against (2.5.x)
+    // groovy-all stays on 2.5 — matches joelwetzel's compiled-against
+    // Groovy, and is closest to Hubitat's runtime Groovy 2.4.
     testImplementation 'org.codehaus.groovy:groovy-all:2.5.23'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-2.5'
-    testImplementation 'me.biocomp.hubitat_ci:hubitat_ci:0.17'
+    // joelwetzel/hubitat_ci pinned by commit SHA. Bumped by tracking
+    // issues from .github/workflows/hubitat-ci-version-check.yml.
+    testImplementation 'com.github.joelwetzel:hubitat_ci:a62a351eed'
     // Required by Spock to Mock/Spy non-interface types (TestDevice, TestChildApp).
     // Spock 2.x can use either byte-buddy or cglib-nodep as its class-gen
-    // backend; neither is a transitive dep of spock-core on the groovy-2.5
-    // variant.
-    testImplementation 'net.bytebuddy:byte-buddy:1.14.18'
+    // backend; neither is a transitive dep of spock-core on the groovy-2.5 variant.
+    testImplementation 'net.bytebuddy:byte-buddy:1.18.8'
 }
 
 java {
@@ -40,14 +63,11 @@ test {
     // specs installing and uninstalling these at the same time would race.
     maxParallelForks = 1
     // Silence Groovy 2.5.23's reflective access under JDK 11+.
-    // We're pinned to Groovy 2.5 by hubitat_ci's compiled-against
-    // version; each --add-opens grants access to a java.base package
-    // that Groovy's CachedClass / CachedConstructor reflects into
-    // on initialization. Each suppression tends to reveal the next
-    // path the first time a spec exercises it — the set below covers
-    // the packages Groovy 2.5 is known to reach into. Add more as
-    // new warnings surface, or drop the whole block when hubitat_ci
-    // moves to Groovy 4.
+    // joelwetzel's fork stays on Groovy 2.5 to match Hubitat's runtime;
+    // each --add-opens grants access to a java.base package that Groovy's
+    // CachedClass / CachedConstructor reflects into on initialization.
+    // The set below covers the packages Groovy 2.5 is known to reach into.
+    // Drop the whole block if/when hubitat_ci moves to Groovy 3+.
     jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
             '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
             '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',

--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,12 @@ dependencies {
     // Groovy, and is closest to Hubitat's runtime Groovy 2.4.
     testImplementation 'org.codehaus.groovy:groovy-all:2.5.23'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-2.5'
-    // joelwetzel/hubitat_ci pinned by commit SHA. Bumped by tracking
-    // issues from .github/workflows/hubitat-ci-version-check.yml.
-    testImplementation 'com.github.joelwetzel:hubitat_ci:a62a351eed'
+    // joelwetzel/hubitat_ci pinned by JitPack's master-<sha>-<build> build
+    // identifier (reproducible, resolves instantly, avoids the read-timeout
+    // that 'master-SNAPSHOT' or a bare commit hash can trigger on first
+    // request). Bumped by tracking issues from
+    // .github/workflows/hubitat-ci-version-check.yml.
+    testImplementation 'com.github.joelwetzel:hubitat_ci:master-a62a351eed-1'
     // Required by Spock to Mock/Spy non-interface types (TestDevice, TestChildApp).
     // Spock 2.x can use either byte-buddy or cglib-nodep as its class-gen
     // backend; neither is a transitive dep of spock-core on the groovy-2.5 variant.


### PR DESCRIPTION
Supersedes #84.

## Why

biocomp/hubitat_ci — the dep we pinned in PR #81 — has been dormant since
2019 on the Maven side (latest upstream publish: v0.17, 2019-08-29). After
PR #81 and the related CI-warning work in PR #83, we were burning effort on
workarounds for that staleness (14 `--add-opens` entries, a version-check
workflow pointed at a feed that hasn't published in 6 years).

## Fork evaluation

| Fork | Last push | Groovy | Tags | Drop-in? | Trade-off |
|---|---|---|---|---|---|
| **joelwetzel** | 2026-03-20 | 2.5.4 | (no tags, pin by SHA) | **yes** | keep --add-opens |
| eighty20results | 2026-03-20 | 3.0.21 | v0.28.x releases | **no** — 3 specs fail | drop --add-opens |
| biocomp (current) | 2024-04 (2019 Maven) | 2.5.x | 0.17 only | n/a | dead dep |

### Why joelwetzel

- **Drop-in compatibility.** HarnessSpec, ToolSpecBase, PermissiveLog, and
  every spec under `src/test/groovy/` compile and run without changes.
- **Still actively maintained** (last push 2026-03-20, 127 commits beyond
  biocomp, version 0.49).
- **Adds an integration-testing framework** (time control, device fixtures,
  scheduler simulation) beyond biocomp's baseline — available if we later
  want integration-style coverage.
- **Groovy 2.5 matches Hubitat's runtime** (Groovy 2.4) more closely than
  eighty20results' 3.0. Edge-case syntax/semantic divergence is smaller.

### Why NOT eighty20results (despite Groovy 3)

Attempted the migration first; CI surfaced substantive breaking API changes:
- `HubitatAppSandbox.compile` now requires a `childAppResolver` closure
  → `ToolCreateRuleSpec` fails with `IllegalArgumentException: childAppResolver is required`.
- `InstalledAppWrapperImpl.methodMissing` throws instead of dispatching
  → `RuleEngineSmokeSpec` fails on `parent.findDevice(1)`.
- `getChildApps()` no longer routes through the AppExecutor mock
  → `ToolUpdateRuleSpec` fails with `Rule not found: 42` even when
    `childAppsList << mockChildApp` is populated.

Fixing those requires harness rework with uncertain scope (rewiring
child-app resolution through a new registry model, porting
`RuleEngineSmokeSpec` off method-missing dispatch, refactoring
`toolCreateRule`'s test path around the resolver requirement). The
Groovy 3.0 win is real but cosmetic for our current use; the
migration-cost blowup is not.

eighty20results remains a candidate for a future, focused migration
PR — once we have appetite for the harness-level changes.

### Why NOT biocomp (status quo)

Dormant upstream. No Hubitat-behavior fixes since 2019. `--add-opens`
workarounds pile up on modern JDKs. `hubitat-ci-version-check.yml` would
effectively be monitoring a dead feed.

## Groovy 2.4 (Hubitat) vs 2.5 (joelwetzel)

Hubitat runs Groovy 2.4.x (per the Hubitat community: platform 2.2.2
updated 2.4.10 → 2.4.19). Groovy 2.5 is a minor bump — mostly additive
features, no breaking changes for the simple scripting patterns Hubitat
scripts use. Safe to use 2.5 test-side.

## Changes

### `build.gradle`

- Replace Azure Artifacts Maven repo with `https://jitpack.io`
  (scoped to `com.github.joelwetzel`).
- Replace dep `me.biocomp.hubitat_ci:hubitat_ci:0.17` with
  `com.github.joelwetzel:hubitat_ci:a62a351eed` (pinned by commit SHA;
  no upstream tags yet).
- Bump `byte-buddy` 1.14.18 → 1.18.8 (stale patch, no Groovy coupling).
- Keep `groovy-all:2.5.23`, `spock-core:2.3-groovy-2.5`, and the
  `--add-opens` block from PR #83.

### `.github/dependabot.yml` (new — was in PR #84, rescoped here)

- `github-actions` weekly, grouped. Picks up the Node 20 → 24 action
  bumps that resolve the only remaining Unit Tests log warning.
- `gradle` monthly, grouped, with ignores for `groovy-all`
  minor+major, `spock-core` (variant-suffix pin), and
  `com.github.joelwetzel:hubitat_ci` (JitPack SHA managed by the
  workflow below).

### `.github/workflows/hubitat-ci-version-check.yml` (new — was in PR #84, rescoped here)

Weekly poll of `joelwetzel/hubitat_ci`'s master HEAD SHA. Parses the
pinned coord from `build.gradle`, compares against the GitHub API's
commit SHA, opens a tracking issue with a compare-view link and
up-to-20-commit summary when the pin is behind. De-dups across
open + closed issues.

## Verification

Unit Tests CI runs on this branch. Watching for:
1. JitPack-served `com.github.joelwetzel:hubitat_ci:a62a351eed` resolves
   and compiles.
2. Existing specs still pass (no harness changes needed for joelwetzel).
3. `--add-opens` block silences Groovy 2.5 reflection warnings as before.

## Close #84

PR #84's biocomp-oriented Dependabot config and Maven-metadata poller
are superseded by this PR. Close it once this lands.