### PR TITLE
docs: credit biocomp and joelwetzel for the test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1586,6 +1586,8 @@ MIT License - see [LICENSE](LICENSE)
 - Inspired by the [Model Context Protocol](https://modelcontextprotocol.io/)
 - Inspired by the [Home Assistant MCP](https://github.com/homeassistant-ai/ha-mcp/)
 - Thanks to the Hubitat community for documentation and examples
+- [biocomp/hubitat_ci](https://github.com/biocomp/hubitat_ci) ([@biocomp](https://github.com/biocomp)) — original Hubitat Groovy unit-testing framework our harness is built on (Apache 2.0)
+- [joelwetzel/hubitat_ci](https://github.com/joelwetzel/hubitat_ci) ([@joelwetzel](https://github.com/joelwetzel)) — actively-maintained fork of the above, consumed as our test dependency via JitPack
 - [@ashwinma14](https://github.com/ashwinma14) - Fix for StackOverflowError on app install ([#15](https://github.com/kingpanther13/Hubitat-local-MCP-server/pull/15))
 - [@level99](https://github.com/level99) - Enriched `list_devices` summary + server-side `filter` arg ([#63](https://github.com/kingpanther13/Hubitat-local-MCP-server/pull/63)) and `get_hub_logs` ordering fix + `deviceId`/`appId` server-side scope ([#64](https://github.com/kingpanther13/Hubitat-local-MCP-server/pull/64))
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,9 +1,9 @@
 # Testing
 
-Groovy unit tests run under Spock + [HubitatCI](https://github.com/biocomp/hubitat_ci) via the Gradle wrapper. CI runs `./gradlew test` on every PR and push to `main` (`.github/workflows/unit-tests.yml`).
+Groovy unit tests run under Spock + HubitatCI via the Gradle wrapper. CI runs `./gradlew test` on every PR and push to `main` (`.github/workflows/unit-tests.yml`).
 
 - **Test framework:** Spock 2.3 on Groovy 2.5 (matches the Hubitat hub runtime)
-- **Hubitat sandbox:** HubitatCI 0.17 from `me.biocomp.hubitat_ci:hubitat_ci:0.17` (Azure Artifacts public feed)
+- **Hubitat sandbox:** [joelwetzel/hubitat_ci](https://github.com/joelwetzel/hubitat_ci) — an actively-maintained fork of the original [biocomp/hubitat_ci](https://github.com/biocomp/hubitat_ci) (Apache 2.0). Consumed as `com.github.joelwetzel:hubitat_ci:<sha>` via JitPack; the pinned SHA in `build.gradle` is bumped by tracking issues from `.github/workflows/hubitat-ci-version-check.yml`.
 - **JVM:** OpenJDK 17 in CI; locally, JDK 11+ via the Gradle toolchain
 - **Build:** Gradle 8.10 via wrapper (`./gradlew test`)
 


### PR DESCRIPTION
Two small doc updates the earlier harness work missed:

- **README.md Acknowledgments** — add bullets for
  [biocomp/hubitat_ci](https://github.com/biocomp/hubitat_ci) (original
  Apache 2.0 framework our harness is built on) and
  [joelwetzel/hubitat_ci](https://github.com/joelwetzel/hubitat_ci)
  (the actively-maintained fork we consume via JitPack since PR #85).

- **docs/testing.md** — update the testing framework reference to
  point at joelwetzel's fork (via JitPack coord) while linking back
  to biocomp as original. Fixes stale references to HubitatCI 0.17
  on the Azure Artifacts feed that are no longer accurate.

Docs only; no code paths touched.