### PR TITLE
build: assignment syntax for url + exceptionFormat (Gradle 10 prep)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
     // Pinned by commit SHA since the fork doesn't cut release tags yet.
     // Tracked by .github/workflows/hubitat-ci-version-check.yml.
     maven {
-        url 'https://jitpack.io'
+        url = 'https://jitpack.io'
         content {
             includeGroup 'com.github.joelwetzel'
         }
@@ -88,6 +88,6 @@ test {
             '--add-opens=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED'
     testLogging {
         events 'passed', 'skipped', 'failed'
-        exceptionFormat 'full'
+        exceptionFormat = 'full'
     }
 }


### PR DESCRIPTION
Two-character fix. PR #86 bumped Gradle 8.10 → 9.4.1, which deprecated
the Groovy-DSL space-assignment syntax (`propName value`) in favour of
explicit assignment (`propName = value`). Our `build.gradle` had two
instances that now print as deprecation warnings on every Unit Tests run:

```
url 'https://jitpack.io'   →   url = 'https://jitpack.io'
exceptionFormat 'full'     →   exceptionFormat = 'full'
```

No semantic change — Gradle resolves both forms identically today.
Clears the deprecation noise from the CI log, and means the next
major-Gradle Dependabot bump (9.x → 10.x, when it removes the old
syntax entirely) doesn't fail the build.