### PR TITLE
fix(lint): scan GString interpolations for sandbox violations

### DIFF
--- a/.github/workflows/sandbox-lint.yml
+++ b/.github/workflows/sandbox-lint.yml
@@ -15,4 +15,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
-      - run: python tests/sandbox_lint.py
+      - name: Sandbox-lint self-test
+        run: python tests/sandbox_lint.py --self-test
+      - name: Sandbox-lint scan
+        run: python tests/sandbox_lint.py

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -125,12 +125,18 @@ RULES = [
 
 
 def strip_comments_and_strings(source: str) -> list[str]:
-    """Return lines with comments and string contents replaced.
+    """Return lines with comments and literal string contents replaced.
 
     - Block comments (/* ... */) → replaced with blank lines (preserves line count)
     - Line comments (// ...) → stripped from end of line
-    - String literal contents → replaced with __STR__ placeholder
-    - Handles triple-quoted strings, double-quoted, and single-quoted strings
+    - Single-quoted strings → contents replaced with spaces (not GStrings in Groovy)
+    - Double-quoted strings (GStrings) → literal text replaced with spaces,
+      but ${...} interpolation bodies are preserved verbatim so rules scan
+      the Groovy expression they contain (e.g. ${foo.getClass()} still
+      triggers SANDBOX-001).
+    - Triple-quoted single-quoted strings → fully blanked
+    - Triple-quoted double-quoted strings → same GString treatment as "..."
+      when closing on the same line; multi-line bodies fall back to blanked
     """
     lines = source.split("\n")
     result: list[str] = []
@@ -163,43 +169,78 @@ def strip_comments_and_strings(source: str) -> list[str]:
             # Line comment
             elif line[i : i + 2] == "//":
                 break
-            # Triple-quoted string (Groovy)
-            elif line[i : i + 3] in ('"""', "'''"):
-                quote = line[i : i + 3]
-                cleaned.append(quote[0] + "__STR__" + quote[0])
-                j = i + 3
-                # Find closing triple quote — may span lines but we handle
-                # single-line case; multi-line triple quotes rarely contain
-                # sandbox-violating patterns
-                end = line.find(quote, j)
+            # Triple-double-quoted GString (may contain ${...})
+            elif line[i : i + 3] == '"""':
+                end = line.find('"""', i + 3)
                 if end != -1:
+                    cleaned.append("   ")
+                    cleaned.append(_scrub_gstring_body(line[i + 3 : end]))
+                    cleaned.append("   ")
                     i = end + 3
                 else:
+                    # Multi-line triple-quoted body — rare; fall back to blanks
+                    cleaned.append(" " * (len(line) - i))
                     i = len(line)
-            # Double-quoted string
+            # Triple-single-quoted (plain string, no interpolation)
+            elif line[i : i + 3] == "'''":
+                end = line.find("'''", i + 3)
+                if end != -1:
+                    cleaned.append(" " * (end + 3 - i))
+                    i = end + 3
+                else:
+                    cleaned.append(" " * (len(line) - i))
+                    i = len(line)
+            # Double-quoted GString — preserve ${...} bodies, blank literal text
             elif line[i] == '"':
-                cleaned.append('"__STR__"')
+                cleaned.append(" ")  # opening quote
                 j = i + 1
                 while j < len(line):
                     if line[j] == "\\" and j + 1 < len(line):
+                        cleaned.append("  ")
                         j += 2
                     elif line[j] == '"':
+                        cleaned.append(" ")
                         j += 1
                         break
+                    elif line[j] == "$" and j + 1 < len(line) and line[j + 1] == "{":
+                        # Preserve interpolation body verbatim so rules can
+                        # scan the Groovy expression inside.
+                        depth = 1
+                        k = j + 2
+                        cleaned.append("  ")  # ${
+                        while k < len(line) and depth > 0:
+                            if line[k] == "{":
+                                depth += 1
+                                cleaned.append(line[k])
+                            elif line[k] == "}":
+                                depth -= 1
+                                if depth == 0:
+                                    cleaned.append(" ")  # closing }
+                                    k += 1
+                                    break
+                                cleaned.append(line[k])
+                            else:
+                                cleaned.append(line[k])
+                            k += 1
+                        j = k
                     else:
+                        cleaned.append(" ")
                         j += 1
                 i = j
-            # Single-quoted string
+            # Single-quoted string — plain string in Groovy, no interpolation
             elif line[i] == "'":
-                cleaned.append("'__STR__'")
+                cleaned.append(" ")
                 j = i + 1
                 while j < len(line):
                     if line[j] == "\\" and j + 1 < len(line):
+                        cleaned.append("  ")
                         j += 2
                     elif line[j] == "'":
+                        cleaned.append(" ")
                         j += 1
                         break
                     else:
+                        cleaned.append(" ")
                         j += 1
                 i = j
             else:
@@ -209,6 +250,40 @@ def strip_comments_and_strings(source: str) -> list[str]:
         result.append("".join(cleaned))
 
     return result
+
+
+def _scrub_gstring_body(body: str) -> str:
+    """Within a triple-double-quoted GString body, blank literal text but
+    keep ${...} interpolations verbatim (same treatment as a "..." GString)."""
+    out = []
+    i = 0
+    while i < len(body):
+        if body[i] == "\\" and i + 1 < len(body):
+            out.append("  ")
+            i += 2
+        elif body[i] == "$" and i + 1 < len(body) and body[i + 1] == "{":
+            depth = 1
+            k = i + 2
+            out.append("  ")
+            while k < len(body) and depth > 0:
+                if body[k] == "{":
+                    depth += 1
+                    out.append(body[k])
+                elif body[k] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        out.append(" ")
+                        k += 1
+                        break
+                    out.append(body[k])
+                else:
+                    out.append(body[k])
+                k += 1
+            i = k
+        else:
+            out.append(" ")
+            i += 1
+    return "".join(out)
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +429,99 @@ def format_annotation(f: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
+SELF_TEST_CASES = [
+    # (description, groovy source, list of (rule_id, should_match))
+    (
+        "getClass() inside a GString interpolation is flagged",
+        'log.warn "type=${obj?.getClass()?.simpleName}"',
+        [("SANDBOX-001", True)],
+    ),
+    (
+        "getClass() as plain string literal content is NOT flagged",
+        'log.warn "text mentioning getClass() as example"',
+        [("SANDBOX-001", False)],
+    ),
+    (
+        "getClass() inside a single-quoted string is NOT flagged (not a GString)",
+        "log.warn 'type=${obj?.getClass()?.simpleName}'",
+        [("SANDBOX-001", False)],
+    ),
+    (
+        "getClass() inside a triple-double-quoted GString interpolation is flagged",
+        'def s = """prefix ${obj.getClass()} suffix"""',
+        [("SANDBOX-001", True)],
+    ),
+    (
+        "Bare getClass() call is flagged",
+        "def t = obj.getClass().simpleName",
+        [("SANDBOX-001", True)],
+    ),
+    (
+        "Nested braces inside a GString interpolation don't break the scanner",
+        'def s = "count=${list.findAll { it.getClass() }.size()}"',
+        [("SANDBOX-001", True)],
+    ),
+    (
+        "Locale inside a GString interpolation is flagged",
+        'log.info "loc=${Locale.default}"',
+        [("SANDBOX-002", True)],
+    ),
+    (
+        "Escaped dollar does not open an interpolation",
+        'def s = "literal \\${getClass()}"',
+        [("SANDBOX-001", False)],
+    ),
+]
+
+
+def run_self_test() -> int:
+    """Scan inline fixtures and confirm each rule triggers where expected."""
+    from tempfile import NamedTemporaryFile
+
+    failures = 0
+    for i, (desc, source, expected) in enumerate(SELF_TEST_CASES, start=1):
+        with NamedTemporaryFile(
+            mode="w", suffix=".groovy", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(source + "\n")
+            tmp = Path(fh.name)
+        try:
+            stripped = strip_comments_and_strings(source)
+            # Build a findings-like set from the stripped output
+            hits = {
+                rule["id"]
+                for line in stripped
+                for rule in RULES
+                if re.search(rule["pattern"], line)
+            }
+            for rule_id, should_match in expected:
+                matched = rule_id in hits
+                if matched != should_match:
+                    failures += 1
+                    print(
+                        f"SELF-TEST FAIL [{i}] {desc}\n"
+                        f"  rule={rule_id} expected={'hit' if should_match else 'miss'} "
+                        f"actual={'hit' if matched else 'miss'}\n"
+                        f"  source: {source!r}\n"
+                        f"  stripped: {stripped!r}"
+                    )
+        finally:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+    if failures:
+        print(f"--- {failures} self-test failure(s) ---")
+        return 1
+    print(f"Self-test: {len(SELF_TEST_CASES)} case(s) passed.")
+    return 0
+
+
 def main() -> int:
+    if "--self-test" in sys.argv[1:]:
+        return run_self_test()
+
     all_findings: list[dict] = []
 
     # Scan groovy files

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -124,19 +124,92 @@ RULES = [
 # ---------------------------------------------------------------------------
 
 
+def _consume_gstring_interpolation(text: str, start: int) -> tuple[str, int]:
+    """Walk from `start` (index of `$` in `${`) to the matching `}`, returning
+    (preserved_text, index_past_close).
+
+    The body is preserved verbatim so downstream regex rules scan the Groovy
+    expression, except that nested string literals inside the body have their
+    contents blanked (so a `}` inside `"literal }"` doesn't close the
+    interpolation early, and a stray `getClass()` inside a nested literal
+    doesn't trigger a false positive).
+
+    Assumes `text[start] == '$'` and `text[start+1] == '{'`.
+    """
+    out = ["  "]  # ${
+    depth = 1
+    k = start + 2
+    n = len(text)
+    while k < n and depth > 0:
+        ch = text[k]
+        if ch == "{":
+            depth += 1
+            out.append(ch)
+            k += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                out.append(" ")  # closing }
+                k += 1
+                break
+            out.append(ch)
+            k += 1
+        elif ch == '"' or ch == "'":
+            # Nested string literal inside the interpolation body. Skip past
+            # its contents (respecting escapes) so embedded `}` characters
+            # don't decrement our depth counter and stray sandbox-forbidden
+            # names inside literal text don't trigger false positives.
+            out.append(" ")
+            k += 1
+            while k < n:
+                if text[k] == "\\" and k + 1 < n:
+                    out.append("  ")
+                    k += 2
+                elif text[k] == ch:
+                    out.append(" ")
+                    k += 1
+                    break
+                else:
+                    out.append(" ")
+                    k += 1
+        elif ch == "\\" and k + 1 < n:
+            out.append(str(text[k]) + str(text[k + 1]))
+            k += 2
+        else:
+            out.append(ch)
+            k += 1
+    return "".join(out), k
+
+
 def strip_comments_and_strings(source: str) -> list[str]:
     """Return lines with comments and literal string contents replaced.
 
-    - Block comments (/* ... */) → replaced with blank lines (preserves line count)
+    Behavior:
+    - Block comments (/* ... */) → replaced with spaces (preserves line count)
     - Line comments (// ...) → stripped from end of line
-    - Single-quoted strings → contents replaced with spaces (not GStrings in Groovy)
-    - Double-quoted strings (GStrings) → literal text replaced with spaces,
-      but ${...} interpolation bodies are preserved verbatim so rules scan
-      the Groovy expression they contain (e.g. ${foo.getClass()} still
-      triggers SANDBOX-001).
-    - Triple-quoted single-quoted strings → fully blanked
-    - Triple-quoted double-quoted strings → same GString treatment as "..."
+    - Single-quoted strings ('...') → fully blanked (not GStrings in Groovy)
+    - Triple-single-quoted strings ('''...''') → fully blanked
+    - Double-quoted strings ("...") → literal text blanked, ${...}
+      interpolation bodies preserved so rules scan the Groovy expression
+      (e.g. ${foo.getClass()} still triggers SANDBOX-001)
+    - Triple-double-quoted strings (\"\"\"...\"\"\") → same GString treatment
       when closing on the same line; multi-line bodies fall back to blanked
+
+    Invariants:
+    - Output preserves the column and line count of the input so finding
+      line numbers match the original source.
+    - Spaces (not sentinel tokens like __STR__) are used so downstream regex
+      rules can't accidentally match the sentinel itself.
+
+    Known limitations (deliberate, not bugs):
+    - Bare `$identifier[.prop...]` GString form (no braces) is NOT preserved;
+      only `${...}` interpolations are. Groovy allows `"x=$foo.getClass"` as
+      a property-access GString, but the bare form is rare in practice and
+      ambiguous to scan. See the self-test fixture for pinned behavior.
+    - Slashy strings (/.../) and dollar-slashy ($/.../$/) are not recognized
+      and will be scanned as raw source. Rare in real Hubitat code.
+    - Multi-line triple-quoted bodies (opening and closing on different
+      lines) are blanked wholesale.
     """
     lines = source.split("\n")
     result: list[str] = []
@@ -203,26 +276,8 @@ def strip_comments_and_strings(source: str) -> list[str]:
                         j += 1
                         break
                     elif line[j] == "$" and j + 1 < len(line) and line[j + 1] == "{":
-                        # Preserve interpolation body verbatim so rules can
-                        # scan the Groovy expression inside.
-                        depth = 1
-                        k = j + 2
-                        cleaned.append("  ")  # ${
-                        while k < len(line) and depth > 0:
-                            if line[k] == "{":
-                                depth += 1
-                                cleaned.append(line[k])
-                            elif line[k] == "}":
-                                depth -= 1
-                                if depth == 0:
-                                    cleaned.append(" ")  # closing }
-                                    k += 1
-                                    break
-                                cleaned.append(line[k])
-                            else:
-                                cleaned.append(line[k])
-                            k += 1
-                        j = k
+                        body, j = _consume_gstring_interpolation(line, j)
+                        cleaned.append(body)
                     else:
                         cleaned.append(" ")
                         j += 1
@@ -253,33 +308,20 @@ def strip_comments_and_strings(source: str) -> list[str]:
 
 
 def _scrub_gstring_body(body: str) -> str:
-    """Within a triple-double-quoted GString body, blank literal text but
-    keep ${...} interpolations verbatim (same treatment as a "..." GString)."""
+    """Blank literal text in a triple-double-quoted GString body while
+    preserving ${...} interpolations verbatim. Shares nested-string-aware
+    brace handling with the single-line GString walker via
+    _consume_gstring_interpolation."""
     out = []
     i = 0
-    while i < len(body):
-        if body[i] == "\\" and i + 1 < len(body):
+    n = len(body)
+    while i < n:
+        if body[i] == "\\" and i + 1 < n:
             out.append("  ")
             i += 2
-        elif body[i] == "$" and i + 1 < len(body) and body[i + 1] == "{":
-            depth = 1
-            k = i + 2
-            out.append("  ")
-            while k < len(body) and depth > 0:
-                if body[k] == "{":
-                    depth += 1
-                    out.append(body[k])
-                elif body[k] == "}":
-                    depth -= 1
-                    if depth == 0:
-                        out.append(" ")
-                        k += 1
-                        break
-                    out.append(body[k])
-                else:
-                    out.append(body[k])
-                k += 1
-            i = k
+        elif body[i] == "$" and i + 1 < n and body[i + 1] == "{":
+            preserved, i = _consume_gstring_interpolation(body, i)
+            out.append(preserved)
         else:
             out.append(" ")
             i += 1
@@ -447,6 +489,11 @@ SELF_TEST_CASES = [
         [("SANDBOX-001", False)],
     ),
     (
+        "getClass() inside a triple-single-quoted string is NOT flagged",
+        "def s = '''text ${obj.getClass()} here'''",
+        [("SANDBOX-001", False)],
+    ),
+    (
         "getClass() inside a triple-double-quoted GString interpolation is flagged",
         'def s = """prefix ${obj.getClass()} suffix"""',
         [("SANDBOX-001", True)],
@@ -457,9 +504,29 @@ SELF_TEST_CASES = [
         [("SANDBOX-001", True)],
     ),
     (
-        "Nested braces inside a GString interpolation don't break the scanner",
+        "Nested closure braces inside a GString interpolation don't break the scanner",
         'def s = "count=${list.findAll { it.getClass() }.size()}"',
         [("SANDBOX-001", True)],
+    ),
+    (
+        "Nested double-quoted string inside a GString interpolation is scanned correctly",
+        'log.info "${ "literal".getClass() }"',
+        [("SANDBOX-001", True)],
+    ),
+    (
+        "Brace inside a nested string inside a GString does not close the interpolation early",
+        'log.info "${foo.replace(\'}\', \'\').getClass()}"',
+        [("SANDBOX-001", True)],
+    ),
+    (
+        "getClass() inside a nested string inside an interpolation is NOT flagged",
+        'def s = "ok=${foo.toString().replace("getClass()", "X")}"',
+        [("SANDBOX-001", False)],
+    ),
+    (
+        "Back-to-back interpolations are both scanned",
+        'log.warn "${a.getClass()}${Locale.default}"',
+        [("SANDBOX-001", True), ("SANDBOX-002", True)],
     ),
     (
         "Locale inside a GString interpolation is flagged",
@@ -471,45 +538,49 @@ SELF_TEST_CASES = [
         'def s = "literal \\${getClass()}"',
         [("SANDBOX-001", False)],
     ),
+    (
+        "Line comment containing GString-like text is NOT flagged",
+        '// this is a comment mentioning "${foo.getClass()}"',
+        [("SANDBOX-001", False)],
+    ),
+    (
+        "Block comment containing GString-like text is NOT flagged",
+        '/* "${foo.getClass()}" example */',
+        [("SANDBOX-001", False)],
+    ),
+    (
+        # Known limitation: the bare `$var.prop` GString form without braces
+        # is not preserved. Pinned as a miss so any future change is
+        # intentional. Groovy allows this form only for property access.
+        "Bare $var.getClass GString form is a known false-negative (not flagged)",
+        'log.warn "type=$obj.getClass"',
+        [("SANDBOX-001", False)],
+    ),
 ]
 
 
 def run_self_test() -> int:
     """Scan inline fixtures and confirm each rule triggers where expected."""
-    from tempfile import NamedTemporaryFile
-
     failures = 0
     for i, (desc, source, expected) in enumerate(SELF_TEST_CASES, start=1):
-        with NamedTemporaryFile(
-            mode="w", suffix=".groovy", delete=False, encoding="utf-8"
-        ) as fh:
-            fh.write(source + "\n")
-            tmp = Path(fh.name)
-        try:
-            stripped = strip_comments_and_strings(source)
-            # Build a findings-like set from the stripped output
-            hits = {
-                rule["id"]
-                for line in stripped
-                for rule in RULES
-                if re.search(rule["pattern"], line)
-            }
-            for rule_id, should_match in expected:
-                matched = rule_id in hits
-                if matched != should_match:
-                    failures += 1
-                    print(
-                        f"SELF-TEST FAIL [{i}] {desc}\n"
-                        f"  rule={rule_id} expected={'hit' if should_match else 'miss'} "
-                        f"actual={'hit' if matched else 'miss'}\n"
-                        f"  source: {source!r}\n"
-                        f"  stripped: {stripped!r}"
-                    )
-        finally:
-            try:
-                tmp.unlink()
-            except OSError:
-                pass
+        stripped = strip_comments_and_strings(source)
+        hits = {
+            rule["id"]
+            for line in stripped
+            for rule in RULES
+            if re.search(rule["pattern"], line)
+        }
+        for rule_id, should_match in expected:
+            matched = rule_id in hits
+            if matched != should_match:
+                failures += 1
+                print(
+                    f"SELF-TEST FAIL [{i}] {desc}\n"
+                    f"  rule={rule_id} expected={'hit' if should_match else 'miss'} "
+                    f"actual={'hit' if matched else 'miss'}\n"
+                    f"  source: {source!r}\n"
+                    f"  stripped: {stripped!r}"
+                )
 
     if failures:
         print(f"--- {failures} self-test failure(s) ---")

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -52,8 +52,10 @@ VERSION_SOURCES = {
 
 RULES = [
     {
+        # Match both `getClass()` invocations and bare property-access form
+        # (`obj.getClass` in a GString triggers the no-arg method at runtime).
         "id": "SANDBOX-001",
-        "pattern": r"\bgetClass\s*\(",
+        "pattern": r"\bgetClass\b",
         "message": "getClass() blocked in Hubitat sandbox",
         "severity": "error",
     },
@@ -124,6 +126,41 @@ RULES = [
 # ---------------------------------------------------------------------------
 
 
+_BARE_GSTRING_IDENT_START = re.compile(r"[A-Za-z_]")
+_BARE_GSTRING_IDENT_CHAR = re.compile(r"[A-Za-z0-9_]")
+
+
+def _consume_bare_gstring_var(text: str, start: int) -> tuple[str, int]:
+    """Consume a bare `$identifier[.identifier]*` GString reference.
+
+    Assumes `text[start] == '$'` and `text[start + 1]` is an identifier
+    start character. Returns (preserved_text, index_past_end). The leading
+    `$` is blanked (we only care about what follows for rule matching) but
+    the identifier chain is preserved verbatim so rules like SANDBOX-001
+    can match `$foo.getClass` (a legal bare-form Groovy property access
+    that triggers the no-arg method at runtime).
+    """
+    n = len(text)
+    out = [" "]  # blank the $
+    k = start + 1
+    # First identifier
+    while k < n and _BARE_GSTRING_IDENT_CHAR.match(text[k]):
+        out.append(text[k])
+        k += 1
+    # Subsequent .identifier segments
+    while (
+        k + 1 < n
+        and text[k] == "."
+        and _BARE_GSTRING_IDENT_START.match(text[k + 1])
+    ):
+        out.append(".")
+        k += 1
+        while k < n and _BARE_GSTRING_IDENT_CHAR.match(text[k]):
+            out.append(text[k])
+            k += 1
+    return "".join(out), k
+
+
 def _consume_gstring_interpolation(text: str, start: int) -> tuple[str, int]:
     """Walk from `start` (index of `$` in `${`) to the matching `}`, returning
     (preserved_text, index_past_close).
@@ -189,9 +226,10 @@ def strip_comments_and_strings(source: str) -> list[str]:
     - Line comments (// ...) → stripped from end of line
     - Single-quoted strings ('...') → fully blanked (not GStrings in Groovy)
     - Triple-single-quoted strings ('''...''') → fully blanked
-    - Double-quoted strings ("...") → literal text blanked, ${...}
-      interpolation bodies preserved so rules scan the Groovy expression
-      (e.g. ${foo.getClass()} still triggers SANDBOX-001)
+    - Double-quoted strings ("...") → literal text blanked; ${...}
+      interpolation bodies AND bare $identifier[.prop...] references are
+      preserved so rules scan the Groovy expression (e.g. ${foo.getClass()}
+      and $foo.getClass both trigger SANDBOX-001)
     - Triple-double-quoted strings (\"\"\"...\"\"\") → same GString treatment
       when closing on the same line; multi-line bodies fall back to blanked
 
@@ -202,12 +240,11 @@ def strip_comments_and_strings(source: str) -> list[str]:
       rules can't accidentally match the sentinel itself.
 
     Known limitations (deliberate, not bugs):
-    - Bare `$identifier[.prop...]` GString form (no braces) is NOT preserved;
-      only `${...}` interpolations are. Groovy allows `"x=$foo.getClass"` as
-      a property-access GString, but the bare form is rare in practice and
-      ambiguous to scan. See the self-test fixture for pinned behavior.
     - Slashy strings (/.../) and dollar-slashy ($/.../$/) are not recognized
-      and will be scanned as raw source. Rare in real Hubitat code.
+      as strings — their content is scanned as raw source. Rare in real
+      Hubitat code; the only existing use is a bare Pattern literal with no
+      interpolation. False positives would require literal sandbox-forbidden
+      names inside a regex body, which is implausible.
     - Multi-line triple-quoted bodies (opening and closing on different
       lines) are blanked wholesale.
     """
@@ -278,6 +315,13 @@ def strip_comments_and_strings(source: str) -> list[str]:
                     elif line[j] == "$" and j + 1 < len(line) and line[j + 1] == "{":
                         body, j = _consume_gstring_interpolation(line, j)
                         cleaned.append(body)
+                    elif (
+                        line[j] == "$"
+                        and j + 1 < len(line)
+                        and _BARE_GSTRING_IDENT_START.match(line[j + 1])
+                    ):
+                        body, j = _consume_bare_gstring_var(line, j)
+                        cleaned.append(body)
                     else:
                         cleaned.append(" ")
                         j += 1
@@ -309,9 +353,9 @@ def strip_comments_and_strings(source: str) -> list[str]:
 
 def _scrub_gstring_body(body: str) -> str:
     """Blank literal text in a triple-double-quoted GString body while
-    preserving ${...} interpolations verbatim. Shares nested-string-aware
-    brace handling with the single-line GString walker via
-    _consume_gstring_interpolation."""
+    preserving ${...} interpolations and bare `$identifier[.prop...]`
+    references. Shares nested-string-aware brace handling with the
+    single-line GString walker via _consume_gstring_interpolation."""
     out = []
     i = 0
     n = len(body)
@@ -321,6 +365,13 @@ def _scrub_gstring_body(body: str) -> str:
             i += 2
         elif body[i] == "$" and i + 1 < n and body[i + 1] == "{":
             preserved, i = _consume_gstring_interpolation(body, i)
+            out.append(preserved)
+        elif (
+            body[i] == "$"
+            and i + 1 < n
+            and _BARE_GSTRING_IDENT_START.match(body[i + 1])
+        ):
+            preserved, i = _consume_bare_gstring_var(body, i)
             out.append(preserved)
         else:
             out.append(" ")
@@ -333,28 +384,38 @@ def _scrub_gstring_body(body: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def scan_file(filepath: Path) -> list[dict]:
-    """Scan a single groovy file for sandbox anti-patterns."""
+def scan_source(source: str, display_path: str) -> list[dict]:
+    """Scan Groovy source text for sandbox anti-patterns.
+
+    Separated from scan_file so the self-test can exercise the same code
+    path without touching disk.
+    """
     findings = []
-    source = filepath.read_text(encoding="utf-8", errors="replace")
     stripped_lines = strip_comments_and_strings(source)
-    rel_path = filepath.relative_to(REPO_ROOT)
+    source_lines = source.split("\n")
 
     for line_num, line in enumerate(stripped_lines, start=1):
         for rule in RULES:
             if re.search(rule["pattern"], line):
                 findings.append(
                     {
-                        "file": str(rel_path),
+                        "file": display_path,
                         "line": line_num,
                         "rule": rule["id"],
                         "message": rule["message"],
                         "severity": rule["severity"],
-                        "source": source.split("\n")[line_num - 1].strip(),
+                        "source": source_lines[line_num - 1].strip(),
                     }
                 )
 
     return findings
+
+
+def scan_file(filepath: Path) -> list[dict]:
+    """Scan a single groovy file for sandbox anti-patterns."""
+    source = filepath.read_text(encoding="utf-8", errors="replace")
+    rel_path = str(filepath.relative_to(REPO_ROOT))
+    return scan_source(source, rel_path)
 
 
 # ---------------------------------------------------------------------------
@@ -549,31 +610,45 @@ SELF_TEST_CASES = [
         [("SANDBOX-001", False)],
     ),
     (
-        # Known limitation: the bare `$var.prop` GString form without braces
-        # is not preserved. Pinned as a miss so any future change is
-        # intentional. Groovy allows this form only for property access.
-        "Bare $var.getClass GString form is a known false-negative (not flagged)",
+        # Groovy's bare-form GString supports `$identifier[.prop...]` for
+        # property access. `$foo.getClass` (no parens) is legal and triggers
+        # the no-arg method at runtime, so the sandbox restriction applies.
+        "Bare $obj.getClass GString form is flagged",
         'log.warn "type=$obj.getClass"',
+        [("SANDBOX-001", True)],
+    ),
+    (
+        "Bare $var reference without a forbidden identifier is NOT flagged",
+        'log.warn "name=$user.email"',
+        [("SANDBOX-001", False), ("SANDBOX-002", False)],
+    ),
+    (
+        "Bare $var inside a single-quoted string is NOT expanded (still a miss)",
+        "log.warn 'type=$obj.getClass'",
         [("SANDBOX-001", False)],
+    ),
+    (
+        "Bare $Locale.default in an interpolation is flagged",
+        'log.info "loc=$Locale.default"',
+        [("SANDBOX-002", True)],
     ),
 ]
 
 
 def run_self_test() -> int:
-    """Scan inline fixtures and confirm each rule triggers where expected."""
+    """Scan inline fixtures through scan_source and confirm each rule
+    triggers where expected. Uses scan_source (not strip_comments_and_strings
+    + inline rule loop) so the self-test exercises the same code path
+    CI uses for real files."""
     failures = 0
     for i, (desc, source, expected) in enumerate(SELF_TEST_CASES, start=1):
-        stripped = strip_comments_and_strings(source)
-        hits = {
-            rule["id"]
-            for line in stripped
-            for rule in RULES
-            if re.search(rule["pattern"], line)
-        }
+        findings = scan_source(source, f"<self-test case {i}>")
+        hits = {f["rule"] for f in findings}
         for rule_id, should_match in expected:
             matched = rule_id in hits
             if matched != should_match:
                 failures += 1
+                stripped = strip_comments_and_strings(source)
                 print(
                     f"SELF-TEST FAIL [{i}] {desc}\n"
                     f"  rule={rule_id} expected={'hit' if should_match else 'miss'} "


### PR DESCRIPTION
## Summary

`sandbox_lint.py` stripped all string contents before running its regex rules, which meant violations inside GString `${...}` interpolations were silently skipped. GString interpolations are evaluated as Groovy at runtime, so an expression like `"type=${rawKey?.getClass()?.simpleName}"` compiles fine, passes lint, and then raises `SecurityException` on a real hub.

Found during PR #79 review: `hubitat-mcp-server.groovy:7761` (on the PR branch) had exactly this shape and the existing linter missed it.

## Changes

- **Stripper now preserves `${...}` interpolation bodies** for double-quoted and triple-double-quoted strings, blanking only the literal text. Single-quoted strings are still fully blanked (Groovy single-quotes aren't GStrings).
- Respects nested braces inside interpolations (closures, method chains like `${list.findAll { it.getClass() }.size()}`).
- Respects escaped `\${` as literal text (no interpolation opened).
- **New `--self-test` mode** with 8 fixture cases pinning the intended behavior:
  - `getClass()` in a `"..."` GString → flagged
  - `getClass()` in a `"""..."""` GString → flagged
  - `getClass()` in a `'...'` single-quote → NOT flagged (not a GString)
  - `getClass()` as plain literal text in a string → NOT flagged
  - Nested closure inside interpolation → correctly scanned
  - `Locale.default` inside an interpolation → flagged (SANDBOX-002)
  - Escaped `\${...}` → NOT flagged
  - Bare `obj.getClass()` call → still flagged (regression guard)
- `.github/workflows/sandbox-lint.yml` runs `--self-test` before the main scan.

## Verified

- Against `main`: clean (0 errors, 0 warnings) — no new violations surface.
- Against PR #79 head (`fbd5385`): now flags `hubitat-mcp-server.groovy:7761` with `[SANDBOX-001] getClass() blocked in Hubitat sandbox` — the original motivation for this change.
- `python tests/sandbox_lint.py --self-test` → all 8 cases pass.

## Test plan

- [ ] CI: sandbox-lint workflow runs `--self-test` then `scan`, both green on this branch.
- [ ] After merge, PR #79 (if rebased on main) will now surface the `:7761` regression automatically.