### PR TITLE
perf(test): cache HubitatAppSandbox parse per spec class (5m → 1.5m)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,9 +21,11 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
       - name: Run unit tests
         run: ./gradlew test --info --warning-mode all
-      - name: Upload test report on failure
-        if: failure()
+      - name: Upload test report
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-report
-          path: build/reports/tests/test/
+          path: |
+            build/reports/tests/test/
+            build/test-results/test/

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,10 @@ test {
     // specs installing and uninstalling these at the same time would race.
     maxParallelForks = 1
     testLogging {
-        events 'passed', 'skipped', 'failed'
+        // Include 'started' so CI streams per-test output live — without
+        // it, a slow spec leaves the runner silent for minutes and the
+        // next regression in harness overhead is invisible in the job log.
+        events 'started', 'passed', 'skipped', 'failed'
         exceptionFormat = 'full'
     }
 }

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -5,36 +5,53 @@ import me.biocomp.hubitat_ci.api.common_api.Location
 import me.biocomp.hubitat_ci.api.common_api.Log
 import me.biocomp.hubitat_ci.app.HubitatAppSandbox
 import me.biocomp.hubitat_ci.validation.Flags
+import spock.lang.Shared
 import spock.lang.Specification
 import support.PassThroughAppValidator
 import support.TestChildApp
 
 /**
  * Loads hubitat-mcp-rule.groovy (the rule-engine child app — separate
- * from the MCP server app) into a HubitatCI sandbox for unit testing.
+ * from the MCP server app) into a HubitatCI sandbox once per spec class
+ * and reuses the compiled script across feature methods. See the Javadoc
+ * on {@link support.HarnessSpec} for the broader rationale; the rule
+ * file is ~4000 lines, and paying its parse+compile once per Spock spec
+ * class (instead of once per feature method) is where the bulk of the
+ * test-job speedup comes from for rule specs.
  *
- * Same load/wiring approach as support.HarnessSpec: `sandbox.run()` with
- * an explicit `PassThroughAppValidator` (see HarnessSpec Javadoc for the
- * compile-vs-run precedence trap), state/atomicState/settings/now/log
- * flow through the AppExecutor mock + userSettingValues + metaclass.
+ * Same load/wiring approach as {@link support.HarnessSpec}:
+ * {@code sandbox.run()} with an explicit {@link PassThroughAppValidator}
+ * (see HarnessSpec Javadoc for the compile-vs-run precedence trap),
+ * state/atomicState/settings/now/log flow through the AppExecutor mock
+ * + userSettingValues + metaclass.
  *
- * `parent` is exposed as a writable property — specs assign it in their
- * `given:` block (e.g. `parent = new SmokeParent(...)`), and the setter
- * propagates the value to the script via `HubitatAppScript.setParent()`
- * so that `parent.findDevice(id)` inside the rule engine resolves to the
- * spec's stub. eighty20results' HubitatAppScript defines `parent` as a
- * private field accessed via its @CompileStatic `getProperty("parent")`
- * override, so mocking `AppExecutor.getParent()` no longer intercepts
- * property access — setParent is the only reliable hook.
+ * {@code parent} is exposed as a writable property — specs assign it in
+ * their {@code given:} block (e.g. {@code parent = new SmokeParent(...)}),
+ * and the setter propagates the value to the shared script via
+ * {@code HubitatAppScript.setParent()} so that {@code parent.findDevice(id)}
+ * inside the rule engine resolves to the spec's stub. eighty20results'
+ * HubitatAppScript defines {@code parent} as a private field accessed via
+ * its {@code @CompileStatic getProperty("parent")} override, so mocking
+ * {@code AppExecutor.getParent()} no longer intercepts property access —
+ * {@code setParent} is the only reliable hook. {@code setup()} resets
+ * {@code _parent} and re-applies it to the shared script so specs that
+ * expected {@code parent == null} on entry don't see the previous test's
+ * value.
  */
 abstract class RuleHarnessSpec extends Specification {
-    protected AppExecutor appExecutor
-    protected script
-    protected Map stateMap = [:]
-    protected Map atomicStateMap = [:]
-    // Must be non-empty — see HarnessSpec for why.
-    protected Map settingsMap = [_harness: true]
+    // Shared across the spec class — see HarnessSpec for why.
+    @Shared protected AppExecutor appExecutor
+    @Shared protected script
 
+    // Stable references captured by setupSpec's stubs; reset in setup().
+    @Shared protected final Map stateMap = [:]
+    @Shared protected final Map atomicStateMap = [:]
+    // Must be non-empty at sandbox.run() time — see HarnessSpec.
+    @Shared protected final Map settingsMap = [_harness: true]
+
+    // Per-feature backing field — each test gets its own instance, so
+    // resetting _parent to null in setup() guarantees isolation without
+    // having to @Shared the state.
     private Object _parent
 
     /** Assigning `parent = foo` in a given: block routes through here. */
@@ -47,14 +64,12 @@ abstract class RuleHarnessSpec extends Specification {
 
     Object getParent() { _parent }
 
-    def setup() {
+    def setupSpec() {
         def sandbox = new HubitatAppSandbox(new File('hubitat-mcp-rule.groovy'))
-        def stateRef = stateMap
-        def atomicStateRef = atomicStateMap
         def logMock = Mock(Log)
         appExecutor = Mock(AppExecutor) {
-            _ * getState() >> stateRef
-            _ * getAtomicState() >> atomicStateRef
+            _ * getState() >> stateMap
+            _ * getAtomicState() >> atomicStateMap
             // app / location are in HubitatCI's AppExecutor interface (so they
             // resolve via @Delegate, not metaClass). Script code calls
             // `app.id` (ruleLog) and `location.mode` (substituteVariables)
@@ -87,12 +102,24 @@ abstract class RuleHarnessSpec extends Specification {
             } as Closure,
             validator: validator
         )
+    }
+
+    def setup() {
+        stateMap.clear()
+        atomicStateMap.clear()
+        settingsMap.clear()
+        settingsMap._harness = true
         // Propagate unconditionally so the script's parent exactly matches
-        // the spec's `_parent` — including null. eighty20results' sandbox
-        // supplies a default `InstalledAppWrapperImpl` when options.parent
-        // is absent, so without this reset a spec that expects
-        // `parent == null` would see the default wrapper instead.
-        script.setParent(_parent)
+        // a freshly-reset `_parent` (null) on entry to each test.
+        // eighty20results' sandbox installs a default InstalledAppWrapperImpl
+        // when options.parent is absent at run() time, so without this reset
+        // a spec that expects `parent == null` would see the default wrapper
+        // instead — or worse, the previous test's parent.
+        _parent = null
+        script.setParent(null)
+        // Re-run per-test wires (metaClass overrides etc.) after clearing
+        // state. Called from setup() rather than setupSpec() so subclass
+        // overrides can capture the current feature instance's fields.
         wireOverrides()
     }
 

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -2,12 +2,12 @@ package rules
 
 import me.biocomp.hubitat_ci.api.app_api.AppExecutor
 import me.biocomp.hubitat_ci.api.common_api.Location
-import me.biocomp.hubitat_ci.api.common_api.Log
 import me.biocomp.hubitat_ci.app.HubitatAppSandbox
 import me.biocomp.hubitat_ci.validation.Flags
 import spock.lang.Shared
 import spock.lang.Specification
 import support.PassThroughAppValidator
+import support.PermissiveLog
 import support.TestChildApp
 
 /**
@@ -42,6 +42,12 @@ abstract class RuleHarnessSpec extends Specification {
     // Shared across the spec class — see HarnessSpec for why.
     @Shared protected AppExecutor appExecutor
     @Shared protected script
+    // Matches HarnessSpec's PermissiveLog usage — a concrete shim that
+    // accepts both the single-arg methods on HubitatCI's Log interface and
+    // the 2-arg (String, Throwable) overloads the real Hubitat runtime
+    // supports. A Spock Mock(Log) would throw MissingMethodException on
+    // script code like `log.error(msg, e)` under dynamic Groovy dispatch.
+    @Shared private PermissiveLog sharedLog = new PermissiveLog()
 
     // Stable references captured by setupSpec's stubs; reset in setup().
     @Shared protected final Map stateMap = [:]
@@ -66,7 +72,6 @@ abstract class RuleHarnessSpec extends Specification {
 
     def setupSpec() {
         def sandbox = new HubitatAppSandbox(new File('hubitat-mcp-rule.groovy'))
-        def logMock = Mock(Log)
         appExecutor = Mock(AppExecutor) {
             _ * getState() >> stateMap
             _ * getAtomicState() >> atomicStateMap
@@ -84,7 +89,7 @@ abstract class RuleHarnessSpec extends Specification {
                 getId      : { -> 1L }
             ] as Location)
             _ * now() >> 1234567890000L
-            _ * getLog() >> logMock
+            _ * getLog() >> sharedLog
         }
         def validator = new PassThroughAppValidator([
             Flags.DontValidatePreferences,
@@ -117,6 +122,11 @@ abstract class RuleHarnessSpec extends Specification {
         // instead — or worse, the previous test's parent.
         _parent = null
         script.setParent(null)
+        // Drop any per-test metaClass writes from the previous feature
+        // before re-installing the standard hooks below — prevents
+        // per-feature stubs (e.g. `script.metaClass.getGlobalVar = { ... }`
+        // installed directly in given: blocks) from leaking forward.
+        GroovySystem.metaClassRegistry.removeMetaClass(script.getClass())
         // Re-run per-test wires (metaClass overrides etc.) after clearing
         // state. Called from setup() rather than setupSpec() so subclass
         // overrides can capture the current feature instance's fields.

--- a/src/test/groovy/support/HarnessSpec.groovy
+++ b/src/test/groovy/support/HarnessSpec.groovy
@@ -150,6 +150,14 @@ abstract class HarnessSpec extends Specification {
         childDevicesList.clear()
         childAppsList.clear()
         hubGet.reset()
+        // Drop any per-test metaClass writes installed on the shared
+        // script by previous features (e.g. individual specs' given:
+        // blocks that do `script.metaClass.getRooms = { ... }`).
+        // Without this the @Shared script would carry accumulated
+        // overrides into the next feature, making tests order-dependent.
+        // The standard hooks installed by wireScriptOverrides() below are
+        // re-applied immediately so they're always present.
+        GroovySystem.metaClassRegistry.removeMetaClass(script.getClass())
         // Re-run metaClass + reflective wires in setup (not setupSpec) so
         // closures capture the *current* Specification instance. This lets
         // subclasses override wireScriptOverrides() with closures that

--- a/src/test/groovy/support/HarnessSpec.groovy
+++ b/src/test/groovy/support/HarnessSpec.groovy
@@ -4,95 +4,120 @@ import me.biocomp.hubitat_ci.api.app_api.AppExecutor
 import me.biocomp.hubitat_ci.app.HubitatAppSandbox
 import me.biocomp.hubitat_ci.app.HubitatAppScript
 import me.biocomp.hubitat_ci.validation.Flags
+import spock.lang.Shared
 import spock.lang.Specification
 
 /**
  * Base class for server and rule-engine specs. Loads the real Groovy app
- * file into a HubitatCI sandbox on each test so specs exercise actual
- * handler code, not re-implementations.
+ * file into a HubitatCI sandbox once per spec class (in {@code setupSpec})
+ * and reuses the compiled script across feature methods, with {@code setup}
+ * clearing the shared fixture collections so tests stay isolated.
  *
- * Uses `sandbox.run()` with an explicit `PassThroughAppValidator` (not
- * `sandbox.compile()`) for two reasons:
+ * Before this refactor, {@code setup()} re-read, re-parsed, re-AST-validated
+ * and re-compiled the 8000+ line {@code hubitat-mcp-server.groovy} file on
+ * every single feature method — ~3 seconds of pure compile overhead per
+ * test, which added up to most of the CI test-job runtime. Caching the
+ * sandbox+script at spec-class scope removes that overhead.
  *
- * 1. `PassThroughAppValidator` swaps in `PassThroughSandboxClassLoader`
- *    so sandbox-loaded script references to `hubitat.helper.RMUtils` /
- *    `NetworkUtils` resolve to our literal-named main-source-set stubs
+ * Isolation contract: subclasses interact with the same set of protected
+ * fields as before ({@code script}, {@code appExecutor}, {@code stateMap},
+ * {@code atomicStateMap}, {@code settingsMap}, {@code childDevicesList},
+ * {@code childAppsList}, {@code mockChildAppForCreate}, {@code hubGet}).
+ * The collection fields keep stable references across tests — only the
+ * contents reset between features — so any closure, delegate or metaClass
+ * hook set up in {@code setupSpec} continues to see the current test's
+ * state through the live map/list.
+ *
+ * Uses {@code sandbox.run()} with an explicit {@link PassThroughAppValidator}
+ * (not {@code sandbox.compile()}) for two reasons:
+ *
+ * 1. {@code PassThroughAppValidator} swaps in {@code PassThroughSandboxClassLoader}
+ *    so sandbox-loaded script references to {@code hubitat.helper.RMUtils} /
+ *    {@code NetworkUtils} resolve to our literal-named main-source-set stubs
  *    instead of failing the JVM's §5.3.5 name-equality check against
- *    eighty20results' remapped `common_api.RMUtils`. Without this, any
- *    sandbox-compiled spec that calls into `hubitat.helper.*` (e.g. PR
- *    #79's `manage_rule_machine` gateway tools) throws NCDFE at runtime.
- * 2. `sandbox.compile()` eagerly adds `DontRunScript` to
- *    `validationFlags`, which flips `readValidator`'s precedence and
- *    silently discards the `validator:` option — so even if we pass
- *    `validator: new PassThroughAppValidator(...)`, `compile()` throws
- *    it away. `sandbox.run()` preserves the validator; we include
- *    `Flags.DontRunScript` in the validator's own flag set to keep
- *    `setupImpl` from invoking `script.run()`.
+ *    eighty20results' remapped {@code common_api.RMUtils}. Without this, any
+ *    sandbox-compiled spec that calls into {@code hubitat.helper.*} (e.g. PR
+ *    #79's {@code manage_rule_machine} gateway tools) throws NCDFE at runtime.
+ * 2. {@code sandbox.compile()} eagerly adds {@code DontRunScript} to
+ *    {@code validationFlags}, which flips {@code readValidator}'s precedence
+ *    and silently discards the {@code validator:} option — so even if we pass
+ *    {@code validator: new PassThroughAppValidator(...)}, {@code compile()}
+ *    throws it away. {@code sandbox.run()} preserves the validator; we include
+ *    {@code Flags.DontRunScript} in the validator's own flag set to keep
+ *    {@code setupImpl} from invoking {@code script.run()}.
  *
- * `settings` is wired via userSettingValues (AppPreferencesReader holds
- * onto the Map reference, so mutating it from a spec's `given:` block
- * updates what `script.settings.foo` sees). `getState`/`getAtomicState`/
- * `getChildDevices`/`now`/`getLog` are wired through the AppExecutor mock
- * — eighty20results' AppChildExecutor leaves these on the @Delegate path
- * to the supplied AppExecutor. `hubInternalGet` isn't on AppExecutor's
- * interface so it's metaclass-injected on the script.
+ * {@code settings} is wired via userSettingValues (AppPreferencesReader
+ * holds onto the Map reference from the {@code sandbox.run()} call, so
+ * clearing and re-populating {@code settingsMap} from a spec's
+ * {@code given:} block updates what {@code script.settings.foo} sees).
+ * {@code getState}/{@code getAtomicState}/{@code getChildDevices}/
+ * {@code now}/{@code getLog} are wired through the AppExecutor mock —
+ * eighty20results' AppChildExecutor leaves these on the {@code @Delegate}
+ * path to the supplied AppExecutor. Stubs on the shared mock return the
+ * stable collection references, so clearing the collections each test
+ * gives each feature a fresh view. {@code hubInternalGet} isn't on
+ * AppExecutor's interface so it's metaclass-injected on the script.
  *
- * `addChildApp` and `getChildApps` can't be intercepted via the
- * AppExecutor mock: eighty20results' AppChildExecutor excludes both from
- * its @Delegate chain, and HubitatAppScript defines concrete methods for
- * each that route through private closure fields (`childAppFactory`,
- * `childAppAccessor`). Per-instance metaClass overrides on those
- * concrete superclass methods are skipped by the script body's
- * intra-class dispatch (verified empirically — metaClass.addChildApp was
- * bypassed in PR #100's first CI run). Instead, we reflect into the
- * private closure fields on HubitatAppScript and replace them with test
- * closures so the script's own `addChildApp` / `getChildApps` /
- * `getChildAppById` implementations route to the spec's fixture maps.
+ * {@code addChildApp} and {@code getChildApps} can't be intercepted via
+ * the AppExecutor mock: eighty20results' AppChildExecutor excludes both
+ * from its {@code @Delegate} chain, and HubitatAppScript defines concrete
+ * methods for each that route through private closure fields
+ * ({@code childAppFactory}, {@code childAppAccessor}). Per-instance
+ * metaClass overrides on those concrete superclass methods are skipped
+ * by the script body's intra-class dispatch (verified empirically —
+ * metaClass.addChildApp was bypassed in PR #100's first CI run). Instead,
+ * we reflect into the private closure fields on HubitatAppScript and
+ * replace them with test closures so the script's own
+ * {@code addChildApp} / {@code getChildApps} / {@code getChildAppById}
+ * implementations route to the spec's fixture maps.
  *
- * `childAppResolver` is still supplied so eighty20results' options
+ * {@code childAppResolver} is still supplied so eighty20results' options
  * validator accepts the sandbox options; its closure body throws
- * `IllegalStateException` instead of returning null, because the
- * replacement `childAppFactory` should short-circuit before any real
- * child-script resolution ever happens — if it fires, that's a loud
- * signal the harness needs updating for an eighty20results API change.
+ * {@code IllegalStateException} instead of returning null, because the
+ * replacement {@code childAppFactory} should short-circuit before any
+ * real child-script resolution ever happens — if it fires, that's a
+ * loud signal the harness needs updating for an eighty20results API
+ * change.
  */
 abstract class HarnessSpec extends Specification {
-    protected AppExecutor appExecutor
-    protected script
-    protected Map stateMap = [:]
-    protected Map atomicStateMap = [:]
-    // Must be non-empty at setup() time — HubitatCI's readUserSettingValues
-    // uses a Groovy truthy check on the passed map and silently swaps in a
-    // fresh empty Map when it's empty, breaking the shared reference that
-    // specs rely on to mutate settings from their `given:` blocks.
-    protected Map settingsMap = [selectedDevices: []]
-    protected List childDevicesList = []
-    protected List childAppsList = []
-    protected def mockChildAppForCreate  // tests set this to drive addChildApp's return value
-    protected HubInternalGetMock hubGet = new HubInternalGetMock()
+    // Shared across every feature method in a given spec class — the
+    // sandbox parse+compile (~3s for the 8000-line server file) is the
+    // dominant cost, so amortising it across all tests in a class keeps
+    // the CI job from scaling linearly with test count.
+    @Shared protected AppExecutor appExecutor
+    @Shared protected script
+    @Shared private PermissiveLog sharedLog = new PermissiveLog()
 
-    def setup() {
+    // Stable references — contents mutated by tests and cleared in setup().
+    // The AppExecutor mock's stubs capture these references in setupSpec,
+    // so per-test content updates are visible via the normal stub paths.
+    @Shared protected final Map stateMap = [:]
+    @Shared protected final Map atomicStateMap = [:]
+    // Must be non-empty at sandbox.run() time — HubitatCI's
+    // readUserSettingValues does a Groovy truthy check on the passed map
+    // and silently swaps in a fresh empty Map when it's empty, breaking
+    // the shared reference that specs rely on to mutate settings from
+    // their given: blocks. setup() restores this seed entry after
+    // clearing so every test starts from the same baseline.
+    @Shared protected final Map settingsMap = [selectedDevices: []]
+    @Shared protected final List childDevicesList = []
+    @Shared protected final List childAppsList = []
+    @Shared protected final HubInternalGetMock hubGet = new HubInternalGetMock()
+
+    // Per-test fixture — specs assign in given: blocks to drive
+    // addChildApp's return value. Not @Shared: wireScriptOverrides() runs
+    // in setup() each test, so the reflective childAppFactory closure
+    // captures the current feature instance and reads this field from it.
+    protected def mockChildAppForCreate
+
+    def setupSpec() {
         def sandbox = new HubitatAppSandbox(new File('hubitat-mcp-server.groovy'))
-        def stateRef = stateMap
-        def atomicStateRef = atomicStateMap
-        def childDevicesRef = childDevicesList
-        def self = this
-        // Permissive log shim instead of Mock(Log): HubitatCI's Log
-        // interface only declares single-arg level methods, but the real
-        // Hubitat runtime also accepts (String, Throwable). A Proxy-based
-        // Mock — or a Map coerced with `as Log` — rejects the 2-arg call
-        // with MissingMethodException, which makes
-        // handleToolsCall's generic-catch path (log.error(msg, e) at line
-        // 415) untestable. A concrete class that implements Log and adds
-        // the 2-arg overloads dispatches correctly under dynamic Groovy.
-        // No spec currently asserts log interactions, so no behaviour regresses.
-        def logMock = new PermissiveLog()
         appExecutor = Mock(AppExecutor) {
-            _ * getState() >> stateRef
-            _ * getAtomicState() >> atomicStateRef
-            _ * getChildDevices() >> childDevicesRef
+            _ * getState() >> stateMap
+            _ * getAtomicState() >> atomicStateMap
+            _ * getChildDevices() >> childDevicesList
             _ * now() >> 1234567890000L
-            _ * getLog() >> logMock
+            _ * getLog() >> sharedLog
         }
         def validator = new PassThroughAppValidator([
             Flags.DontValidatePreferences,
@@ -111,6 +136,25 @@ abstract class HarnessSpec extends Specification {
             } as Closure,
             validator: validator
         )
+    }
+
+    def setup() {
+        // Reset every mutable fixture before each feature. Collections
+        // keep their identity (the AppExecutor mock's stubs captured
+        // references in setupSpec), so clear-and-repopulate rather than
+        // reassign.
+        stateMap.clear()
+        atomicStateMap.clear()
+        settingsMap.clear()
+        settingsMap.selectedDevices = []
+        childDevicesList.clear()
+        childAppsList.clear()
+        hubGet.reset()
+        // Re-run metaClass + reflective wires in setup (not setupSpec) so
+        // closures capture the *current* Specification instance. This lets
+        // subclasses override wireScriptOverrides() with closures that
+        // reference non-@Shared spec fields (e.g. per-feature stubs) and
+        // still see their own test's values.
         wireScriptOverrides()
     }
 
@@ -120,14 +164,19 @@ abstract class HarnessSpec extends Specification {
         def self = this
         // hubInternalGet has no declaration on HubitatAppScript — it's
         // pure dynamic Groovy resolved through metaClass, so the
-        // per-instance metaClass write here intercepts cleanly.
+        // per-instance metaClass write here intercepts cleanly. The
+        // captured hubGetRef is the @Shared HubInternalGetMock whose
+        // internal maps get reset() between tests, so a single wire-up
+        // in setupSpec routes all tests to a fresh-feeling stub.
         script.metaClass.hubInternalGet = { String p, Map pp = [:], Integer t = 30 ->
             hubGetRef.call(p, pp)
         }
         // Replace HubitatAppScript's private factory closures so the
         // script's own concrete addChildApp / getChildApps / getChildAppById
         // route to spec-controlled fixtures. See class javadoc for why
-        // metaClass overrides don't work here.
+        // metaClass overrides don't work here. Wired once against the
+        // shared script; the closures read from @Shared fields so each
+        // test's fixture content is visible without re-wiring.
         def factoryField = HubitatAppScript.getDeclaredField('childAppFactory')
         factoryField.accessible = true
         factoryField.set(script, { String ns, String name, String label, Map props = [:] ->

--- a/src/test/groovy/support/HubInternalGetMock.groovy
+++ b/src/test/groovy/support/HubInternalGetMock.groovy
@@ -22,4 +22,10 @@ class HubInternalGetMock {
         }
         return handler(params)
     }
+
+    /** Clears registered handlers and recorded calls so a shared instance is safe to reuse across tests. */
+    void reset() {
+        handlers.clear()
+        calls.clear()
+    }
 }


### PR DESCRIPTION
## Summary

- Move `HubitatAppSandbox` parse/compile from Spock's per-feature `setup()` into `setupSpec()` with `@Shared` script + AppExecutor mock, so the 8000-line `hubitat-mcp-server.groovy` (and 4000-line `hubitat-mcp-rule.groovy`) are compiled once per Spec class instead of once per test method.
- Local JDK 11, fresh daemon, 81 tests, `--rerun-tasks`: **5m 7s → 1m 36s** wall clock (**69% reduction**); test-time **289.9s → 70.6s** (**76% reduction**). The 7m job on #79 should land around the 2m mark.
- No subclass changes required — the protected `HarnessSpec` / `RuleHarnessSpec` API (`script`, `appExecutor`, `stateMap`, `atomicStateMap`, `settingsMap`, `childDevicesList`, `childAppsList`, `mockChildAppForCreate`, `hubGet`) is preserved, and `wireScriptOverrides()` / `wireOverrides()` still run per test so overrides that capture per-feature fields (e.g. `SubstituteVariablesSpec.globalVars`) keep working.

## Changes

- **`src/test/groovy/support/HarnessSpec.groovy`**: `setupSpec()` builds `HubitatAppSandbox` + `AppExecutor` mock + script once; `setup()` clears the `@Shared final` fixture collections and re-runs `wireScriptOverrides()`. The mock's stubs (`_ * getState() >> stateMap` etc.) capture the stable collection references, so clearing contents each test gives each feature a fresh view.
- **`src/test/groovy/rules/RuleHarnessSpec.groovy`**: same shape for the rule-engine app file. `_parent` stays per-feature; `setup()` resets it and calls `script.setParent(null)` to cancel out the previous test's state on the shared script.
- **`src/test/groovy/support/HubInternalGetMock.groovy`**: add `reset()` (clears `handlers` + `calls`) so the shared instance is safe to reuse.
- **`build.gradle`**: add `'started'` to `testLogging.events`. The original 7m run on #79 had *zero* test-event output between JVM start and finish; adding `started` streams per-test names live so the next harness regression is visible in the job log.
- **`.github/workflows/unit-tests.yml`**: upload `build/reports/tests/test` + `build/test-results/test` unconditionally (`if: always()`). With the XMLs available on every run we can track per-spec `time=` values for future perf regressions.

## Testing

- Local full run (JDK 11 via `EclipseAdoptium.Temurin.11.JDK`, fresh daemon, `./gradlew test --rerun-tasks`): 81 tests, 0 failures, 0 errors, 1m 36s.
- Per-spec times after the refactor are flat at ~4-6s per Spec class (single parse + fast tests) regardless of test count — e.g. `rules.EvaluateComparisonSpec` went from 48.3s/13 tests (3.7s/test) to 4.0s/13 tests (0.3s/test).
- PassThrough scaffold behaviour is unchanged — `support.RMUtilsSandboxInterceptionSpec` still passes.

## Checklist

- [x] **Unit tests added for any new MCP tools** — N/A (no tool changes; test-infrastructure only)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py` — N/A (no production Groovy changes)
- [x] `./gradlew test` passes locally (or CI confirms)
- [x] Live-hub BAT tests updated if tool behaviour changed — N/A
- [x] Documentation updated if user-facing behaviour or tool surface changed — N/A