### PR TITLE
test(rm-interop): pin registerRmRule warn-log emission and type classification

### DIFF
--- a/src/test/groovy/server/ToolListRmRulesSpec.groovy
+++ b/src/test/groovy/server/ToolListRmRulesSpec.groovy
@@ -232,9 +232,18 @@ class ToolListRmRulesSpec extends ToolSpecBase {
         result.warning.contains('v4=')
     }
 
-    def "registerRmRule skips entries with non-Integer-coercible keys (Groovy-sandbox-safe warn log)"() {
+    def "registerRmRule skips entries with non-Integer-coercible keys and emits a sandbox-safe warn log"() {
         given:
         settingsMap.enableBuiltinAppRead = true
+
+        and: 'collect mcpLog calls via per-test metaClass override'
+        // mcpLog is a script-local method (not inherited from AppExecutor /
+        // HubitatAppScript), so per-instance metaClass override works here —
+        // see docs/testing.md "Which interception point to use".
+        def mcpLogCalls = []
+        script.metaClass.mcpLog = { String level, String component, String msg ->
+            mcpLogCalls << [level: level, component: component, msg: msg]
+        }
 
         and: 'v5 list contains one bad String key and one valid numeric key'
         rmUtils.stubRuleList5 = [
@@ -248,10 +257,21 @@ class ToolListRmRulesSpec extends ToolSpecBase {
         then: 'only the valid rule is returned'
         result.rules*.id == [123]
         result.count == 1
-        // Implicit coverage: the test running under HubitatAppSandbox.run()
-        // exercises the sandbox security manager, so any getClass()/Eval.me
-        // reintroduced in registerRmRule would blow up the test loudly.
         result.success != false
+
+        and: 'warn log fires with the instanceof-ladder type classification'
+        // Pins the sandbox-safe replacement for the old
+        // `${rawKey?.getClass()?.simpleName}` GString. If registerRmRule ever
+        // reverts to getClass(), sandbox_lint.py's SANDBOX-001 (GString-aware
+        // after #103) catches it at CI lint; this assertion catches the
+        // behavioral side (warn message still mentions the key type) so the
+        // guard holds even if the linter is edited.
+        mcpLogCalls.any {
+            it.level == 'warn' &&
+            it.component == 'rm-interop' &&
+            it.msg.contains("'not-a-number'") &&
+            it.msg.contains('type=String')
+        }
     }
 
     def "gateway dispatch via handleGateway routes to list_rm_rules"() {

--- a/src/test/groovy/server/ToolListRmRulesSpec.groovy
+++ b/src/test/groovy/server/ToolListRmRulesSpec.groovy
@@ -260,12 +260,16 @@ class ToolListRmRulesSpec extends ToolSpecBase {
         result.success != false
 
         and: 'warn log fires with the instanceof-ladder type classification'
-        // Pins the sandbox-safe replacement for the old
-        // `${rawKey?.getClass()?.simpleName}` GString. If registerRmRule ever
-        // reverts to getClass(), sandbox_lint.py's SANDBOX-001 (GString-aware
-        // after #103) catches it at CI lint; this assertion catches the
-        // behavioral side (warn message still mentions the key type) so the
-        // guard holds even if the linter is edited.
+        // Catches: deleting the mcpLog call, dropping the NumberFormatException
+        // catch, removing (type=${keyType}) from the template, or collapsing
+        // the instanceof ladder so a String key no longer yields 'String'.
+        //
+        // Does NOT catch a getClass() revert on its own: under HarnessSpec's
+        // Flags.DontRestrictGroovy, rawKey.getClass().simpleName returns
+        // "String" at runtime -- byte-identical to the instanceof-ladder
+        // output for this fixture, so the message text is unchanged. The
+        // getClass()-revert guard lives in sandbox_lint.py's SANDBOX-001
+        // (GString-aware after #103); this assertion is orthogonal to it.
         mcpLogCalls.any {
             it.level == 'warn' &&
             it.component == 'rm-interop' &&


### PR DESCRIPTION
## Summary

Follow-up to the round-2 review on #79. The new regression-guard spec in `ToolListRmRulesSpec` (`"registerRmRule skips entries with non-Integer-coercible keys..."`) carried an inline comment claiming the test would loudly fail if `getClass()`/`Eval.me` were reintroduced, courtesy of `HubitatAppSandbox.run()`'s security manager. That claim is wrong: `HarnessSpec` passes `Flags.DontRestrictGroovy` to the validator, which explicitly disables the AST restrictions that enforce SANDBOX-001 on a real hub. Under the test harness, `getClass()` compiles and runs fine — the old buggy `${rawKey?.getClass()?.simpleName}` GString would have passed the test. The real guard against that regression is `sandbox_lint.py`'s SANDBOX-001 rule, which #103 broadened to scan GString interpolations.

Rather than drop the comment, this PR promotes it to an actual behavioral assertion that pins the sandbox-safe replacement (the `Number`/`String`/`other` instanceof ladder) to the warn-log output.

## Changes

- `ToolListRmRulesSpec.groovy` — install a per-test `script.metaClass.mcpLog` collector (same pattern `ToolGetDeviceInUseBySpec` uses) and assert `mcpLogCalls.any { level=='warn' && component=='rm-interop' && msg.contains("'not-a-number'") && msg.contains('type=String') }`. Valid interception because `mcpLog` is script-local, not inherited from `AppExecutor`/`HubitatAppScript` — see `docs/testing.md` dispatch cheat sheet.
- Renamed the feature string so the "sandbox-safe" claim is no longer load-bearing in the spec description.
- Removed the misleading inline comment; replaced with a short one pointing at `sandbox_lint.py` for the `getClass()`-revert guard.

## What the test now actually pins

- Deleting the `mcpLog("warn", ...)` line in `registerRmRule` → assertion fails.
- Refactoring the instanceof ladder so the warn message no longer surfaces the key type → assertion fails.
- Reverting to `getClass()` → still caught, but by `sandbox_lint.py` at lint time (the correct layer).

## Test plan

- [ ] CI: `./gradlew test` passes with the new assertion on the good state.
- [ ] Sanity: swapping the production warn-log back to a `getClass()` GString locally and running `python tests/sandbox_lint.py` surfaces SANDBOX-001 on `registerRmRule`.