### PR TITLE
fix(release): cascade skip flags + retry PR lookup for indexing lag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,25 @@ jobs:
           SHA: ${{ github.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_JSON=$(gh api "/repos/${{ github.repository }}/commits/${SHA}/pulls" --jq '.[0] // empty')
+          # GitHub's commit-to-PR index is eventually consistent. When the
+          # push event fires immediately after a merge, the association is
+          # often not yet visible (run #26 on PR #108's merge hit this
+          # and got an empty result within ~15s of merge). Retry with
+          # backoff before declaring "no PR".
+          PR_JSON=""
+          for attempt in 1 2 3 4 5; do
+            PR_JSON=$(gh api "/repos/${{ github.repository }}/commits/${SHA}/pulls" --jq '.[0] // empty')
+            if [ -n "$PR_JSON" ]; then
+              echo "commits-to-PR lookup succeeded on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "Attempt $attempt returned empty, retrying in 6s..."
+              sleep 6
+            fi
+          done
           if [ -z "$PR_JSON" ]; then
-            echo "::notice::No PR associated with ${SHA} — direct push or unrelated event, skipping"
+            echo "::notice::No PR associated with ${SHA} after 5 attempts — direct push or unrelated event, skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -95,7 +111,7 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Checkout main
-        if: steps.label.outputs.skip != 'true'
+        if: steps.label.outputs.skip == 'false'
         uses: actions/checkout@v6
         with:
           ref: main
@@ -103,12 +119,12 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v6
-        if: steps.label.outputs.skip != 'true'
+        if: steps.label.outputs.skip == 'false'
         with:
           python-version: '3.x'
 
       - name: Bump version and rewrite files
-        if: steps.label.outputs.skip != 'true'
+        if: steps.label.outputs.skip == 'false'
         id: bump
         env:
           LABEL: ${{ steps.label.outputs.label }}
@@ -117,7 +133,7 @@ jobs:
         run: python .github/scripts/release_bump.py
 
       - name: Commit, tag, and push
-        if: steps.label.outputs.skip != 'true'
+        if: steps.label.outputs.skip == 'false'
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new_version }}
           PR_AUTHOR: ${{ steps.pr.outputs.author }}


### PR DESCRIPTION
## Summary

Fixes two bugs in the release workflow exposed by run #26 (the first push-event run of `.github/workflows/release.yml` after PR #108 merged). Both are in the same file; no other surface area.

## Bugs fixed

### 1. Skipped-step outputs are empty strings, not `'true'`

Downstream steps used `if: steps.label.outputs.skip != 'true'`. When the `Determine release label` step was skipped because an earlier step set `skip=true`, its outputs are **empty** — and `'' != 'true'` evaluates to **true**, so the guarded steps ran anyway.

Result on run #26: `Bump version and rewrite files` executed with `LABEL` unset, exited 1 with "LABEL env var not set", and the job was marked **failure** when it should have been a clean skip.

**Fix:** Use positive-polarity check `if: steps.label.outputs.skip == 'false'`. Empty strings fail that comparison, so skipped ancestors correctly cascade.

### 2. Commit-to-PR API has indexing lag

Run #26 fired at 22:41:36, ~15s after PR #108 merged. The `gh api /repos/{owner}/{repo}/commits/{sha}/pulls` lookup returned empty, producing "No PR associated with <sha>". A manual re-query a few minutes later returned PR #108 correctly — GitHub's commit-to-PR index is eventually consistent.

**Fix:** Retry the lookup up to 5 times with 6-second backoff (30s worst case) before declaring "no PR". Adds small latency to legitimate direct-push skips (workflow runs 30s before skipping), but avoids false negatives when a merge did happen.

## Testing

- [x] YAML shape validated (actionlint passes locally)
- [x] Trace re-walked:
  - Merge commit with PR eventually findable: loop succeeds on attempt 1-5, downstream `== 'false'` checks see label.skip='false', bump runs ✓
  - No `release:*` label: label.skip='true', downstream `== 'false'` checks all see 'true' → all skip ✓
  - Direct push (no PR ever): all 5 retries empty → pr.skip='true' → label skipped (no output) → downstream `== 'false'` sees empty → all skip ✓
  - Bot's own release commit: precheck.skip='true' → pr step skipped (no output) → label step skipped (no output) → downstream `== 'false'` sees empty → all skip ✓
- [ ] **Live verification after merge** — this PR's own merge-event run will exercise the retry path since the indexing lag is reproducible.

## Checklist

- [x] **Unit tests added for any new MCP tools** — N/A (CI-only)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py` — N/A (no production Groovy changes)
- [x] `./gradlew test` passes locally (or CI confirms) — N/A (no code changes)
- [x] Live-hub BAT tests updated if tool behaviour changed — N/A
- [x] Documentation updated if user-facing behaviour or tool surface changed — N/A (internal workflow plumbing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)