### PR TITLE
test(server): unit-test manage_logs / manage_diagnostics / manage_files gateways

### DIFF
--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -1,0 +1,666 @@
+package server
+
+import groovy.json.JsonOutput
+import spock.lang.Shared
+import support.TestChildApp
+import support.TestDevice
+import support.TestLocation
+import support.ToolSpecBase
+
+/**
+ * Spec for the manage_diagnostics gateway tools (hubitat-mcp-server.groovy):
+ *
+ * - toolGetHubPerformance   -> get_set_hub_metrics
+ * - toolGetMemoryHistory    -> get_memory_history
+ * - toolForceGarbageCollection -> force_garbage_collection
+ * - toolDeviceHealthCheck   -> device_health_check
+ * - toolGetRuleDiagnostics  -> get_rule_diagnostics
+ * - toolGetZwaveDetails     -> get_zwave_details
+ * - toolGetZigbeeDetails    -> get_zigbee_details
+ * - toolZwaveRepair         -> zwave_repair        (Hub Admin Write + confirm)
+ * - toolListCapturedStates  -> list_captured_states
+ * - toolDeleteCapturedState -> delete_captured_state
+ * - toolClearCapturedStates -> clear_captured_states
+ *
+ * Mocking strategy (see docs/testing.md):
+ *   - hubInternalGet      -> HarnessSpec's hubGet.register(path) closures
+ *   - hubInternalPost     -> stubbed per-test on script.metaClass
+ *   - downloadHubFile /
+ *     uploadHubFile       -> stubbed per-test on script.metaClass
+ *   - location.hub        -> appExecutor.getLocation() returns sharedLocation;
+ *                            individual tests set `sharedLocation.hub = [...]`
+ *                            to drive location.hub reads (e.g. zwaveVersion,
+ *                            zigbeeChannel, uptime)
+ *   - app (for completeness; this gateway doesn't call app.updateSetting)
+ *
+ * NOTE on clear_captured_states / delete_captured_state: the current server
+ * source (hubitat-mcp-server.groovy) does not gate these on confirm=true —
+ * issue #74 lists them as "test confirm gating" but the dispatch is direct
+ * through clearAllCapturedStates() / deleteCapturedState(stateId). Tests
+ * here pin the existing no-confirm behaviour; adding a confirm gate would
+ * be a separate design change.
+ */
+class ToolManageDiagnosticsSpec extends ToolSpecBase {
+
+    @Shared private TestLocation sharedLocation = new TestLocation()
+
+    def setupSpec() {
+        appExecutor.getLocation() >> sharedLocation
+    }
+
+    def cleanup() {
+        sharedLocation.hub = null
+    }
+
+    private void enableHubAdminWrite() {
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L  // matches fixed now()
+    }
+
+    // -------- toolGetHubPerformance (get_set_hub_metrics) --------
+
+    def "get_set_hub_metrics throws when Hub Admin Read is disabled"() {
+        when:
+        script.toolGetHubPerformance([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Read')
+    }
+
+    def "get_set_hub_metrics snapshots memory/temp/db and records a CSV row"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = [uptime: 172800L]  // 2 days
+        hubGet.register('/hub/advanced/freeOSMemory') { params -> '123456' }
+        hubGet.register('/hub/advanced/internalTempCelsius') { params -> '45.5' }
+        hubGet.register('/hub/advanced/databaseSize') { params -> '200000' }
+
+        and: 'no existing CSV history on disk'
+        script.metaClass.downloadHubFile = { String fileName -> null }
+
+        and: 'uploadHubFile captures what we would have written'
+        def uploaded = [:]
+        script.metaClass.uploadHubFile = { String fileName, byte[] content ->
+            uploaded[fileName] = new String(content, 'UTF-8')
+        }
+
+        when:
+        def result = script.toolGetHubPerformance([:])
+
+        then:
+        result.current.freeMemoryKB == '123456'
+        result.current.internalTempC == '45.5'
+        result.current.databaseSizeKB == '200000'
+        result.current.uptimeSeconds == 172800L
+        result.current.uptimeFormatted == '2d 0h 0m'
+        result.historyFile == 'mcp-performance-history.csv'
+        result.trendPointsAvailable == 1
+
+        and: 'the CSV snapshot was written to File Manager'
+        uploaded['mcp-performance-history.csv']?.contains('freeMemoryKB')
+        uploaded['mcp-performance-history.csv']?.contains('123456')
+    }
+
+    def "get_set_hub_metrics warns on low memory"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = [uptime: 3600L]
+        hubGet.register('/hub/advanced/freeOSMemory') { params -> '40000' }  // <50000 triggers warning
+        hubGet.register('/hub/advanced/internalTempCelsius') { params -> '40' }
+        hubGet.register('/hub/advanced/databaseSize') { params -> '100000' }
+        script.metaClass.downloadHubFile = { String fileName -> null }
+        script.metaClass.uploadHubFile = { String fileName, byte[] content -> }
+
+        when:
+        def result = script.toolGetHubPerformance([recordSnapshot: false])
+
+        then:
+        result.current.memoryWarning.contains('LOW MEMORY')
+        result.current.memoryWarning.contains('40000')
+    }
+
+    def "get_set_hub_metrics respects recordSnapshot=false (no CSV write)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = [uptime: 0L]
+        hubGet.register('/hub/advanced/freeOSMemory') { params -> '100000' }
+        hubGet.register('/hub/advanced/internalTempCelsius') { params -> '50' }
+        hubGet.register('/hub/advanced/databaseSize') { params -> '100000' }
+        script.metaClass.downloadHubFile = { String fileName -> null }
+        def uploadCalled = false
+        script.metaClass.uploadHubFile = { String fileName, byte[] content -> uploadCalled = true }
+
+        when:
+        def result = script.toolGetHubPerformance([recordSnapshot: false])
+
+        then:
+        !uploadCalled
+        result.trendPointsAvailable == 0
+    }
+
+    // -------- toolGetMemoryHistory --------
+
+    def "get_memory_history throws when Hub Admin Read is disabled"() {
+        when:
+        script.toolGetMemoryHistory([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Read')
+    }
+
+    def "get_memory_history parses CSV rows and computes summary"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        def csv = [
+            'Date/time,Free OS,5m CPU avg,Total Java,Free Java,Direct Java',
+            '2026-04-19 10:00,200000,0.5,500000,100000,2000',
+            '2026-04-19 10:05,150000,0.6,500000, 90000,2100',
+            '2026-04-19 10:10,100000,0.9,500000, 80000,2200'
+        ].join('\n')
+        hubGet.register('/hub/advanced/freeOSMemoryHistory') { params -> csv }
+
+        when:
+        def result = script.toolGetMemoryHistory([:])
+
+        then:
+        result.entries.size() == 3
+        result.summary.totalEntries == 3
+        result.summary.currentMemoryKB == 100000
+        result.summary.minMemoryKB == 100000
+        result.summary.maxMemoryKB == 200000
+        result.summary.avgMemoryKB == 150000
+        result.summary.totalJavaKB == 500000
+        result.summary.freeJavaKB == 80000
+        result.summary.directJavaKB == 2200
+        result.summary.directJavaMinKB == 2000
+        result.summary.directJavaMaxKB == 2200
+    }
+
+    def "get_memory_history emits low-memory warning when current is below 50000"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/hub/advanced/freeOSMemoryHistory') { params ->
+            'Date/time,Free OS,5m CPU avg\n2026-04-19 10:00,30000,0.5\n'
+        }
+
+        when:
+        def result = script.toolGetMemoryHistory([:])
+
+        then:
+        result.summary.memoryWarning.contains('LOW MEMORY')
+        result.summary.memoryWarning.contains('30000')
+    }
+
+    def "get_memory_history applies limit to entries but keeps summary on full set"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        def rows = (1..10).collect { i -> "2026-04-19 10:0${i},${100000 + i * 1000},0.${i}".toString() }
+        hubGet.register('/hub/advanced/freeOSMemoryHistory') { params ->
+            (['Date/time,Free OS,5m CPU avg'] + rows).join('\n')
+        }
+
+        when:
+        def result = script.toolGetMemoryHistory([limit: 3])
+
+        then:
+        result.entries.size() == 3
+        result.summary.totalEntries == 10
+        result.summary.truncated == true
+        result.summary.showing.contains('3 of 10')
+    }
+
+    def "get_memory_history handles empty response"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/hub/advanced/freeOSMemoryHistory') { params -> null }
+
+        when:
+        def result = script.toolGetMemoryHistory([:])
+
+        then:
+        result.entries == []
+        result.summary.message.contains('No memory history')
+    }
+
+    // -------- toolForceGarbageCollection --------
+
+    def "force_garbage_collection throws when Hub Admin Read is disabled"() {
+        when:
+        script.toolForceGarbageCollection([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Read')
+    }
+
+    def "force_garbage_collection triggers GC and reports before/after"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        def beforeAfter = ['90000', '120000']
+        def idx = 0
+        hubGet.register('/hub/advanced/freeOSMemory') { params -> beforeAfter[idx++] }
+        def gcCalled = false
+        hubGet.register('/hub/forceGC') { params -> gcCalled = true; '' }
+
+        when:
+        def result = script.toolForceGarbageCollection([:])
+
+        then:
+        gcCalled
+        result.beforeFreeMemoryKB == 90000
+        result.afterFreeMemoryKB == 120000
+        result.deltaKB == 30000
+        result.memoryReclaimed == true
+        result.summary.contains('90000KB → 120000KB')
+        result.summary.contains('+30000KB')
+    }
+
+    def "force_garbage_collection reports 'could not read' summary when memory probes fail"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/hub/advanced/freeOSMemory') { params -> 'not a number' }
+        hubGet.register('/hub/forceGC') { params -> '' }
+
+        when:
+        def result = script.toolForceGarbageCollection([:])
+
+        then:
+        result.beforeFreeMemoryKB == null
+        result.afterFreeMemoryKB == null
+        result.summary.contains('could not read memory values')
+    }
+
+    // -------- toolDeviceHealthCheck --------
+
+    def "device_health_check returns empty summary when no devices are selected"() {
+        when:
+        def result = script.toolDeviceHealthCheck([:])
+
+        then:
+        result.message.contains('No devices selected')
+        result.summary.totalDevices == 0
+    }
+
+    def "device_health_check classifies devices as healthy, stale, and unknown"() {
+        given:
+        def nowMs = 1234567890000L
+        def fresh = new TestDevice(id: 1, name: 'Fresh', label: 'Fresh Sensor')
+        fresh.metaClass.getLastActivity = { -> new Date(nowMs - 3600000L) }  // 1h ago
+        def stale = new TestDevice(id: 2, name: 'Stale', label: 'Stale Sensor')
+        stale.metaClass.getLastActivity = { -> new Date(nowMs - (48 * 3600000L)) }  // 48h ago
+        def never = new TestDevice(id: 3, name: 'Never', label: 'Never-reported')
+        never.metaClass.getLastActivity = { -> null }
+        settingsMap.selectedDevices = [fresh, stale, never]
+
+        when:
+        def result = script.toolDeviceHealthCheck([staleHours: 24])
+
+        then:
+        result.summary.totalDevices == 3
+        result.summary.healthyCount == 1
+        result.summary.staleCount == 1
+        result.summary.unknownCount == 1
+        result.staleDevices[0].name == 'Stale Sensor'
+        result.unknownDevices[0].lastActivity == 'never'
+        result.recommendation.contains('1 stale and 1 unknown')
+    }
+
+    def "device_health_check includeHealthy=true attaches healthyDevices list"() {
+        given:
+        def nowMs = 1234567890000L
+        def fresh = new TestDevice(id: 1, name: 'Fresh', label: 'Fresh Sensor')
+        fresh.metaClass.getLastActivity = { -> new Date(nowMs - 600000L) }
+        settingsMap.selectedDevices = [fresh]
+
+        when:
+        def result = script.toolDeviceHealthCheck([includeHealthy: true])
+
+        then:
+        result.healthyDevices.size() == 1
+        result.healthyDevices[0].name == 'Fresh Sensor'
+    }
+
+    // -------- toolGetRuleDiagnostics --------
+
+    def "get_rule_diagnostics throws when the ruleId is not found"() {
+        when:
+        script.toolGetRuleDiagnostics([ruleId: 'nope'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found')
+    }
+
+    def "get_rule_diagnostics returns rule structure + recent logs + errors"() {
+        given: 'a MCP rule child app with 2 triggers / 1 condition / 3 actions'
+        def rule = new TestChildApp(id: 42L, label: 'My Rule')
+        rule.ruleData = [
+            id: 42L, name: 'My Rule', description: 'desc',
+            enabled: true, createdAt: 1000L, updatedAt: 2000L,
+            executionCount: 5, lastTriggered: 3000L,
+            triggers: [[type: 'device'], [type: 'time']],
+            conditions: [[op: '>']],
+            actions: [[cmd: 'on'], [cmd: 'off'], [cmd: 'setLevel']],
+            conditionLogic: 'all',
+            localVariables: [counter: 3]
+        ]
+        childAppsList << rule
+
+        and: 'some recent + error debug logs for this rule'
+        stateMap.debugLogs = [
+            entries: [
+                [timestamp: 1L, level: 'info',  component: 'rules', message: 'ran', ruleId: '42'],
+                [timestamp: 2L, level: 'error', component: 'rules', message: 'boom', ruleId: '42', stackTrace: 't1'],
+                [timestamp: 3L, level: 'info',  component: 'rules', message: 'other', ruleId: '99']
+            ],
+            config: [logLevel: 'debug', maxEntries: 100]
+        ]
+
+        when:
+        def result = script.toolGetRuleDiagnostics([ruleId: '42'])
+
+        then:
+        result.rule.id == 42L
+        result.rule.name == 'My Rule'
+        result.execution.count == 5
+        result.structure.triggerCount == 2
+        result.structure.conditionCount == 1
+        result.structure.actionCount == 3
+        result.structure.conditionLogic == 'all'
+        result.logs.recentCount == 2
+        result.logs.errorCount == 1
+        result.logs.errors[0].message == 'boom'
+    }
+
+    // -------- toolGetZwaveDetails --------
+
+    def "get_zwave_details throws when Hub Admin Read is disabled"() {
+        when:
+        script.toolGetZwaveDetails([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Read')
+    }
+
+    def "get_zwave_details combines hub-SDK zwaveVersion with parsed /hub/zwaveDetails/json"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = [zwaveVersion: '7.17.1']
+        hubGet.register('/hub/zwaveDetails/json') { params ->
+            JsonOutput.toJson([firmware: '7.17.1', sdkVersion: '6.82', deviceCount: 12])
+        }
+
+        when:
+        def result = script.toolGetZwaveDetails([:])
+
+        then:
+        result.zwaveVersion == '7.17.1'
+        result.source == 'hub_api'
+        result.endpoint == '/hub/zwaveDetails/json'
+        result.zwaveData.firmware == '7.17.1'
+        result.zwaveData.deviceCount == 12
+    }
+
+    def "get_zwave_details falls back to sdk_only when all zwave endpoints fail"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = [zwaveVersion: '7.0.0']
+        // No registered endpoints for /hub/zwaveDetails/json or /hub2/zwaveInfo —
+        // HubInternalGetMock throws, which the tool catches per endpoint.
+
+        when:
+        def result = script.toolGetZwaveDetails([:])
+
+        then:
+        result.source == 'sdk_only'
+        result.note.contains('unavailable')
+        result.zwaveVersion == '7.0.0'
+    }
+
+    def "get_zwave_details captures raw response when endpoint returns non-JSON"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = [zwaveVersion: '7.0.0']
+        hubGet.register('/hub/zwaveDetails/json') { params -> '<html>not json</html>' }
+
+        when:
+        def result = script.toolGetZwaveDetails([:])
+
+        then:
+        result.source == 'hub_api_raw'
+        result.rawResponse.contains('not json')
+        result.note.contains('not JSON')
+    }
+
+    // -------- toolGetZigbeeDetails --------
+
+    def "get_zigbee_details throws when Hub Admin Read is disabled"() {
+        when:
+        script.toolGetZigbeeDetails([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Read')
+    }
+
+    def "get_zigbee_details returns channel + zigbeeId + parsed details"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = [zigbeeChannel: 25, zigbeeId: '0x1234']
+        hubGet.register('/hub/zigbeeDetails/json') { params ->
+            JsonOutput.toJson([panId: '0xABCD', channel: 25, deviceCount: 7])
+        }
+
+        when:
+        def result = script.toolGetZigbeeDetails([:])
+
+        then:
+        result.zigbeeChannel == 25
+        result.zigbeeId == '0x1234'
+        result.source == 'hub_api'
+        result.zigbeeData.panId == '0xABCD'
+        result.zigbeeData.deviceCount == 7
+    }
+
+    def "get_zigbee_details falls back to sdk_only when all endpoints fail"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = [zigbeeChannel: 20, zigbeeId: '0xAAAA']
+
+        when:
+        def result = script.toolGetZigbeeDetails([:])
+
+        then:
+        result.source == 'sdk_only'
+        result.zigbeeChannel == 20
+    }
+
+    // -------- toolZwaveRepair (DESTRUCTIVE: confirm + Hub Admin Write gate) --------
+
+    def "zwave_repair throws when confirm is not provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolZwaveRepair([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('SAFETY CHECK FAILED')
+        ex.message.contains('confirm=true')
+    }
+
+    def "zwave_repair throws when Hub Admin Write is disabled"() {
+        when:
+        script.toolZwaveRepair([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Write')
+    }
+
+    def "zwave_repair throws when no recent backup exists"() {
+        given:
+        settingsMap.enableHubAdminWrite = true
+        // No stateMap.lastBackupTimestamp
+
+        when:
+        script.toolZwaveRepair([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('BACKUP REQUIRED')
+    }
+
+    def "zwave_repair posts to /hub/zwaveRepair and reports success with warning"() {
+        given:
+        enableHubAdminWrite()
+        def postedPath = null
+        script.metaClass.hubInternalPost = { String path, Map body = null ->
+            postedPath = path
+            'repair started'
+        }
+
+        when:
+        def result = script.toolZwaveRepair([confirm: true])
+
+        then:
+        postedPath == '/hub/zwaveRepair'
+        result.success == true
+        result.message.contains('Z-Wave network repair')
+        result.warning.contains('unresponsive')
+        result.duration.contains('5-30 minutes')
+        result.response == 'repair started'
+    }
+
+    def "zwave_repair reports failure without throwing when POST throws"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPost = { String path, Map body = null ->
+            throw new RuntimeException('hub unreachable')
+        }
+
+        when:
+        def result = script.toolZwaveRepair([confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('Z-Wave repair failed')
+        result.error.contains('hub unreachable')
+    }
+
+    // -------- toolListCapturedStates --------
+
+    def "list_captured_states returns an empty list with count when state is empty"() {
+        when:
+        def result = script.toolListCapturedStates()
+
+        then:
+        result.capturedStates == []
+        result.count == 0
+        result.maxLimit != null
+    }
+
+    def "list_captured_states returns entries sorted newest-first"() {
+        given:
+        stateMap.capturedDeviceStates = [
+            older: [devices: [[id: '1', name: 'D1']], timestamp: 1000L, deviceCount: 1],
+            newer: [devices: [[id: '2', name: 'D2'], [id: '3', name: 'D3']], timestamp: 5000L, deviceCount: 2]
+        ]
+
+        when:
+        def result = script.toolListCapturedStates()
+
+        then:
+        result.count == 2
+        result.capturedStates[0].stateId == 'newer'
+        result.capturedStates[0].deviceCount == 2
+        result.capturedStates[1].stateId == 'older'
+    }
+
+    def "list_captured_states surfaces an at-capacity warning"() {
+        given: 'maxCapturedStates default is 20; seed exactly 20 entries'
+        settingsMap.maxCapturedStates = 5
+        stateMap.capturedDeviceStates = (1..5).collectEntries { i ->
+            ["s${i}".toString(), [devices: [], timestamp: (i * 1000L), deviceCount: 0]]
+        }
+
+        when:
+        def result = script.toolListCapturedStates()
+
+        then:
+        result.count == 5
+        result.warning.contains('maximum capacity')
+    }
+
+    // -------- toolDeleteCapturedState --------
+
+    def "delete_captured_state throws when stateId is missing"() {
+        when:
+        script.toolDeleteCapturedState(null)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('stateId is required')
+    }
+
+    def "delete_captured_state removes the specified entry"() {
+        given:
+        stateMap.capturedDeviceStates = [
+            keep: [devices: [], timestamp: 1000L, deviceCount: 0],
+            gone: [devices: [], timestamp: 2000L, deviceCount: 0]
+        ]
+
+        when:
+        def result = script.toolDeleteCapturedState('gone')
+
+        then:
+        result.success == true
+        result.remaining == 1
+        stateMap.capturedDeviceStates.containsKey('keep')
+        !stateMap.capturedDeviceStates.containsKey('gone')
+    }
+
+    def "delete_captured_state reports not-found without throwing"() {
+        given:
+        stateMap.capturedDeviceStates = [keep: [devices: [], timestamp: 1000L, deviceCount: 0]]
+
+        when:
+        def result = script.toolDeleteCapturedState('absent')
+
+        then:
+        result.success == false
+        result.message.contains("'absent' not found")
+    }
+
+    // -------- toolClearCapturedStates --------
+
+    def "clear_captured_states empties state.capturedDeviceStates and returns count"() {
+        given:
+        stateMap.capturedDeviceStates = [
+            a: [devices: [], timestamp: 1000L, deviceCount: 0],
+            b: [devices: [], timestamp: 2000L, deviceCount: 0],
+            c: [devices: [], timestamp: 3000L, deviceCount: 0]
+        ]
+
+        when:
+        def result = script.toolClearCapturedStates()
+
+        then:
+        result.success == true
+        result.cleared == 3
+        stateMap.capturedDeviceStates == [:]
+    }
+
+    def "clear_captured_states is idempotent on empty state"() {
+        when:
+        def result = script.toolClearCapturedStates()
+
+        then:
+        result.success == true
+        result.cleared == 0
+    }
+}

--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -4,6 +4,7 @@ import groovy.json.JsonOutput
 import spock.lang.Shared
 import support.TestChildApp
 import support.TestDevice
+import support.TestHub
 import support.TestLocation
 import support.ToolSpecBase
 
@@ -28,9 +29,12 @@ import support.ToolSpecBase
  *   - downloadHubFile /
  *     uploadHubFile       -> stubbed per-test on script.metaClass
  *   - location.hub        -> appExecutor.getLocation() returns sharedLocation;
- *                            individual tests set `sharedLocation.hub = [...]`
- *                            to drive location.hub reads (e.g. zwaveVersion,
- *                            zigbeeChannel, uptime)
+ *                            individual tests set `sharedLocation.hub = new
+ *                            TestHub(zwaveVersion: ..., uptime: ...)` to drive
+ *                            location.hub reads. TestLocation's `hub` field
+ *                            must be typed Hub (not Object) because
+ *                            Location.getHub()'s declared return type is Hub —
+ *                            Groovy's override check rejects `def hub`.
  *   - app (for completeness; this gateway doesn't call app.updateSetting)
  *
  * NOTE on clear_captured_states / delete_captured_state: the current server
@@ -71,7 +75,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     def "get_set_hub_metrics snapshots memory/temp/db and records a CSV row"() {
         given:
         settingsMap.enableHubAdminRead = true
-        sharedLocation.hub = [uptime: 172800L]  // 2 days
+        sharedLocation.hub = new TestHub(uptime: 172800G)  // 2 days
         hubGet.register('/hub/advanced/freeOSMemory') { params -> '123456' }
         hubGet.register('/hub/advanced/internalTempCelsius') { params -> '45.5' }
         hubGet.register('/hub/advanced/databaseSize') { params -> '200000' }
@@ -92,7 +96,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         result.current.freeMemoryKB == '123456'
         result.current.internalTempC == '45.5'
         result.current.databaseSizeKB == '200000'
-        result.current.uptimeSeconds == 172800L
+        result.current.uptimeSeconds == 172800G
         result.current.uptimeFormatted == '2d 0h 0m'
         result.historyFile == 'mcp-performance-history.csv'
         result.trendPointsAvailable == 1
@@ -105,7 +109,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     def "get_set_hub_metrics warns on low memory"() {
         given:
         settingsMap.enableHubAdminRead = true
-        sharedLocation.hub = [uptime: 3600L]
+        sharedLocation.hub = new TestHub(uptime: 3600G)
         hubGet.register('/hub/advanced/freeOSMemory') { params -> '40000' }  // <50000 triggers warning
         hubGet.register('/hub/advanced/internalTempCelsius') { params -> '40' }
         hubGet.register('/hub/advanced/databaseSize') { params -> '100000' }
@@ -123,7 +127,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     def "get_set_hub_metrics respects recordSnapshot=false (no CSV write)"() {
         given:
         settingsMap.enableHubAdminRead = true
-        sharedLocation.hub = [uptime: 0L]
+        sharedLocation.hub = new TestHub(uptime: 0G)
         hubGet.register('/hub/advanced/freeOSMemory') { params -> '100000' }
         hubGet.register('/hub/advanced/internalTempCelsius') { params -> '50' }
         hubGet.register('/hub/advanced/databaseSize') { params -> '100000' }
@@ -388,7 +392,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     def "get_zwave_details combines hub-SDK zwaveVersion with parsed /hub/zwaveDetails/json"() {
         given:
         settingsMap.enableHubAdminRead = true
-        sharedLocation.hub = [zwaveVersion: '7.17.1']
+        sharedLocation.hub = new TestHub(zwaveVersion: '7.17.1')
         hubGet.register('/hub/zwaveDetails/json') { params ->
             JsonOutput.toJson([firmware: '7.17.1', sdkVersion: '6.82', deviceCount: 12])
         }
@@ -407,7 +411,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     def "get_zwave_details falls back to sdk_only when all zwave endpoints fail"() {
         given:
         settingsMap.enableHubAdminRead = true
-        sharedLocation.hub = [zwaveVersion: '7.0.0']
+        sharedLocation.hub = new TestHub(zwaveVersion: '7.0.0')
         // No registered endpoints for /hub/zwaveDetails/json or /hub2/zwaveInfo —
         // HubInternalGetMock throws, which the tool catches per endpoint.
 
@@ -423,7 +427,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     def "get_zwave_details captures raw response when endpoint returns non-JSON"() {
         given:
         settingsMap.enableHubAdminRead = true
-        sharedLocation.hub = [zwaveVersion: '7.0.0']
+        sharedLocation.hub = new TestHub(zwaveVersion: '7.0.0')
         hubGet.register('/hub/zwaveDetails/json') { params -> '<html>not json</html>' }
 
         when:
@@ -449,7 +453,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     def "get_zigbee_details returns channel + zigbeeId + parsed details"() {
         given:
         settingsMap.enableHubAdminRead = true
-        sharedLocation.hub = [zigbeeChannel: 25, zigbeeId: '0x1234']
+        sharedLocation.hub = new TestHub(zigbeeChannel: 25, zigbeeId: '0x1234')
         hubGet.register('/hub/zigbeeDetails/json') { params ->
             JsonOutput.toJson([panId: '0xABCD', channel: 25, deviceCount: 7])
         }
@@ -468,7 +472,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     def "get_zigbee_details falls back to sdk_only when all endpoints fail"() {
         given:
         settingsMap.enableHubAdminRead = true
-        sharedLocation.hub = [zigbeeChannel: 20, zigbeeId: '0xAAAA']
+        sharedLocation.hub = new TestHub(zigbeeChannel: 20, zigbeeId: '0xAAAA')
 
         when:
         def result = script.toolGetZigbeeDetails([:])

--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -35,7 +35,6 @@ import support.ToolSpecBase
  *                            must be typed Hub (not Object) because
  *                            Location.getHub()'s declared return type is Hub —
  *                            Groovy's override check rejects `def hub`.
- *   - app (for completeness; this gateway doesn't call app.updateSetting)
  *
  * NOTE on clear_captured_states / delete_captured_state: the current server
  * source (hubitat-mcp-server.groovy) does not gate these on confirm=true —
@@ -106,6 +105,41 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         uploaded['mcp-performance-history.csv']?.contains('123456')
     }
 
+    def "get_set_hub_metrics warns on high temperature"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = new TestHub(uptime: 3600G)
+        hubGet.register('/hub/advanced/freeOSMemory') { params -> '200000' }
+        hubGet.register('/hub/advanced/internalTempCelsius') { params -> '75' }  // >70 triggers warning
+        hubGet.register('/hub/advanced/databaseSize') { params -> '100000' }
+        script.metaClass.downloadHubFile = { String fileName -> null }
+        script.metaClass.uploadHubFile = { String fileName, byte[] content -> }
+
+        when:
+        def result = script.toolGetHubPerformance([recordSnapshot: false])
+
+        then:
+        result.current.temperatureWarning.contains('HIGH TEMPERATURE')
+        result.current.temperatureWarning.contains('75')
+    }
+
+    def "get_set_hub_metrics warns on large database"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = new TestHub(uptime: 3600G)
+        hubGet.register('/hub/advanced/freeOSMemory') { params -> '200000' }
+        hubGet.register('/hub/advanced/internalTempCelsius') { params -> '40' }
+        hubGet.register('/hub/advanced/databaseSize') { params -> '600000' }  // >500000 triggers warning
+        script.metaClass.downloadHubFile = { String fileName -> null }
+        script.metaClass.uploadHubFile = { String fileName, byte[] content -> }
+
+        when:
+        def result = script.toolGetHubPerformance([recordSnapshot: false])
+
+        then:
+        result.current.databaseWarning.contains('LARGE DATABASE')
+    }
+
     def "get_set_hub_metrics warns on low memory"() {
         given:
         settingsMap.enableHubAdminRead = true
@@ -131,14 +165,16 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         hubGet.register('/hub/advanced/freeOSMemory') { params -> '100000' }
         hubGet.register('/hub/advanced/internalTempCelsius') { params -> '50' }
         hubGet.register('/hub/advanced/databaseSize') { params -> '100000' }
-        script.metaClass.downloadHubFile = { String fileName -> null }
+        def downloadCalled = false
+        script.metaClass.downloadHubFile = { String fileName -> downloadCalled = true; null }
         def uploadCalled = false
         script.metaClass.uploadHubFile = { String fileName, byte[] content -> uploadCalled = true }
 
         when:
         def result = script.toolGetHubPerformance([recordSnapshot: false])
 
-        then:
+        then: 'the CSV read still runs (trend points come from prior runs), but no write'
+        downloadCalled
         !uploadCalled
         result.trendPointsAvailable == 0
     }
@@ -240,7 +276,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     }
 
     def "force_garbage_collection triggers GC and reports before/after"() {
-        given:
+        given: 'two freeOSMemory reads pre + post, one forceGC between. pauseExecution is a no-op on the AppExecutor mock.'
         settingsMap.enableHubAdminRead = true
         def beforeAfter = ['90000', '120000']
         def idx = 0
@@ -251,7 +287,8 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         when:
         def result = script.toolForceGarbageCollection([:])
 
-        then:
+        then: 'both memory reads fired (tool must probe before AND after), and GC was triggered between'
+        idx == 2
         gcCalled
         result.beforeFreeMemoryKB == 90000
         result.afterFreeMemoryKB == 120000
@@ -409,11 +446,11 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     }
 
     def "get_zwave_details falls back to sdk_only when all zwave endpoints fail"() {
-        given:
+        given: 'both zwave endpoints throw realistic hub errors (404 on older firmware)'
         settingsMap.enableHubAdminRead = true
         sharedLocation.hub = new TestHub(zwaveVersion: '7.0.0')
-        // No registered endpoints for /hub/zwaveDetails/json or /hub2/zwaveInfo —
-        // HubInternalGetMock throws, which the tool catches per endpoint.
+        hubGet.register('/hub/zwaveDetails/json') { params -> throw new RuntimeException('404 Not Found') }
+        hubGet.register('/hub2/zwaveInfo')        { params -> throw new RuntimeException('404 Not Found') }
 
         when:
         def result = script.toolGetZwaveDetails([:])
@@ -470,9 +507,11 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     }
 
     def "get_zigbee_details falls back to sdk_only when all endpoints fail"() {
-        given:
+        given: 'both zigbee endpoints throw realistic hub errors'
         settingsMap.enableHubAdminRead = true
         sharedLocation.hub = new TestHub(zigbeeChannel: 20, zigbeeId: '0xAAAA')
+        hubGet.register('/hub/zigbeeDetails/json') { params -> throw new RuntimeException('404 Not Found') }
+        hubGet.register('/hub2/zigbeeInfo')        { params -> throw new RuntimeException('404 Not Found') }
 
         when:
         def result = script.toolGetZigbeeDetails([:])
@@ -480,6 +519,21 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         then:
         result.source == 'sdk_only'
         result.zigbeeChannel == 20
+    }
+
+    def "get_zigbee_details captures raw response when endpoint returns non-JSON"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        sharedLocation.hub = new TestHub(zigbeeChannel: 25, zigbeeId: '0x1234')
+        hubGet.register('/hub/zigbeeDetails/json') { params -> '<html>not json</html>' }
+
+        when:
+        def result = script.toolGetZigbeeDetails([:])
+
+        then:
+        result.source == 'hub_api_raw'
+        result.rawResponse.contains('not json')
+        result.note.contains('not JSON')
     }
 
     // -------- toolZwaveRepair (DESTRUCTIVE: confirm + Hub Admin Write gate) --------
@@ -554,12 +608,13 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         result.success == false
         result.error.contains('Z-Wave repair failed')
         result.error.contains('hub unreachable')
+        result.note.contains('Z-Wave Details')
     }
 
     // -------- toolListCapturedStates --------
 
     def "list_captured_states returns an empty list with count when state is empty"() {
-        when:
+        when: 'no confirm arg — pins the current no-gate behaviour; a future confirm gate would flip this'
         def result = script.toolListCapturedStates()
 
         then:
@@ -586,7 +641,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
     }
 
     def "list_captured_states surfaces an at-capacity warning"() {
-        given: 'maxCapturedStates default is 20; seed exactly 20 entries'
+        given: 'override the cap to 5 so filling capacity only takes 5 seed entries'
         settingsMap.maxCapturedStates = 5
         stateMap.capturedDeviceStates = (1..5).collectEntries { i ->
             ["s${i}".toString(), [devices: [], timestamp: (i * 1000L), deviceCount: 0]]
@@ -598,6 +653,22 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         then:
         result.count == 5
         result.warning.contains('maximum capacity')
+    }
+
+    def "list_captured_states surfaces the approaching-limit warning at max-4 slots"() {
+        given: 'max=10, 7 entries → count >= max-4 branch (source hubitat-mcp-server.groovy:3174)'
+        settingsMap.maxCapturedStates = 10
+        stateMap.capturedDeviceStates = (1..7).collectEntries { i ->
+            ["s${i}".toString(), [devices: [], timestamp: (i * 1000L), deviceCount: 0]]
+        }
+
+        when:
+        def result = script.toolListCapturedStates()
+
+        then:
+        result.count == 7
+        result.warning.contains('Approaching limit')
+        result.warning.contains('7/10')
     }
 
     // -------- toolDeleteCapturedState --------

--- a/src/test/groovy/server/ToolManageFilesSpec.groovy
+++ b/src/test/groovy/server/ToolManageFilesSpec.groovy
@@ -1,0 +1,437 @@
+package server
+
+import groovy.json.JsonOutput
+import support.ToolSpecBase
+
+/**
+ * Spec for the manage_files gateway tools (hubitat-mcp-server.groovy):
+ *
+ * - toolListFiles  -> list_files
+ * - toolReadFile   -> read_file
+ * - toolWriteFile  -> write_file   (Hub Admin Write + confirm)
+ * - toolDeleteFile -> delete_file  (Hub Admin Write + confirm)
+ *
+ * Mocking strategy (see docs/testing.md):
+ *   - hubInternalGet                        -> HarnessSpec's hubGet.register(path)
+ *   - downloadHubFile / uploadHubFile /
+ *     deleteHubFile                         -> stubbed per-test on script.metaClass
+ *
+ * write_file + delete_file are gated by requireHubAdminWrite(args.confirm), which
+ * requires enableHubAdminWrite=true, confirm=true, AND a lastBackupTimestamp
+ * within 24h — see ToolDestructiveHubOpsSpec for the same gate's dedicated tests
+ * on reboot_hub / shutdown_hub / delete_device. The Hub-Admin-Write safety gate
+ * tests here are explicit rather than shared so each tool's gate regression is
+ * discoverable from its own spec.
+ */
+class ToolManageFilesSpec extends ToolSpecBase {
+
+    private void enableHubAdminWrite() {
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L  // matches HarnessSpec's fixed now()
+    }
+
+    // -------- toolListFiles --------
+
+    def "list_files returns the parsed JSON file list from /hub/fileManager/json"() {
+        given:
+        hubGet.register('/hub/fileManager/json') { params ->
+            JsonOutput.toJson([
+                [name: 'b.csv', size: 200, date: '2026-04-19'],
+                [name: 'a.txt', size: 100, date: '2026-04-18']
+            ])
+        }
+
+        when:
+        def result = script.toolListFiles()
+
+        then: 'sorted alphabetically by name'
+        result.total == 2
+        result.files[0].name == 'a.txt'
+        result.files[1].name == 'b.csv'
+        result.files[0].size == 100
+        result.files[0].lastModified == '2026-04-18'
+        result.files[0].directDownload.contains('/local/a.txt')
+    }
+
+    def "list_files falls back to /hub/fileManager when /json fails"() {
+        given:
+        hubGet.register('/hub/fileManager/json') { params ->
+            throw new RuntimeException('endpoint 404')
+        }
+        hubGet.register('/hub/fileManager') { params ->
+            JsonOutput.toJson([files: [[name: 'only.txt', size: 10]]])
+        }
+
+        when:
+        def result = script.toolListFiles()
+
+        then:
+        result.total == 1
+        result.files[0].name == 'only.txt'
+    }
+
+    def "list_files returns 'API not available' message when no endpoint responds"() {
+        given:
+        hubGet.register('/hub/fileManager/json') { params -> null }
+        hubGet.register('/hub/fileManager') { params -> null }
+
+        when:
+        def result = script.toolListFiles()
+
+        then:
+        result.total == 0
+        result.files == []
+        result.message.contains('File Manager API not available')
+        result.manualAccess.contains('Settings > File Manager')
+    }
+
+    def "list_files extracts file names from an HTML fallback response"() {
+        given:
+        hubGet.register('/hub/fileManager/json') { params ->
+            '''<html><body>
+               <a href="/local/foo.txt">foo.txt</a>
+               <a href="/local/bar%20baz.csv">bar baz.csv</a>
+               </body></html>'''
+        }
+
+        when:
+        def result = script.toolListFiles()
+
+        then:
+        result.total == 2
+        result.files*.name.sort() == ['bar baz.csv', 'foo.txt']
+        result.note.contains('HTML')
+    }
+
+    // -------- toolReadFile --------
+
+    def "read_file throws when fileName is missing"() {
+        when:
+        script.toolReadFile([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('fileName is required')
+    }
+
+    def "read_file returns full content when it fits in one chunk"() {
+        given:
+        script.metaClass.downloadHubFile = { String name ->
+            name == 'notes.txt' ? 'Hello, world!'.getBytes('UTF-8') : null
+        }
+
+        when:
+        def result = script.toolReadFile([fileName: 'notes.txt'])
+
+        then:
+        result.success == true
+        result.fileName == 'notes.txt'
+        result.content == 'Hello, world!'
+        result.totalLength == 13
+        result.offset == 0
+        result.chunkLength == 13
+        result.hasMore == false
+        result.directDownload.contains('/local/notes.txt')
+    }
+
+    def "read_file returns a chunk + nextOffset hint when content exceeds max chunk"() {
+        given:
+        def big = 'x' * 70000  // exceeds the 60000 max chunk
+        script.metaClass.downloadHubFile = { String name -> big.getBytes('UTF-8') }
+
+        when:
+        def result = script.toolReadFile([fileName: 'big.txt'])
+
+        then:
+        result.chunkLength == 60000
+        result.totalLength == 70000
+        result.hasMore == true
+        result.nextOffset == 60000
+        result.remainingChars == 10000
+        result.hint.contains('offset: 60000')
+    }
+
+    def "read_file honours an explicit offset + length"() {
+        given:
+        script.metaClass.downloadHubFile = { String name -> '0123456789'.getBytes('UTF-8') }
+
+        when:
+        def result = script.toolReadFile([fileName: 'nums.txt', offset: 2, length: 4])
+
+        then:
+        result.content == '2345'
+        result.offset == 2
+        result.chunkLength == 4
+        result.hasMore == true
+        result.nextOffset == 6
+    }
+
+    def "read_file returns an error map when the file is missing"() {
+        given:
+        script.metaClass.downloadHubFile = { String name -> null }
+
+        when:
+        def result = script.toolReadFile([fileName: 'missing.txt'])
+
+        then:
+        result.success == false
+        result.error.contains('missing.txt')
+        result.suggestion.contains('File Manager')
+    }
+
+    // -------- toolWriteFile (DESTRUCTIVE: confirm + Hub Admin Write gate) --------
+
+    def "write_file throws when confirm is not provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolWriteFile([fileName: 'x.txt', content: 'hi'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('SAFETY CHECK FAILED')
+        ex.message.contains('confirm=true')
+    }
+
+    def "write_file throws when Hub Admin Write is disabled"() {
+        when:
+        script.toolWriteFile([fileName: 'x.txt', content: 'hi', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Write')
+    }
+
+    def "write_file throws when no recent backup exists"() {
+        given:
+        settingsMap.enableHubAdminWrite = true
+        // stateMap.lastBackupTimestamp is unset
+
+        when:
+        script.toolWriteFile([fileName: 'x.txt', content: 'hi', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('BACKUP REQUIRED')
+    }
+
+    def "write_file throws when fileName is missing"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolWriteFile([content: 'hi', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('fileName is required')
+    }
+
+    def "write_file throws when content is missing"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolWriteFile([fileName: 'x.txt', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('content is required')
+    }
+
+    def "write_file rejects invalid file names"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolWriteFile([fileName: badName, content: 'ok', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Invalid file name')
+
+        where:
+        badName       | _
+        '../escape'   | _
+        '.hidden'     | _
+        'with space'  | _
+        'x/y'         | _
+    }
+
+    def "write_file creates a new file when none exists"() {
+        given:
+        enableHubAdminWrite()
+        def uploads = []
+        script.metaClass.downloadHubFile = { String name -> null }  // no existing file
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploads << [name: name, content: new String(content, 'UTF-8')]
+        }
+
+        when:
+        def result = script.toolWriteFile([fileName: 'new.txt', content: 'hello', confirm: true])
+
+        then:
+        result.success == true
+        result.message.contains("'new.txt' created")
+        result.fileName == 'new.txt'
+        result.contentLength == 5
+        result.backupFile == null
+        uploads.size() == 1
+        uploads[0].name == 'new.txt'
+        uploads[0].content == 'hello'
+    }
+
+    def "write_file backs up an existing file before overwriting"() {
+        given:
+        enableHubAdminWrite()
+        def uploads = []
+        script.metaClass.downloadHubFile = { String name ->
+            name == 'notes.txt' ? 'old content'.getBytes('UTF-8') : null
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploads << [name: name, content: new String(content, 'UTF-8')]
+        }
+
+        when:
+        def result = script.toolWriteFile([fileName: 'notes.txt', content: 'new content', confirm: true])
+
+        then: 'backup upload preceded the write, and both land on the hub'
+        uploads.size() == 2
+        uploads[0].name.startsWith('notes_backup_')
+        uploads[0].name.endsWith('.txt')
+        uploads[0].content == 'old content'
+        uploads[1].name == 'notes.txt'
+        uploads[1].content == 'new content'
+
+        and: 'response surfaces the backup name + download URL'
+        result.success == true
+        result.backupFile.startsWith('notes_backup_')
+        result.backupDownload.contains('/local/notes_backup_')
+        result.message.contains('updated')
+    }
+
+    def "write_file reports failure without throwing when uploadHubFile errors"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.downloadHubFile = { String name -> null }
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            throw new RuntimeException('hub storage full')
+        }
+
+        when:
+        def result = script.toolWriteFile([fileName: 'x.txt', content: 'hi', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('hub storage full')
+    }
+
+    // -------- toolDeleteFile (DESTRUCTIVE: confirm + Hub Admin Write gate) --------
+
+    def "delete_file throws when confirm is not provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolDeleteFile([fileName: 'x.txt'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('SAFETY CHECK FAILED')
+        ex.message.contains('confirm=true')
+    }
+
+    def "delete_file throws when Hub Admin Write is disabled"() {
+        when:
+        script.toolDeleteFile([fileName: 'x.txt', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Write')
+    }
+
+    def "delete_file throws when fileName is missing"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolDeleteFile([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('fileName is required')
+    }
+
+    def "delete_file backs up then deletes a normal file"() {
+        given:
+        enableHubAdminWrite()
+        def uploads = []
+        def deleted = []
+        script.metaClass.downloadHubFile = { String name ->
+            name == 'notes.txt' ? 'saved content'.getBytes('UTF-8') : null
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploads << name
+        }
+        script.metaClass.deleteHubFile = { String name ->
+            deleted << name
+        }
+
+        when:
+        def result = script.toolDeleteFile([fileName: 'notes.txt', confirm: true])
+
+        then: 'backup upload precedes the delete'
+        uploads.size() == 1
+        uploads[0].startsWith('notes_backup_')
+        uploads[0].endsWith('.txt')
+        deleted == ['notes.txt']
+
+        and: 'result reports the backup and a recovery hint'
+        result.success == true
+        result.fileName == 'notes.txt'
+        result.backupFile.startsWith('notes_backup_')
+        result.backupDownload.contains('/local/notes_backup_')
+        result.undoHint.contains('read_file')
+    }
+
+    def "delete_file skips auto-backup on files that are already backups"() {
+        given:
+        enableHubAdminWrite()
+        def uploads = []
+        def deleted = []
+        script.metaClass.downloadHubFile = { String name -> 'ignored'.getBytes('UTF-8') }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> uploads << name }
+        script.metaClass.deleteHubFile = { String name -> deleted << name }
+
+        when:
+        def result = script.toolDeleteFile([fileName: 'notes_backup_20260419-100000.txt', confirm: true])
+
+        then: 'no backup-of-a-backup is written'
+        uploads == []
+        deleted == ['notes_backup_20260419-100000.txt']
+
+        and:
+        result.success == true
+        result.message.contains('Backup file')
+        result.message.contains('deleted permanently')
+    }
+
+    def "delete_file reports failure without throwing when deleteHubFile errors"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.downloadHubFile = { String name -> 'bytes'.getBytes('UTF-8') }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.deleteHubFile = { String name ->
+            throw new RuntimeException('permission denied')
+        }
+
+        when:
+        def result = script.toolDeleteFile([fileName: 'notes.txt', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('permission denied')
+        result.suggestion.contains('list_files')
+    }
+}

--- a/src/test/groovy/server/ToolManageFilesSpec.groovy
+++ b/src/test/groovy/server/ToolManageFilesSpec.groovy
@@ -85,6 +85,20 @@ class ToolManageFilesSpec extends ToolSpecBase {
         result.manualAccess.contains('Settings > File Manager')
     }
 
+    def "list_files returns 'API not available' when both endpoints throw (hub network failure)"() {
+        given:
+        hubGet.register('/hub/fileManager/json') { params -> throw new RuntimeException('Connection refused') }
+        hubGet.register('/hub/fileManager')      { params -> throw new RuntimeException('Connection refused') }
+
+        when:
+        def result = script.toolListFiles()
+
+        then:
+        result.total == 0
+        result.files == []
+        result.message.contains('File Manager API not available')
+    }
+
     def "list_files extracts file names from an HTML fallback response"() {
         given:
         hubGet.register('/hub/fileManager/json') { params ->
@@ -252,11 +266,14 @@ class ToolManageFilesSpec extends ToolSpecBase {
         ex.message.contains('Invalid file name')
 
         where:
-        badName       | _
-        '../escape'   | _
-        '.hidden'     | _
-        'with space'  | _
-        'x/y'         | _
+        badName         | _
+        '../escape'     | _
+        '.hidden'       | _
+        'with space'    | _
+        'x/y'           | _
+        '_leading_us'   | _   // underscore isn't allowed as first char
+        'foo$bar'       | _   // $ isn't in the allowed [A-Za-z0-9._-] set
+        'café.txt'      | _   // non-ASCII rejected — ASCII-only allowlist
     }
 
     def "write_file creates a new file when none exists"() {
@@ -311,18 +328,48 @@ class ToolManageFilesSpec extends ToolSpecBase {
         result.message.contains('updated')
     }
 
-    def "write_file reports failure without throwing when uploadHubFile errors"() {
+    def "write_file treats a download-throws exception as 'no existing file' and skips the backup step"() {
+        // Pins the current server behaviour: the backup attempt is wrapped in
+        // a try/catch that swallows ANY download throw and proceeds as if
+        // there was no prior file (hubitat-mcp-server.groovy:4512-4515). Note
+        // this means a transient File-Manager read failure on a file that
+        // DOES exist would cause the overwrite to silently skip the backup —
+        // worth future design review, but pinning current behaviour here.
         given:
         enableHubAdminWrite()
+        def uploads = []
+        script.metaClass.downloadHubFile = { String name ->
+            throw new RuntimeException('File Manager API transient error')
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploads << [name: name, content: new String(content, 'UTF-8')]
+        }
+
+        when:
+        def result = script.toolWriteFile([fileName: 'x.txt', content: 'hi', confirm: true])
+
+        then: 'one upload (the write itself) — no backup attempted because the download threw'
+        uploads.size() == 1
+        uploads[0].name == 'x.txt'
+        result.success == true
+        result.backupFile == null
+    }
+
+    def "write_file reports failure without throwing when uploadHubFile errors"() {
+        given: 'no existing file — so the only upload attempt is the new-file write itself'
+        enableHubAdminWrite()
+        def uploadCalls = []
         script.metaClass.downloadHubFile = { String name -> null }
         script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploadCalls << name
             throw new RuntimeException('hub storage full')
         }
 
         when:
         def result = script.toolWriteFile([fileName: 'x.txt', content: 'hi', confirm: true])
 
-        then:
+        then: 'exactly one upload attempt (the write itself) — no spurious backup attempt for a nonexistent file'
+        uploadCalls == ['x.txt']
         result.success == false
         result.error.contains('hub storage full')
     }
@@ -395,8 +442,8 @@ class ToolManageFilesSpec extends ToolSpecBase {
         result.undoHint.contains('read_file')
     }
 
-    def "delete_file skips auto-backup on files that are already backups"() {
-        given:
+    def "delete_file skips auto-backup on files that are already backups (#fileName)"() {
+        given: 'isBackupFile trips on any of three markers (source ~line 4555): _backup_ substring, mcp-backup- prefix, mcp-prerestore- prefix'
         enableHubAdminWrite()
         def uploads = []
         def deleted = []
@@ -405,16 +452,20 @@ class ToolManageFilesSpec extends ToolSpecBase {
         script.metaClass.deleteHubFile = { String name -> deleted << name }
 
         when:
-        def result = script.toolDeleteFile([fileName: 'notes_backup_20260419-100000.txt', confirm: true])
+        def result = script.toolDeleteFile([fileName: fileName, confirm: true])
 
-        then: 'no backup-of-a-backup is written'
+        then: 'no backup-of-a-backup is written — each trigger wired independently'
         uploads == []
-        deleted == ['notes_backup_20260419-100000.txt']
-
-        and:
+        deleted == [fileName]
         result.success == true
         result.message.contains('Backup file')
         result.message.contains('deleted permanently')
+
+        where:
+        fileName                              | _
+        'notes_backup_20260419-100000.txt'    | _   // substring _backup_
+        'mcp-backup-app-42.groovy'            | _   // prefix mcp-backup-
+        'mcp-prerestore-driver-9.groovy'      | _   // prefix mcp-prerestore-
     }
 
     def "delete_file reports failure without throwing when deleteHubFile errors"() {

--- a/src/test/groovy/server/ToolManageLogsSpec.groovy
+++ b/src/test/groovy/server/ToolManageLogsSpec.groovy
@@ -30,10 +30,8 @@ import support.ToolSpecBase
  *                           clears the settingsStore between tests.
  *   - debug-log state    -> state.debugLogs is a plain Map, seeded in given:
  *
- * Additional get_hub_logs coverage — ToolGetHubLogsSpec already covers
- * most-recent-first ordering and the PR #64 validation regressions; this
- * spec adds: level filter across all four levels, source substring matching,
- * explicit limit trimming, and empty-response handling.
+ * Additional get_hub_logs coverage — this spec complements ToolGetHubLogsSpec
+ * with level/source/limit/empty-response/deviceId/appId/truncation cases.
  */
 class ToolManageLogsSpec extends ToolSpecBase {
 
@@ -43,7 +41,8 @@ class ToolManageLogsSpec extends ToolSpecBase {
         // HarnessSpec.setupSpec runs first (Spock auto-invokes superclass
         // fixtures in declaration order). Layering getApp() onto the
         // already-built mock here gives toolSetLogLevel's app.updateSetting
-        // call a non-null target.
+        // call a non-null target. Same additive-stub pattern that
+        // ToolRoomsSpec uses for appExecutor.httpPost(_, _).
         appExecutor.getApp() >> sharedAppStub
     }
 
@@ -95,7 +94,7 @@ class ToolManageLogsSpec extends ToolSpecBase {
         when:
         def result = script.toolGetHubLogs([source: 'kitchen'])
 
-        then: 'matches "Kitchen" in the name field, case-insensitively'
+        then: 'case-insensitive substring match against message or name'
         result.logs.size() == 2
         result.logs.every { it.name.toLowerCase().contains('kitchen') }
     }
@@ -117,6 +116,75 @@ class ToolManageLogsSpec extends ToolSpecBase {
         result.logs[0].message == 'Message 10'
         result.logs[1].message == 'Message 9'
         result.logs[2].message == 'Message 8'
+    }
+
+    def "get_hub_logs scopes to a selected device and passes type=dev&id=X in query"() {
+        given: 'a selected device so findDevice succeeds'
+        settingsMap.enableHubAdminRead = true
+        def device = new TestDevice(id: 42, name: 'K', label: 'K')
+        settingsMap.selectedDevices = [device]
+        def capturedParams = null
+        hubGet.register('/logs/past/json') { params ->
+            capturedParams = params
+            JsonOutput.toJson(['K\tinfo\thi\t2026-04-19 10:00:00.000\ttype'])
+        }
+
+        when:
+        def result = script.toolGetHubLogs([deviceId: '42'])
+
+        then:
+        capturedParams == [type: 'dev', id: '42']
+        result.logs.size() == 1
+    }
+
+    def "get_hub_logs rejects an unknown deviceId before hitting the hub"() {
+        given: 'no selected device with id 999'
+        settingsMap.enableHubAdminRead = true
+        // If the tool ever called hubInternalGet, HubInternalGetMock would throw
+        // (unstubbed), so the IllegalArgumentException below proves the pre-HTTP
+        // validation fired.
+
+        when:
+        script.toolGetHubLogs([deviceId: '999'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Device not found')
+    }
+
+    def "get_hub_logs scopes to an app and passes type=app&id=X in query"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        def capturedParams = null
+        hubGet.register('/logs/past/json') { params ->
+            capturedParams = params
+            JsonOutput.toJson(['App 7\tinfo\thi\t2026-04-19 10:00:00.000\ttype'])
+        }
+
+        when:
+        def result = script.toolGetHubLogs([appId: '7'])
+
+        then:
+        capturedParams == [type: 'app', id: '7']
+        result.logs.size() == 1
+    }
+
+    def "get_hub_logs truncates messages when estimated JSON exceeds the 120KB cloud limit"() {
+        given: 'many entries with long messages so estimatedJsonSize trips the 120000-byte truncation guard'
+        settingsMap.enableHubAdminRead = true
+        def longMsg = 'x' * 2000
+        def lines = (1..200).collect { i ->
+            "App 1\tinfo\t${longMsg}\t2026-04-19 10:00:${String.format('%02d', (i % 60))}.000\ttype".toString()
+        }
+        hubGet.register('/logs/past/json') { params -> JsonOutput.toJson(lines) }
+
+        when: 'limit=200 means ~200 entries × (2000 message + overhead) > 120000'
+        def result = script.toolGetHubLogs([limit: 200])
+
+        then:
+        result.truncated == true
+        result.note.contains('truncated')
+        result.logs.every { it.message.length() <= 200 }
     }
 
     def "get_hub_logs handles empty hub response gracefully"() {
@@ -157,7 +225,11 @@ class ToolManageLogsSpec extends ToolSpecBase {
         given: 'a selected device whose eventsSince returns 2 events'
         def fixedDate = new Date(1234567880000L)
         def device = new TestDevice(id: 42, name: 'Kitchen Light', label: 'Kitchen Light')
+        def capturedSince = null
+        def capturedOpts = null
         device.metaClass.eventsSince = { Date since, Map opts ->
+            capturedSince = since
+            capturedOpts = opts
             [
                 [name: 'switch', value: 'on', unit: null, descriptionText: 'turned on', date: fixedDate, isStateChange: true],
                 [name: 'level', value: '75', unit: '%', descriptionText: 'dimmed', date: fixedDate, isStateChange: true]
@@ -166,9 +238,14 @@ class ToolManageLogsSpec extends ToolSpecBase {
         settingsMap.selectedDevices = [device]
 
         when:
-        def result = script.toolGetDeviceHistory([deviceId: '42', hoursBack: 12])
+        def result = script.toolGetDeviceHistory([deviceId: '42', hoursBack: 12, limit: 50])
 
-        then:
+        then: 'eventsSince receives the hoursBack-derived sinceDate and the limit via opts.max'
+        capturedSince != null
+        capturedSince.time == 1234567890000L - (12 * 3600000L)
+        capturedOpts == [max: 50]
+
+        and:
         result.deviceId == '42'
         result.device == 'Kitchen Light'
         result.hoursBack == 12
@@ -211,8 +288,9 @@ class ToolManageLogsSpec extends ToolSpecBase {
         when:
         def result = script.toolGetDeviceHistory([deviceId: '42'])
 
-        then:
-        result.error.contains('eventsSince not supported')
+        then: 'the thrown message is preserved in the "failed" half so a caller can debug'
+        result.error.contains('failed')
+        result.error.contains('event store unavailable')
         result.deviceId == '42'
     }
 
@@ -292,8 +370,56 @@ class ToolManageLogsSpec extends ToolSpecBase {
         result.appSummary.appCount == 1
     }
 
-    def "get_performance_stats returns an error map when Hub Admin Read is disabled"() {
-        when: 'enableHubAdminRead is not set, so fetchLogsJson throws inside the tool'
+    def "get_performance_stats surfaces the largeState flag on flagged entries"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/logs/json') { params ->
+            JsonOutput.toJson([
+                uptime: 'x',
+                deviceStats: [
+                    [id: 1, name: 'FatState', pct: 10.0, count: 50, total: 100, stateSize: 50000, formattedPct: '10.00', largeState: true],
+                    [id: 2, name: 'LeanState', pct: 1.0, count: 5, total: 10, stateSize: 100, formattedPct: '1.00']
+                ],
+                appStats: []
+            ])
+        }
+
+        when:
+        def result = script.toolGetPerformanceStats([:])
+
+        then:
+        result.deviceStats[0].name == 'FatState'
+        result.deviceStats[0].largeState == true
+        result.deviceStats[1].name == 'LeanState'
+        !result.deviceStats[1].containsKey('largeState')
+    }
+
+    def "get_performance_stats limit=0 returns all entries with the unlimited-response note"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/logs/json') { params ->
+            JsonOutput.toJson([
+                uptime: 'x',
+                deviceStats: [[id: 1, name: 'A', pct: 1.0, formattedPct: '1.00']],
+                appStats: [[id: 2, name: 'B', pct: 1.0, formattedPct: '1.00']]
+            ])
+        }
+
+        when:
+        def result = script.toolGetPerformanceStats([type: 'both', limit: 0])
+
+        then:
+        result.note?.contains('Returning all')
+        result.note?.contains('2 entries')
+    }
+
+    def "get_performance_stats returns an error map when fetchLogsJson throws (Hub Admin Read gate is indirect)"() {
+        // toolGetPerformanceStats has no direct requireHubAdminRead() call;
+        // the gate fires deeper inside fetchLogsJson (server ~line 5508)
+        // and the IllegalArgumentException is caught and wrapped into the
+        // returned error map at ~line 5524. Asserting "Hub Admin Read"
+        // in the error pins the current wrapping, not a public-surface gate.
+        when:
         def result = script.toolGetPerformanceStats([:])
 
         then:
@@ -381,6 +507,25 @@ class ToolManageLogsSpec extends ToolSpecBase {
         result.entries[0].message == 'e1'
     }
 
+    def "get_debug_logs filters by ruleId"() {
+        given:
+        stateMap.debugLogs = [
+            entries: [
+                [timestamp: 1L, level: 'info', component: 'rules', message: 'r42a', ruleId: '42'],
+                [timestamp: 2L, level: 'info', component: 'rules', message: 'r99',  ruleId: '99'],
+                [timestamp: 3L, level: 'info', component: 'rules', message: 'r42b', ruleId: '42']
+            ],
+            config: [logLevel: 'debug', maxEntries: 100]
+        ]
+
+        when:
+        def result = script.toolGetDebugLogs([ruleId: '42'])
+
+        then:
+        result.count == 2
+        result.entries*.message == ['r42a', 'r42b']
+    }
+
     def "get_debug_logs filters by component substring"() {
         given:
         stateMap.debugLogs = [
@@ -445,10 +590,13 @@ class ToolManageLogsSpec extends ToolSpecBase {
     }
 
     def "clear_debug_logs succeeds when there are no entries"() {
+        given: 'explicit logLevel=error so the post-clear info log is below threshold — pinned against initDebugLogs default drift'
+        stateMap.debugLogs = [entries: [], config: [logLevel: 'error', maxEntries: 100]]
+
         when:
         def result = script.toolClearDebugLogs([:])
 
-        then: 'initDebugLogs defaults logLevel=error so the post-clear info log is below threshold and entries stays []'
+        then:
         result.success == true
         result.clearedCount == 0
         stateMap.debugLogs.entries == []

--- a/src/test/groovy/server/ToolManageLogsSpec.groovy
+++ b/src/test/groovy/server/ToolManageLogsSpec.groovy
@@ -421,7 +421,7 @@ class ToolManageLogsSpec extends ToolSpecBase {
     // -------- toolClearDebugLogs --------
 
     def "clear_debug_logs empties state.debugLogs.entries and reports count"() {
-        given:
+        given: 'logLevel=debug so the post-clear confirmation mcpLog write is retained'
         stateMap.debugLogs = [
             entries: [
                 [timestamp: 1L, level: 'info', component: 'c', message: 'a'],
@@ -436,16 +436,22 @@ class ToolManageLogsSpec extends ToolSpecBase {
         then:
         result.success == true
         result.clearedCount == 2
-        stateMap.debugLogs.entries == []
+
+        and: 'the tool logs a confirmation entry AFTER clearing — `entries` now holds only that line, not the 2 pre-clear entries'
+        stateMap.debugLogs.entries.size() == 1
+        stateMap.debugLogs.entries[0].level == 'info'
+        stateMap.debugLogs.entries[0].message.contains('cleared')
+        stateMap.debugLogs.entries[0].message.contains('(2 entries removed)')
     }
 
     def "clear_debug_logs succeeds when there are no entries"() {
         when:
         def result = script.toolClearDebugLogs([:])
 
-        then:
+        then: 'initDebugLogs defaults logLevel=error so the post-clear info log is below threshold and entries stays []'
         result.success == true
         result.clearedCount == 0
+        stateMap.debugLogs.entries == []
     }
 
     // -------- toolSetLogLevel --------

--- a/src/test/groovy/server/ToolManageLogsSpec.groovy
+++ b/src/test/groovy/server/ToolManageLogsSpec.groovy
@@ -1,0 +1,519 @@
+package server
+
+import groovy.json.JsonOutput
+import spock.lang.Shared
+import support.TestChildApp
+import support.TestDevice
+import support.ToolSpecBase
+
+/**
+ * Spec for the manage_logs gateway tools (hubitat-mcp-server.groovy):
+ *
+ * - toolGetHubLogs         -> get_hub_logs          (additional coverage beyond ToolGetHubLogsSpec)
+ * - toolGetDeviceHistory   -> get_device_history
+ * - toolGetPerformanceStats-> get_performance_stats
+ * - toolGetHubJobs         -> get_hub_jobs
+ * - toolGetDebugLogs       -> get_debug_logs
+ * - toolClearDebugLogs     -> clear_debug_logs
+ * - toolSetLogLevel        -> set_log_level
+ * - toolGetLoggingStatus   -> get_logging_status
+ *
+ * Mocking strategy (see docs/testing.md):
+ *   - hubInternalGet     -> HarnessSpec's hubGet.register(path) closures
+ *   - eventsSince(...)   -> per-test metaClass stub on the TestDevice instance
+ *   - app.updateSetting  -> the @Shared appExecutor Mock has getApp() stubbed
+ *                           once in setupSpec to return sharedAppStub (a
+ *                           TestChildApp). HubitatAppScript's @Delegate to
+ *                           AppExecutor resolves script.app through this stub
+ *                           rather than returning null and NPE'ing when the
+ *                           server calls app.updateSetting(...). cleanup()
+ *                           clears the settingsStore between tests.
+ *   - debug-log state    -> state.debugLogs is a plain Map, seeded in given:
+ *
+ * Additional get_hub_logs coverage — ToolGetHubLogsSpec already covers
+ * most-recent-first ordering and the PR #64 validation regressions; this
+ * spec adds: level filter across all four levels, source substring matching,
+ * explicit limit trimming, and empty-response handling.
+ */
+class ToolManageLogsSpec extends ToolSpecBase {
+
+    @Shared private TestChildApp sharedAppStub = new TestChildApp(id: 1L, label: 'MCP')
+
+    def setupSpec() {
+        // HarnessSpec.setupSpec runs first (Spock auto-invokes superclass
+        // fixtures in declaration order). Layering getApp() onto the
+        // already-built mock here gives toolSetLogLevel's app.updateSetting
+        // call a non-null target.
+        appExecutor.getApp() >> sharedAppStub
+    }
+
+    def cleanup() {
+        sharedAppStub.settingsStore.clear()
+    }
+
+    // -------- toolGetHubLogs (additional coverage) --------
+
+    def "get_hub_logs filters by level=#level"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/logs/past/json') { params ->
+            JsonOutput.toJson([
+                'App 1\tdebug\tDebug msg\t2026-04-19 10:00:00.000\ttype',
+                'App 1\tinfo\tInfo msg\t2026-04-19 10:00:01.000\ttype',
+                'App 1\twarn\tWarn msg\t2026-04-19 10:00:02.000\ttype',
+                'App 1\terror\tError msg\t2026-04-19 10:00:03.000\ttype'
+            ])
+        }
+
+        when:
+        def result = script.toolGetHubLogs([level: level])
+
+        then:
+        result.logs.size() == 1
+        result.logs[0].level == level
+        result.logs[0].message == expectedMsg
+
+        where:
+        level   | expectedMsg
+        'debug' | 'Debug msg'
+        'info'  | 'Info msg'
+        'warn'  | 'Warn msg'
+        'error' | 'Error msg'
+    }
+
+    def "get_hub_logs filters by source substring (case-insensitive)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/logs/past/json') { params ->
+            JsonOutput.toJson([
+                'Kitchen Light\tinfo\tSwitch turned on\t2026-04-19 10:00:00.000\ttype',
+                'Bedroom Fan\tinfo\tSpeed set\t2026-04-19 10:00:01.000\ttype',
+                'Kitchen Motion\tinfo\tMotion detected\t2026-04-19 10:00:02.000\ttype'
+            ])
+        }
+
+        when:
+        def result = script.toolGetHubLogs([source: 'kitchen'])
+
+        then: 'matches "Kitchen" in the name field, case-insensitively'
+        result.logs.size() == 2
+        result.logs.every { it.name.toLowerCase().contains('kitchen') }
+    }
+
+    def "get_hub_logs trims to the limit argument (keeping newest)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        def lines = (1..10).collect { i ->
+            "App 1\tinfo\tMessage ${i}\t2026-04-19 10:00:0${i}.000\ttype".toString()
+        }
+        hubGet.register('/logs/past/json') { params -> JsonOutput.toJson(lines) }
+
+        when:
+        def result = script.toolGetHubLogs([limit: 3])
+
+        then:
+        result.logs.size() == 3
+        result.count == 3
+        result.logs[0].message == 'Message 10'
+        result.logs[1].message == 'Message 9'
+        result.logs[2].message == 'Message 8'
+    }
+
+    def "get_hub_logs handles empty hub response gracefully"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/logs/past/json') { params -> null }
+
+        when:
+        def result = script.toolGetHubLogs([:])
+
+        then:
+        result.logs == []
+        result.count == 0
+        result.message.contains('No log data')
+    }
+
+    // -------- toolGetDeviceHistory --------
+
+    def "get_device_history throws when deviceId is missing"() {
+        when:
+        script.toolGetDeviceHistory([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('deviceId is required')
+    }
+
+    def "get_device_history throws when device is not found"() {
+        when:
+        script.toolGetDeviceHistory([deviceId: '999'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Device not found')
+    }
+
+    def "get_device_history returns events for a selected device"() {
+        given: 'a selected device whose eventsSince returns 2 events'
+        def fixedDate = new Date(1234567880000L)
+        def device = new TestDevice(id: 42, name: 'Kitchen Light', label: 'Kitchen Light')
+        device.metaClass.eventsSince = { Date since, Map opts ->
+            [
+                [name: 'switch', value: 'on', unit: null, descriptionText: 'turned on', date: fixedDate, isStateChange: true],
+                [name: 'level', value: '75', unit: '%', descriptionText: 'dimmed', date: fixedDate, isStateChange: true]
+            ]
+        }
+        settingsMap.selectedDevices = [device]
+
+        when:
+        def result = script.toolGetDeviceHistory([deviceId: '42', hoursBack: 12])
+
+        then:
+        result.deviceId == '42'
+        result.device == 'Kitchen Light'
+        result.hoursBack == 12
+        result.count == 2
+        result.events[0].name == 'switch'
+        result.events[0].value == 'on'
+        result.events[1].name == 'level'
+    }
+
+    def "get_device_history applies attribute filter"() {
+        given:
+        def fixedDate = new Date(1234567880000L)
+        def device = new TestDevice(id: 42, name: 'Multi', label: 'Multi')
+        device.metaClass.eventsSince = { Date since, Map opts ->
+            [
+                [name: 'switch', value: 'on',  date: fixedDate, isStateChange: true],
+                [name: 'level',  value: '50',  date: fixedDate, isStateChange: true],
+                [name: 'switch', value: 'off', date: fixedDate, isStateChange: true]
+            ]
+        }
+        settingsMap.selectedDevices = [device]
+
+        when:
+        def result = script.toolGetDeviceHistory([deviceId: '42', attribute: 'switch'])
+
+        then:
+        result.count == 2
+        result.events.every { it.name == 'switch' }
+        result.attributeFilter == 'switch'
+    }
+
+    def "get_device_history returns an error map when eventsSince throws"() {
+        given:
+        def device = new TestDevice(id: 42, name: 'Broken', label: 'Broken')
+        device.metaClass.eventsSince = { Date since, Map opts ->
+            throw new RuntimeException('event store unavailable')
+        }
+        settingsMap.selectedDevices = [device]
+
+        when:
+        def result = script.toolGetDeviceHistory([deviceId: '42'])
+
+        then:
+        result.error.contains('eventsSince not supported')
+        result.deviceId == '42'
+    }
+
+    // -------- toolGetPerformanceStats --------
+
+    def "get_performance_stats returns device stats sorted by pct (default)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/logs/json') { params ->
+            JsonOutput.toJson([
+                uptime: '5d 2h',
+                totalDevicesRuntime: 1000,
+                devicePct: 12.5,
+                totalAppsRuntime: 500,
+                appPct: 6.25,
+                deviceStats: [
+                    [id: 1, name: 'SlowDevice', pct: 15.0, count: 100, total: 500, stateSize: 1000, formattedPct: '15.00', formattedPctTotal: '50.00'],
+                    [id: 2, name: 'FastDevice', pct: 2.0, count: 5, total: 10, stateSize: 100, formattedPct: '2.00', formattedPctTotal: '1.00']
+                ],
+                appStats: []
+            ])
+        }
+
+        when:
+        def result = script.toolGetPerformanceStats([:])
+
+        then: 'sorted descending by pct'
+        result.deviceStats.size() == 2
+        result.deviceStats[0].name == 'SlowDevice'
+        result.deviceStats[1].name == 'FastDevice'
+        result.deviceSummary.deviceCount == 2
+        result.uptime == '5d 2h'
+    }
+
+    def "get_performance_stats sortBy=count reorders results"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/logs/json') { params ->
+            JsonOutput.toJson([
+                uptime: 'x',
+                deviceStats: [
+                    [id: 1, name: 'Few', count: 2, pct: 50.0, total: 100, formattedPct: '50.00'],
+                    [id: 2, name: 'Many', count: 200, pct: 1.0, total: 50, formattedPct: '1.00']
+                ],
+                appStats: []
+            ])
+        }
+
+        when:
+        def result = script.toolGetPerformanceStats([sortBy: 'count'])
+
+        then:
+        result.deviceStats[0].name == 'Many'
+        result.deviceStats[1].name == 'Few'
+    }
+
+    def "get_performance_stats type=app returns only app stats"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/logs/json') { params ->
+            JsonOutput.toJson([
+                uptime: 'x',
+                totalAppsRuntime: 100,
+                appPct: 5.0,
+                deviceStats: [[id: 1, name: 'D', pct: 1.0, formattedPct: '1.00']],
+                appStats: [[id: 99, name: 'MyApp', pct: 5.0, count: 10, total: 200, formattedPct: '5.00']]
+            ])
+        }
+
+        when:
+        def result = script.toolGetPerformanceStats([type: 'app'])
+
+        then:
+        result.appStats.size() == 1
+        result.appStats[0].name == 'MyApp'
+        result.deviceStats == null
+        result.appSummary.appCount == 1
+    }
+
+    def "get_performance_stats returns an error map when Hub Admin Read is disabled"() {
+        when: 'enableHubAdminRead is not set, so fetchLogsJson throws inside the tool'
+        def result = script.toolGetPerformanceStats([:])
+
+        then:
+        result.error.contains('Hub Admin Read')
+    }
+
+    // -------- toolGetHubJobs --------
+
+    def "get_hub_jobs returns scheduled + running + hubActions"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/logs/json') { params ->
+            JsonOutput.toJson([
+                uptime: '1d',
+                jobs: [
+                    [id: 1, name: 'NightlyBackup', recurring: true, methodName: 'runBackup', nextRun: '2026-04-21 02:00:00'],
+                    [id: 2, name: 'Poll',          recurring: true, methodName: 'poll',      nextRun: '2026-04-21 10:00:00']
+                ],
+                runningJobs: [
+                    [id: 3, name: 'HubCheck', methodName: 'checkHealth']
+                ],
+                hubCommands: ['cmd1', 'cmd2', 'cmd3']
+            ])
+        }
+
+        when:
+        def result = script.toolGetHubJobs([:])
+
+        then:
+        result.scheduledJobs.count == 2
+        result.scheduledJobs.jobs[0].name == 'NightlyBackup'
+        result.runningJobs.count == 1
+        result.hubActions.count == 3
+        result.uptime == '1d'
+    }
+
+    def "get_hub_jobs returns an error map when fetchLogsJson fails"() {
+        when: 'Hub Admin Read disabled — fetchLogsJson throws inside the tool'
+        def result = script.toolGetHubJobs([:])
+
+        then:
+        result.error.contains('Hub Admin Read')
+    }
+
+    // -------- toolGetDebugLogs --------
+
+    def "get_debug_logs returns recent entries with metadata"() {
+        given:
+        stateMap.debugLogs = [
+            entries: [
+                [timestamp: 1234567880000L, level: 'info',  component: 'server', message: 'old'],
+                [timestamp: 1234567890000L, level: 'error', component: 'rules',  message: 'boom', ruleId: '5', stackTrace: 'trace']
+            ],
+            config: [logLevel: 'debug', maxEntries: 100]
+        ]
+
+        when:
+        def result = script.toolGetDebugLogs([:])
+
+        then:
+        result.count == 2
+        result.totalStored == 2
+        result.entries[-1].message == 'boom'
+        result.entries[-1].ruleId == '5'
+        result.entries[-1].stackTrace == 'trace'
+        result.currentLogLevel != null
+    }
+
+    def "get_debug_logs filters by level"() {
+        given:
+        stateMap.debugLogs = [
+            entries: [
+                [timestamp: 1L, level: 'debug', component: 'c', message: 'd1'],
+                [timestamp: 2L, level: 'info',  component: 'c', message: 'i1'],
+                [timestamp: 3L, level: 'error', component: 'c', message: 'e1']
+            ],
+            config: [logLevel: 'debug', maxEntries: 100]
+        ]
+
+        when:
+        def result = script.toolGetDebugLogs([level: 'error'])
+
+        then:
+        result.count == 1
+        result.entries[0].message == 'e1'
+    }
+
+    def "get_debug_logs filters by component substring"() {
+        given:
+        stateMap.debugLogs = [
+            entries: [
+                [timestamp: 1L, level: 'info', component: 'server',      message: 's1'],
+                [timestamp: 2L, level: 'info', component: 'rules',       message: 'r1'],
+                [timestamp: 3L, level: 'info', component: 'rules-eval',  message: 'r2']
+            ],
+            config: [logLevel: 'debug', maxEntries: 100]
+        ]
+
+        when:
+        def result = script.toolGetDebugLogs([component: 'rules'])
+
+        then:
+        result.count == 2
+        result.entries*.message == ['r1', 'r2']
+    }
+
+    def "get_debug_logs caps at limit argument (most recent)"() {
+        given:
+        stateMap.debugLogs = [
+            entries: (1..10).collect { i ->
+                [timestamp: i as Long, level: 'info', component: 'c', message: "m${i}".toString()]
+            },
+            config: [logLevel: 'debug', maxEntries: 100]
+        ]
+
+        when:
+        def result = script.toolGetDebugLogs([limit: 3])
+
+        then:
+        result.count == 3
+        result.entries*.message == ['m8', 'm9', 'm10']
+        result.totalStored == 10
+    }
+
+    // -------- toolClearDebugLogs --------
+
+    def "clear_debug_logs empties state.debugLogs.entries and reports count"() {
+        given:
+        stateMap.debugLogs = [
+            entries: [
+                [timestamp: 1L, level: 'info', component: 'c', message: 'a'],
+                [timestamp: 2L, level: 'info', component: 'c', message: 'b']
+            ],
+            config: [logLevel: 'debug', maxEntries: 100]
+        ]
+
+        when:
+        def result = script.toolClearDebugLogs([:])
+
+        then:
+        result.success == true
+        result.clearedCount == 2
+        stateMap.debugLogs.entries == []
+    }
+
+    def "clear_debug_logs succeeds when there are no entries"() {
+        when:
+        def result = script.toolClearDebugLogs([:])
+
+        then:
+        result.success == true
+        result.clearedCount == 0
+    }
+
+    // -------- toolSetLogLevel --------
+
+    def "set_log_level throws for an invalid level"() {
+        when:
+        script.toolSetLogLevel([level: 'trace'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Invalid log level')
+    }
+
+    def "set_log_level updates state + setting and returns previous level"() {
+        given: 'prior log level is info and app.updateSetting routes through the shared TestChildApp stub'
+        stateMap.debugLogs = [entries: [], config: [logLevel: 'info', maxEntries: 100]]
+
+        when:
+        def result = script.toolSetLogLevel([level: 'warn'])
+
+        then:
+        result.success == true
+        result.previousLevel == 'info'
+        result.newLevel == 'warn'
+        stateMap.debugLogs.config.logLevel == 'warn'
+        sharedAppStub.settingsStore['mcpLogLevel'] == [type: 'enum', value: 'warn']
+    }
+
+    // -------- toolGetLoggingStatus --------
+
+    def "get_logging_status reports counts by level + current config"() {
+        given:
+        stateMap.debugLogs = [
+            entries: [
+                [timestamp: 100L, level: 'debug', component: 'c', message: 'd'],
+                [timestamp: 200L, level: 'info',  component: 'c', message: 'i'],
+                [timestamp: 300L, level: 'warn',  component: 'c', message: 'w1'],
+                [timestamp: 400L, level: 'warn',  component: 'c', message: 'w2'],
+                [timestamp: 500L, level: 'error', component: 'c', message: 'e']
+            ],
+            config: [logLevel: 'debug', maxEntries: 100]
+        ]
+
+        when:
+        def result = script.toolGetLoggingStatus([:])
+
+        then:
+        result.totalEntries == 5
+        result.entriesByLevel.debug == 1
+        result.entriesByLevel.info == 1
+        result.entriesByLevel.warn == 2
+        result.entriesByLevel.error == 1
+        result.currentLogLevel == 'debug'
+        result.availableLevels == ['debug', 'info', 'warn', 'error']
+        result.oldestEntry != null
+        result.newestEntry != null
+    }
+
+    def "get_logging_status handles empty buffer"() {
+        when:
+        def result = script.toolGetLoggingStatus([:])
+
+        then:
+        result.totalEntries == 0
+        result.oldestEntry == null
+        result.newestEntry == null
+    }
+
+    // get_rule_diagnostics is in the DIAGNOSTICS gateway, covered by
+    // ToolManageDiagnosticsSpec rather than this spec.
+}

--- a/src/test/groovy/support/TestHub.groovy
+++ b/src/test/groovy/support/TestHub.groovy
@@ -1,0 +1,29 @@
+package support
+
+import groovy.transform.AutoImplement
+import me.biocomp.hubitat_ci.api.common_api.Hub
+
+/**
+ * Hub stub for tests that exercise {@code location.hub.X} property reads in the
+ * server. {@code @AutoImplement} fills the Hub interface with default null/zero
+ * returns; this class adds the handful of properties the MCP server actually
+ * reads — some declared on the Hub interface ({@code zigbeeId}, {@code uptime})
+ * and some not ({@code zwaveVersion}, {@code zigbeeChannel}, which Hubitat's real
+ * Hub class exposes at runtime but eighty20results' {@code Hub} interface stub
+ * doesn't declare). The latter are accessible via dynamic Groovy property
+ * dispatch on concrete TestHub instances even though they aren't part of the
+ * interface contract, which mirrors how the real hub runtime behaves.
+ *
+ * Usage: {@code new TestHub(zwaveVersion: '7.17.1', uptime: 172800G)}
+ */
+@AutoImplement
+class TestHub implements Hub {
+    // Declared on Hub — auto-generated getters satisfy the abstract contract.
+    String zigbeeId
+    BigInteger uptime
+
+    // Not declared on Hub — property-access only, resolved via Groovy's
+    // dynamic property dispatch when tools read `hub.zwaveVersion` etc.
+    String zwaveVersion
+    Integer zigbeeChannel
+}

--- a/src/test/groovy/support/TestHub.groovy
+++ b/src/test/groovy/support/TestHub.groovy
@@ -8,22 +8,30 @@ import me.biocomp.hubitat_ci.api.common_api.Hub
  * server. {@code @AutoImplement} fills the Hub interface with default null/zero
  * returns; this class adds the handful of properties the MCP server actually
  * reads — some declared on the Hub interface ({@code zigbeeId}, {@code uptime})
- * and some not ({@code zwaveVersion}, {@code zigbeeChannel}, which Hubitat's real
- * Hub class exposes at runtime but eighty20results' {@code Hub} interface stub
- * doesn't declare). The latter are accessible via dynamic Groovy property
+ * and some not ({@code zwaveVersion}, {@code zigbeeChannel}), which Hubitat's
+ * real Hub class exposes at runtime but eighty20results' {@code Hub} interface
+ * stub doesn't declare. The latter are accessible via dynamic Groovy property
  * dispatch on concrete TestHub instances even though they aren't part of the
- * interface contract, which mirrors how the real hub runtime behaves.
+ * interface contract — mirroring how the real hub runtime behaves.
+ *
+ * As of hubitat_ci v0.28.6 (the tag pinned in build.gradle at the time of this
+ * file's creation), Hub declares getZigbeeId()/getUptime() but does NOT declare
+ * getZwaveVersion()/getZigbeeChannel(). Revisit on eighty20results bumps — if a
+ * newer tag adds either property to the interface, drop it from the RUNTIME-ONLY
+ * section and let @AutoImplement absorb the new abstract.
  *
  * Usage: {@code new TestHub(zwaveVersion: '7.17.1', uptime: 172800G)}
  */
 @AutoImplement
 class TestHub implements Hub {
-    // Declared on Hub — auto-generated getters satisfy the abstract contract.
+    // --- INTERFACE (declared abstract on Hub — auto-generated getters satisfy the contract) ---
     String zigbeeId
     BigInteger uptime
 
-    // Not declared on Hub — property-access only, resolved via Groovy's
-    // dynamic property dispatch when tools read `hub.zwaveVersion` etc.
+    // --- RUNTIME-ONLY (not on Hub interface — property-access only, resolved
+    // via Groovy's dynamic property dispatch when tools read e.g.
+    // location.hub.zwaveVersion — see hubitat-mcp-server.groovy:5155 for the
+    // zwaveVersion read and :5202 for the zigbeeChannel read) ---
     String zwaveVersion
     Integer zigbeeChannel
 }

--- a/src/test/groovy/support/TestLocation.groovy
+++ b/src/test/groovy/support/TestLocation.groovy
@@ -1,0 +1,30 @@
+package support
+
+import groovy.transform.AutoImplement
+import me.biocomp.hubitat_ci.api.common_api.Location
+
+/**
+ * Location stub for server tool specs that exercise `location.hub`, `location.mode`,
+ * or other Location properties. `@AutoImplement` fills in the large Location interface
+ * with default null/zero returns — tests override the handful of methods they care about
+ * by constructing instances with overridden closures or setting `hub` directly.
+ *
+ * `hub` is a non-interface field because Hubitat's real Location exposes `hub` as a
+ * magic property (single-hub convenience over getHubs().first()) that eighty20results'
+ * `Location` interface doesn't declare. Tests set `new TestLocation(hub: [...])` to
+ * drive `location.hub` reads in tools like toolGetZwaveDetails / toolGetZigbeeDetails /
+ * toolGetHubPerformance. Methods declared on the Location interface stay overridable
+ * via subclass or `metaClass` assignment.
+ */
+@AutoImplement
+class TestLocation implements Location {
+    /** Populated by tests; read by the server via `location.hub`. Accepts any Map / Expando /
+     *  POGO with the fields the tool under test consumes (e.g. zwaveVersion, uptime). */
+    def hub
+
+    // Common overrides with sensible defaults — tests can override per-instance
+    // via `metaClass.getMode = { -> 'Night' }` when they need to.
+    @Override String getMode() { 'Home' }
+    @Override String getName() { 'TestLocation' }
+    @Override Long getId() { 1L }
+}

--- a/src/test/groovy/support/TestLocation.groovy
+++ b/src/test/groovy/support/TestLocation.groovy
@@ -1,26 +1,24 @@
 package support
 
 import groovy.transform.AutoImplement
+import me.biocomp.hubitat_ci.api.common_api.Hub
 import me.biocomp.hubitat_ci.api.common_api.Location
 
 /**
  * Location stub for server tool specs that exercise `location.hub`, `location.mode`,
  * or other Location properties. `@AutoImplement` fills in the large Location interface
  * with default null/zero returns — tests override the handful of methods they care about
- * by constructing instances with overridden closures or setting `hub` directly.
+ * by constructing instances or assigning to `hub` directly.
  *
- * `hub` is a non-interface field because Hubitat's real Location exposes `hub` as a
- * magic property (single-hub convenience over getHubs().first()) that eighty20results'
- * `Location` interface doesn't declare. Tests set `new TestLocation(hub: [...])` to
- * drive `location.hub` reads in tools like toolGetZwaveDetails / toolGetZigbeeDetails /
- * toolGetHubPerformance. Methods declared on the Location interface stay overridable
- * via subclass or `metaClass` assignment.
+ * `hub` is typed as {@link Hub} so Groovy auto-generates a {@code Hub getHub()} that
+ * satisfies the interface (a raw {@code def hub} generates {@code Object getHub()} and
+ * fails to override the interface method). Tests assign a {@link TestHub} instance
+ * with the fields their tool under test reads (e.g. {@code zwaveVersion}, {@code uptime}).
  */
 @AutoImplement
 class TestLocation implements Location {
-    /** Populated by tests; read by the server via `location.hub`. Accepts any Map / Expando /
-     *  POGO with the fields the tool under test consumes (e.g. zwaveVersion, uptime). */
-    def hub
+    /** Populated by tests; read by the server via `location.hub`. */
+    Hub hub
 
     // Common overrides with sensible defaults — tests can override per-instance
     // via `metaClass.getMode = { -> 'Night' }` when they need to.


### PR DESCRIPTION
Closes #74.

## Summary

- Adds golden-path + error-path unit tests for every tool across three gateways (23 tools total): `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4).
- Adds `TestLocation` support fixture (`@AutoImplement` on `Location` with a settable `hub` field) so tests can drive `location.hub.zwaveVersion` / `location.hub.uptime` without re-implementing the 20+ Location interface methods.

## Coverage per gateway

**manage_logs** — `get_hub_logs` (expanded beyond `ToolGetHubLogsSpec`: per-level filter, source substring, limit trim, empty-response), `get_device_history` (missing deviceId, device-not-found, attribute filter, eventsSince failure), `get_performance_stats` (default sort, `sortBy=count`, `type=app`, Hub Admin Read gate), `get_hub_jobs`, `get_debug_logs` (level / component / limit filters), `clear_debug_logs`, `set_log_level` (invalid level, state + setting persistence), `get_logging_status`.

**manage_diagnostics** — `get_set_hub_metrics` (CSV snapshot write, low-memory warning, `recordSnapshot=false` skip), `get_memory_history` (CSV parsing + summary + limit truncation), `force_garbage_collection` (before/after delta, non-numeric probe handling), `device_health_check` (healthy / stale / unknown classification + `includeHealthy`), `get_rule_diagnostics`, `get_zwave_details` / `get_zigbee_details` (sdk_only fallback + hub_api_raw + hub_api branches), `zwave_repair` (confirm + Hub Admin Write gate + POST success/failure), `list_captured_states` (sorted newest-first, at-capacity warning), `delete_captured_state` (not-found), `clear_captured_states`.

**manage_files** — `list_files` (JSON + HTML fallback + API-unavailable), `read_file` (full-chunk, chunk boundary + `nextOffset` hint, offset+length, missing-file), `write_file` (confirm gate, Hub Admin Write gate, missing-backup gate, invalid filenames via `where:` table, existing-file backup chain, upload failure), `delete_file` (confirm gate, skip-backup-of-backup, delete failure).

## Harness wiring

- Two `@Shared` stubs layered on the AppExecutor mock in each spec's `setupSpec`:
  - `ToolManageLogsSpec`: `getApp() >> sharedAppStub` (TestChildApp) so `toolSetLogLevel`'s `app.updateSetting(...)` resolves through the `@Delegate` chain without NPE. `cleanup()` clears `settingsStore` between tests.
  - `ToolManageDiagnosticsSpec`: `getLocation() >> sharedLocation` (TestLocation) so tools that read `location.hub.X` see per-test hub data. `cleanup()` resets `hub = null` between tests.
- Per-test stubs stay on `script.metaClass` (`hubInternalPost`, `downloadHubFile`, `uploadHubFile`, `deleteHubFile`) since `HarnessSpec.setup()` wipes the script metaClass between features.

## Note on captured-state confirm gating

Issue #74 lists `clear_captured_states` under confirm-gated tools, but the current server source dispatches through `clearAllCapturedStates()` / `deleteCapturedState(stateId)` with no confirm check. These tests pin the existing no-confirm behaviour; adding a confirm gate would be a separate design change.

## Test plan

- [ ] CI `./gradlew test` green on all three new specs
- [ ] No regression in existing specs (`ToolGetHubLogsSpec`, etc.) — `ToolManageLogsSpec` intentionally adds coverage alongside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)