### PR TITLE
Add get_app_config + list_app_pages (manage_installed_apps gateway)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ config.local.*
 # E2E test config (contains hub IP and access token)
 tests/e2e_config.json
 
+# Shape-drift audit config (personalized hub app IDs)
+scripts/audit_config.json
+
 # Gemini Code Assist config (may contain access tokens)
 .gemini/
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 81 tools total — 22 core tools are always visible, while 59 additional tools are organized behind 11 domain-named gateways to keep the tool list manageable.
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 82 tools total — 23 core tools are always visible, while 59 additional tools are organized behind 11 domain-named gateways to keep the tool list manageable.
 
 ## Requirements
 
@@ -221,11 +221,11 @@ For free remote access without a Hubitat Cloud subscription:
 
 ## Features
 
-### MCP Tools (81 total — 33 on tools/list)
+### MCP Tools (82 total — 34 on tools/list)
 
-The server has 81 tools total. To keep the MCP `tools/list` manageable, **22 core tools** are always visible and **59 additional tools** are organized behind **11 domain-named gateways**. The AI sees 33 items on `tools/list` (22 + 11 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
+The server has 82 tools total. To keep the MCP `tools/list` manageable, **23 core tools** are always visible and **59 additional tools** are organized behind **11 domain-named gateways**. The AI sees 34 items on `tools/list` (23 + 11 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
 
-#### Core Tools (22) — Always visible on tools/list
+#### Core Tools (23) — Always visible on tools/list
 
 <details>
 <summary><b>Devices</b> (5) — Control and query devices</summary>
@@ -292,6 +292,15 @@ The server has 81 tools total. To keep the MCP `tools/list` manageable, **22 cor
 | `create_hub_backup` | Create full hub backup (required before admin writes) |
 | `check_for_update` | Check if a newer MCP server version is available |
 | `generate_bug_report` | Generate comprehensive diagnostic report |
+
+</details>
+
+<details>
+<summary><b>App Introspection</b> (1) — Read installed app configurations</summary>
+
+| Tool | Description |
+|------|-------------|
+| `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.) — sections, inputs, values. Multi-page apps via `pageName`. Read-only. Hub Admin Read. |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 82 tools total — 22 core tools are always visible, while 60 additional tools are organized behind 11 domain-named gateways to keep the tool list manageable.
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 83 tools total — 22 core tools are always visible, while 61 additional tools are organized behind 11 domain-named gateways to keep the tool list manageable.
 
 ## Requirements
 
@@ -221,9 +221,9 @@ For free remote access without a Hubitat Cloud subscription:
 
 ## Features
 
-### MCP Tools (82 total — 33 on tools/list)
+### MCP Tools (83 total — 33 on tools/list)
 
-The server has 82 tools total. To keep the MCP `tools/list` manageable, **22 core tools** are always visible and **60 additional tools** are organized behind **11 domain-named gateways**. The AI sees 33 items on `tools/list` (22 + 11 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
+The server has 83 tools total. To keep the MCP `tools/list` manageable, **22 core tools** are always visible and **61 additional tools** are organized behind **11 domain-named gateways**. The AI sees 33 items on `tools/list` (22 + 11 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
 
 #### Core Tools (22) — Always visible on tools/list
 
@@ -442,15 +442,16 @@ Write/delete require Hub Admin Write + confirm.
 </details>
 
 <details>
-<summary><b>manage_installed_apps</b> (3) — Built-in app visibility and configuration</summary>
+<summary><b>manage_installed_apps</b> (4) — Built-in app visibility and configuration</summary>
 
 | Tool | Description |
 |------|-------------|
 | `list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by builtin/user/disabled/parents/children. |
 | `get_device_in_use_by` | Find all apps that reference a specific device (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.) |
 | `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.) — sections, inputs, values. Multi-page apps via `pageName`. Read-only. Hub Admin Read. |
+| `list_app_pages` | List known page names for a multi-page app (HPM, Room Lighting, etc.). Returns curated directory + live primary page. Use before `get_app_config` on multi-page apps to avoid guessing page names. Hub Admin Read. |
 
-`list_installed_apps` and `get_device_in_use_by` require opt-in **Enable Built-in App Tools** setting. `get_app_config` requires Hub Admin Read.
+`list_installed_apps` and `get_device_in_use_by` require opt-in **Enable Built-in App Tools** setting. `get_app_config` and `list_app_pages` require Hub Admin Read.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hubitat MCP Server
 
-A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 81 MCP tools (33 on `tools/list` via category gateways).
+A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 82 MCP tools (33 on `tools/list` via category gateways).
 
 > **BETA SOFTWARE**: This project is ~99% AI-generated ("vibe coded") using Claude. It's a work in progress — contributions and [bug reports](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues) are welcome!
 
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 82 tools total — 23 core tools are always visible, while 59 additional tools are organized behind 11 domain-named gateways to keep the tool list manageable.
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 82 tools total — 22 core tools are always visible, while 60 additional tools are organized behind 11 domain-named gateways to keep the tool list manageable.
 
 ## Requirements
 
@@ -221,11 +221,11 @@ For free remote access without a Hubitat Cloud subscription:
 
 ## Features
 
-### MCP Tools (82 total — 34 on tools/list)
+### MCP Tools (82 total — 33 on tools/list)
 
-The server has 82 tools total. To keep the MCP `tools/list` manageable, **23 core tools** are always visible and **59 additional tools** are organized behind **11 domain-named gateways**. The AI sees 34 items on `tools/list` (23 + 11 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
+The server has 82 tools total. To keep the MCP `tools/list` manageable, **22 core tools** are always visible and **60 additional tools** are organized behind **11 domain-named gateways**. The AI sees 33 items on `tools/list` (22 + 11 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
 
-#### Core Tools (23) — Always visible on tools/list
+#### Core Tools (22) — Always visible on tools/list
 
 <details>
 <summary><b>Devices</b> (5) — Control and query devices</summary>
@@ -292,15 +292,6 @@ The server has 82 tools total. To keep the MCP `tools/list` manageable, **23 cor
 | `create_hub_backup` | Create full hub backup (required before admin writes) |
 | `check_for_update` | Check if a newer MCP server version is available |
 | `generate_bug_report` | Generate comprehensive diagnostic report |
-
-</details>
-
-<details>
-<summary><b>App Introspection</b> (1) — Read installed app configurations</summary>
-
-| Tool | Description |
-|------|-------------|
-| `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.) — sections, inputs, values. Multi-page apps via `pageName`. Read-only. Hub Admin Read. |
 
 </details>
 
@@ -451,14 +442,15 @@ Write/delete require Hub Admin Write + confirm.
 </details>
 
 <details>
-<summary><b>manage_installed_apps</b> (2) — Built-in app visibility</summary>
+<summary><b>manage_installed_apps</b> (3) — Built-in app visibility and configuration</summary>
 
 | Tool | Description |
 |------|-------------|
 | `list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by builtin/user/disabled/parents/children. |
 | `get_device_in_use_by` | Find all apps that reference a specific device (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.) |
+| `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.) — sections, inputs, values. Multi-page apps via `pageName`. Read-only. Hub Admin Read. |
 
-Requires opt-in **Enable Built-in App Tools** setting.
+`list_installed_apps` and `get_device_in_use_by` require opt-in **Enable Built-in App Tools** setting. `get_app_config` requires Hub Admin Read.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hubitat MCP Server
 
-A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 82 MCP tools (33 on `tools/list` via category gateways).
+A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 83 MCP tools (33 on `tools/list` via category gateways).
 
 > **BETA SOFTWARE**: This project is ~99% AI-generated ("vibe coded") using Claude. It's a work in progress — contributions and [bug reports](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues) are welcome!
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hubitat-mcp-server
-description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 82 tools (33 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver management, installed-app visibility, and Rule Machine interoperability.
+description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 83 tools (33 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver management, installed-app visibility, and Rule Machine interoperability.
 license: MIT
 ---
 
@@ -32,7 +32,7 @@ There are **no external dependencies, build steps, or test frameworks**. Everyth
 │  │  MCP Rule Server (parent app)             │  │
 │  │  - OAuth endpoint: /apps/api/<id>/mcp     │  │
 │  │  - JSON-RPC 2.0 handler                   │  │
-│  │  - 82 tools (33 on tools/list + gateways) │  │
+│  │  - 83 tools (33 on tools/list + gateways) │  │
 │  │  - Device access gate (selectedDevices)   │  │
 │  │  - Hub Admin tools (internal API calls)   │  │
 │  │  - Hub Security cookie auth               │  │
@@ -93,19 +93,19 @@ New code should be placed in the appropriate section. New sections should follow
 
 ### Category Gateway Proxy (v0.8.0+)
 
-The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 82 items to 33. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
+The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 83 items to 33. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
 
 **Architecture:**
 - `getGatewayConfig()` — defines 11 gateways, each with a description, tools list, and summaries map
 - `getToolDefinitions()` — returns 22 core tools + 11 gateway tool definitions (client-visible)
-- `getAllToolDefinitions()` — returns all 82 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
+- `getAllToolDefinitions()` — returns all 83 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
 - `handleGateway(gatewayName, toolName, toolArgs)` — catalog mode (no args → full schemas) or execute mode (tool + args → dispatch)
 
 **Gateway calling convention:**
 1. AI calls `manage_<domain>()` with no args → gets full tool schemas (catalog mode)
 2. AI calls `manage_<domain>(tool="tool_name", args={...})` → executes the proxied tool
 
-**11 gateways (60 proxied tools):**
+**11 gateways (61 proxied tools):**
 | Gateway | Tools | Domain |
 |---------|-------|--------|
 | `manage_rules_admin` | 5 | Rule delete/test/export/import/clone |
@@ -117,7 +117,7 @@ The server uses a **category gateway proxy** pattern to reduce the MCP `tools/li
 | `manage_logs` | 8 | Logs, monitoring, performance stats, hub jobs, debug tools |
 | `manage_diagnostics` | 11 | Diagnostics, state capture, zwave/zigbee details, zwave repair, memory history, GC |
 | `manage_files` | 4 | File Manager CRUD |
-| `manage_installed_apps` | 3 | Built-in + user app visibility, device-in-use-by lookup, app config inspection |
+| `manage_installed_apps` | 4 | Built-in + user app visibility, device-in-use-by lookup, app config inspection, page-name directory |
 | `manage_rule_machine` | 5 | Rule Machine interop via RMUtils — list/run/pause/resume/boolean |
 
 **22 core tools:** `list_devices`, `get_device`, `get_attribute`, `send_command`, `get_device_events`, `list_rules`, `get_rule`, `create_rule`, `update_rule`, `update_device`, `manage_virtual_device` (action enum: "create", "delete"), `list_virtual_devices`, `get_hub_info` (comprehensive: hardware, health — memory, temp, DB size — and MCP stats always available; PII/location data — name, IP, timezone, coordinates, zip — gated behind Hub Admin Read), `get_modes`, `set_mode`, `get_hsm_status`, `set_hsm`, `create_hub_backup`, `check_for_update`, `generate_bug_report`, `get_tool_guide`, `search_tools` (BM25 natural language search across all tools)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hubitat-mcp-server
-description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 81 tools (33 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver management, installed-app visibility, and Rule Machine interoperability.
+description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 82 tools (33 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver management, installed-app visibility, and Rule Machine interoperability.
 license: MIT
 ---
 
@@ -32,7 +32,7 @@ There are **no external dependencies, build steps, or test frameworks**. Everyth
 │  │  MCP Rule Server (parent app)             │  │
 │  │  - OAuth endpoint: /apps/api/<id>/mcp     │  │
 │  │  - JSON-RPC 2.0 handler                   │  │
-│  │  - 81 tools (33 on tools/list + gateways) │  │
+│  │  - 82 tools (33 on tools/list + gateways) │  │
 │  │  - Device access gate (selectedDevices)   │  │
 │  │  - Hub Admin tools (internal API calls)   │  │
 │  │  - Hub Security cookie auth               │  │
@@ -93,19 +93,19 @@ New code should be placed in the appropriate section. New sections should follow
 
 ### Category Gateway Proxy (v0.8.0+)
 
-The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 81 items to 33. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
+The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 82 items to 33. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
 
 **Architecture:**
 - `getGatewayConfig()` — defines 11 gateways, each with a description, tools list, and summaries map
 - `getToolDefinitions()` — returns 22 core tools + 11 gateway tool definitions (client-visible)
-- `getAllToolDefinitions()` — returns all 81 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
+- `getAllToolDefinitions()` — returns all 82 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
 - `handleGateway(gatewayName, toolName, toolArgs)` — catalog mode (no args → full schemas) or execute mode (tool + args → dispatch)
 
 **Gateway calling convention:**
 1. AI calls `manage_<domain>()` with no args → gets full tool schemas (catalog mode)
 2. AI calls `manage_<domain>(tool="tool_name", args={...})` → executes the proxied tool
 
-**11 gateways (59 proxied tools):**
+**11 gateways (60 proxied tools):**
 | Gateway | Tools | Domain |
 |---------|-------|--------|
 | `manage_rules_admin` | 5 | Rule delete/test/export/import/clone |
@@ -117,7 +117,7 @@ The server uses a **category gateway proxy** pattern to reduce the MCP `tools/li
 | `manage_logs` | 8 | Logs, monitoring, performance stats, hub jobs, debug tools |
 | `manage_diagnostics` | 11 | Diagnostics, state capture, zwave/zigbee details, zwave repair, memory history, GC |
 | `manage_files` | 4 | File Manager CRUD |
-| `manage_installed_apps` | 2 | Built-in + user app visibility, device-in-use-by lookup |
+| `manage_installed_apps` | 3 | Built-in + user app visibility, device-in-use-by lookup, app config inspection |
 | `manage_rule_machine` | 5 | Rule Machine interop via RMUtils — list/run/pause/resume/boolean |
 
 **22 core tools:** `list_devices`, `get_device`, `get_attribute`, `send_command`, `get_device_events`, `list_rules`, `get_rule`, `create_rule`, `update_rule`, `update_device`, `manage_virtual_device` (action enum: "create", "delete"), `list_virtual_devices`, `get_hub_info` (comprehensive: hardware, health — memory, temp, DB size — and MCP stats always available; PII/location data — name, IP, timezone, coordinates, zip — gated behind Hub Admin Read), `get_modes`, `set_mode`, `get_hsm_status`, `set_hsm`, `create_hub_backup`, `check_for_update`, `generate_bug_report`, `get_tool_guide`, `search_tools` (BM25 natural language search across all tools)
@@ -496,6 +496,7 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 | `/logs/past/json` | Hub log buffer as JSON array of tab-delimited strings (chronological order, oldest first — reverse client-side for newest-first). Accepts optional `?type=dev&id=<deviceId>` or `?type=app&id=<appId>` to scope server-side to a single source. |
 | `/hub2/appsList` | All installed apps (built-in + user) as JSON. Keys: `systemAppTypes[]`, `userAppTypes[]`, `apps[]` (instance tree). Each `apps[]` entry has `{key, id, data: {id, name, type, disabled, user, hidden, appTypeId}, parent: bool, child: bool, children: [...]}`. Used by `list_installed_apps`. |
 | `/device/fullJson/<id>` | Comprehensive device JSON — includes `appsUsing` array (apps referencing this device: `{id, name, label, trueLabel, disabled}`), `appsUsingCount`, `parentApp`, plus device commands/attributes/settings/dashboards. Used by `get_device_in_use_by`. |
+| `/installedapp/configure/json/<id>[/<pageName>]` | SDK-level config-page serialization for any installed app using `dynamicPage()`. Returns `{app, configPage: {name, title, sections: [{title, input: [...], body: [...]}]}, settings, childApps}`. `app` carries identity (label, name, appType, disabled, parentAppId). Sections hold typed inputs with current values. The Web UI itself consumes this endpoint. Used by `get_app_config`. |
 
 **Write endpoints (POST):**
 | Path | Body | Purpose |

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -279,6 +279,13 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 - Up to 7 days of history
 - Use attribute filter to reduce data volume
 
+**get_app_config:**
+- Reads any legacy SmartApp's configuration page: RM rules, Room Lighting instances, Basic Rules, HPM, Mode Manager, Button Controllers, third-party community apps
+- Default response includes `app` (identity), `page` (section/input structure with current values), `childApps` summary
+- Raw app-internal `settings` map (~100-1000 keys with app-specific encoding) omitted by default — pass `includeSettings=true` for power-user inspection
+- Multi-page apps (RM 5.1, HPM) expose sub-pages via `pageName` — e.g. `get_app_config(appId=35, pageName="prefPkgModify")` lists HPM's installed packages
+- Read-only, does not modify anything. Requires Hub Admin Read.
+
 ---
 
 ## Built-in App Tools

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -4,13 +4,13 @@ Detailed reference for MCP Rule Server tools. Consult this when tool description
 
 ## Category Gateway Proxy (v0.8.0+)
 
-As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 33 items (22 core + 11 gateways) covering 81 total tools. Use `search_tools` to find any tool by natural language query.
+As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 33 items (22 core + 11 gateways) covering 82 total tools. Use `search_tools` to find any tool by natural language query.
 
 **How to use a gateway:**
 1. Call the gateway with no arguments to see full parameter schemas for all its tools
 2. Call with `tool='<tool_name>'` and `args={...}` to execute a specific tool
 
-**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (2), `manage_rule_machine` (5)
+**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (3), `manage_rule_machine` (5)
 
 All safety gates (Hub Admin Read/Write, confirm, backup checks) are preserved — they are enforced in the handler functions, not the dispatch layer.
 
@@ -292,7 +292,7 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 
 All tools in `manage_installed_apps` and `manage_rule_machine` gateways require the **Enable Built-in App Tools** toggle in MCP Rule Server app settings. If the user sees "Built-in App Tools are disabled" errors, direct them to the MCP Rule Server app settings page.
 
-### manage_installed_apps (2 tools)
+### manage_installed_apps (3 tools)
 
 - **`list_installed_apps`** — enumerate ALL apps on the hub (built-in + user) with parent/child tree
   - `filter="all"` (default) | `"builtin"` | `"user"` | `"disabled"` | `"parents"` | `"children"`
@@ -305,6 +305,10 @@ All tools in `manage_installed_apps` and `manage_rule_machine` gateways require 
   - Use BEFORE deleting a device, disabling a device, or troubleshooting unexpected behavior
   - Returns `appsUsing` array with each app's `id`, `name` (type like "Room Lights" or "Rule-5.1"), `label` (user-visible), `trueLabel` (HTML-stripped), `disabled`
   - Answers "if I delete/disable this device, which automations break?"
+
+- **`get_app_config`** — read an installed app's configuration page (Hub Admin Read required)
+  - See usage tips above for full details on response shape, pageName navigation, and includeSettings flag
+  - Workflow: `list_installed_apps` or `list_rm_rules` to find an `appId`, then `get_app_config` to inspect it
 
 ### manage_rule_machine (5 tools)
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -290,7 +290,7 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 
 ## Built-in App Tools
 
-All tools in `manage_installed_apps` and `manage_rule_machine` gateways require the **Enable Built-in App Tools** toggle in MCP Rule Server app settings. If the user sees "Built-in App Tools are disabled" errors, direct them to the MCP Rule Server app settings page.
+Tools in `manage_installed_apps` and `manage_rule_machine` gateways have mixed gate requirements. `list_installed_apps` and `get_device_in_use_by` require the **Enable Built-in App Tools** toggle (`requireBuiltinAppRead`). `get_app_config` and `list_app_pages` require **Hub Admin Read** (`requireHubAdminRead`). `manage_rule_machine` tools require the **Enable Built-in App Tools** toggle. If the user sees "Built-in App Tools are disabled" errors, direct them to the MCP Rule Server app settings page.
 
 ### manage_installed_apps (4 tools)
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -4,13 +4,13 @@ Detailed reference for MCP Rule Server tools. Consult this when tool description
 
 ## Category Gateway Proxy (v0.8.0+)
 
-As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 33 items (22 core + 11 gateways) covering 82 total tools. Use `search_tools` to find any tool by natural language query.
+As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 33 items (22 core + 11 gateways) covering 83 total tools. Use `search_tools` to find any tool by natural language query.
 
 **How to use a gateway:**
 1. Call the gateway with no arguments to see full parameter schemas for all its tools
 2. Call with `tool='<tool_name>'` and `args={...}` to execute a specific tool
 
-**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (3), `manage_rule_machine` (5)
+**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_rule_machine` (5)
 
 All safety gates (Hub Admin Read/Write, confirm, backup checks) are preserved — they are enforced in the handler functions, not the dispatch layer.
 
@@ -283,7 +283,7 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 - Reads any legacy SmartApp's configuration page: RM rules, Room Lighting instances, Basic Rules, HPM, Mode Manager, Button Controllers, third-party community apps
 - Default response includes `app` (identity), `page` (section/input structure with current values), `childApps` summary
 - Raw app-internal `settings` map (~100-1000 keys with app-specific encoding) omitted by default — pass `includeSettings=true` for power-user inspection
-- Multi-page apps (RM 5.1, HPM) expose sub-pages via `pageName` — e.g. `get_app_config(appId=35, pageName="prefPkgModify")` lists HPM's installed packages
+- Multi-page apps (HPM, multi-page Room Lighting) expose sub-pages via `pageName`. For HPM specifically: `pageName="prefPkgUninstall"` returns the FULL installed-package list as an enum; `pageName="prefPkgModify"` returns only the subset with optional components; `pageName="prefOptions"` is the main menu (navigation links, no package data).
 - Read-only, does not modify anything. Requires Hub Admin Read.
 
 ---
@@ -292,7 +292,7 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 
 All tools in `manage_installed_apps` and `manage_rule_machine` gateways require the **Enable Built-in App Tools** toggle in MCP Rule Server app settings. If the user sees "Built-in App Tools are disabled" errors, direct them to the MCP Rule Server app settings page.
 
-### manage_installed_apps (3 tools)
+### manage_installed_apps (4 tools)
 
 - **`list_installed_apps`** — enumerate ALL apps on the hub (built-in + user) with parent/child tree
   - `filter="all"` (default) | `"builtin"` | `"user"` | `"disabled"` | `"parents"` | `"children"`
@@ -309,6 +309,13 @@ All tools in `manage_installed_apps` and `manage_rule_machine` gateways require 
 - **`get_app_config`** — read an installed app's configuration page (Hub Admin Read required)
   - See usage tips above for full details on response shape, pageName navigation, and includeSettings flag
   - Workflow: `list_installed_apps` or `list_rm_rules` to find an `appId`, then `get_app_config` to inspect it
+
+- **`list_app_pages`** — list known page names for a multi-page app (Hub Admin Read required)
+  - Returns the primary page (introspected from the hub) plus a curated directory of known sub-pages for well-known app types
+  - Curated directories: HPM (prefOptions, prefPkgUninstall, prefPkgModify, prefPkgInstall, prefPkgMatchUp), RM rules (mainPage only -- single-page), Room Lighting (mainPage), Mode Manager (mainPage)
+  - Unknown app types: returns the primary page only plus a note about consulting the app's source or Web UI for additional page names
+  - Use this before `get_app_config` on multi-page apps to avoid guessing page names
+  - Args: `appId` (required)
 
 ### manage_rule_machine (5 tools)
 

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Smart home assistant for Hubitat Elevation hubs via MCP. Use when c
 
 # Hubitat MCP Server - Smart Home Assistant
 
-You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 82 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, and Rule Machine interop. The tools are organized as **23 core tools** (always visible) plus **11 domain-named gateways** that proxy 59 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
+You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 82 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, and Rule Machine interop. The tools are organized as **22 core tools** (always visible) plus **11 domain-named gateways** that proxy 60 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
 
 ## Core Principles
 

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Smart home assistant for Hubitat Elevation hubs via MCP. Use when c
 
 # Hubitat MCP Server - Smart Home Assistant
 
-You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 81 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, and Rule Machine interop. The tools are organized as **22 core tools** (always visible) plus **11 domain-named gateways** that proxy 59 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
+You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 82 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, and Rule Machine interop. The tools are organized as **23 core tools** (always visible) plus **11 domain-named gateways** that proxy 59 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
 
 ## Core Principles
 

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Smart home assistant for Hubitat Elevation hubs via MCP. Use when c
 
 # Hubitat MCP Server - Smart Home Assistant
 
-You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 82 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, and Rule Machine interop. The tools are organized as **22 core tools** (always visible) plus **11 domain-named gateways** that proxy 60 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
+You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 83 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, and Rule Machine interop. The tools are organized as **22 core tools** (always visible) plus **11 domain-named gateways** that proxy 61 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
 
 ## Core Principles
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -1,10 +1,10 @@
 # Tool Reference
 
-Quick reference for all 82 MCP tools. The server exposes **34 items on `tools/list`**: 23 core tools + 11 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
+Quick reference for all 82 MCP tools. The server exposes **33 items on `tools/list`**: 22 core tools + 11 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
 
 For the most authoritative reference, call `get_tool_guide` via MCP.
 
-## Core Tools (23) — Always visible on tools/list
+## Core Tools (22) — Always visible on tools/list
 
 ### Device Tools (5)
 
@@ -50,12 +50,6 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | `create_hub_backup` | Create full hub database backup. | Hub Admin Write |
 | `check_for_update` | Check for MCP server updates. | None |
 | `generate_bug_report` | Generate comprehensive diagnostic report. | None |
-
-### App Introspection (1)
-
-| Tool | Description | Access Gate |
-|------|-------------|-------------|
-| `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.). Returns sections/inputs/values; multi-page apps via `pageName`. Read-only. | Hub Admin Read |
 
 ### Reference (2)
 
@@ -185,14 +179,15 @@ Manage hub File Manager: list, read, write, and delete files stored on the hub.
 | `write_file` | Create/update a file (auto-backs up existing). | Hub Admin Write |
 | `delete_file` | Delete a file (auto-backs up first). | Hub Admin Write |
 
-### manage_installed_apps (2 tools)
+### manage_installed_apps (3 tools)
 
-Read-only visibility into all installed apps (built-in + user): enumerate with parent/child tree, find apps using a specific device. Requires Built-in App Tools enabled in MCP app settings.
+Read-only visibility into all installed apps (built-in + user): enumerate with parent/child tree, find apps using a specific device, inspect an app's configuration page.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by `all`/`builtin`/`user`/`disabled`/`parents`/`children`. | Built-in App Read |
 | `get_device_in_use_by` | Given a `deviceId`, list apps referencing it (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.). | Built-in App Read |
+| `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.). Returns sections/inputs/values; multi-page apps via `pageName`. Read-only. | Hub Admin Read |
 
 ### manage_rule_machine (5 tools)
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -1,10 +1,10 @@
 # Tool Reference
 
-Quick reference for all 81 MCP tools. The server exposes **33 items on `tools/list`**: 22 core tools + 11 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
+Quick reference for all 82 MCP tools. The server exposes **34 items on `tools/list`**: 23 core tools + 11 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
 
 For the most authoritative reference, call `get_tool_guide` via MCP.
 
-## Core Tools (22) — Always visible on tools/list
+## Core Tools (23) — Always visible on tools/list
 
 ### Device Tools (5)
 
@@ -51,12 +51,18 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | `check_for_update` | Check for MCP server updates. | None |
 | `generate_bug_report` | Generate comprehensive diagnostic report. | None |
 
+### App Introspection (1)
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.). Returns sections/inputs/values; multi-page apps via `pageName`. Read-only. | Hub Admin Read |
+
 ### Reference (2)
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `get_tool_guide` | Full tool reference from the MCP server itself. | None |
-| `search_tools` | BM25 natural language search across all 81 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
+| `search_tools` | BM25 natural language search across all 82 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
 
 ---
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-Quick reference for all 82 MCP tools. The server exposes **33 items on `tools/list`**: 22 core tools + 11 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
+Quick reference for all 83 MCP tools. The server exposes **33 items on `tools/list`**: 22 core tools + 11 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
 
 For the most authoritative reference, call `get_tool_guide` via MCP.
 
@@ -56,7 +56,7 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `get_tool_guide` | Full tool reference from the MCP server itself. | None |
-| `search_tools` | BM25 natural language search across all 82 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
+| `search_tools` | BM25 natural language search across all 83 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
 
 ---
 
@@ -179,15 +179,16 @@ Manage hub File Manager: list, read, write, and delete files stored on the hub.
 | `write_file` | Create/update a file (auto-backs up existing). | Hub Admin Write |
 | `delete_file` | Delete a file (auto-backs up first). | Hub Admin Write |
 
-### manage_installed_apps (3 tools)
+### manage_installed_apps (4 tools)
 
-Read-only visibility into all installed apps (built-in + user): enumerate with parent/child tree, find apps using a specific device, inspect an app's configuration page.
+Read-only visibility into all installed apps (built-in + user): enumerate with parent/child tree, find apps using a specific device, inspect an app's configuration page, discover page names for multi-page apps.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by `all`/`builtin`/`user`/`disabled`/`parents`/`children`. | Built-in App Read |
 | `get_device_in_use_by` | Given a `deviceId`, list apps referencing it (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.). | Built-in App Read |
-| `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.). Returns sections/inputs/values; multi-page apps via `pageName`. Read-only. | Hub Admin Read |
+| `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.). Returns sections/inputs/values; multi-page apps via `pageName`. Workflow: list_installed_apps or list_rm_rules -> get_app_config with appId; multi-page apps accept pageName (HPM: prefPkgUninstall for full list). Read-only. | Hub Admin Read |
+| `list_app_pages` | List known page names for a multi-page app (HPM, Room Lighting, etc.). Returns curated directory + live primary page. Use before get_app_config on multi-page apps. | Hub Admin Read |
 
 ### manage_rule_machine (5 tools)
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -616,17 +616,19 @@ def getGatewayConfig() {
             ]
         ],
         manage_installed_apps: [
-            description: "Read-only visibility into all installed apps (built-in + user): enumerate apps with parent/child tree, find apps using a device, inspect an app's configuration page. Requires Built-in App Tools enabled in MCP app settings (list/device-in-use-by); get_app_config requires Hub Admin Read.",
-            tools: ["list_installed_apps", "get_device_in_use_by", "get_app_config"],
+            description: "Read-only visibility into all installed apps (built-in + user): enumerate apps with parent/child tree, find apps using a device, inspect an app's configuration page, list page names for multi-page apps. Requires Built-in App Tools enabled in MCP app settings (list/device-in-use-by); get_app_config and list_app_pages require Hub Admin Read.",
+            tools: ["list_installed_apps", "get_device_in_use_by", "get_app_config", "list_app_pages"],
             summaries: [
                 list_installed_apps: "List all installed apps with parent/child tree. Args: filter (all/builtin/user/disabled/parents/children), includeHidden",
                 get_device_in_use_by: "List all apps that reference a device (Room Lighting, Rule Machine, Groups, etc.). Args: deviceId",
-                get_app_config: "Read an installed app's configuration page (sections, inputs, current values). Works for Rule Machine, Room Lighting, Basic Rules, HPM, etc. Args: appId, pageName (optional), includeSettings (optional)"
+                get_app_config: "Read an installed app's configuration page (sections, inputs, current values). Works for Rule Machine, Room Lighting, Basic Rules, HPM, etc. Args: appId, pageName (optional), includeSettings (optional)",
+                list_app_pages: "List known page names for a multi-page app (HPM, Room Lighting, etc.). Curated directory + live primary page. Args: appId"
             ],
             searchHints: [
                 list_installed_apps: "rule machine room lighting scenes mode manager hsm dashboards groups button controllers native builtin",
                 get_device_in_use_by: "which apps use device reference inUseBy appsUsing dependencies affected by",
-                get_app_config: "read inspect app configuration page settings inputs values rule machine room lighting hpm mode manager"
+                get_app_config: "read inspect app configuration page settings inputs values rule machine room lighting hpm mode manager",
+                list_app_pages: "page names sub-pages pageName multi-page hpm prefPkgUninstall prefPkgModify prefOptions navigation discover"
             ]
         ],
         manage_rule_machine: [
@@ -1651,13 +1653,35 @@ Returns the app's identity (label, type, parent, disabled state) and its current
 
 Use to: understand what an existing automation actually does, audit rules for best-practice issues, diff two similar apps, generate human-readable summaries, or answer "which app is doing X" after list_installed_apps / get_device_in_use_by narrows the field.
 
+Workflow: (1) Get the appId from list_installed_apps (all apps), list_rm_rules (RM rules specifically -- these are Rule-5.x appIds under parent Rule Machine; use this, not list_rules / get_rule, which only handle MCP-native rules), or list_installed_apps with filter=parents to explore app hierarchy. (2) Call get_app_config with the appId. (3) For multi-page apps, optionally pass pageName -- call list_app_pages first to discover available page names. Common multi-page names: HPM uses prefPkgUninstall (full installed-package list), prefPkgModify (modifiable subset only), prefOptions (main menu / navigation); RM and Room Lighting use a single mainPage (no pageName needed).
+
 Requires Hub Admin Read.""",
             inputSchema: [
                 type: "object",
                 properties: [
                     appId: [type: "string", description: "Installed-app ID (decimal). From list_installed_apps, list_rm_rules, or the numeric id in the Hubitat UI URL (/installedapp/configure/<id>)."],
-                    pageName: [type: "string", description: "Optional sub-page name for multi-page apps. Main page is used when omitted. Known examples: HPM's 'prefPkgModify' lists installed packages; RM 5.1 has per-section sub-pages."],
+                    pageName: [type: "string", description: "Optional sub-page name for multi-page apps. Main page is used when omitted. Call list_app_pages to discover available pages. HPM: prefPkgUninstall (full installed-package list), prefPkgModify (modifiable subset), prefOptions (main menu). RM / Room Lighting: mainPage only."],
                     includeSettings: [type: "boolean", description: "Include the raw app-internal settings key-value map. Default false -- large apps can have 500-1000 keys with app-specific encoding (e.g. Room Lighting's dm~<deviceId>~<scene>). Set true only for power-user inspection.", default: false]
+                ],
+                required: ["appId"]
+            ]
+        ],
+        // Hub Admin App Pages Directory
+        [
+            name: "list_app_pages",
+            description: """List known page names for a multi-page installed app. Returns the primary page (introspected live from the hub) plus a curated directory of known sub-pages for well-known app types.
+
+Curated directories: HPM (prefOptions main menu, prefPkgUninstall full installed-package list, prefPkgModify modifiable subset, prefPkgInstall install flow, prefPkgMatchUp match-up flow); Rule Machine rules (mainPage only -- rules are single-page); Room Lighting (mainPage); Mode Manager (mainPage).
+
+Unknown app types return the primary page only, plus a note directing you to consult the app's source or Web UI navigation for additional page names.
+
+Use this before get_app_config on multi-page apps to avoid guessing page names.
+
+Requires Hub Admin Read.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    appId: [type: "string", description: "Installed-app ID (decimal). From list_installed_apps, list_rm_rules, or the Hubitat UI URL (/installedapp/configure/<id>)."]
                 ],
                 required: ["appId"]
             ]
@@ -1834,6 +1858,7 @@ def executeTool(toolName, args) {
 
         // Hub Admin App Configuration Read
         case "get_app_config": return toolGetAppConfig(args)
+        case "list_app_pages": return toolListAppPages(args)
 
         // Hub Admin App/Driver Management
         case "get_app_source": return toolGetAppSource(args)
@@ -6288,7 +6313,7 @@ def toolGetAppConfig(args) {
         return [success: false, error: "Unexpected response shape: missing 'configPage' object. Firmware may have changed the endpoint contract.", appId: appIdStr as Integer, fingerprint: "missing configPage"]
     }
     if (!(parsed.configPage.sections instanceof List)) {
-        return [success: false, error: "Unexpected response shape: configPage.sections is not a list. Firmware may have changed the endpoint contract.", appId: appIdStr as Integer, fingerprint: "sections not a list"]
+        return [success: false, error: "Unexpected response shape: configPage.sections is not a list. This page may be a dynamic redirect or action-only page (common in HPM multi-step flows). Try a different pageName -- call list_app_pages for this app, or consult get_tool_guide section=builtin_app_tools for common multi-page app names.", appId: appIdStr as Integer, fingerprint: "sections not a list"]
     }
 
     // Hub returns app.appType as a ~30-key metadata object (author, classLocation,
@@ -6402,6 +6427,113 @@ def toolGetAppConfig(args) {
     }
 
     return result
+}
+
+/**
+ * List known page names for a multi-page installed app.
+ *
+ * Combines live introspection of the primary page (one hub API call) with a
+ * curated directory of known sub-page names for well-known app types (HPM,
+ * Rule Machine, Room Lighting, Mode Manager). For unknown app types the
+ * response contains only the primary page and a note about finding additional
+ * pages via the app source or Web UI navigation.
+ *
+ * Gate: requireHubAdminRead() -- read-only, reads app metadata.
+ * Args: appId (required, numeric string or integer)
+ */
+private Map toolListAppPages(Map args) {
+    requireHubAdminRead()
+
+    if (args?.appId == null || args.appId.toString().trim() == "") {
+        throw new IllegalArgumentException("appId is required")
+    }
+    def appIdStr = args.appId.toString().trim()
+    if (!appIdStr.isInteger()) {
+        throw new IllegalArgumentException("appId must be numeric: ${appIdStr}")
+    }
+
+    mcpLog("info", "hub-admin", "list_app_pages appId=${appIdStr}")
+
+    def path = "/installedapp/configure/json/${appIdStr}"
+    def responseText
+    try {
+        responseText = hubInternalGet(path, null, 30)
+    } catch (Exception e) {
+        mcpLog("error", "hub-admin", "list_app_pages failed: ${e.message}")
+        return [success: false, error: "Failed to fetch app config: ${e.message}", appId: appIdStr as Integer]
+    }
+
+    if (!responseText) {
+        return [success: false, error: "Empty response from ${path}. App may not exist or hub internal API is unavailable.", appId: appIdStr as Integer]
+    }
+
+    def parsed
+    try {
+        parsed = new groovy.json.JsonSlurper().parseText(responseText)
+    } catch (Exception e) {
+        return [success: false, error: "Failed to parse app config JSON: ${e.message}", appId: appIdStr as Integer]
+    }
+
+    if (!(parsed instanceof Map) || !(parsed.app instanceof Map)) {
+        return [success: false, error: "Unexpected response shape from hub -- app may not exist.", appId: appIdStr as Integer]
+    }
+
+    def appTypeRaw = parsed.app.appType
+    def appTypeName = (appTypeRaw instanceof Map) ? (appTypeRaw.name ?: "") : ""
+    def appLabel = stripAppConfigHtml(parsed.app.trueLabel ?: parsed.app.label) ?: ""
+
+    // Primary page: introspected from the hub response
+    def primaryPageName = (parsed.configPage instanceof Map) ? (parsed.configPage.name ?: "mainPage") : "mainPage"
+    def primaryPageTitle = (parsed.configPage instanceof Map) ? stripAppConfigHtml(parsed.configPage.title) : null
+    def primaryPage = [name: primaryPageName, title: primaryPageTitle, role: "primary"]
+
+    def appObj = [
+        id: parsed.app.id,
+        label: appLabel,
+        name: parsed.app.name,
+        appTypeName: appTypeName
+    ]
+
+    // Curated directory dispatch -- case-insensitive substring matching for robustness.
+    def appTypeNameLower = appTypeName.toLowerCase()
+    def pages
+    def note = null
+
+    if (appTypeNameLower.contains("hubitat package manager")) {
+        pages = [
+            [name: "prefOptions",    title: "Main Menu",                role: "navigation"],
+            [name: "prefPkgUninstall", title: "Uninstall / Full Package List", role: "full_package_list"],
+            [name: "prefPkgModify",  title: "Modify Package (optional-components subset)", role: "modifiable_subset"],
+            [name: "prefPkgInstall", title: "Install New Package",       role: "install_flow"],
+            [name: "prefPkgMatchUp", title: "Match Up Packages",         role: "matching_flow"]
+        ]
+    } else if (appTypeNameLower.contains("rule-5") || appTypeNameLower.contains("rule machine")) {
+        pages = [
+            [name: "mainPage", title: appLabel ?: "Rule Settings", role: "primary"]
+        ]
+        note = "Rule Machine rules are single-page. No sub-pages available."
+    } else if (appTypeNameLower.contains("room lights") || appTypeNameLower.contains("room lighting")) {
+        pages = [
+            [name: "mainPage", title: appLabel ?: "Room Lighting Settings", role: "primary"]
+        ]
+        note = "Room Lighting instances use a single mainPage. No named sub-pages."
+    } else if (appTypeNameLower.contains("mode manager")) {
+        pages = [
+            [name: "mainPage", title: "Manage Setting of Modes", role: "primary"]
+        ]
+        note = "Mode Manager uses a single mainPage. No named sub-pages."
+    } else {
+        pages = [primaryPage]
+        note = "App-type-specific page directory not curated; only primary page known. For multi-page apps, consult the app's Groovy source or the Web UI navigation for sub-page names."
+    }
+
+    return [
+        success: true,
+        app: appObj,
+        primaryPage: primaryPage,
+        pages: pages,
+        note: note
+    ]
 }
 
 def toolGetAppSource(args) {
@@ -8675,9 +8807,14 @@ All tools in the manage_installed_apps and manage_rule_machine gateways require 
 
 - **get_app_config** — read an installed app's configuration page (Hub Admin Read required)
   - Returns app identity (label, type, disabled), config page sections/inputs/values, and child apps
-  - Multi-page apps (RM 5.1, HPM) expose sub-pages via pageName -- e.g. pageName="prefPkgModify" for HPM packages
-  - includeSettings=true adds the raw internal settings map (large apps: 500-1000 keys)
-  - Workflow: list_installed_apps or list_rm_rules to find appId, then get_app_config to inspect
+  - Multi-page apps expose sub-pages via pageName. For HPM: use pageName="prefPkgUninstall" for the FULL installed-package list; pageName="prefPkgModify" returns only the subset with optional components; pageName="prefOptions" is the main-menu navigation (no package data). RM 5.x and Room Lighting use a single mainPage (no pageName needed). Call list_app_pages first to discover available page names for any multi-page app.
+  - includeSettings=true adds the raw internal settings map (large apps: 500-1000 keys with app-specific encoding)
+  - Workflow: list_installed_apps (or list_rm_rules for RM rules specifically -- note that list_rules / get_rule handle only MCP-native rules, not Hubitat's built-in Rule Machine) to find appId, then get_app_config to inspect. For multi-page apps, consider list_app_pages first.
+
+- **list_app_pages** — discover what pageNames a given app accepts (Hub Admin Read required)
+  - Input: appId
+  - Returns curated page directory for known app types (HPM, RM 5.x, Room Lighting, Mode Manager) plus an introspected primary page for unknown app types
+  - Cuts the page-name guessing cycle for multi-page apps. Especially useful for HPM which exposes multiple sub-pages (prefPkgUninstall / prefPkgModify / prefPkgInstall / prefPkgMatchUp) for different operations.
 
 **manage_rule_machine (5 tools) — read + trigger existing RM rules only, NO create/modify/delete:**
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6188,6 +6188,36 @@ private String stripAppConfigHtml(value) {
 }
 
 /**
+ * Walk an input's options structure and strip HTML from any label values. Hubitat's
+ * SDK emits options in two shapes depending on input type:
+ *   - List of single-entry maps: [{"<value>": "<label>"}, ...]  (enum)
+ *   - Map of value-to-label: {"<value>": "<label>"}  (some capability inputs)
+ * Both can contain color-span HTML on labels (e.g. state badges). Leaves unknown
+ * shapes alone rather than guessing wrong and breaking them.
+ */
+private stripOptionsHtml(options) {
+    if (options instanceof List) {
+        def out = []
+        for (entry in options) {
+            if (entry instanceof Map) {
+                def cleaned = [:]
+                entry.each { k, v -> cleaned[k] = (v instanceof String) ? stripAppConfigHtml(v) : v }
+                out << cleaned
+            } else {
+                out << entry
+            }
+        }
+        return out
+    }
+    if (options instanceof Map) {
+        def cleaned = [:]
+        options.each { k, v -> cleaned[k] = (v instanceof String) ? stripAppConfigHtml(v) : v }
+        return cleaned
+    }
+    return options
+}
+
+/**
  * Read an installed app's configuration via the hub's SDK-level rendering endpoint
  * /installedapp/configure/json/<appId>[/<pageName>]. Returns a normalized structure
  * covering app identity, page sections, inputs, and optionally the raw settings map.
@@ -6305,7 +6335,7 @@ def toolGetAppConfig(args) {
             if (i.required == true) input.required = true
             def desc = stripAppConfigHtml(i.description)
             if (desc && desc != "Click to set") input.description = desc
-            if (i.options) input.options = i.options
+            if (i.options) input.options = stripOptionsHtml(i.options)
             // Current values: 'defaultValue' is the rendered value for most input types
             // (despite the misleading name), 'value' is used on some. Include whichever
             // is non-null and not the boolean 'true' sentinel the SDK uses for "has value".
@@ -6313,12 +6343,14 @@ def toolGetAppConfig(args) {
             else if (i.value != null && i.value != true) input.value = i.value
             section.inputs << input
         }
-        // Paragraph/body content (informational text in the config page)
+        // Paragraph/body content (informational text in the config page). Keep any
+        // non-"Click to set" string — including short labels like "Enabled" / "Warning!"
+        // that the SDK emits as standalone body paragraphs.
         def paragraphs = []
         for (b in (s.body ?: [])) {
             if (!(b instanceof Map)) continue
             def text = stripAppConfigHtml(b.description ?: b.title)
-            if (text && text.length() > 10 && text != "Click to set") paragraphs << text
+            if (text && text != "Click to set") paragraphs << text
         }
         if (paragraphs) section.paragraphs = paragraphs
         sections << section

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -616,15 +616,17 @@ def getGatewayConfig() {
             ]
         ],
         manage_installed_apps: [
-            description: "Read-only visibility into all installed apps (built-in + user): enumerate apps with parent/child tree, find apps using a device. Requires Built-in App Tools enabled in MCP app settings.",
-            tools: ["list_installed_apps", "get_device_in_use_by"],
+            description: "Read-only visibility into all installed apps (built-in + user): enumerate apps with parent/child tree, find apps using a device, inspect an app's configuration page. Requires Built-in App Tools enabled in MCP app settings (list/device-in-use-by); get_app_config requires Hub Admin Read.",
+            tools: ["list_installed_apps", "get_device_in_use_by", "get_app_config"],
             summaries: [
                 list_installed_apps: "List all installed apps with parent/child tree. Args: filter (all/builtin/user/disabled/parents/children), includeHidden",
-                get_device_in_use_by: "List all apps that reference a device (Room Lighting, Rule Machine, Groups, etc.). Args: deviceId"
+                get_device_in_use_by: "List all apps that reference a device (Room Lighting, Rule Machine, Groups, etc.). Args: deviceId",
+                get_app_config: "Read an installed app's configuration page (sections, inputs, current values). Works for Rule Machine, Room Lighting, Basic Rules, HPM, etc. Args: appId, pageName (optional), includeSettings (optional)"
             ],
             searchHints: [
                 list_installed_apps: "rule machine room lighting scenes mode manager hsm dashboards groups button controllers native builtin",
-                get_device_in_use_by: "which apps use device reference inUseBy appsUsing dependencies affected by"
+                get_device_in_use_by: "which apps use device reference inUseBy appsUsing dependencies affected by",
+                get_app_config: "read inspect app configuration page settings inputs values rule machine room lighting hpm mode manager"
             ]
         ],
         manage_rule_machine: [
@@ -1408,26 +1410,6 @@ Requires Hub Admin Write.""",
             ]
         ],
 
-        // Hub Admin App Configuration Read
-        [
-            name: "get_app_config",
-            description: """Read an installed app's configuration — the same structured data the Hubitat Web UI shows on each app's settings page. Works for Rule Machine rules, Room Lighting instances, Basic Rules, Button Controllers, Hubitat Package Manager, Mode Manager, and any other legacy SmartApp.
-
-Returns the app's identity (label, type, parent, disabled state) and its current config page: sections, inputs (name, type, title, description, options, current value). Multi-page apps (e.g. RM 5.1) expose sub-pages by name — pass pageName to navigate into them. Read-only; does not modify anything.
-
-Use to: understand what an existing automation actually does, audit rules for best-practice issues, diff two similar apps, generate human-readable summaries, or answer "which app is doing X" after list_installed_apps / get_device_in_use_by narrows the field.
-
-Requires Hub Admin Read.""",
-            inputSchema: [
-                type: "object",
-                properties: [
-                    appId: [type: ["integer", "string"], description: "Installed-app ID (decimal). From list_installed_apps, list_rm_rules, or the numeric id in the Hubitat UI URL (/installedapp/configure/<id>)."],
-                    pageName: [type: "string", description: "Optional sub-page name for multi-page apps. Main page is used when omitted. Known examples: HPM's 'prefPkgModify' lists installed packages; RM 5.1 has per-section sub-pages."],
-                    includeSettings: [type: "boolean", description: "Include the raw app-internal settings key-value map. Default false — large apps can have 500-1000 keys with app-specific encoding (e.g. Room Lighting's dm~<deviceId>~<scene>). Set true only for power-user inspection.", default: false]
-                ],
-                required: ["appId"]
-            ]
-        ],
         // Hub Admin App/Driver Source Read Tools
         [
             name: "get_app_source",
@@ -1658,6 +1640,26 @@ Returns: deviceId, deviceName, appsUsing array (each entry: id, name=app type, l
                     deviceId: [type: "string", description: "Device ID from list_devices"]
                 ],
                 required: ["deviceId"]
+            ]
+        ],
+        // Hub Admin App Configuration Read (grouped with installed-apps peers)
+        [
+            name: "get_app_config",
+            description: """Read an installed app's configuration — the same structured data the Hubitat Web UI shows on each app's settings page. Works for Rule Machine rules, Room Lighting instances, Basic Rules, Button Controllers, Hubitat Package Manager, Mode Manager, and any other legacy SmartApp.
+
+Returns the app's identity (label, type, parent, disabled state) and its current config page: sections, inputs (name, type, title, description, options, current value). Multi-page apps (e.g. RM 5.1) expose sub-pages by name — pass pageName to navigate into them. Read-only; does not modify anything.
+
+Use to: understand what an existing automation actually does, audit rules for best-practice issues, diff two similar apps, generate human-readable summaries, or answer "which app is doing X" after list_installed_apps / get_device_in_use_by narrows the field.
+
+Requires Hub Admin Read.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    appId: [type: "string", description: "Installed-app ID (decimal). From list_installed_apps, list_rm_rules, or the numeric id in the Hubitat UI URL (/installedapp/configure/<id>)."],
+                    pageName: [type: "string", description: "Optional sub-page name for multi-page apps. Main page is used when omitted. Known examples: HPM's 'prefPkgModify' lists installed packages; RM 5.1 has per-section sub-pages."],
+                    includeSettings: [type: "boolean", description: "Include the raw app-internal settings key-value map. Default false -- large apps can have 500-1000 keys with app-specific encoding (e.g. Room Lighting's dm~<deviceId>~<scene>). Set true only for power-user inspection.", default: false]
+                ],
+                required: ["appId"]
             ]
         ],
         // Rule Machine Integration (read + trigger + pause/resume only — platform blocks CRUD)
@@ -6338,7 +6340,22 @@ def toolGetAppConfig(args) {
             if (i.options) input.options = stripOptionsHtml(i.options)
             // Current values: 'defaultValue' is the rendered value for most input types
             // (despite the misleading name), 'value' is used on some. Include whichever
-            // is non-null and not the boolean 'true' sentinel the SDK uses for "has value".
+            // is non-null and not the boolean 'true' sentinel.
+            //
+            // The boolean 'true' sentinel: Hubitat's legacy SmartApp SDK populates
+            // defaultValue=true on capability.* and device-list input types (e.g.
+            // type="capability.*", type="device.switch") to indicate "this input has a
+            // configured value" rather than encoding the actual selection as defaultValue.
+            // For those types the actual selected device label appears separately in the
+            // rendered description. Excluding defaultValue==true prevents emitting a bare
+            // true into the value field for every populated device-picker input.
+            //
+            // Risk: a boolean input whose user-configured value is literally true would
+            // also be filtered here. In practice, boolean inputs (type="bool") carry
+            // their actual value in i.value, not i.defaultValue, so the filter fires on
+            // the i.defaultValue branch only and the i.value fallback below correctly
+            // picks up the bool. Re-verify this assumption if new SDK input types emerge
+            // that use defaultValue for genuine boolean config (observed: firmware 2.3.x-2.4.x).
             if (i.defaultValue != null && i.defaultValue != true) input.value = i.defaultValue
             else if (i.value != null && i.value != true) input.value = i.value
             section.inputs << input
@@ -6381,7 +6398,7 @@ def toolGetAppConfig(args) {
     if (includeSettings) {
         result.settings = parsed.settings ?: [:]
     } else if (settingsCount > 0) {
-        result.settingsNote = "Raw settings omitted — pass includeSettings=true to include. Large apps (Room Lighting, RM 5.1) may have 500-1000 keys with app-specific encoding (e.g. 'dm~<deviceId>~<scene>' for Room Lighting dim presets) that is non-trivial to decode without app-specific knowledge."
+        result.settingsNote = "Raw settings omitted -- pass includeSettings=true to include. Large apps (Room Lighting, RM 5.1) may have 500-1000 keys with app-specific encoding (e.g. \"dm~<deviceId>~<scene>\" for Room Lighting dim presets) that is non-trivial to decode without app-specific knowledge."
     }
 
     return result
@@ -8642,7 +8659,7 @@ Files stored at http://<HUB_IP>/local/<filename>
 
 All tools in the manage_installed_apps and manage_rule_machine gateways require the "Enable Built-in App Tools" toggle in MCP Rule Server app settings. If the user sees "Built-in App Tools are disabled" errors, direct them to the MCP Rule Server app settings page.
 
-**manage_installed_apps (2 tools):**
+**manage_installed_apps (3 tools):**
 
 - **list_installed_apps** — enumerate ALL apps on the hub (built-in + user) with parent/child tree
   - filter="all" (default) | "builtin" | "user" | "disabled" | "parents" | "children"
@@ -8655,6 +8672,12 @@ All tools in the manage_installed_apps and manage_rule_machine gateways require 
   - Use BEFORE deleting a device, disabling a device, or troubleshooting unexpected behavior
   - Returns appsUsing array with each app's id, name (type like "Room Lights" or "Rule-5.1"), label (user-visible), trueLabel (HTML-stripped), disabled
   - Answers "if I delete this device, which automations break?"
+
+- **get_app_config** — read an installed app's configuration page (Hub Admin Read required)
+  - Returns app identity (label, type, disabled), config page sections/inputs/values, and child apps
+  - Multi-page apps (RM 5.1, HPM) expose sub-pages via pageName -- e.g. pageName="prefPkgModify" for HPM packages
+  - includeSettings=true adds the raw internal settings map (large apps: 500-1000 keys)
+  - Workflow: list_installed_apps or list_rm_rules to find appId, then get_app_config to inspect
 
 **manage_rule_machine (5 tools) — read + trigger existing RM rules only, NO create/modify/delete:**
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6283,8 +6283,8 @@ def toolGetAppConfig(args) {
     try {
         responseText = hubInternalGet(path, null, 30)
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "get_app_config failed: ${e.message}")
-        return [success: false, error: "Failed to fetch app config: ${e.message}", appId: appIdStr as Integer]
+        mcpLogError("hub-admin", "get_app_config fetch failed", e)
+        return [success: false, error: "Failed to fetch app config [${e.class.simpleName}]: ${e.message}", appId: appIdStr as Integer]
     }
 
     if (!responseText) {
@@ -6295,6 +6295,7 @@ def toolGetAppConfig(args) {
     try {
         parsed = new groovy.json.JsonSlurper().parseText(responseText)
     } catch (Exception e) {
+        mcpLogError("hub-admin", "get_app_config JSON parse failed", e)
         return [success: false, error: "Failed to parse app config JSON: ${e.message}. Hubitat firmware may have changed the endpoint contract.", appId: appIdStr as Integer]
     }
 
@@ -6442,7 +6443,7 @@ def toolGetAppConfig(args) {
  * Gate: requireHubAdminRead() -- read-only, reads app metadata.
  * Args: appId (required, numeric string or integer)
  */
-private Map toolListAppPages(Map args) {
+def toolListAppPages(args) {
     requireHubAdminRead()
 
     if (args?.appId == null || args.appId.toString().trim() == "") {
@@ -6460,8 +6461,8 @@ private Map toolListAppPages(Map args) {
     try {
         responseText = hubInternalGet(path, null, 30)
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "list_app_pages failed: ${e.message}")
-        return [success: false, error: "Failed to fetch app config: ${e.message}", appId: appIdStr as Integer]
+        mcpLogError("hub-admin", "list_app_pages fetch failed", e)
+        return [success: false, error: "Failed to fetch app config [${e.class.simpleName}]: ${e.message}", appId: appIdStr as Integer]
     }
 
     if (!responseText) {
@@ -6472,20 +6473,27 @@ private Map toolListAppPages(Map args) {
     try {
         parsed = new groovy.json.JsonSlurper().parseText(responseText)
     } catch (Exception e) {
-        return [success: false, error: "Failed to parse app config JSON: ${e.message}", appId: appIdStr as Integer]
+        mcpLogError("hub-admin", "list_app_pages JSON parse failed", e)
+        return [success: false, error: "Failed to parse app config JSON: ${e.message}. Hubitat firmware may have changed the endpoint contract.", appId: appIdStr as Integer]
     }
 
-    if (!(parsed instanceof Map) || !(parsed.app instanceof Map)) {
-        return [success: false, error: "Unexpected response shape from hub -- app may not exist.", appId: appIdStr as Integer]
+    if (!(parsed instanceof Map)) {
+        return [success: false, error: "Unexpected response shape: expected a JSON object. Firmware may have changed the endpoint contract.", appId: appIdStr as Integer, fingerprint: "top-level not a Map"]
+    }
+    if (!(parsed.app instanceof Map)) {
+        return [success: false, error: "Unexpected response shape: missing 'app' object. Firmware may have changed the endpoint contract.", appId: appIdStr as Integer, fingerprint: "missing app"]
+    }
+    if (!(parsed.configPage instanceof Map)) {
+        return [success: false, error: "Unexpected response shape: missing 'configPage' object. Firmware may have changed the endpoint contract.", appId: appIdStr as Integer, fingerprint: "missing configPage"]
     }
 
     def appTypeRaw = parsed.app.appType
     def appTypeName = (appTypeRaw instanceof Map) ? (appTypeRaw.name ?: "") : ""
     def appLabel = stripAppConfigHtml(parsed.app.trueLabel ?: parsed.app.label) ?: ""
 
-    // Primary page: introspected from the hub response
-    def primaryPageName = (parsed.configPage instanceof Map) ? (parsed.configPage.name ?: "mainPage") : "mainPage"
-    def primaryPageTitle = (parsed.configPage instanceof Map) ? stripAppConfigHtml(parsed.configPage.title) : null
+    // Primary page: introspected from the hub response (configPage guaranteed Map by fingerprint check above)
+    def primaryPageName = parsed.configPage.name ?: "mainPage"
+    def primaryPageTitle = stripAppConfigHtml(parsed.configPage.title)
     def primaryPage = [name: primaryPageName, title: primaryPageTitle, role: "primary"]
 
     def appObj = [
@@ -8790,9 +8798,9 @@ Files stored at http://<HUB_IP>/local/<filename>
 
         builtin_app_tools: '''## Built-in App Tools
 
-All tools in the manage_installed_apps and manage_rule_machine gateways require the "Enable Built-in App Tools" toggle in MCP Rule Server app settings. If the user sees "Built-in App Tools are disabled" errors, direct them to the MCP Rule Server app settings page.
+Tools in the manage_installed_apps and manage_rule_machine gateways have mixed gate requirements. list_installed_apps and get_device_in_use_by require the "Enable Built-in App Tools" toggle (requireBuiltinAppRead). get_app_config and list_app_pages require Hub Admin Read (requireHubAdminRead). manage_rule_machine tools require the "Enable Built-in App Tools" toggle. If the user sees "Built-in App Tools are disabled" errors, direct them to the MCP Rule Server app settings page.
 
-**manage_installed_apps (3 tools):**
+**manage_installed_apps (4 tools):**
 
 - **list_installed_apps** — enumerate ALL apps on the hub (built-in + user) with parent/child tree
   - filter="all" (default) | "builtin" | "user" | "disabled" | "parents" | "children"

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1408,6 +1408,26 @@ Requires Hub Admin Write.""",
             ]
         ],
 
+        // Hub Admin App Configuration Read
+        [
+            name: "get_app_config",
+            description: """Read an installed app's configuration — the same structured data the Hubitat Web UI shows on each app's settings page. Works for Rule Machine rules, Room Lighting instances, Basic Rules, Button Controllers, Hubitat Package Manager, Mode Manager, and any other legacy SmartApp.
+
+Returns the app's identity (label, type, parent, disabled state) and its current config page: sections, inputs (name, type, title, description, options, current value). Multi-page apps (e.g. RM 5.1) expose sub-pages by name — pass pageName to navigate into them. Read-only; does not modify anything.
+
+Use to: understand what an existing automation actually does, audit rules for best-practice issues, diff two similar apps, generate human-readable summaries, or answer "which app is doing X" after list_installed_apps / get_device_in_use_by narrows the field.
+
+Requires Hub Admin Read.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    appId: [type: ["integer", "string"], description: "Installed-app ID (decimal). From list_installed_apps, list_rm_rules, or the numeric id in the Hubitat UI URL (/installedapp/configure/<id>)."],
+                    pageName: [type: "string", description: "Optional sub-page name for multi-page apps. Main page is used when omitted. Known examples: HPM's 'prefPkgModify' lists installed packages; RM 5.1 has per-section sub-pages."],
+                    includeSettings: [type: "boolean", description: "Include the raw app-internal settings key-value map. Default false — large apps can have 500-1000 keys with app-specific encoding (e.g. Room Lighting's dm~<deviceId>~<scene>). Set true only for power-user inspection.", default: false]
+                ],
+                required: ["appId"]
+            ]
+        ],
         // Hub Admin App/Driver Source Read Tools
         [
             name: "get_app_source",
@@ -1809,6 +1829,9 @@ def executeTool(toolName, args) {
         case "create_room": return toolCreateRoom(args)
         case "delete_room": return toolDeleteRoom(args)
         case "rename_room": return toolRenameRoom(args)
+
+        // Hub Admin App Configuration Read
+        case "get_app_config": return toolGetAppConfig(args)
 
         // Hub Admin App/Driver Management
         case "get_app_source": return toolGetAppSource(args)
@@ -6150,6 +6173,186 @@ def toolGetItemSource(String type, String idParam, args) {
         mcpLog("error", "hub-admin", "Failed to get ${type} source: ${e.message}")
         return [success: false, error: "Failed to get ${type} source: ${e.message}"]
     }
+}
+
+/**
+ * Strip HTML tags from a string (Hubitat frequently embeds color spans in app labels
+ * and page titles). Null-safe. Does not try to be a real HTML parser — SDK-generated
+ * tags are predictable (<span>, <b>, <i>) and this is adequate.
+ */
+private String stripAppConfigHtml(value) {
+    if (value == null) return null
+    def s = value.toString()
+    if (!s.contains("<")) return s
+    return s.replaceAll(/<[^>]+>/, "").trim()
+}
+
+/**
+ * Read an installed app's configuration via the hub's SDK-level rendering endpoint
+ * /installedapp/configure/json/<appId>[/<pageName>]. Returns a normalized structure
+ * covering app identity, page sections, inputs, and optionally the raw settings map.
+ *
+ * This endpoint is what the Hubitat Web UI itself consumes to render each app's
+ * config page. The top-level shape {configPage, app, settings, childApps} is SDK-level
+ * and consistent across every legacy SmartApp (Rule Machine, Room Lighting, Basic
+ * Rules, HPM, Mode Manager, etc.). The runtime fingerprint check below asserts the
+ * shape invariants; if Hubitat firmware drifts the contract, callers see a clear
+ * error rather than malformed data.
+ */
+def toolGetAppConfig(args) {
+    requireHubAdminRead()
+
+    if (args?.appId == null || args.appId.toString().trim() == "") {
+        throw new IllegalArgumentException("appId is required")
+    }
+    def appIdStr = args.appId.toString().trim()
+    if (!appIdStr.isInteger()) {
+        throw new IllegalArgumentException("appId must be numeric: ${appIdStr}")
+    }
+
+    def pageName = args?.pageName?.toString()?.trim()
+    if (pageName && !pageName.matches(/[A-Za-z0-9_]+/)) {
+        throw new IllegalArgumentException("pageName must be alphanumeric/underscore only: ${pageName}")
+    }
+
+    boolean includeSettings = args?.includeSettings == true
+
+    def path = "/installedapp/configure/json/${appIdStr}"
+    if (pageName) path += "/${pageName}"
+
+    mcpLog("info", "hub-admin", "get_app_config appId=${appIdStr} page=${pageName ?: 'main'} includeSettings=${includeSettings}")
+
+    def responseText
+    try {
+        responseText = hubInternalGet(path, null, 30)
+    } catch (Exception e) {
+        mcpLog("error", "hub-admin", "get_app_config failed: ${e.message}")
+        return [success: false, error: "Failed to fetch app config: ${e.message}", appId: appIdStr as Integer]
+    }
+
+    if (!responseText) {
+        return [success: false, error: "Empty response from ${path}. App may not exist or hub internal API is unavailable.", appId: appIdStr as Integer]
+    }
+
+    def parsed
+    try {
+        parsed = new groovy.json.JsonSlurper().parseText(responseText)
+    } catch (Exception e) {
+        return [success: false, error: "Failed to parse app config JSON: ${e.message}. Hubitat firmware may have changed the endpoint contract.", appId: appIdStr as Integer]
+    }
+
+    // Runtime fingerprint: confirm the SDK-level shape this tool depends on.
+    // The /installedapp/configure/json/<id> endpoint returns {app, configPage, settings, childApps, ...}
+    // consistently across every legacy SmartApp. If any of these top-level invariants are
+    // missing, the firmware likely changed the contract — fail explicitly rather than
+    // returning malformed data.
+    if (!(parsed instanceof Map)) {
+        return [success: false, error: "Unexpected response shape: expected a JSON object. Firmware may have changed the endpoint contract.", appId: appIdStr as Integer, fingerprint: "top-level not a Map"]
+    }
+    if (!(parsed.app instanceof Map)) {
+        return [success: false, error: "Unexpected response shape: missing 'app' object. Firmware may have changed the endpoint contract.", appId: appIdStr as Integer, fingerprint: "missing app"]
+    }
+    if (!(parsed.configPage instanceof Map)) {
+        return [success: false, error: "Unexpected response shape: missing 'configPage' object. Firmware may have changed the endpoint contract.", appId: appIdStr as Integer, fingerprint: "missing configPage"]
+    }
+    if (!(parsed.configPage.sections instanceof List)) {
+        return [success: false, error: "Unexpected response shape: configPage.sections is not a list. Firmware may have changed the endpoint contract.", appId: appIdStr as Integer, fingerprint: "sections not a list"]
+    }
+
+    // Hub returns app.appType as a ~30-key metadata object (author, classLocation,
+    // createTime, deprecated, etc.). Extract only the useful fields — the rest is
+    // either internal SDK state or duplicates what's already on app itself.
+    def appTypeRaw = parsed.app.appType
+    def appTypeSummary = null
+    if (appTypeRaw instanceof Map) {
+        appTypeSummary = [
+            name: appTypeRaw.name,
+            namespace: appTypeRaw.namespace,
+            author: appTypeRaw.author,
+            category: appTypeRaw.category,
+            classLocation: appTypeRaw.classLocation,
+            deprecated: appTypeRaw.deprecated == true,
+            system: appTypeRaw.system == true,
+            documentationLink: appTypeRaw.documentationLink
+        ]
+    }
+
+    def appObj = [
+        id: parsed.app.id,
+        label: stripAppConfigHtml(parsed.app.trueLabel ?: parsed.app.label),
+        name: parsed.app.name,
+        appType: appTypeSummary,
+        disabled: parsed.app.disabled == true,
+        parentAppId: parsed.app.parentAppId,
+        installed: parsed.app.installed == true
+    ]
+
+    def sections = []
+    for (s in parsed.configPage.sections) {
+        if (!(s instanceof Map)) continue
+        def section = [
+            title: stripAppConfigHtml(s.title),
+            inputs: []
+        ]
+        for (i in (s.input ?: [])) {
+            if (!(i instanceof Map)) continue
+            def input = [
+                name: i.name,
+                type: i.type,
+                title: stripAppConfigHtml(i.title)
+            ]
+            if (i.multiple == true) input.multiple = true
+            if (i.required == true) input.required = true
+            def desc = stripAppConfigHtml(i.description)
+            if (desc && desc != "Click to set") input.description = desc
+            if (i.options) input.options = i.options
+            // Current values: 'defaultValue' is the rendered value for most input types
+            // (despite the misleading name), 'value' is used on some. Include whichever
+            // is non-null and not the boolean 'true' sentinel the SDK uses for "has value".
+            if (i.defaultValue != null && i.defaultValue != true) input.value = i.defaultValue
+            else if (i.value != null && i.value != true) input.value = i.value
+            section.inputs << input
+        }
+        // Paragraph/body content (informational text in the config page)
+        def paragraphs = []
+        for (b in (s.body ?: [])) {
+            if (!(b instanceof Map)) continue
+            def text = stripAppConfigHtml(b.description ?: b.title)
+            if (text && text.length() > 10 && text != "Click to set") paragraphs << text
+        }
+        if (paragraphs) section.paragraphs = paragraphs
+        sections << section
+    }
+
+    def children = []
+    for (c in (parsed.childApps ?: [])) {
+        if (!(c instanceof Map)) continue
+        children << [id: c.id, label: stripAppConfigHtml(c.label ?: c.name), name: c.name]
+    }
+
+    def result = [
+        success: true,
+        app: appObj,
+        page: [
+            name: parsed.configPage.name,
+            title: stripAppConfigHtml(parsed.configPage.title),
+            install: parsed.configPage.install == true,
+            refreshInterval: parsed.configPage.refreshInterval,
+            sections: sections
+        ],
+        childApps: children,
+        endpoint: path
+    ]
+
+    int settingsCount = (parsed.settings instanceof Map) ? parsed.settings.size() : 0
+    result.settingsKeyCount = settingsCount
+    if (includeSettings) {
+        result.settings = parsed.settings ?: [:]
+    } else if (settingsCount > 0) {
+        result.settingsNote = "Raw settings omitted — pass includeSettings=true to include. Large apps (Room Lighting, RM 5.1) may have 500-1000 keys with app-specific encoding (e.g. 'dm~<deviceId>~<scene>' for Room Lighting dim presets) that is non-trivial to decode without app-specific knowledge."
+    }
+
+    return result
 }
 
 def toolGetAppSource(args) {

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6375,14 +6375,15 @@ def toolGetAppConfig(args) {
             // rendered description. Excluding defaultValue==true prevents emitting a bare
             // true into the value field for every populated device-picker input.
             //
-            // Risk: a boolean input whose user-configured value is literally true would
-            // also be filtered here. In practice, boolean inputs (type="bool") carry
-            // their actual value in i.value, not i.defaultValue, so the filter fires on
-            // the i.defaultValue branch only and the i.value fallback below correctly
-            // picks up the bool. Re-verify this assumption if new SDK input types emerge
-            // that use defaultValue for genuine boolean config (observed: firmware 2.3.x-2.4.x).
-            if (i.defaultValue != null && i.defaultValue != true) input.value = i.defaultValue
-            else if (i.value != null && i.value != true) input.value = i.value
+            // Exception for type="bool": boolean (checkbox) inputs use true/false as their
+            // actual user-configured state values -- not as sentinel markers. The filter
+            // is bypassed when i.type == "bool" so that both true (enabled) and false
+            // (disabled) checkbox states are preserved in the output. Without this bypass,
+            // enabled checkboxes (value==true) would be silently dropped, making the AI
+            // believe the setting is unconfigured when it is actually set to enabled.
+            // (observed: firmware 2.3.x-2.4.x; sentinel confirmed on capability.* types)
+            if (i.defaultValue != null && (i.defaultValue != true || i.type == "bool")) input.value = i.defaultValue
+            else if (i.value != null && (i.value != true || i.type == "bool")) input.value = i.value
             section.inputs << input
         }
         // Paragraph/body content (informational text in the config page). Keep any

--- a/scripts/app_config_audit.py
+++ b/scripts/app_config_audit.py
@@ -19,8 +19,13 @@ A minimum set that covers all three legacy-app rendering paths (RM, Room Lightin
 non-default page) is recommended. At least one user-created rule and one system app.
 
 Usage:
-    uv run --python 3.12 scripts/app_config_audit.py --hub-url http://<hub> [--strict]
+    uv run --python 3.12 scripts/app_config_audit.py --hub-url http://<hub>
     uv run --python 3.12 scripts/app_config_audit.py --config scripts/audit_config.json
+
+Note: Requires Hub Security to be disabled (or the hub to accept unauthenticated requests
+on /installedapp/configure/json). On hubs with Hub Security enabled the request is redirected
+to the login page; urllib.request has no cookie/session support so this script will parse the
+login-redirect HTML as JSON and report contract failures as "top-level not an object".
 
 Exit codes:
     0 — all targets passed invariants
@@ -126,7 +131,6 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     parser.add_argument("--hub-url", required=True, help="Hub URL (e.g. http://hubitat.local)")
     parser.add_argument("--config", help="JSON file with target app IDs to audit (see scripts/audit_config.example.json)")
-    parser.add_argument("--strict", action="store_true", help="Exit non-zero on any failure (default: exit 0 with warnings)")
     args = parser.parse_args()
 
     targets = DEFAULT_TARGETS[:]
@@ -147,22 +151,22 @@ def main() -> int:
         try:
             payload = fetch(args.hub_url, app_id, page_name)
         except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, OSError) as e:
-            print(f"[FAIL] {label}: fetch error: {e}")
+            print(f"[FAIL] {label}: fetch error: {e}", file=sys.stderr)
             total_failures += 1
             continue
 
         failures = check_invariants(payload)
         if failures:
-            print(f"[FAIL] {label}:")
+            print(f"[FAIL] {label}:", file=sys.stderr)
             for f in failures:
-                print(f"    - {f}")
+                print(f"    - {f}", file=sys.stderr)
             total_failures += 1
         else:
             print(f"[OK]   {label}")
 
     print()
     print(f"Audited {len(targets)} target(s). {total_failures} failure(s).")
-    return (1 if total_failures and args.strict else 0)
+    return (1 if total_failures else 0)
 
 
 if __name__ == "__main__":

--- a/scripts/app_config_audit.py
+++ b/scripts/app_config_audit.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Shape-drift audit for the get_app_config tool's underlying hub endpoint.
+
+Fetches /installedapp/configure/json/<id>[/<pageName>] for a set of known app IDs,
+asserts the top-level shape invariants that the Groovy tool depends on, and reports
+any drift. Run nightly or after each firmware update to catch contract changes before
+they surface as runtime errors for users.
+
+Invariants checked (per PR description of get_app_config):
+  - Response is a JSON object
+  - Top-level has 'app' (object), 'configPage' (object), and 'settings' (object or absent)
+  - configPage has 'sections' (array)
+  - Each section has 'input' (array or absent) and 'body' (array or absent)
+  - Each input has 'name' (string) and 'type' (string)
+
+Expected sample IDs are declared inline — edit the TARGETS list to match your hub.
+A minimum set that covers all three legacy-app rendering paths (RM, Room Lighting, HPM
+non-default page) is recommended. At least one user-created rule and one system app.
+
+Usage:
+    uv run --python 3.12 scripts/app_config_audit.py --hub-url http://<hub> [--strict]
+    uv run --python 3.12 scripts/app_config_audit.py --config scripts/audit_config.json
+
+Exit codes:
+    0 — all targets passed invariants
+    1 — at least one target failed invariants (drift detected)
+    2 — network/config error
+
+Non-goals: does not validate app-specific content (trigger types, Room Lighting setting
+encoding, etc.) — those are fragile by design. Only the SDK-level shape contract is audited.
+"""
+
+import argparse
+import json
+import sys
+import urllib.request
+import urllib.error
+from typing import Any
+
+# Edit to match the sample IDs on your hub. Each target is a (description, appId, pageName|None).
+# Pick one of each rendering path so a firmware change that only affects one is still caught:
+#   - Rule Machine rule (Rule-5.x)
+#   - Room Lighting instance (Room Lights)
+#   - Basic Rules (if any)
+#   - HPM main page
+#   - HPM sub-page (tests pageName navigation)
+DEFAULT_TARGETS: list[tuple[str, int, str | None]] = [
+    # ("description", appId, pageName or None)
+]
+
+
+def load_targets_from_config(path: str) -> list[tuple[str, int, str | None]]:
+    with open(path) as f:
+        raw = json.load(f)
+    return [(t["description"], int(t["appId"]), t.get("pageName")) for t in raw.get("targets", [])]
+
+
+def fetch(hub_url: str, app_id: int, page_name: str | None, timeout: int = 15) -> dict[str, Any]:
+    url = f"{hub_url.rstrip('/')}/installedapp/configure/json/{app_id}"
+    if page_name:
+        url += f"/{page_name}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+    return json.loads(body)
+
+
+def check_invariants(payload: Any) -> list[str]:
+    """Return a list of failure messages. Empty list means all invariants held."""
+    failures: list[str] = []
+
+    if not isinstance(payload, dict):
+        return [f"top-level is {type(payload).__name__}, expected object"]
+
+    if not isinstance(payload.get("app"), dict):
+        failures.append("missing or non-object 'app'")
+    else:
+        # app must have at least id and name
+        app = payload["app"]
+        if "id" not in app:
+            failures.append("app.id missing")
+        if "name" not in app:
+            failures.append("app.name missing")
+
+    config_page = payload.get("configPage")
+    if not isinstance(config_page, dict):
+        failures.append("missing or non-object 'configPage'")
+        return failures
+
+    sections = config_page.get("sections")
+    if not isinstance(sections, list):
+        failures.append("configPage.sections is not a list")
+        return failures
+
+    # Check each section's shape
+    for si, section in enumerate(sections):
+        if not isinstance(section, dict):
+            failures.append(f"sections[{si}] is {type(section).__name__}, expected object")
+            continue
+        inputs = section.get("input")
+        if inputs is not None:
+            if not isinstance(inputs, list):
+                failures.append(f"sections[{si}].input is {type(inputs).__name__}, expected list")
+            else:
+                for ii, inp in enumerate(inputs):
+                    if not isinstance(inp, dict):
+                        failures.append(f"sections[{si}].input[{ii}] is {type(inp).__name__}, expected object")
+                        continue
+                    if not isinstance(inp.get("name"), str):
+                        failures.append(f"sections[{si}].input[{ii}].name is not a string")
+                    if not isinstance(inp.get("type"), str):
+                        failures.append(f"sections[{si}].input[{ii}].type is not a string")
+        body = section.get("body")
+        if body is not None and not isinstance(body, list):
+            failures.append(f"sections[{si}].body is {type(body).__name__}, expected list")
+
+    settings = payload.get("settings")
+    if settings is not None and not isinstance(settings, dict):
+        failures.append(f"'settings' is {type(settings).__name__}, expected object or absent")
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument("--hub-url", required=True, help="Hub URL (e.g. http://hubitat.local)")
+    parser.add_argument("--config", help="JSON file with target app IDs to audit (see scripts/audit_config.example.json)")
+    parser.add_argument("--strict", action="store_true", help="Exit non-zero on any failure (default: exit 0 with warnings)")
+    args = parser.parse_args()
+
+    targets = DEFAULT_TARGETS[:]
+    if args.config:
+        try:
+            targets.extend(load_targets_from_config(args.config))
+        except (OSError, json.JSONDecodeError, KeyError, ValueError) as e:
+            print(f"Failed to load config {args.config}: {e}", file=sys.stderr)
+            return 2
+
+    if not targets:
+        print("No targets to audit. Pass --config with audit_config.json, or populate DEFAULT_TARGETS.", file=sys.stderr)
+        return 2
+
+    total_failures = 0
+    for desc, app_id, page_name in targets:
+        label = f"{desc} (appId={app_id}{', page=' + page_name if page_name else ''})"
+        try:
+            payload = fetch(args.hub_url, app_id, page_name)
+        except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, OSError) as e:
+            print(f"[FAIL] {label}: fetch error: {e}")
+            total_failures += 1
+            continue
+
+        failures = check_invariants(payload)
+        if failures:
+            print(f"[FAIL] {label}:")
+            for f in failures:
+                print(f"    - {f}")
+            total_failures += 1
+        else:
+            print(f"[OK]   {label}")
+
+    print()
+    print(f"Audited {len(targets)} target(s). {total_failures} failure(s).")
+    return (1 if total_failures and args.strict else 0)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_config.example.json
+++ b/scripts/audit_config.example.json
@@ -5,6 +5,7 @@
     {"description": "Rule Machine 5.1 rule", "appId": 832},
     {"description": "Room Lighting instance", "appId": 839},
     {"description": "HPM main page", "appId": 35},
-    {"description": "HPM sub-page (package list)", "appId": 35, "pageName": "prefPkgModify"}
+    {"description": "HPM sub-page (full installed-package list)", "appId": 35, "pageName": "prefPkgUninstall"},
+    {"description": "HPM sub-page (modifiable subset)", "appId": 35, "pageName": "prefPkgModify"}
   ]
 }

--- a/scripts/audit_config.example.json
+++ b/scripts/audit_config.example.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Edit this file (rename to audit_config.json) with app IDs from your hub. Pick one per rendering path.",
+  "targets": [
+    {"description": "Rule Machine 5.0 rule", "appId": 413},
+    {"description": "Rule Machine 5.1 rule", "appId": 832},
+    {"description": "Room Lighting instance", "appId": 839},
+    {"description": "HPM main page", "appId": 35},
+    {"description": "HPM sub-page (package list)", "appId": 35, "pageName": "prefPkgModify"}
+  ]
+}

--- a/src/test/groovy/server/ToolGetAppConfigSpec.groovy
+++ b/src/test/groovy/server/ToolGetAppConfigSpec.groovy
@@ -374,7 +374,7 @@ class ToolGetAppConfigSpec extends ToolSpecBase {
         result.error?.toLowerCase()?.contains('parse') == true
     }
 
-    def "returns success=false with fingerprint when configPage.sections is not a list"() {
+    def "returns success=false with fingerprint and list_app_pages hint when configPage.sections is not a list"() {
         given:
         settingsMap.enableHubAdminRead = true
         hubGet.register('/installedapp/configure/json/35') { params ->
@@ -392,6 +392,8 @@ class ToolGetAppConfigSpec extends ToolSpecBase {
         then:
         result.success == false
         result.fingerprint == 'sections not a list'
+        // Note must guide the agent toward list_app_pages and away from dead-end retries
+        result.error.contains('list_app_pages')
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/groovy/server/ToolGetAppConfigSpec.groovy
+++ b/src/test/groovy/server/ToolGetAppConfigSpec.groovy
@@ -1,0 +1,430 @@
+package server
+
+import groovy.json.JsonOutput
+import support.ToolSpecBase
+
+/**
+ * Spec for toolGetAppConfig (hubitat-mcp-server.groovy approx line 6232).
+ * Gateway tool under manage_installed_apps — executeTool() dispatches via case "get_app_config".
+ *
+ * Covers:
+ *  - Hub Admin Read gate (throws when disabled)
+ *  - Missing appId validation (throws before HTTP)
+ *  - Non-numeric appId validation (throws before HTTP)
+ *  - pageName sanitization (throws on path-separator characters)
+ *  - Golden path: single-page app with sections, inputs, child apps
+ *  - pageName arg: URL includes the page segment
+ *  - includeSettings=false (default): settings key absent, settingsNote present
+ *  - includeSettings=true: settings key populated
+ *  - Empty hub response: returns success=false
+ *  - Unknown appId (hub returns {app:null}): fingerprint check fires, success=false
+ *  - HTML stripping: span tags removed from labels
+ */
+class ToolGetAppConfigSpec extends ToolSpecBase {
+
+    // Canonical hub response for a simple single-page app.
+    // Shape mirrors what /installedapp/configure/json/<id> actually returns
+    // for legacy SmartApps (Rule Machine, Basic Rules, etc.).
+    private static String makeAppConfigJson(Map overrides = [:]) {
+        def base = [
+            app: [
+                id        : 35,
+                trueLabel : 'My Rule',
+                label     : 'My Rule',
+                name      : 'Rule-5.1',
+                disabled  : false,
+                installed : true,
+                parentAppId: null,
+                appType: [
+                    name     : 'Rule Machine',
+                    namespace: 'hubitat',
+                    author   : 'Hubitat',
+                    category : 'Utility',
+                    classLocation: 'builtin',
+                    deprecated: false,
+                    system   : true,
+                    documentationLink: null
+                ]
+            ],
+            configPage: [
+                name    : 'mainPage',
+                title   : 'Rule Settings',
+                install : true,
+                refreshInterval: null,
+                sections: [
+                    [
+                        title: 'Triggers',
+                        input: [
+                            [
+                                name        : 'triggerDevice',
+                                type        : 'capability.*',
+                                title       : 'Which device triggers this rule?',
+                                description : null,
+                                multiple    : true,
+                                required    : false,
+                                defaultValue: 'Kitchen Switch',
+                                options     : null
+                            ]
+                        ],
+                        body: []
+                    ]
+                ]
+            ],
+            settings  : [
+                triggerDevice: 'Kitchen Switch',
+                ruleEnable   : true
+            ],
+            childApps : [
+                [id: 101, label: 'Sub Rule', name: 'Rule-5.1']
+            ]
+        ]
+        // Merge overrides at top level
+        overrides.each { k, v -> base[k] = v }
+        return JsonOutput.toJson(base)
+    }
+
+    // -------------------------------------------------------------------------
+    // Gate enforcement
+    // -------------------------------------------------------------------------
+
+    def "throws when Hub Admin Read is disabled"() {
+        given:
+        settingsMap.enableHubAdminRead = false
+
+        when:
+        script.toolGetAppConfig([appId: 35])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Read')
+    }
+
+    // -------------------------------------------------------------------------
+    // Input validation (all must throw before any HTTP call)
+    // -------------------------------------------------------------------------
+
+    def "throws when appId is missing from args"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Do NOT register the endpoint; if HTTP fires the HubInternalGetMock throws,
+        // exposing a different failure mode than the expected validation exception.
+
+        when:
+        script.toolGetAppConfig([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('appid is required')
+    }
+
+    def "throws when appId is blank string"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetAppConfig([appId: '   '])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('appid is required')
+    }
+
+    def "throws when appId is non-numeric (no HTTP call made)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Do NOT register the hub endpoint — if the code reaches HTTP before
+        // validation, HubInternalGetMock will throw an unregistered-path error,
+        // which would surface as a different failure than the expected IAE.
+
+        when:
+        script.toolGetAppConfig([appId: 'not-a-number'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('numeric')
+    }
+
+    def "throws when pageName contains a path separator"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetAppConfig([appId: 35, pageName: '../etc/passwd'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('pagename')
+    }
+
+    def "throws when pageName contains a space"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetAppConfig([appId: 35, pageName: 'page name'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('pagename')
+    }
+
+    // -------------------------------------------------------------------------
+    // Golden path — single-page app
+    // -------------------------------------------------------------------------
+
+    def "golden path: returns app identity, sections, inputs, and child apps"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        and: 'hub returns a well-formed config page for app 35'
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppConfigJson()
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then: 'top-level success'
+        result.success == true
+
+        and: 'app identity fields populated'
+        result.app.id == 35
+        result.app.label == 'My Rule'
+        result.app.name == 'Rule-5.1'
+        result.app.disabled == false
+
+        and: 'page structure correct'
+        result.page.name == 'mainPage'
+        result.page.title == 'Rule Settings'
+        result.page.sections.size() == 1
+        result.page.sections[0].title == 'Triggers'
+        result.page.sections[0].inputs.size() == 1
+        result.page.sections[0].inputs[0].name == 'triggerDevice'
+        result.page.sections[0].inputs[0].value == 'Kitchen Switch'
+
+        and: 'child apps listed'
+        result.childApps.size() == 1
+        result.childApps[0].id == 101
+        result.childApps[0].label == 'Sub Rule'
+
+        and: 'endpoint field present for debugging'
+        result.endpoint == '/installedapp/configure/json/35'
+    }
+
+    def "golden path: hub endpoint includes pageName segment when supplied"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        and: 'hub endpoint must include the pageName path segment'
+        boolean correctPathCalled = false
+        hubGet.register('/installedapp/configure/json/35/prefPkgModify') { params ->
+            correctPathCalled = true
+            makeAppConfigJson()
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35, pageName: 'prefPkgModify'])
+
+        then:
+        result.success == true
+        correctPathCalled == true
+        result.endpoint == '/installedapp/configure/json/35/prefPkgModify'
+    }
+
+    // -------------------------------------------------------------------------
+    // HTML stripping
+    // -------------------------------------------------------------------------
+
+    def "HTML span tags in app label are stripped from the response"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        def jsonWithHtml = makeAppConfigJson([
+            app: [
+                id       : 42,
+                trueLabel: '<span style="color:green">Colored Rule</span>',
+                label    : 'Colored Rule (raw)',
+                name     : 'Rule-5.1',
+                disabled : false,
+                installed: true,
+                parentAppId: null,
+                appType  : null
+            ]
+        ])
+        hubGet.register('/installedapp/configure/json/42') { params -> jsonWithHtml }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 42])
+
+        then:
+        result.success == true
+        result.app.label == 'Colored Rule'
+        !result.app.label.contains('<span')
+    }
+
+    // -------------------------------------------------------------------------
+    // includeSettings flag
+    // -------------------------------------------------------------------------
+
+    def "includeSettings=false (default): settings key absent, settingsNote present when count > 0"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppConfigJson()
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == true
+        result.containsKey('settingsKeyCount')
+        result.settingsKeyCount > 0
+        !result.containsKey('settings')
+        result.settingsNote != null
+        result.settingsNote.contains('includeSettings=true')
+    }
+
+    def "includeSettings=true: settings map present and populated"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppConfigJson()
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35, includeSettings: true])
+
+        then:
+        result.success == true
+        result.containsKey('settings')
+        result.settings instanceof Map
+        result.settings.size() == 2
+        result.settings.triggerDevice == 'Kitchen Switch'
+    }
+
+    // -------------------------------------------------------------------------
+    // Error paths
+    // -------------------------------------------------------------------------
+
+    def "returns success=false when hub returns empty body"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/99') { params -> '' }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 99])
+
+        then:
+        result.success == false
+        result.error != null
+        result.error.toLowerCase().contains('empty')
+    }
+
+    def "returns success=false with fingerprint when app.app is null (unknown appId)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Hub returns top-level object but with app=null — matches what Hubitat
+        // returns for an unknown/deleted appId.
+        hubGet.register('/installedapp/configure/json/9999') { params ->
+            JsonOutput.toJson([
+                app       : null,
+                configPage: [:],
+                settings  : [:],
+                childApps : []
+            ])
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 9999])
+
+        then:
+        result.success == false
+        result.error != null
+        result.error.toLowerCase().contains('app')
+        // Fingerprint distinguishes "app not found" (missing app) from firmware contract drift
+        result.fingerprint == 'missing app'
+    }
+
+    def "returns success=false with fingerprint when response is not a JSON object"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params -> '"just a string"' }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == false
+        result.error != null
+        // Production code's fingerprint for "top-level not a Map"
+        result.fingerprint == 'top-level not a Map'
+    }
+
+    def "returns success=false when hub response is unparseable JSON"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params -> '{not valid json' }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == false
+        result.error?.toLowerCase()?.contains('parse') == true
+    }
+
+    def "returns success=false with fingerprint when configPage.sections is not a list"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            JsonOutput.toJson([
+                app       : [id: 35, label: 'X', name: 'X', disabled: false],
+                configPage: [name: 'mainPage', title: 'X', sections: 'not-a-list'],
+                settings  : [:],
+                childApps : []
+            ])
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == false
+        result.fingerprint == 'sections not a list'
+    }
+
+    // -------------------------------------------------------------------------
+    // appId type coercion (integer arg passes isInteger check)
+    // -------------------------------------------------------------------------
+
+    def "integer appId arg is accepted (passes isInteger after toString)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppConfigJson()
+        }
+
+        when:
+        // Pass as native integer rather than string — production does .toString().trim().isInteger()
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == true
+        result.app.id == 35
+    }
+
+    def "string numeric appId arg '35' is accepted"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppConfigJson()
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: '35'])
+
+        then:
+        result.success == true
+    }
+}

--- a/src/test/groovy/server/ToolGetAppConfigSpec.groovy
+++ b/src/test/groovy/server/ToolGetAppConfigSpec.groovy
@@ -429,4 +429,134 @@ class ToolGetAppConfigSpec extends ToolSpecBase {
         then:
         result.success == true
     }
+
+    // -------------------------------------------------------------------------
+    // bool input sentinel fix (value==true must not be filtered for type="bool")
+    // -------------------------------------------------------------------------
+
+    def "bool input with value=true is preserved (not filtered by sentinel)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // i.value==true is the legitimate "checkbox enabled" state for type="bool".
+        // Before the fix, this would be filtered out (sentinel path), making the
+        // AI believe the setting was unconfigured.
+        def json = JsonOutput.toJson([
+            app       : [id: 35, trueLabel: 'My Rule', label: 'My Rule',
+                         name: 'Rule-5.1', disabled: false, installed: true,
+                         parentAppId: null, appType: null],
+            configPage: [
+                name    : 'mainPage',
+                title   : 'Settings',
+                install : true,
+                refreshInterval: null,
+                sections: [
+                    [
+                        title: 'Logging',
+                        input: [
+                            [name: 'logging', type: 'bool', title: 'Enable logging',
+                             description: null, multiple: false, required: false,
+                             defaultValue: null, options: null, value: true]
+                        ],
+                        body: []
+                    ]
+                ]
+            ],
+            settings  : [logging: true],
+            childApps : []
+        ])
+        hubGet.register('/installedapp/configure/json/35') { params -> json }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == true
+        def loggingInput = result.page.sections[0].inputs.find { it.name == 'logging' }
+        loggingInput != null
+        loggingInput.containsKey('value')
+        loggingInput.value == true
+    }
+
+    def "bool input with value=false is preserved"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        def json = JsonOutput.toJson([
+            app       : [id: 35, trueLabel: 'My Rule', label: 'My Rule',
+                         name: 'Rule-5.1', disabled: false, installed: true,
+                         parentAppId: null, appType: null],
+            configPage: [
+                name    : 'mainPage',
+                title   : 'Settings',
+                install : true,
+                refreshInterval: null,
+                sections: [
+                    [
+                        title: 'Logging',
+                        input: [
+                            [name: 'logging', type: 'bool', title: 'Enable logging',
+                             description: null, multiple: false, required: false,
+                             defaultValue: null, options: null, value: false]
+                        ],
+                        body: []
+                    ]
+                ]
+            ],
+            settings  : [logging: false],
+            childApps : []
+        ])
+        hubGet.register('/installedapp/configure/json/35') { params -> json }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == true
+        def loggingInput = result.page.sections[0].inputs.find { it.name == 'logging' }
+        loggingInput != null
+        loggingInput.containsKey('value')
+        loggingInput.value == false
+    }
+
+    def "non-bool input with defaultValue=true is still filtered (sentinel preserved)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // capability.* inputs use defaultValue=true as a "has configured value" sentinel --
+        // NOT as the actual selection. The output's value field should be absent for these.
+        def json = JsonOutput.toJson([
+            app       : [id: 35, trueLabel: 'My Rule', label: 'My Rule',
+                         name: 'Rule-5.1', disabled: false, installed: true,
+                         parentAppId: null, appType: null],
+            configPage: [
+                name    : 'mainPage',
+                title   : 'Settings',
+                install : true,
+                refreshInterval: null,
+                sections: [
+                    [
+                        title: 'Devices',
+                        input: [
+                            [name: 'mySensor', type: 'capability.motionSensor',
+                             title: 'Motion sensor', description: 'Kitchen Motion',
+                             multiple: false, required: false,
+                             defaultValue: true, options: null, value: null]
+                        ],
+                        body: []
+                    ]
+                ]
+            ],
+            settings  : [:],
+            childApps : []
+        ])
+        hubGet.register('/installedapp/configure/json/35') { params -> json }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == true
+        def sensorInput = result.page.sections[0].inputs.find { it.name == 'mySensor' }
+        sensorInput != null
+        // Sentinel: value must NOT be emitted as bare 'true' for non-bool capability types
+        !sensorInput.containsKey('value')
+    }
 }

--- a/src/test/groovy/server/ToolGetAppConfigSpec.groovy
+++ b/src/test/groovy/server/ToolGetAppConfigSpec.groovy
@@ -374,6 +374,28 @@ class ToolGetAppConfigSpec extends ToolSpecBase {
         result.error?.toLowerCase()?.contains('parse') == true
     }
 
+    def "returns success=false with fingerprint when configPage is missing (app exists but no configPage)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Hub returns a well-formed app object but no configPage key -- can happen
+        // for apps that have been partially uninstalled or on edge-case firmware builds.
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            JsonOutput.toJson([
+                app      : [id: 35, label: 'My Rule', name: 'Rule-5.1', disabled: false],
+                childApps: []
+                // configPage intentionally absent
+            ])
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == false
+        result.fingerprint == 'missing configPage'
+        result.error?.toLowerCase()?.contains('configpage') == true
+    }
+
     def "returns success=false with fingerprint and list_app_pages hint when configPage.sections is not a list"() {
         given:
         settingsMap.enableHubAdminRead = true
@@ -394,6 +416,106 @@ class ToolGetAppConfigSpec extends ToolSpecBase {
         result.fingerprint == 'sections not a list'
         // Note must guide the agent toward list_app_pages and away from dead-end retries
         result.error.contains('list_app_pages')
+    }
+
+    // -------------------------------------------------------------------------
+    // stripOptionsHtml -- List and Map option shapes
+    // -------------------------------------------------------------------------
+
+    def "enum input with List-shape options has HTML stripped from option labels"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Room Lighting scenes and RM rule references use List<Map> options --
+        // each entry is a single-key map {value: label} where label may have HTML badges.
+        def json = JsonOutput.toJson([
+            app       : [id: 35, trueLabel: 'My Rule', label: 'My Rule',
+                         name: 'Rule-5.1', disabled: false, installed: true,
+                         parentAppId: null, appType: null],
+            configPage: [
+                name    : 'mainPage',
+                title   : 'Settings',
+                install : true,
+                refreshInterval: null,
+                sections: [
+                    [
+                        title: 'Mode',
+                        input: [
+                            [name: 'modeSelect', type: 'enum', title: 'Select mode',
+                             description: null, multiple: false, required: false,
+                             defaultValue: null, options: [
+                                ['day': '<span style="color:blue">Day</span>'],
+                                ['night': 'Night']
+                             ], value: 'day']
+                        ],
+                        body: []
+                    ]
+                ]
+            ],
+            settings  : [modeSelect: 'day'],
+            childApps : []
+        ])
+        hubGet.register('/installedapp/configure/json/35') { params -> json }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == true
+        def modeInput = result.page.sections[0].inputs.find { it.name == 'modeSelect' }
+        modeInput != null
+        modeInput.options instanceof List
+        // HTML stripped from 'Day' label
+        def dayEntry = modeInput.options.find { it.containsKey('day') }
+        dayEntry != null
+        dayEntry['day'] == 'Day'
+        !dayEntry['day'].contains('<span')
+    }
+
+    def "enum input with Map-shape options has HTML stripped from option values"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Some capability inputs encode options as a plain Map {value: label}.
+        def json = JsonOutput.toJson([
+            app       : [id: 35, trueLabel: 'My Rule', label: 'My Rule',
+                         name: 'Rule-5.1', disabled: false, installed: true,
+                         parentAppId: null, appType: null],
+            configPage: [
+                name    : 'mainPage',
+                title   : 'Settings',
+                install : true,
+                refreshInterval: null,
+                sections: [
+                    [
+                        title: 'Scene',
+                        input: [
+                            [name: 'sceneSelect', type: 'enum', title: 'Select scene',
+                             description: null, multiple: false, required: false,
+                             defaultValue: null,
+                             options: [
+                                on : '<span style="color:green">On</span>',
+                                off: 'Off'
+                             ], value: 'on']
+                        ],
+                        body: []
+                    ]
+                ]
+            ],
+            settings  : [sceneSelect: 'on'],
+            childApps : []
+        ])
+        hubGet.register('/installedapp/configure/json/35') { params -> json }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 35])
+
+        then:
+        result.success == true
+        def sceneInput = result.page.sections[0].inputs.find { it.name == 'sceneSelect' }
+        sceneInput != null
+        sceneInput.options instanceof Map
+        // HTML stripped from 'On' label
+        sceneInput.options['on'] == 'On'
+        !sceneInput.options['on'].contains('<span')
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/groovy/server/ToolListAppPagesSpec.groovy
+++ b/src/test/groovy/server/ToolListAppPagesSpec.groovy
@@ -219,7 +219,7 @@ class ToolListAppPagesSpec extends ToolSpecBase {
         result.error.toLowerCase().contains('empty')
     }
 
-    def "returns success=false when hub returns app=null (unknown appId)"() {
+    def "returns success=false with fingerprint when hub returns app=null (unknown appId)"() {
         given:
         settingsMap.enableHubAdminRead = true
         hubGet.register('/installedapp/configure/json/9999') { params ->
@@ -237,6 +237,55 @@ class ToolListAppPagesSpec extends ToolSpecBase {
         then:
         result.success == false
         result.error != null
+        result.fingerprint == 'missing app'
+    }
+
+    def "returns success=false with fingerprint when response is not a JSON object"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params -> '"just a string"' }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == false
+        result.fingerprint == 'top-level not a Map'
+    }
+
+    def "returns success=false with fingerprint when configPage is missing"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            JsonOutput.toJson([
+                app      : [id: 35, label: 'My Rule', name: 'Rule-5.1', disabled: false,
+                            appType: [name: 'Rule-5.1']],
+                childApps: []
+                // configPage intentionally absent
+            ])
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == false
+        result.fingerprint == 'missing configPage'
+        result.error?.toLowerCase()?.contains('configpage') == true
+    }
+
+    def "returns success=false when hub response is unparseable JSON"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params -> '{not valid json' }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == false
+        result.error?.toLowerCase()?.contains('parse') == true
+        result.error?.toLowerCase()?.contains('firmware') == true
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/groovy/server/ToolListAppPagesSpec.groovy
+++ b/src/test/groovy/server/ToolListAppPagesSpec.groovy
@@ -1,0 +1,259 @@
+package server
+
+import groovy.json.JsonOutput
+import support.ToolSpecBase
+
+/**
+ * Spec for toolListAppPages (hubitat-mcp-server.groovy).
+ * Gateway tool under manage_installed_apps -- executeTool() dispatches via case "list_app_pages".
+ *
+ * Covers:
+ *  - Hub Admin Read gate (throws when disabled)
+ *  - Missing appId validation (throws before HTTP)
+ *  - Blank appId validation (throws before HTTP)
+ *  - Non-numeric appId validation (throws before HTTP)
+ *  - Golden path HPM: pages list contains all curated HPM pages
+ *  - Golden path RM rule: single-page result with note
+ *  - Unknown app type: single-page result with uncurated note
+ *  - Empty hub response: returns success=false
+ *  - Unknown appId (hub returns {app:null}): fingerprint check fires, success=false
+ */
+class ToolListAppPagesSpec extends ToolSpecBase {
+
+    // Helper: build a minimal hub response for /installedapp/configure/json/<id>
+    private static String makeAppJson(String appTypeName, String primaryPageName = 'mainPage', String pageTitle = 'Settings') {
+        def data = [
+            app: [
+                id       : 35,
+                trueLabel: appTypeName + ' Instance',
+                label    : appTypeName + ' Instance',
+                name     : appTypeName,
+                disabled : false,
+                installed: true,
+                parentAppId: null,
+                appType: [
+                    name     : appTypeName,
+                    namespace: 'hubitat',
+                    author   : 'Hubitat',
+                    category : 'Utility',
+                    classLocation: 'builtin',
+                    deprecated: false,
+                    system   : true,
+                    documentationLink: null
+                ]
+            ],
+            configPage: [
+                name   : primaryPageName,
+                title  : pageTitle,
+                install: true,
+                refreshInterval: null,
+                sections: []
+            ],
+            settings : [:],
+            childApps: []
+        ]
+        return JsonOutput.toJson(data)
+    }
+
+    // -------------------------------------------------------------------------
+    // Gate enforcement
+    // -------------------------------------------------------------------------
+
+    def "throws when Hub Admin Read is disabled"() {
+        given:
+        settingsMap.enableHubAdminRead = false
+
+        when:
+        script.toolListAppPages([appId: 35])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Read')
+    }
+
+    // -------------------------------------------------------------------------
+    // Input validation (all must throw before any HTTP call)
+    // -------------------------------------------------------------------------
+
+    def "throws when appId is missing from args"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolListAppPages([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('appid is required')
+    }
+
+    def "throws when appId is blank string"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolListAppPages([appId: '   '])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('appid is required')
+    }
+
+    def "throws when appId is non-numeric (no HTTP call made)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Do NOT register the hub endpoint -- if validation fails to fire,
+        // HubInternalGetMock will throw an unregistered-path error, which
+        // surfaces as a different failure than the expected IAE.
+
+        when:
+        script.toolListAppPages([appId: 'not-a-number'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('numeric')
+    }
+
+    // -------------------------------------------------------------------------
+    // Golden path -- HPM (curated multi-page directory)
+    // -------------------------------------------------------------------------
+
+    def "golden path HPM: returns all curated HPM page names"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppJson('Hubitat Package Manager', 'prefOptions', 'Main Menu')
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then: 'top-level success'
+        result.success == true
+
+        and: 'app identity present'
+        result.app.id == 35
+        result.app.appTypeName == 'Hubitat Package Manager'
+
+        and: 'primary page introspected from hub'
+        result.primaryPage.name == 'prefOptions'
+
+        and: 'all curated HPM pages present'
+        def pageNames = result.pages*.name
+        pageNames.contains('prefOptions')
+        pageNames.contains('prefPkgUninstall')
+        pageNames.contains('prefPkgModify')
+        pageNames.contains('prefPkgInstall')
+        pageNames.contains('prefPkgMatchUp')
+        result.pages.size() == 5
+
+        and: 'prefPkgUninstall is marked as full_package_list'
+        def uninstallPage = result.pages.find { it.name == 'prefPkgUninstall' }
+        uninstallPage.role == 'full_package_list'
+
+        and: 'no limiting note for curated HPM type'
+        result.note == null
+    }
+
+    // -------------------------------------------------------------------------
+    // Golden path -- Rule Machine rule (single-page)
+    // -------------------------------------------------------------------------
+
+    def "golden path RM rule: returns single mainPage with single-page note"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppJson('Rule-5.1', 'mainPage', 'My Rule')
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == true
+        result.pages.size() == 1
+        result.pages[0].name == 'mainPage'
+        result.pages[0].role == 'primary'
+        result.note != null
+        result.note.toLowerCase().contains('single')
+    }
+
+    // -------------------------------------------------------------------------
+    // Unknown app type -- uncurated note
+    // -------------------------------------------------------------------------
+
+    def "unknown app type: returns primary page only with uncurated note"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppJson('MyCustomCommunityApp', 'mainPage', 'Custom Settings')
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == true
+        result.pages.size() == 1
+        result.pages[0].name == 'mainPage'
+        // Note must hint that directory is not curated
+        result.note != null
+        result.note.toLowerCase().contains('not curated') || result.note.toLowerCase().contains('uncurated') || result.note.toLowerCase().contains('not available') || result.note.contains('only primary page known')
+    }
+
+    // -------------------------------------------------------------------------
+    // Error paths
+    // -------------------------------------------------------------------------
+
+    def "returns success=false when hub returns empty body"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/99') { params -> '' }
+
+        when:
+        def result = script.toolListAppPages([appId: 99])
+
+        then:
+        result.success == false
+        result.error != null
+        result.error.toLowerCase().contains('empty')
+    }
+
+    def "returns success=false when hub returns app=null (unknown appId)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/9999') { params ->
+            JsonOutput.toJson([
+                app       : null,
+                configPage: [:],
+                settings  : [:],
+                childApps : []
+            ])
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 9999])
+
+        then:
+        result.success == false
+        result.error != null
+    }
+
+    // -------------------------------------------------------------------------
+    // appId type coercion (integer arg passes isInteger check)
+    // -------------------------------------------------------------------------
+
+    def "integer appId is accepted (passes isInteger after toString)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppJson('Hubitat Package Manager', 'prefOptions', 'Main Menu')
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == true
+    }
+}

--- a/src/test/groovy/server/ToolListAppPagesSpec.groovy
+++ b/src/test/groovy/server/ToolListAppPagesSpec.groovy
@@ -240,6 +240,90 @@ class ToolListAppPagesSpec extends ToolSpecBase {
     }
 
     // -------------------------------------------------------------------------
+    // Curated dispatch -- parametric coverage for known appType variants
+    // -------------------------------------------------------------------------
+
+    def "Room Lighting curated match: '#appTypeName' returns mainPage with Room Lighting note"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppJson(appTypeName, 'mainPage', 'Room Settings')
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == true
+        result.pages.size() == 1
+        result.pages[0].name == 'mainPage'
+        result.note != null
+        result.note.toLowerCase().contains('room lighting') || result.note.toLowerCase().contains('room lights')
+
+        where:
+        appTypeName << ['Room Lights', 'Room Lighting']
+    }
+
+    def "Mode Manager curated match returns mainPage with Mode Manager note"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppJson('Mode Manager', 'mainPage', 'Manage Setting of Modes')
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == true
+        result.pages.size() == 1
+        result.pages[0].name == 'mainPage'
+        result.note != null
+        result.note.toLowerCase().contains('mode manager')
+    }
+
+    def "Rule Machine parent app curated match returns mainPage with single-page note"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // "Rule Machine" is the parent app container (not an individual rule).
+        // The production matcher uses contains("rule machine") -- should match.
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppJson('Rule Machine', 'mainPage', 'Rule Machine')
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == true
+        result.pages.size() == 1
+        result.pages[0].name == 'mainPage'
+        result.note != null
+
+    }
+
+    def "HPM curated dispatch is case-insensitive: '#appTypeName'"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        hubGet.register('/installedapp/configure/json/35') { params ->
+            makeAppJson(appTypeName, 'prefOptions', 'Main Menu')
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 35])
+
+        then:
+        result.success == true
+        result.pages.size() == 5
+        result.pages*.name.contains('prefOptions')
+        result.pages*.name.contains('prefPkgUninstall')
+        result.note == null
+
+        where:
+        appTypeName << ['hubitat package manager', 'HUBITAT PACKAGE MANAGER', 'Hubitat Package Manager']
+    }
+
+    // -------------------------------------------------------------------------
     // appId type coercion (integer arg passes isInteger check)
     // -------------------------------------------------------------------------
 

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -2139,18 +2139,18 @@ These operations are too destructive for automated testing. Test manually with e
 | Core tools on `tools/list` | 22 |
 | Gateways on `tools/list` | 11 |
 | Total visible on `tools/list` | 33 |
-| Tools proxied behind gateways | 60 |
-| Total tools in codebase | 82 |
+| Tools proxied behind gateways | 61 |
+| Total tools in codebase | 83 |
 
-**11 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (3), `manage_rule_machine` (5)
+**11 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_rule_machine` (5)
 
 ### Tool Coverage (non-destructive tools only)
 
-All 82 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
+All 83 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
 
 Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
 
-**Total: 186 test scenarios** (107 explicit + 65 natural language + 14 built-in-app integration) plus 13 excluded destructive operations documented for manual testing
+**Total: 193 test scenarios** (107 explicit + 65 natural language + 21 built-in-app integration) plus 13 excluded destructive operations documented for manual testing
 
 ---
 

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -1,6 +1,6 @@
 # Bot Acceptance Test (BAT) Suite — v2
 
-Updated for the installed-apps + Rule Machine interop architecture (22 core + 11 gateways = 33 on tools/list, 60 proxied, 82 total).
+Updated for the installed-apps + Rule Machine interop architecture (22 core + 11 gateways = 33 on tools/list, 61 proxied, 83 total).
 
 Comprehensive test scenarios for the Hubitat MCP Rule Server. Modeled after ha-mcp's BAT framework.
 
@@ -2328,15 +2328,15 @@ These tools require `Enable Built-in App Tools` to be enabled in the MCP Rule Se
 
 **Expected**: Calls `manage_installed_apps(tool='get_app_config', args={appId: 35})`. Returns `app` (label, type), `page` (sections with inputs showing configured triggers, conditions, actions). AI summarizes the rule's behavior from the structured response. Tool is accessed via the `manage_installed_apps` gateway.
 
-### T213 — get_app_config multi-page (HPM package list)
+### T213 — get_app_config multi-page (HPM full package list)
 
 ```json
 {
-  "test_prompt": "Use get_app_config to list the packages installed via Hubitat Package Manager. Pass pageName='prefPkgModify' to navigate to the package list page."
+  "test_prompt": "Use get_app_config to list ALL packages installed via Hubitat Package Manager."
 }
 ```
 
-**Expected**: Calls `get_app_config(appId=<HPM_app_id>, pageName='prefPkgModify')`. Returns the packages input section showing installed packages. AI extracts and lists the package names.
+**Expected**: AI calls `list_installed_apps` (or knows HPM appId), then calls `get_app_config(appId=<HPM_app_id>, pageName='prefPkgUninstall')`. Returns the full installed-package enum. AI extracts and lists package names. Note: `pageName='prefPkgModify'` returns only the modifiable subset (those with optional components) -- the correct page for the FULL list is `prefPkgUninstall`.
 
 ### T214 — get_app_config with includeSettings=true (power user)
 
@@ -2369,13 +2369,35 @@ These tools require `Enable Built-in App Tools` to be enabled in the MCP Rule Se
 
 **Expected**: `get_app_config` throws `IllegalArgumentException: Hub Admin Read access is disabled...`. AI reports the gate requirement and directs user to enable it in MCP app settings.
 
+### T217 — list_app_pages for HPM (discover sub-page names)
+
+```json
+{
+  "setup_prompt": "Hub Admin Read is enabled. Use list_installed_apps to find the Hubitat Package Manager app ID.",
+  "test_prompt": "I want to inspect HPM's configuration but I don't know the page names. What pages are available for HPM?"
+}
+```
+
+**Expected**: AI calls `manage_installed_apps(tool='list_app_pages', args={appId: <HPM_app_id>})`. Returns a `pages` list including at least `prefOptions`, `prefPkgUninstall`, `prefPkgModify`, `prefPkgInstall`, `prefPkgMatchUp`. AI lists the available page names and explains their roles (e.g. prefPkgUninstall = full installed-package list). Tool is accessed via the `manage_installed_apps` gateway.
+
+### T218 — list_app_pages for Rule Machine rule (single-page confirmation)
+
+```json
+{
+  "setup_prompt": "Hub Admin Read is enabled. Use list_rm_rules to find an existing Rule Machine rule and note its app ID.",
+  "test_prompt": "What pages are available for Rule Machine rule app ID 35?"
+}
+```
+
+**Expected**: AI calls `manage_installed_apps(tool='list_app_pages', args={appId: 35})`. Returns a `pages` list with a single entry `{name: 'mainPage', role: 'primary'}` plus a `note` confirming rules are single-page. AI explains there is only one page (mainPage) and no sub-pages are available.
+
 ---
 
 ## Changes from BAT v1
 
 Key differences from the original BAT.md (which targets the pre-v0.8.0 architecture):
 
-1. **Architecture**: 18 core + 8 gateways (26 total) → **22 core + 11 gateways (33 total, 82 tools)** post installed-apps + RM interop (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
+1. **Architecture**: 18 core + 8 gateways (26 total) → **22 core + 11 gateways (33 total, 83 tools)** post installed-apps + RM interop + list_app_pages (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
 2. **Merged tools**: `enable_rule`/`disable_rule` → `update_rule` (enabled=true/false); `create_virtual_device`/`delete_virtual_device` → `manage_virtual_device` (action enum)
 3. **Promoted to core**: `create_hub_backup`, `check_for_update`, `generate_bug_report`
 4. **Dissolved gateway**: `manage_hub_info` — radio details moved to `manage_diagnostics`, other tools merged into `get_hub_info` (core) or promoted

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -2156,7 +2156,7 @@ Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests 
 
 ## Section 11: Built-in App Integration Tests
 
-These tools require `Enable Built-in App Tools` to be enabled in the MCP Rule Server app settings. Tests assume at least one Rule Machine rule and at least one Room Lighting or other multi-app configuration exists on the hub.
+Tools in this section have mixed gate requirements. `list_installed_apps` and `get_device_in_use_by` require the `Enable Built-in App Tools` toggle (`requireBuiltinAppRead`). `get_app_config` and `list_app_pages` require Hub Admin Read (`requireHubAdminRead`). `manage_rule_machine` tools require `Enable Built-in App Tools`. Tests assume at least one Rule Machine rule and at least one Room Lighting or other multi-app configuration exists on the hub.
 
 ### Safety Rules for Section 11
 
@@ -2320,39 +2320,41 @@ These tools require `Enable Built-in App Tools` to be enabled in the MCP Rule Se
 
 ```json
 {
-  "setup_prompt": "Hub Admin Read is enabled. Use list_installed_apps or the Hubitat UI to identify a Rule Machine rule by its app ID.",
-  "test_prompt": "Show me the configuration of the Rule Machine rule with app ID 35 — what conditions and actions does it have?",
+  "setup_prompt": "Hub Admin Read is enabled. Use list_installed_apps to find any Rule Machine rule and note its app ID.",
+  "test_prompt": "Show me the configuration of that Rule Machine rule — what conditions and actions does it have?",
   "teardown_prompt": "No teardown needed — get_app_config is read-only."
 }
 ```
 
-**Expected**: Calls `manage_installed_apps(tool='get_app_config', args={appId: 35})`. Returns `app` (label, type), `page` (sections with inputs showing configured triggers, conditions, actions). AI summarizes the rule's behavior from the structured response. Tool is accessed via the `manage_installed_apps` gateway.
+**Expected**: AI first calls `list_installed_apps` (or `list_rm_rules`) to discover a Rule Machine app ID, then calls `manage_installed_apps(tool='get_app_config', args={appId: <discovered_id>})`. Returns `app` (label, type), `page` (sections with inputs showing configured triggers, conditions, actions). AI summarizes the rule's behavior from the structured response. Tool is accessed via the `manage_installed_apps` gateway.
 
 ### T213 — get_app_config multi-page (HPM full package list)
 
 ```json
 {
+  "setup_prompt": "Use list_installed_apps to find the Hubitat Package Manager app ID.",
   "test_prompt": "Use get_app_config to list ALL packages installed via Hubitat Package Manager."
 }
 ```
 
-**Expected**: AI calls `list_installed_apps` (or knows HPM appId), then calls `get_app_config(appId=<HPM_app_id>, pageName='prefPkgUninstall')`. Returns the full installed-package enum. AI extracts and lists package names. Note: `pageName='prefPkgModify'` returns only the modifiable subset (those with optional components) -- the correct page for the FULL list is `prefPkgUninstall`.
+**Expected**: AI calls `list_installed_apps` to discover the HPM app ID, then calls `get_app_config(appId=<discovered_id>, pageName='prefPkgUninstall')`. Returns the full installed-package enum. AI extracts and lists package names. Note: `pageName='prefPkgModify'` returns only the modifiable subset (those with optional components) -- the correct page for the FULL list is `prefPkgUninstall`.
 
 ### T214 — get_app_config with includeSettings=true (power user)
 
 ```json
 {
-  "test_prompt": "Get the raw settings map for app ID 35 — include all internal keys."
+  "setup_prompt": "Use list_rm_rules or list_installed_apps to find an existing Rule Machine rule and note its app ID.",
+  "test_prompt": "Get the raw settings map for that Rule Machine rule — include all internal keys."
 }
 ```
 
-**Expected**: Calls `get_app_config(appId=35, includeSettings=true)`. Response includes `settings` map with raw key-value pairs. AI notes the size and encoding (e.g., RM 5.1 dm~ prefixes).
+**Expected**: AI discovers a Rule Machine app ID, then calls `get_app_config(appId=<discovered_id>, includeSettings=true)`. Response includes `settings` map with raw key-value pairs. AI notes the size and encoding (e.g., RM 5.1 dm~ prefixes).
 
 ### T215 — get_app_config invalid (non-numeric appId)
 
 ```json
 {
-  "test_prompt": "Try to get the app config for app ID 'abc123' and tell me what happens."
+  "test_prompt": "Try to get the app config for app ID 'abc123' and tell me what error you get."
 }
 ```
 
@@ -2363,7 +2365,7 @@ These tools require `Enable Built-in App Tools` to be enabled in the MCP Rule Se
 ```json
 {
   "setup_prompt": "For this test, assume Hub Admin Read is disabled in MCP settings.",
-  "test_prompt": "Get the configuration for app ID 35."
+  "test_prompt": "Get the configuration for any Rule Machine rule (any app ID will do)."
 }
 ```
 
@@ -2373,23 +2375,23 @@ These tools require `Enable Built-in App Tools` to be enabled in the MCP Rule Se
 
 ```json
 {
-  "setup_prompt": "Hub Admin Read is enabled. Use list_installed_apps to find the Hubitat Package Manager app ID.",
-  "test_prompt": "I want to inspect HPM's configuration but I don't know the page names. What pages are available for HPM?"
+  "setup_prompt": "Hub Admin Read is enabled. Use list_installed_apps to find the Hubitat Package Manager app and note its app ID.",
+  "test_prompt": "I want to inspect HPM's configuration but I don't know the page names. Use list_app_pages to discover what pages are available for the HPM app you just found."
 }
 ```
 
-**Expected**: AI calls `manage_installed_apps(tool='list_app_pages', args={appId: <HPM_app_id>})`. Returns a `pages` list including at least `prefOptions`, `prefPkgUninstall`, `prefPkgModify`, `prefPkgInstall`, `prefPkgMatchUp`. AI lists the available page names and explains their roles (e.g. prefPkgUninstall = full installed-package list). Tool is accessed via the `manage_installed_apps` gateway.
+**Expected**: AI uses the HPM app ID discovered in setup, then calls `manage_installed_apps(tool='list_app_pages', args={appId: <discovered_id>})`. Returns a `pages` list including at least `prefOptions`, `prefPkgUninstall`, `prefPkgModify`, `prefPkgInstall`, `prefPkgMatchUp`. AI lists the available page names and explains their roles (e.g. prefPkgUninstall = full installed-package list). Tool is accessed via the `manage_installed_apps` gateway.
 
 ### T218 — list_app_pages for Rule Machine rule (single-page confirmation)
 
 ```json
 {
   "setup_prompt": "Hub Admin Read is enabled. Use list_rm_rules to find an existing Rule Machine rule and note its app ID.",
-  "test_prompt": "What pages are available for Rule Machine rule app ID 35?"
+  "test_prompt": "What pages are available for the Rule Machine rule you just found?"
 }
 ```
 
-**Expected**: AI calls `manage_installed_apps(tool='list_app_pages', args={appId: 35})`. Returns a `pages` list with a single entry `{name: 'mainPage', role: 'primary'}` plus a `note` confirming rules are single-page. AI explains there is only one page (mainPage) and no sub-pages are available.
+**Expected**: AI uses the Rule Machine app ID discovered in setup, then calls `manage_installed_apps(tool='list_app_pages', args={appId: <discovered_id>})`. Returns a `pages` list with a single entry `{name: 'mainPage', role: 'primary'}` plus a `note` confirming rules are single-page. AI explains there is only one page (mainPage) and no sub-pages are available.
 
 ---
 

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -1,6 +1,6 @@
 # Bot Acceptance Test (BAT) Suite — v2
 
-Updated for the installed-apps + Rule Machine interop architecture (22 core + 11 gateways = 33 on tools/list, 59 proxied, 81 total).
+Updated for the installed-apps + Rule Machine interop architecture (22 core + 11 gateways = 33 on tools/list, 60 proxied, 82 total).
 
 Comprehensive test scenarios for the Hubitat MCP Rule Server. Modeled after ha-mcp's BAT framework.
 
@@ -2139,14 +2139,14 @@ These operations are too destructive for automated testing. Test manually with e
 | Core tools on `tools/list` | 22 |
 | Gateways on `tools/list` | 11 |
 | Total visible on `tools/list` | 33 |
-| Tools proxied behind gateways | 59 |
-| Total tools in codebase | 81 |
+| Tools proxied behind gateways | 60 |
+| Total tools in codebase | 82 |
 
-**11 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (2), `manage_rule_machine` (5)
+**11 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (3), `manage_rule_machine` (5)
 
 ### Tool Coverage (non-destructive tools only)
 
-All 81 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
+All 82 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
 
 Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
 
@@ -2316,13 +2316,66 @@ These tools require `Enable Built-in App Tools` to be enabled in the MCP Rule Se
 
 **Expected**: `list_rm_rules` returns `IllegalArgumentException: Built-in App Tools are disabled...`. AI reports the feature flag requirement and points user to the MCP app settings page.
 
+### T212 — Read an installed app's config page (get_app_config — manage_installed_apps gateway)
+
+```json
+{
+  "setup_prompt": "Hub Admin Read is enabled. Use list_installed_apps or the Hubitat UI to identify a Rule Machine rule by its app ID.",
+  "test_prompt": "Show me the configuration of the Rule Machine rule with app ID 35 — what conditions and actions does it have?",
+  "teardown_prompt": "No teardown needed — get_app_config is read-only."
+}
+```
+
+**Expected**: Calls `manage_installed_apps(tool='get_app_config', args={appId: 35})`. Returns `app` (label, type), `page` (sections with inputs showing configured triggers, conditions, actions). AI summarizes the rule's behavior from the structured response. Tool is accessed via the `manage_installed_apps` gateway.
+
+### T213 — get_app_config multi-page (HPM package list)
+
+```json
+{
+  "test_prompt": "Use get_app_config to list the packages installed via Hubitat Package Manager. Pass pageName='prefPkgModify' to navigate to the package list page."
+}
+```
+
+**Expected**: Calls `get_app_config(appId=<HPM_app_id>, pageName='prefPkgModify')`. Returns the packages input section showing installed packages. AI extracts and lists the package names.
+
+### T214 — get_app_config with includeSettings=true (power user)
+
+```json
+{
+  "test_prompt": "Get the raw settings map for app ID 35 — include all internal keys."
+}
+```
+
+**Expected**: Calls `get_app_config(appId=35, includeSettings=true)`. Response includes `settings` map with raw key-value pairs. AI notes the size and encoding (e.g., RM 5.1 dm~ prefixes).
+
+### T215 — get_app_config invalid (non-numeric appId)
+
+```json
+{
+  "test_prompt": "Try to get the app config for app ID 'abc123' and tell me what happens."
+}
+```
+
+**Expected**: `get_app_config` throws `IllegalArgumentException` with a message about numeric appId. AI reports the validation error and asks for a valid numeric ID.
+
+### T216 — get_app_config Hub Admin Read disabled
+
+```json
+{
+  "setup_prompt": "For this test, assume Hub Admin Read is disabled in MCP settings.",
+  "test_prompt": "Get the configuration for app ID 35."
+}
+```
+
+**Expected**: `get_app_config` throws `IllegalArgumentException: Hub Admin Read access is disabled...`. AI reports the gate requirement and directs user to enable it in MCP app settings.
+
 ---
 
 ## Changes from BAT v1
 
 Key differences from the original BAT.md (which targets the pre-v0.8.0 architecture):
 
-1. **Architecture**: 18 core + 8 gateways (26 total) → **22 core + 11 gateways (33 total, 81 tools)** post installed-apps + RM interop (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
+1. **Architecture**: 18 core + 8 gateways (26 total) → **22 core + 11 gateways (33 total, 82 tools)** post installed-apps + RM interop (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
 2. **Merged tools**: `enable_rule`/`disable_rule` → `update_rule` (enabled=true/false); `create_virtual_device`/`delete_virtual_device` → `manage_virtual_device` (action enum)
 3. **Promoted to core**: `create_hub_backup`, `check_for_update`, `generate_bug_report`
 4. **Dissolved gateway**: `manage_hub_info` — radio details moved to `manage_diagnostics`, other tools merged into `get_hub_info` (core) or promoted

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -332,7 +332,7 @@ class TestRunner:
     def test_tools_list(self) -> None:
         result = self.client.list_tools()
         tools = result.get("tools", [])
-        assert len(tools) == 33, f"Expected 33 tools (22 core + 11 gateways), got {len(tools)}"
+        assert len(tools) == 34, f"Expected 34 tools (23 core + 11 gateways), got {len(tools)}"
 
     @test("infrastructure")
     def test_health_endpoint(self) -> None:

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -332,7 +332,7 @@ class TestRunner:
     def test_tools_list(self) -> None:
         result = self.client.list_tools()
         tools = result.get("tools", [])
-        assert len(tools) == 34, f"Expected 34 tools (23 core + 11 gateways), got {len(tools)}"
+        assert len(tools) == 33, f"Expected 33 tools (22 core + 11 gateways), got {len(tools)}"
 
     @test("infrastructure")
     def test_health_endpoint(self) -> None:


### PR DESCRIPTION
## Summary

Adds `get_app_config` + `list_app_pages` to the `manage_installed_apps` gateway — reads `/installedapp/configure/json/<id>[/<pageName>]`, the SDK-level config-page JSON endpoint the Hubitat Web UI consumes. Works for any legacy SmartApp using `dynamicPage()`: RM 5.x rules, Room Lighting, HPM, Mode Manager, Button Controllers, Basic Rules, and third-party community apps. Completes the installed-apps introspection surface started by #79.

## Why

After `list_installed_apps` narrows and `get_device_in_use_by` finds references, these tools answer **"what does this app actually do?"** with structured data — sections, inputs, current values, triggers, conditions, actions — in the same shape the UI renders.

## Tools

### `get_app_config(appId, pageName?, includeSettings?)`
- `appId` (string, numeric); `pageName` optional `[A-Za-z0-9_]+`; `includeSettings` bool, default false
- Gate: `requireHubAdminRead()`. Read-only.
- Returns `{app, configPage, childApps, settings?}`. Raw `settings` omitted by default (100-1000 keys with app-specific encoding — RM uses `actType.N`, Room Lighting uses `dm~<deviceId>~<scene>`); pass `includeSettings=true` for power-user inspection.

### `list_app_pages(appId)`
- Returns `{app, primaryPage, pages: [{name, title, role}], note?}`. Curated directories for HPM (5 pages incl. `prefPkgUninstall`), Rule-5.x, Room Lights, Mode Manager. Unknown app types return primary page from introspection + a note flagging uncurated directory.
- Built to reduce page-name guessing after a live-hub AI-usability smoke test showed agents spending 8-10 tool calls searching HPM pageName space.
- Gate: `requireHubAdminRead()`.

## Gate-tier note (pre-empting review)

Both new tools use `requireHubAdminRead()`, while their gateway siblings (`list_installed_apps`, `get_device_in_use_by`) use `requireBuiltinAppRead()`. Rationale: these tools read user-installed app config (not just built-in apps), so the sensitivity profile is closer to `get_app_source` (also Hub Admin Read) than to "Built-in App Tools" per se. The gateway description at `hubitat-mcp-server.groovy:619` documents the split explicitly. Happy to move to Built-in App Read for sibling consistency if you'd prefer.

## Test coverage

**Unit specs — 28 features, all green under post-#100 harness:**
- `ToolGetAppConfigSpec` (18 features)
- `ToolListAppPagesSpec` (10 features)

**Full `./gradlew test`**: 306/306 PASS in 2m46s. Sandbox lint: clean (0 errors / 0 warnings under PR #103's GString-aware checks).

**BAT-v2 T212-T218**: golden / multi-page / includeSettings / invalid input / gate-off + HPM-pages + RM-pages.

## Live-hub verification

Deployed to prod (firmware 2.4.4.156) and exercised end-to-end:

| # | Test | Result |
|---|---|---|
| A1 | RM 5.1 rule config | ✅ rule logic in page.paragraphs |
| A2 | Room Lighting instance | ✅ 356-key settings, device/room matrix |
| A3 | HPM main page | ✅ prefOptions root |
| A4 | HPM sub-page `prefPkgUninstall` | ✅ full 19-package list |
| A5 | Mode Manager (built-in) | ✅ time-table + switch-based mode control |
| B1 | Non-numeric appId | ✅ `-32602` before HTTP |
| B2 | Unknown appId (99999) | ✅ `success:false` with formatted 404 error * |
| B3 | Path-separator in pageName | ✅ `-32602` on regex violation |
| B4 | `includeSettings=true` on RM rule | ✅ 126-key encoded map returned |
| C1 | Third-party user app (`Device Activity Check`) | ✅ same shape as built-in apps |
| T1-T4 | `list_app_pages` across HPM / RM / Room Lighting / unknown | ✅ curated directories + uncurated fallback |
| T5 | `get_app_config` on HPM dynamic-redirect page | ✅ enriched fingerprint note redirects to `list_app_pages` |

\* B2 note: real hub returns HTTP 404 for unknown appId. Production handles that cleanly (`success:false` + formatted error). The spec also exercises a defensive `app:null` fingerprint path in case the hub's response shape changes — both branches land safely.

## AI-usability validation (blind Sonnet smoke test)

Three Sonnet agents ran natural-language queries against the live hub (no hints about which tools to use; agents discovered via `tools/list` + `search_tools` + `get_tool_guide`):

| Agent | Question | Result | Calls |
|---|---|---|---|
| #1 | "What does the rule 'Auto - Living Room TV Lights' do?" | ✅ accurate trigger / condition / actions extracted | 14 * |
| #2 | "Which HPM packages are installed?" | ✅ correct 19-package list via `prefPkgUninstall` | 9 |
| #3 | "How is Mode Manager configured?" | ✅ full time-table + switch-based mode control | 10 * |

All three landed correct answers. The `list_app_pages` companion + the workflow hint in the tool description keep the HPM query efficient.

\* Agents #1 and #3 spent ~4 calls each in a pre-existing friction path: `list_rules` / `get_rule` / `export_rule` silently return `"Rule not found"` for Rule Machine app IDs (those tools handle only MCP-native rules). The `get_app_config` description explicitly calls this out to pre-empt the detour, but agents who discover `get_app_config` via search rather than via the description may still try the MCP-native tools first. Queued in our fork TODO as a small follow-up PR against those tools' error messages.

## Scope

- New gateway tools + registration: `manage_installed_apps` now 4 tools
- 28-feature Spock suite + 7 BAT scenarios (T212-T218)
- SKILL.md Hub Internal API Endpoints Reference row
- Doc counts: 83 total / 33 on tools/list / 22 core / 61 proxied / 11 gateways
- `scripts/app_config_audit.py` + `scripts/audit_config.example.json` — stdlib-only firmware-shape-drift audit helper (standalone runnable; CI integration deferred pending LAN-reach strategy). `scripts/audit_config.json` gitignored (mirrors `tests/e2e_config.json` pattern).

## Not in this PR

- `get_tool_guide` dedicated `app_introspection` section (follow-up polish)
- `get_rule` / `export_rule` redirect hint for RM rule IDs (queued in fork TODO; pre-existing MCP-native tools)
- Parametric branch coverage on `list_app_pages` curated-dispatch matcher (low-impact follow-up)
- Hyphen support in `pageName` regex (no known sub-page uses hyphens today)

No version bump — maintainer renumbers on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)