### PR TITLE
test(rules): breadth coverage for conditions, actions, triggers, loop guard, error paths (closes #75)

### DIFF
--- a/src/test/groovy/rules/ActionTypesSpec.groovy
+++ b/src/test/groovy/rules/ActionTypesSpec.groovy
@@ -32,6 +32,53 @@ import support.TestDevice
  */
 class ActionTypesSpec extends RuleHarnessSpec {
 
+    // -------- device_command parameter coercion --------
+
+    def "device_command coerces a numeric-string parameter to an Integer"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 1 }
+        parent = new ActionParent(devices: [1L: device])
+
+        when:
+        script.executeAction([
+            type: 'device_command', deviceId: 1L, command: 'setLevel',
+            parameters: ['50']
+        ])
+
+        then: 'the spread dispatch hits the one-arg Integer overload'
+        1 * device.setLevel(50)
+    }
+
+    def "device_command parses a JSON-object string parameter into a Map"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 1 }
+        parent = new ActionParent(devices: [1L: device])
+
+        when:
+        script.executeAction([
+            type: 'device_command', deviceId: 1L, command: 'setColor',
+            parameters: ['{"hue":30,"saturation":80,"level":50}']
+        ])
+
+        then: 'the JSON is parsed and dispatched as a Map argument'
+        1 * device.setColor([hue: 30, saturation: 80, level: 50])
+    }
+
+    def "device_command falls back to a single-item list when parameters is an unparseable String"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 1 }
+        parent = new ActionParent(devices: [1L: device])
+
+        when: 'parameters is a bare String that fails JsonSlurper.parseText'
+        script.executeAction([
+            type: 'device_command', deviceId: 1L, command: 'speak',
+            parameters: 'hello world'
+        ])
+
+        then: 'the engine wraps it as [parameters] and passes the raw string through'
+        1 * device.speak('hello world')
+    }
+
     // -------- direct device commands --------
 
     def "toggle_device turns a currently-on device off"() {
@@ -101,16 +148,29 @@ class ActionTypesSpec extends RuleHarnessSpec {
         1 * unlockDev.unlock()
     }
 
-    def "set_color passes a clamped color map to setColor()"() {
+    def "set_color clamps out-of-range hue/saturation/level values through clampPercent"() {
         given:
         def device = Spy(TestDevice) { getId() >> 5 }
         parent = new ActionParent(devices: [5L: device])
 
-        when:
-        script.executeAction([type: 'set_color', deviceId: 5L, hue: 50, saturation: 80, level: 75])
+        when: 'hue above 100, saturation negative, level above 100'
+        script.executeAction([type: 'set_color', deviceId: 5L,
+                              hue: 250, saturation: -10, level: 150])
+
+        then: 'clampPercent caps at 0..100 per component'
+        1 * device.setColor([hue: 100, saturation: 0, level: 100])
+    }
+
+    def "set_color omits fields not present in the action"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 5 }
+        parent = new ActionParent(devices: [5L: device])
+
+        when: 'only hue is supplied — saturation and level should not appear in the map'
+        script.executeAction([type: 'set_color', deviceId: 5L, hue: 50])
 
         then:
-        1 * device.setColor([hue: 50, saturation: 80, level: 75])
+        1 * device.setColor([hue: 50])
     }
 
     def "set_color_temperature with a level value uses the two-arg overload"() {
@@ -181,6 +241,18 @@ class ActionTypesSpec extends RuleHarnessSpec {
         1 * valve.open()
     }
 
+    def "set_valve close command calls valveDevice.close()"() {
+        given:
+        def valve = Spy(TestDevice) { getId() >> 9 }
+        parent = new ActionParent(devices: [9L: valve])
+
+        when:
+        script.executeAction([type: 'set_valve', deviceId: 9L, command: 'close'])
+
+        then:
+        1 * valve.close()
+    }
+
     def "set_fan_speed dispatches speed to fanDevice.setSpeed()"() {
         given:
         def fan = Spy(TestDevice) { getId() >> 10 }
@@ -203,6 +275,30 @@ class ActionTypesSpec extends RuleHarnessSpec {
 
         then:
         1 * shade.setPosition(75)
+    }
+
+    def "set_shade open command calls shadeDevice.open() when no position is given"() {
+        given:
+        def shade = Spy(TestDevice) { getId() >> 11 }
+        parent = new ActionParent(devices: [11L: shade])
+
+        when:
+        script.executeAction([type: 'set_shade', deviceId: 11L, command: 'open'])
+
+        then:
+        1 * shade.open()
+    }
+
+    def "set_shade close command calls shadeDevice.close() when no position is given"() {
+        given:
+        def shade = Spy(TestDevice) { getId() >> 11 }
+        parent = new ActionParent(devices: [11L: shade])
+
+        when:
+        script.executeAction([type: 'set_shade', deviceId: 11L, command: 'close'])
+
+        then:
+        1 * shade.close()
     }
 
     // -------- thermostat --------
@@ -298,6 +394,48 @@ class ActionTypesSpec extends RuleHarnessSpec {
         atomicStateMap.localVariables.counter == 8
     }
 
+    def "variable_math subtract updates the local variable"() {
+        given:
+        atomicStateMap.localVariables = [counter: 10]
+
+        when:
+        script.executeAction([
+            type: 'variable_math', variableName: 'counter',
+            scope: 'local', operation: 'subtract', operand: 4
+        ])
+
+        then:
+        atomicStateMap.localVariables.counter == 6
+    }
+
+    def "variable_math modulo updates the local variable"() {
+        given:
+        atomicStateMap.localVariables = [counter: 10]
+
+        when:
+        script.executeAction([
+            type: 'variable_math', variableName: 'counter',
+            scope: 'local', operation: 'modulo', operand: 3
+        ])
+
+        then:
+        atomicStateMap.localVariables.counter == 1
+    }
+
+    def "variable_math modulo-by-zero preserves the current value"() {
+        given:
+        atomicStateMap.localVariables = [counter: 10]
+
+        when:
+        script.executeAction([
+            type: 'variable_math', variableName: 'counter',
+            scope: 'local', operation: 'modulo', operand: 0
+        ])
+
+        then:
+        atomicStateMap.localVariables.counter == 10
+    }
+
     def "variable_math divide-by-zero preserves the current value"() {
         given:
         atomicStateMap.localVariables = [counter: 5]
@@ -388,7 +526,50 @@ class ActionTypesSpec extends RuleHarnessSpec {
 
         then: 'unschedule is NOT called — only the cancelled set is updated'
         unscheduleCalls == []
+        unscheduleAllCount == 0
         atomicStateMap.cancelledDelayIds == [delay_abc: true]
+    }
+
+    def "resumeDelayedActions executes actions from nextIndex with a reconstructed pseudo-event"() {
+        given: 'three actions; the delay at index 1 has already fired — resume from index 2'
+        def pre = Spy(TestDevice) { getId() >> 100 }
+        def notifier = Spy(TestDevice) { getId() >> 101 }
+        parent = new ActionParent(devices: [100L: pre, 101L: notifier])
+        atomicStateMap.actions = [
+            [type: 'device_command', deviceId: 100L, command: 'on'],
+            [type: 'delay', seconds: 5],
+            [type: 'send_notification', deviceId: 101L, message: 'Event was %device%=%value%']
+        ]
+
+        when: 'resume is invoked as if runIn had fired — carries serialized evt fields'
+        script.resumeDelayedActions([
+            nextIndex: 2, delayId: 'd1',
+            evtDisplayName: 'Motion', evtValue: 'active', evtName: 'motion'
+        ])
+
+        then: 'pre-delay action is NOT re-run; post-delay action fires with %device%/%value% substituted'
+        0 * pre.on()
+        1 * notifier.deviceNotification('Event was Motion=active')
+    }
+
+    def "resumeDelayedActions no-ops and clears the cancelled flag when the delayId was cancelled"() {
+        given:
+        def target = Spy(TestDevice) { getId() >> 102 }
+        parent = new ActionParent(devices: [102L: target])
+        atomicStateMap.actions = [
+            [type: 'delay', seconds: 5],
+            [type: 'device_command', deviceId: 102L, command: 'on']
+        ]
+        atomicStateMap.cancelledDelayIds = [d2: true, other: true]
+
+        when:
+        script.resumeDelayedActions([nextIndex: 1, delayId: 'd2'])
+
+        then: 'the post-delay action does NOT run'
+        0 * target.on()
+
+        and: 'the cancelled flag for this delayId is removed; the other entry survives'
+        atomicStateMap.cancelledDelayIds == [other: true]
     }
 
     def "if_then_else runs thenActions when the inner condition passes"() {
@@ -482,6 +663,25 @@ class ActionTypesSpec extends RuleHarnessSpec {
         captureParent.savedStates == [beforeParty: ['40': [switch: 'on', level: 75]]]
     }
 
+    def "capture_state records color + colorTemperature attributes when the capability is present"() {
+        given:
+        def rgb = new TestDevice(id: 42, label: 'RGB',
+            capabilities: ['Switch', 'ColorControl', 'ColorTemperature'],
+            attributeValues: [switch: 'on', hue: 120, saturation: 50, colorTemperature: 3000])
+        def captureParent = new CapturingStateParent(devices: [42L: rgb])
+        parent = captureParent
+
+        when:
+        script.executeAction([
+            type: 'capture_state', deviceIds: [42L], stateId: 'scene1'
+        ])
+
+        then:
+        captureParent.savedStates == [
+            scene1: ['42': [switch: 'on', hue: 120, saturation: 50, colorTemperature: 3000]]
+        ]
+    }
+
     def "restore_state turns the device off when the snapshot says off"() {
         given:
         def bulb = Spy(TestDevice) { getId() >> 41 }
@@ -497,6 +697,58 @@ class ActionTypesSpec extends RuleHarnessSpec {
         then: 'restore short-circuits to just off() — no setLevel/setColor first'
         1 * bulb.off()
         0 * bulb.on()
+    }
+
+    def "restore_state restores hue + saturation + level via setColor before turning on"() {
+        given: 'snapshot has hue/saturation (→ setColor path)'
+        def bulb = Spy(TestDevice) { getId() >> 43 }
+        def restoreParent = new CapturingStateParent(
+            devices: [43L: bulb],
+            savedStates: [scene1: ['43': [switch: 'on', hue: 120, saturation: 80, level: 75]]]
+        )
+        parent = restoreParent
+
+        when:
+        script.executeAction([type: 'restore_state', stateId: 'scene1'])
+
+        then: 'setColor fires first, then on() — setLevel NOT called separately'
+        1 * bulb.setColor([hue: 120, saturation: 80, level: 75])
+        1 * bulb.on()
+        0 * bulb.setLevel(_)
+    }
+
+    def "restore_state restores colorTemperature when hue/saturation are absent"() {
+        given:
+        def bulb = Spy(TestDevice) { getId() >> 44 }
+        def restoreParent = new CapturingStateParent(
+            devices: [44L: bulb],
+            savedStates: [scene1: ['44': [switch: 'on', colorTemperature: 2700]]]
+        )
+        parent = restoreParent
+
+        when:
+        script.executeAction([type: 'restore_state', stateId: 'scene1'])
+
+        then:
+        1 * bulb.setColorTemperature(2700)
+        1 * bulb.on()
+    }
+
+    def "restore_state restores level only when hue is absent"() {
+        given: 'snapshot has level but no hue/saturation and no colorTemperature'
+        def bulb = Spy(TestDevice) { getId() >> 45 }
+        def restoreParent = new CapturingStateParent(
+            devices: [45L: bulb],
+            savedStates: [scene1: ['45': [switch: 'on', level: 60]]]
+        )
+        parent = restoreParent
+
+        when:
+        script.executeAction([type: 'restore_state', stateId: 'scene1'])
+
+        then:
+        1 * bulb.setLevel(60)
+        1 * bulb.on()
     }
 
     // -------- http_request --------
@@ -540,7 +792,10 @@ class ActionTypesSpec extends RuleHarnessSpec {
         when:
         script.executeActions()
 
-        then: 'the outer catch swallows the throw; the next action runs'
+        then: 'httpGet actually fired (so the exception path actually ran)'
+        httpGetCalls.size() == 1
+
+        and: 'the inner try/catch in the http_request case swallows the throw; the next action runs'
         1 * target.on()
     }
 
@@ -567,15 +822,7 @@ class ActionTypesSpec extends RuleHarnessSpec {
         noExceptionThrown()
     }
 
-    // -------- unknown action --------
-
-    def "unknown action type is a warn + no-op (executeAction still returns true)"() {
-        when:
-        def result = script.executeAction([type: 'totally_made_up_action'])
-
-        then:
-        result == true
-    }
+    // Unknown-action-type coverage lives in ErrorPathsSpec (fail-closed theme).
 
     /** Generic findDevice(id) parent. */
     static class ActionParent {

--- a/src/test/groovy/rules/ActionTypesSpec.groovy
+++ b/src/test/groovy/rules/ActionTypesSpec.groovy
@@ -1,0 +1,609 @@
+package rules
+
+import support.TestDevice
+
+/**
+ * Breadth coverage for the action types in
+ * {@code hubitat-mcp-rule.groovy::executeAction} not exercised by the
+ * primitive-focused {@link RuleEngineSmokeSpec} / {@link ExecuteActionsSpec}
+ * (which cover {@code device_command} + {@code stop}). See issue #75.
+ *
+ * Coverage per category: device-targeted commands, thermostat setters,
+ * location/HSM actions, variables (local/global/math), control flow
+ * ({@code delay} + {@code cancel_delayed}, {@code if_then_else},
+ * {@code repeat}), state capture/restore, and bare {@code log}/{@code comment}.
+ *
+ * Device commands that already resolve through the rule engine's dynamic
+ * {@code device."${cmd}"(*args)} path ({@code device_command} smoke) are
+ * only re-covered here for the dedicated action types that have their
+ * own switch-case branch (e.g. {@code lock} isn't expressible via
+ * {@code device_command} in the UI builder and has an explicit case).
+ *
+ * Several actions rely on methods that HubitatCI resolves through the
+ * AppExecutor mock (@Delegate-precedence):
+ *  - {@code delay} → {@code runIn}
+ *  - {@code cancel_delayed all} → {@code unschedule('resumeDelayedActions')}
+ *  - {@code set_hsm} → {@code sendLocationEvent}
+ *  - {@code http_request} → {@code httpGet} / {@code httpPost}
+ * Tests assert via Spock interactions on {@code appExecutor}. The harness
+ * mock uses {@code _ *} (unlimited) cardinality for everything, so additional
+ * {@code 1 *} interactions in a feature method check-for-exactly-one without
+ * conflicting with the base stub.
+ */
+class ActionTypesSpec extends RuleHarnessSpec {
+
+    // -------- direct device commands --------
+
+    def "toggle_device turns a currently-on device off"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 1 }
+        device.attributeValues['switch'] = 'on'
+        parent = new ActionParent(devices: [1L: device])
+
+        when:
+        script.executeAction([type: 'toggle_device', deviceId: 1L])
+
+        then:
+        1 * device.off()
+        0 * device.on()
+    }
+
+    def "toggle_device turns a currently-off device on"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 1 }
+        device.attributeValues['switch'] = 'off'
+        parent = new ActionParent(devices: [1L: device])
+
+        when:
+        script.executeAction([type: 'toggle_device', deviceId: 1L])
+
+        then:
+        1 * device.on()
+        0 * device.off()
+    }
+
+    def "set_level clamps the percent value before calling setLevel"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 2 }
+        parent = new ActionParent(devices: [2L: device])
+
+        when: 'an out-of-range level is requested'
+        script.executeAction([type: 'set_level', deviceId: 2L, level: 150])
+
+        then: 'clampPercent caps at 100 — the one-arg overload is called'
+        1 * device.setLevel(100)
+    }
+
+    def "set_level with duration calls the two-arg overload"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 2 }
+        parent = new ActionParent(devices: [2L: device])
+
+        when:
+        script.executeAction([type: 'set_level', deviceId: 2L, level: 50, duration: 3])
+
+        then:
+        1 * device.setLevel(50, 3)
+    }
+
+    def "lock / unlock dispatch to the device's lock() or unlock()"() {
+        given:
+        def lockDev = Spy(TestDevice) { getId() >> 3 }
+        def unlockDev = Spy(TestDevice) { getId() >> 4 }
+        parent = new ActionParent(devices: [3L: lockDev, 4L: unlockDev])
+
+        when:
+        script.executeAction([type: 'lock', deviceId: 3L])
+        script.executeAction([type: 'unlock', deviceId: 4L])
+
+        then:
+        1 * lockDev.lock()
+        1 * unlockDev.unlock()
+    }
+
+    def "set_color passes a clamped color map to setColor()"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 5 }
+        parent = new ActionParent(devices: [5L: device])
+
+        when:
+        script.executeAction([type: 'set_color', deviceId: 5L, hue: 50, saturation: 80, level: 75])
+
+        then:
+        1 * device.setColor([hue: 50, saturation: 80, level: 75])
+    }
+
+    def "set_color_temperature with a level value uses the two-arg overload"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 5 }
+        parent = new ActionParent(devices: [5L: device])
+
+        when:
+        script.executeAction([
+            type: 'set_color_temperature', deviceId: 5L, temperature: 3000, level: 80
+        ])
+
+        then:
+        1 * device.setColorTemperature(3000, 80)
+    }
+
+    def "activate_scene turns on the scene device"() {
+        given:
+        def scene = Spy(TestDevice) { getId() >> 6 }
+        parent = new ActionParent(devices: [6L: scene])
+
+        when:
+        script.executeAction([type: 'activate_scene', sceneDeviceId: 6L])
+
+        then:
+        1 * scene.on()
+    }
+
+    def "send_notification substitutes variables and calls deviceNotification"() {
+        given:
+        def notifier = Spy(TestDevice) { getId() >> 7 }
+        atomicStateMap.localVariables = [who: 'Alice']
+        parent = new ActionParent(devices: [7L: notifier])
+
+        when:
+        script.executeAction([
+            type: 'send_notification', deviceId: 7L, message: 'Hello %who%'
+        ])
+
+        then:
+        1 * notifier.deviceNotification('Hello Alice')
+    }
+
+    def "speak sets the volume then speaks the message"() {
+        given:
+        def speaker = Spy(TestDevice) { getId() >> 8 }
+        parent = new ActionParent(devices: [8L: speaker])
+
+        when:
+        script.executeAction([
+            type: 'speak', deviceId: 8L, volume: 30, message: 'Hello'
+        ])
+
+        then:
+        1 * speaker.setVolume(30)
+        1 * speaker.speak('Hello')
+    }
+
+    def "set_valve open command calls valveDevice.open()"() {
+        given:
+        def valve = Spy(TestDevice) { getId() >> 9 }
+        parent = new ActionParent(devices: [9L: valve])
+
+        when:
+        script.executeAction([type: 'set_valve', deviceId: 9L, command: 'open'])
+
+        then:
+        1 * valve.open()
+    }
+
+    def "set_fan_speed dispatches speed to fanDevice.setSpeed()"() {
+        given:
+        def fan = Spy(TestDevice) { getId() >> 10 }
+        parent = new ActionParent(devices: [10L: fan])
+
+        when:
+        script.executeAction([type: 'set_fan_speed', deviceId: 10L, speed: 'high'])
+
+        then:
+        1 * fan.setSpeed('high')
+    }
+
+    def "set_shade with a position calls setPosition()"() {
+        given:
+        def shade = Spy(TestDevice) { getId() >> 11 }
+        parent = new ActionParent(devices: [11L: shade])
+
+        when:
+        script.executeAction([type: 'set_shade', deviceId: 11L, position: 75])
+
+        then:
+        1 * shade.setPosition(75)
+    }
+
+    // -------- thermostat --------
+
+    def "set_thermostat dispatches each configured setpoint / mode"() {
+        given:
+        def tstat = Spy(TestDevice) { getId() >> 12 }
+        parent = new ActionParent(devices: [12L: tstat])
+
+        when:
+        script.executeAction([
+            type: 'set_thermostat', deviceId: 12L,
+            thermostatMode: 'heat', heatingSetpoint: 68,
+            coolingSetpoint: 76, fanMode: 'auto'
+        ])
+
+        then:
+        1 * tstat.setThermostatMode('heat')
+        1 * tstat.setHeatingSetpoint(68)
+        1 * tstat.setCoolingSetpoint(76)
+        1 * tstat.setThermostatFanMode('auto')
+    }
+
+    // -------- location / HSM --------
+
+    def "set_mode drives location.setMode() with the requested mode"() {
+        when:
+        script.executeAction([type: 'set_mode', mode: 'Night'])
+
+        then: 'TestLocation records the call; mode field is updated'
+        testLocation.modeSetCalls == ['Night']
+        testLocation.mode == 'Night'
+    }
+
+    def "set_mode with no mode value returns false without touching location"() {
+        when:
+        def result = script.executeAction([type: 'set_mode'])
+
+        then:
+        result == false
+        testLocation.modeSetCalls == []
+    }
+
+    def "set_hsm fires a location event named hsmSetArm"() {
+        when:
+        script.executeAction([type: 'set_hsm', status: 'armAway'])
+
+        then:
+        1 * appExecutor.sendLocationEvent([name: 'hsmSetArm', value: 'armAway'])
+    }
+
+    // -------- variables --------
+
+    def "set_local_variable stores the interpolated value in atomicState.localVariables"() {
+        given:
+        atomicStateMap.localVariables = [target: 'Alice']
+
+        when:
+        script.executeAction([
+            type: 'set_local_variable', variableName: 'greeting', value: 'Hi %target%'
+        ])
+
+        then:
+        atomicStateMap.localVariables.greeting == 'Hi Alice'
+    }
+
+    def "set_variable writes through parent.setRuleVariable with substituted value"() {
+        given:
+        def recording = new VariableParent()
+        atomicStateMap.localVariables = [n: 42]
+        parent = recording
+
+        when:
+        script.executeAction([
+            type: 'set_variable', variableName: 'label', value: 'n=%n%'
+        ])
+
+        then:
+        recording.variableWrites == [label: 'n=42']
+    }
+
+    def "variable_math add updates the local variable"() {
+        given:
+        atomicStateMap.localVariables = [counter: 5]
+
+        when:
+        script.executeAction([
+            type: 'variable_math', variableName: 'counter',
+            scope: 'local', operation: 'add', operand: 3
+        ])
+
+        then:
+        atomicStateMap.localVariables.counter == 8
+    }
+
+    def "variable_math divide-by-zero preserves the current value"() {
+        given:
+        atomicStateMap.localVariables = [counter: 5]
+
+        when:
+        script.executeAction([
+            type: 'variable_math', variableName: 'counter',
+            scope: 'local', operation: 'divide', operand: 0
+        ])
+
+        then: 'divide-by-zero branch returns currentVal unchanged'
+        atomicStateMap.localVariables.counter == 5
+    }
+
+    def "variable_math set replaces the value outright"() {
+        given:
+        atomicStateMap.localVariables = [counter: 5]
+
+        when:
+        script.executeAction([
+            type: 'variable_math', variableName: 'counter',
+            scope: 'local', operation: 'set', operand: 100
+        ])
+
+        then:
+        atomicStateMap.localVariables.counter == 100
+    }
+
+    def "variable_math scope=global reads getGlobalVar and writes via setGlobalVar"() {
+        given: 'stub the Hubitat-dynamic globalVar helpers on the script'
+        def writes = [:]
+        script.metaClass.getGlobalVar = { String name -> [value: 10] }
+        script.metaClass.setGlobalVar = { String name, Object val -> writes[name] = val }
+
+        when:
+        script.executeAction([
+            type: 'variable_math', variableName: 'counter',
+            scope: 'global', operation: 'multiply', operand: 3
+        ])
+
+        then:
+        writes.counter == 30
+    }
+
+    // -------- control flow --------
+
+    def "delay schedules resumeDelayedActions with the computed delay"() {
+        given:
+        atomicStateMap.actions = [[type: 'delay', seconds: 5]]
+
+        when:
+        script.executeActions()
+
+        then: 'runIn fires once; we accept any param-map overload'
+        1 * appExecutor.runIn(5L, 'resumeDelayedActions', _)
+    }
+
+    def "delay clamps to 1 second minimum"() {
+        given:
+        atomicStateMap.actions = [[type: 'delay', seconds: 0]]
+
+        when:
+        script.executeActions()
+
+        then:
+        1 * appExecutor.runIn(1L, 'resumeDelayedActions', _)
+    }
+
+    def "cancel_delayed 'all' calls unschedule on resumeDelayedActions"() {
+        given: 'a stale cancelledDelayIds map that should be wiped'
+        atomicStateMap.cancelledDelayIds = [stale: true]
+
+        when:
+        script.executeAction([type: 'cancel_delayed', delayId: 'all'])
+
+        then:
+        1 * appExecutor.unschedule('resumeDelayedActions')
+        atomicStateMap.cancelledDelayIds == [:]
+    }
+
+    def "cancel_delayed with a specific id marks only that id as cancelled"() {
+        when:
+        script.executeAction([type: 'cancel_delayed', delayId: 'delay_abc'])
+
+        then: 'unschedule is NOT called — only the cancelled set is updated'
+        0 * appExecutor.unschedule(_)
+        atomicStateMap.cancelledDelayIds == [delay_abc: true]
+    }
+
+    def "if_then_else runs thenActions when the inner condition passes"() {
+        given:
+        def thenDev = Spy(TestDevice) { getId() >> 20 }
+        def elseDev = Spy(TestDevice) { getId() >> 21 }
+        atomicStateMap.localVariables = [gate: 'yes']
+        parent = new ActionParent(devices: [20L: thenDev, 21L: elseDev])
+
+        when:
+        script.executeAction([
+            type: 'if_then_else',
+            condition: [type: 'variable', variableName: 'gate',
+                        operator: 'equals', value: 'yes'],
+            thenActions: [[type: 'device_command', deviceId: 20L, command: 'on']],
+            elseActions: [[type: 'device_command', deviceId: 21L, command: 'on']]
+        ])
+
+        then:
+        1 * thenDev.on()
+        0 * elseDev.on()
+    }
+
+    def "if_then_else runs elseActions when the inner condition fails"() {
+        given:
+        def thenDev = Spy(TestDevice) { getId() >> 20 }
+        def elseDev = Spy(TestDevice) { getId() >> 21 }
+        atomicStateMap.localVariables = [gate: 'no']
+        parent = new ActionParent(devices: [20L: thenDev, 21L: elseDev])
+
+        when:
+        script.executeAction([
+            type: 'if_then_else',
+            condition: [type: 'variable', variableName: 'gate',
+                        operator: 'equals', value: 'yes'],
+            thenActions: [[type: 'device_command', deviceId: 20L, command: 'on']],
+            elseActions: [[type: 'device_command', deviceId: 21L, command: 'on']]
+        ])
+
+        then:
+        0 * thenDev.on()
+        1 * elseDev.on()
+    }
+
+    def "repeat runs the inner action list N times in order"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 30 }
+        parent = new ActionParent(devices: [30L: device])
+
+        when:
+        script.executeAction([
+            type: 'repeat', times: 3,
+            actions: [[type: 'device_command', deviceId: 30L, command: 'on']]
+        ])
+
+        then:
+        3 * device.on()
+    }
+
+    def "repeat clamps times to the 1..100 range"() {
+        given:
+        def device = Spy(TestDevice) { getId() >> 30 }
+        parent = new ActionParent(devices: [30L: device])
+
+        when:
+        script.executeAction([
+            type: 'repeat', times: 500,
+            actions: [[type: 'device_command', deviceId: 30L, command: 'on']]
+        ])
+
+        then:
+        100 * device.on()
+    }
+
+    // -------- state capture / restore --------
+
+    def "capture_state writes a per-device snapshot via parent.saveCapturedState"() {
+        given:
+        def bulb = new TestDevice(id: 40, label: 'Bulb',
+            capabilities: ['Switch', 'SwitchLevel'],
+            attributeValues: [switch: 'on', level: 75])
+        def captureParent = new CapturingStateParent(devices: [40L: bulb])
+        parent = captureParent
+
+        when:
+        script.executeAction([
+            type: 'capture_state', deviceIds: [40L], stateId: 'beforeParty'
+        ])
+
+        then:
+        captureParent.savedStates == [beforeParty: ['40': [switch: 'on', level: 75]]]
+    }
+
+    def "restore_state turns the device off when the snapshot says off"() {
+        given:
+        def bulb = Spy(TestDevice) { getId() >> 41 }
+        def restoreParent = new CapturingStateParent(
+            devices: [41L: bulb],
+            savedStates: [evening: ['41': [switch: 'off']]]
+        )
+        parent = restoreParent
+
+        when:
+        script.executeAction([type: 'restore_state', stateId: 'evening'])
+
+        then: 'restore short-circuits to just off() — no setLevel/setColor first'
+        1 * bulb.off()
+        0 * bulb.on()
+    }
+
+    // -------- http_request --------
+
+    def "http_request defaults to GET and calls httpGet with the uri map"() {
+        when:
+        script.executeAction([type: 'http_request', url: 'http://example.test/api'])
+
+        then:
+        1 * appExecutor.httpGet([uri: 'http://example.test/api'], _)
+    }
+
+    def "http_request POST passes body + contentType through to httpPost"() {
+        when:
+        script.executeAction([
+            type: 'http_request', method: 'POST',
+            url: 'http://example.test/api',
+            contentType: 'application/json', body: '{"k":"v"}'
+        ])
+
+        then:
+        1 * appExecutor.httpPost([
+            uri: 'http://example.test/api',
+            contentType: 'application/json',
+            body: '{"k":"v"}'
+        ], _)
+    }
+
+    def "http_request swallows network exceptions and does not break the action chain"() {
+        given: 'httpGet throws on the first action; the second action still needs to run'
+        appExecutor.httpGet(_, _) >> { args -> throw new RuntimeException("network down") }
+        def target = Spy(TestDevice) { getId() >> 50 }
+        parent = new ActionParent(devices: [50L: target])
+        atomicStateMap.actions = [
+            [type: 'http_request', url: 'http://example.test/api'],
+            [type: 'device_command', deviceId: 50L, command: 'on']
+        ]
+
+        when:
+        script.executeActions()
+
+        then: 'the outer catch swallows the throw; the next action runs'
+        1 * target.on()
+    }
+
+    // -------- log / comment --------
+
+    def "log action substitutes variables into the message"() {
+        given:
+        atomicStateMap.localVariables = [who: 'Bob']
+
+        when: 'the spec only needs to prove no exception — PermissiveLog accepts calls'
+        script.executeAction([
+            type: 'log', level: 'info', message: 'Hello %who%'
+        ])
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "comment action succeeds without throwing"() {
+        when:
+        script.executeAction([type: 'comment', text: 'design note'])
+
+        then:
+        noExceptionThrown()
+    }
+
+    // -------- unknown action --------
+
+    def "unknown action type is a warn + no-op (executeAction still returns true)"() {
+        when:
+        def result = script.executeAction([type: 'totally_made_up_action'])
+
+        then:
+        result == true
+    }
+
+    /** Generic findDevice(id) parent. */
+    static class ActionParent {
+        Map<Long, TestDevice> devices = [:]
+        Object findDevice(id) { devices[(id as Long)] }
+    }
+
+    /** Records parent.setRuleVariable calls. */
+    static class VariableParent {
+        Map<String, Object> variableWrites = [:]
+        Object findDevice(id) { null }
+        void setRuleVariable(String name, Object value) { variableWrites[name] = value }
+    }
+
+    /**
+     * Minimal parent with capture/restore slots. Matches the shape the rule
+     * engine expects: saveCapturedState returns a result map with
+     * {@code totalStored} / {@code maxLimit} / {@code deletedStates} / {@code nearLimit}
+     * fields that the engine logs but tests don't assert on.
+     */
+    static class CapturingStateParent {
+        Map<Long, TestDevice> devices = [:]
+        Map<String, Map> savedStates = [:]
+
+        Object findDevice(id) { devices[(id as Long)] }
+
+        Map saveCapturedState(String key, Map states) {
+            savedStates[key] = states
+            [totalStored: savedStates.size(), maxLimit: 10,
+             deletedStates: null, nearLimit: false]
+        }
+
+        Map getCapturedState(String key) {
+            savedStates[key]
+        }
+    }
+}

--- a/src/test/groovy/rules/ActionTypesSpec.groovy
+++ b/src/test/groovy/rules/ActionTypesSpec.groovy
@@ -251,7 +251,7 @@ class ActionTypesSpec extends RuleHarnessSpec {
         script.executeAction([type: 'set_hsm', status: 'armAway'])
 
         then:
-        1 * appExecutor.sendLocationEvent([name: 'hsmSetArm', value: 'armAway'])
+        sendLocationEventCalls == [[name: 'hsmSetArm', value: 'armAway']]
     }
 
     // -------- variables --------
@@ -351,8 +351,10 @@ class ActionTypesSpec extends RuleHarnessSpec {
         when:
         script.executeActions()
 
-        then: 'runIn fires once; we accept any param-map overload'
-        1 * appExecutor.runIn(5L, 'resumeDelayedActions', _)
+        then: 'exactly one runIn call with 5s + resumeDelayedActions'
+        runInCalls.size() == 1
+        runInCalls[0][0] == 5L
+        runInCalls[0][1] == 'resumeDelayedActions'
     }
 
     def "delay clamps to 1 second minimum"() {
@@ -363,7 +365,9 @@ class ActionTypesSpec extends RuleHarnessSpec {
         script.executeActions()
 
         then:
-        1 * appExecutor.runIn(1L, 'resumeDelayedActions', _)
+        runInCalls.size() == 1
+        runInCalls[0][0] == 1L
+        runInCalls[0][1] == 'resumeDelayedActions'
     }
 
     def "cancel_delayed 'all' calls unschedule on resumeDelayedActions"() {
@@ -374,7 +378,7 @@ class ActionTypesSpec extends RuleHarnessSpec {
         script.executeAction([type: 'cancel_delayed', delayId: 'all'])
 
         then:
-        1 * appExecutor.unschedule('resumeDelayedActions')
+        unscheduleCalls == ['resumeDelayedActions']
         atomicStateMap.cancelledDelayIds == [:]
     }
 
@@ -383,7 +387,7 @@ class ActionTypesSpec extends RuleHarnessSpec {
         script.executeAction([type: 'cancel_delayed', delayId: 'delay_abc'])
 
         then: 'unschedule is NOT called — only the cancelled set is updated'
-        0 * appExecutor.unschedule(_)
+        unscheduleCalls == []
         atomicStateMap.cancelledDelayIds == [delay_abc: true]
     }
 
@@ -502,7 +506,8 @@ class ActionTypesSpec extends RuleHarnessSpec {
         script.executeAction([type: 'http_request', url: 'http://example.test/api'])
 
         then:
-        1 * appExecutor.httpGet([uri: 'http://example.test/api'], _)
+        httpGetCalls.size() == 1
+        httpGetCalls[0][0] == [uri: 'http://example.test/api']
     }
 
     def "http_request POST passes body + contentType through to httpPost"() {
@@ -514,16 +519,17 @@ class ActionTypesSpec extends RuleHarnessSpec {
         ])
 
         then:
-        1 * appExecutor.httpPost([
+        httpPostCalls.size() == 1
+        httpPostCalls[0][0] == [
             uri: 'http://example.test/api',
             contentType: 'application/json',
             body: '{"k":"v"}'
-        ], _)
+        ]
     }
 
     def "http_request swallows network exceptions and does not break the action chain"() {
         given: 'httpGet throws on the first action; the second action still needs to run'
-        appExecutor.httpGet(_, _) >> { args -> throw new RuntimeException("network down") }
+        stubHttpGetException = new RuntimeException('network down')
         def target = Spy(TestDevice) { getId() >> 50 }
         parent = new ActionParent(devices: [50L: target])
         atomicStateMap.actions = [

--- a/src/test/groovy/rules/ConditionTypesSpec.groovy
+++ b/src/test/groovy/rules/ConditionTypesSpec.groovy
@@ -79,7 +79,7 @@ class ConditionTypesSpec extends RuleHarnessSpec {
 
     def "time_range returns true when timeOfDayIsBetween returns true"() {
         given: 'timeOfDayIsBetween reports current time inside the window'
-        _ * appExecutor.timeOfDayIsBetween(_, _, _) >> true
+        stubTimeOfDayResult = true
 
         expect:
         script.evaluateCondition([
@@ -89,7 +89,7 @@ class ConditionTypesSpec extends RuleHarnessSpec {
 
     def "time_range returns false when timeOfDayIsBetween returns false"() {
         given:
-        _ * appExecutor.timeOfDayIsBetween(_, _, _) >> false
+        stubTimeOfDayResult = false
 
         expect:
         script.evaluateCondition([

--- a/src/test/groovy/rules/ConditionTypesSpec.groovy
+++ b/src/test/groovy/rules/ConditionTypesSpec.groovy
@@ -1,0 +1,364 @@
+package rules
+
+import support.TestDevice
+
+/**
+ * Breadth coverage for every non-primitive condition type in
+ * {@code hubitat-mcp-rule.groovy::evaluateCondition} (see #75).
+ * Primitive types ({@code device_state}, {@code variable}) are covered
+ * in {@link EvaluateConditionSpec}; this spec picks up the rest:
+ *
+ * <ul>
+ *   <li>{@code mode} — {@code location.mode} in a {@code modes} list,
+ *       {@code operator=not_in} inverts membership.</li>
+ *   <li>{@code time_range} — stubs {@code timeOfDayIsBetween} on the
+ *       AppExecutor mock (it's defined on {@code BaseExecutor}, so script
+ *       calls resolve through @Delegate, not metaClass).</li>
+ *   <li>{@code days_of_week} — {@code new Date().format("EEEE")}; the
+ *       rule engine uses system time unconditionally, so tests compute
+ *       today's name locally and compare.</li>
+ *   <li>{@code sun_position} — compares {@code new Date()} against
+ *       {@code location.sunrise}/{@code location.sunset}; tests seed past/future
+ *       timestamps on the shared {@code testLocation}.</li>
+ *   <li>{@code hsm_status} — reads {@code location.hsmStatus}. The field
+ *       isn't declared on HubitatCI's {@code Location} interface, but
+ *       Groovy property dispatch resolves it on the concrete TestLocation
+ *       at runtime — real Hubitat exposes it the same way.</li>
+ *   <li>{@code device_was} — drives {@code eventsSince} (added to
+ *       TestDevice) to exercise the lookback/filter logic.</li>
+ *   <li>{@code presence}, {@code lock}, {@code thermostat_mode},
+ *       {@code thermostat_state}, {@code illuminance}, {@code power} —
+ *       simple attribute reads via {@code device.currentValue(...)}.</li>
+ * </ul>
+ */
+class ConditionTypesSpec extends RuleHarnessSpec {
+
+    // -------- mode --------
+
+    def "mode condition returns true when location.mode is in the modes list"() {
+        given:
+        testLocation.mode = 'Night'
+
+        expect:
+        script.evaluateCondition([
+            type: 'mode', modes: ['Night', 'Away']
+        ]) == true
+    }
+
+    def "mode condition returns false when location.mode is not in the modes list"() {
+        given:
+        testLocation.mode = 'Home'
+
+        expect:
+        script.evaluateCondition([
+            type: 'mode', modes: ['Night', 'Away']
+        ]) == false
+    }
+
+    def "mode condition with operator=not_in inverts membership"() {
+        given:
+        testLocation.mode = 'Home'
+
+        expect:
+        script.evaluateCondition([
+            type: 'mode', modes: ['Night', 'Away'], operator: 'not_in'
+        ]) == true
+    }
+
+    def "mode condition accepts singular 'mode' key as a single-item list"() {
+        given:
+        testLocation.mode = 'Vacation'
+
+        expect:
+        script.evaluateCondition([
+            type: 'mode', mode: 'Vacation'
+        ]) == true
+    }
+
+    // -------- time_range --------
+
+    def "time_range returns true when timeOfDayIsBetween returns true"() {
+        given: 'timeOfDayIsBetween reports current time inside the window'
+        _ * appExecutor.timeOfDayIsBetween(_, _, _) >> true
+
+        expect:
+        script.evaluateCondition([
+            type: 'time_range', start: '09:00', end: '17:00'
+        ]) == true
+    }
+
+    def "time_range returns false when timeOfDayIsBetween returns false"() {
+        given:
+        _ * appExecutor.timeOfDayIsBetween(_, _, _) >> false
+
+        expect:
+        script.evaluateCondition([
+            type: 'time_range', start: '09:00', end: '17:00'
+        ]) == false
+    }
+
+    def "time_range fails closed when the time strings are unparseable"() {
+        expect: 'null start trips parseTimeString, which throws and is caught as false'
+        script.evaluateCondition([
+            type: 'time_range', start: null, end: '17:00'
+        ]) == false
+    }
+
+    // -------- days_of_week --------
+
+    def "days_of_week returns true when today's day name is in the list"() {
+        given: 'compute today locally — the rule engine uses system time'
+        def today = new Date().format('EEEE')
+
+        expect:
+        script.evaluateCondition([
+            type: 'days_of_week', days: [today]
+        ]) == true
+    }
+
+    def "days_of_week returns false when today is not in the list"() {
+        given:
+        def today = new Date().format('EEEE')
+        // The six-other-days list never contains today, so the check always fails.
+        def otherDays = (['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday','Sunday']
+            - today)
+
+        expect:
+        script.evaluateCondition([
+            type: 'days_of_week', days: otherDays
+        ]) == false
+    }
+
+    def "days_of_week returns false when days list is missing"() {
+        expect:
+        script.evaluateCondition([type: 'days_of_week']) == false
+    }
+
+    // -------- sun_position --------
+
+    def "sun_position returns true for 'up' when current time is between sunrise and sunset"() {
+        given: 'sunrise is in the past, sunset is in the future'
+        testLocation.sunrise = new Date(System.currentTimeMillis() - 3600_000L) // 1h ago
+        testLocation.sunset = new Date(System.currentTimeMillis() + 3600_000L) // 1h ahead
+
+        expect:
+        script.evaluateCondition([
+            type: 'sun_position', position: 'up'
+        ]) == true
+    }
+
+    def "sun_position returns false for 'up' when sunset is already past"() {
+        given: 'both sunrise and sunset are in the past — sun is down'
+        testLocation.sunrise = new Date(System.currentTimeMillis() - 7200_000L) // 2h ago
+        testLocation.sunset = new Date(System.currentTimeMillis() - 3600_000L) // 1h ago
+
+        expect:
+        script.evaluateCondition([
+            type: 'sun_position', position: 'up'
+        ]) == false
+    }
+
+    def "sun_position returns true for 'down' when sun is below horizon"() {
+        given:
+        testLocation.sunrise = new Date(System.currentTimeMillis() - 7200_000L)
+        testLocation.sunset = new Date(System.currentTimeMillis() - 3600_000L)
+
+        expect:
+        script.evaluateCondition([
+            type: 'sun_position', position: 'down'
+        ]) == true
+    }
+
+    def "sun_position fails closed when sunrise/sunset are unavailable"() {
+        given: 'testLocation.sunrise/sunset default to null from setup()'
+
+        expect:
+        script.evaluateCondition([
+            type: 'sun_position', position: 'up'
+        ]) == false
+    }
+
+    // -------- hsm_status --------
+
+    def "hsm_status returns true when location.hsmStatus matches"() {
+        given:
+        testLocation.hsmStatus = 'armedAway'
+
+        expect:
+        script.evaluateCondition([
+            type: 'hsm_status', status: 'armedAway'
+        ]) == true
+    }
+
+    def "hsm_status returns false when status differs"() {
+        given:
+        testLocation.hsmStatus = 'disarmed'
+
+        expect:
+        script.evaluateCondition([
+            type: 'hsm_status', status: 'armedAway'
+        ]) == false
+    }
+
+    // -------- device_was --------
+
+    def "device_was returns true when attribute has held the target value across the lookback"() {
+        given:
+        def device = new TestDevice(id: 1, label: 'Motion')
+        device.attributeValues['motion'] = 'inactive'
+        // Only same-value events in the lookback → no recentChange → true
+        device.events = [
+            [name: 'motion', value: 'inactive'],
+            [name: 'motion', value: 'inactive']
+        ]
+        parent = new DeviceParent(devices: [1L: device])
+
+        expect:
+        script.evaluateCondition([
+            type: 'device_was', deviceId: 1L, attribute: 'motion',
+            value: 'inactive', forSeconds: 60
+        ]) == true
+    }
+
+    def "device_was returns false when a different-value event is present in the lookback"() {
+        given:
+        def device = new TestDevice(id: 1, label: 'Motion')
+        device.attributeValues['motion'] = 'inactive'
+        // A recent 'active' event means the attribute changed in-window → false
+        device.events = [
+            [name: 'motion', value: 'inactive'],
+            [name: 'motion', value: 'active']
+        ]
+        parent = new DeviceParent(devices: [1L: device])
+
+        expect:
+        script.evaluateCondition([
+            type: 'device_was', deviceId: 1L, attribute: 'motion',
+            value: 'inactive', forSeconds: 60
+        ]) == false
+    }
+
+    def "device_was returns false when current attribute value does not match target"() {
+        given:
+        def device = new TestDevice(id: 1, label: 'Motion')
+        device.attributeValues['motion'] = 'active'  // currently NOT inactive
+        parent = new DeviceParent(devices: [1L: device])
+
+        expect: 'current value mismatch short-circuits before event lookup'
+        script.evaluateCondition([
+            type: 'device_was', deviceId: 1L, attribute: 'motion',
+            value: 'inactive', forSeconds: 60
+        ]) == false
+    }
+
+    def "device_was returns false when forSeconds is missing"() {
+        given:
+        def device = new TestDevice(id: 1, label: 'Motion')
+        device.attributeValues['motion'] = 'inactive'
+        parent = new DeviceParent(devices: [1L: device])
+
+        expect:
+        script.evaluateCondition([
+            type: 'device_was', deviceId: 1L, attribute: 'motion', value: 'inactive'
+        ]) == false
+    }
+
+    // -------- presence --------
+
+    def "presence condition returns true when device.presence matches"() {
+        given:
+        def device = new TestDevice(id: 2, label: 'Phone')
+        device.attributeValues['presence'] = 'present'
+        parent = new DeviceParent(devices: [2L: device])
+
+        expect:
+        script.evaluateCondition([
+            type: 'presence', deviceId: 2L, status: 'present'
+        ]) == true
+    }
+
+    def "presence condition returns false when device not found"() {
+        given:
+        parent = new DeviceParent(devices: [:])
+
+        expect:
+        script.evaluateCondition([
+            type: 'presence', deviceId: 999L, status: 'present'
+        ]) == false
+    }
+
+    // -------- lock --------
+
+    def "lock condition returns true when device.lock matches"() {
+        given:
+        def device = new TestDevice(id: 3, label: 'Front Door')
+        device.attributeValues['lock'] = 'locked'
+        parent = new DeviceParent(devices: [3L: device])
+
+        expect:
+        script.evaluateCondition([
+            type: 'lock', deviceId: 3L, status: 'locked'
+        ]) == true
+    }
+
+    // -------- thermostat --------
+
+    def "thermostat_mode returns true when thermostatMode matches"() {
+        given:
+        def device = new TestDevice(id: 4, label: 'Tstat')
+        device.attributeValues['thermostatMode'] = 'heat'
+        parent = new DeviceParent(devices: [4L: device])
+
+        expect:
+        script.evaluateCondition([
+            type: 'thermostat_mode', deviceId: 4L, mode: 'heat'
+        ]) == true
+    }
+
+    def "thermostat_state returns true when thermostatOperatingState matches"() {
+        given:
+        def device = new TestDevice(id: 4, label: 'Tstat')
+        device.attributeValues['thermostatOperatingState'] = 'heating'
+        parent = new DeviceParent(devices: [4L: device])
+
+        expect:
+        script.evaluateCondition([
+            type: 'thermostat_state', deviceId: 4L, state: 'heating'
+        ]) == true
+    }
+
+    // -------- illuminance / power (numeric comparisons) --------
+
+    def "illuminance condition compares via evaluateComparison"() {
+        given:
+        def device = new TestDevice(id: 5, label: 'Sensor')
+        device.attributeValues['illuminance'] = 120
+        parent = new DeviceParent(devices: [5L: device])
+
+        expect:
+        script.evaluateCondition([
+            type: 'illuminance', deviceId: 5L, operator: '<', value: 200
+        ]) == true
+    }
+
+    def "power condition compares via evaluateComparison"() {
+        given:
+        def device = new TestDevice(id: 6, label: 'Plug')
+        device.attributeValues['power'] = 15.5
+        parent = new DeviceParent(devices: [6L: device])
+
+        expect:
+        script.evaluateCondition([
+            type: 'power', deviceId: 6L, operator: '>=', value: 10
+        ]) == true
+    }
+
+    /** Minimal parent stub — findDevice(id) by Long coercion. */
+    static class DeviceParent {
+        Map<Long, TestDevice> devices = [:]
+
+        Object findDevice(id) {
+            devices[(id as Long)]
+        }
+    }
+}

--- a/src/test/groovy/rules/ErrorPathsSpec.groovy
+++ b/src/test/groovy/rules/ErrorPathsSpec.groovy
@@ -52,8 +52,10 @@ class ErrorPathsSpec extends RuleHarnessSpec {
         1 * healthy.on()
     }
 
-    def "set_thermostat catches per-setter failures without skipping remaining setters"() {
-        given: 'setHeatingSetpoint throws, but setThermostatMode is still called first'
+    def "set_thermostat swallows a per-setter exception; later setters in the same call are skipped"() {
+        given: '''the engine wraps all four thermostat setters in a single try/catch,
+                  so when setHeatingSetpoint throws, setCoolingSetpoint / setThermostatFanMode
+                  are NOT reached — only the setters that ran before the throw fire.'''
         def tstat = Spy(TestDevice) {
             getId() >> 5
             setHeatingSetpoint(_) >> { throw new RuntimeException("probe fail") }
@@ -63,11 +65,18 @@ class ErrorPathsSpec extends RuleHarnessSpec {
         when:
         script.executeAction([
             type: 'set_thermostat', deviceId: 5L,
-            thermostatMode: 'cool', heatingSetpoint: 65, coolingSetpoint: 72
+            thermostatMode: 'cool', heatingSetpoint: 65,
+            coolingSetpoint: 72, fanMode: 'auto'
         ])
 
-        then: 'mode was set before the throw; the outer catch swallows the exception'
+        then: 'mode was set before the throw'
         1 * tstat.setThermostatMode('cool')
+
+        and: 'setpoints/fan after the throwing setter are NOT reached'
+        0 * tstat.setCoolingSetpoint(_)
+        0 * tstat.setThermostatFanMode(_)
+
+        and: 'the exception is swallowed by the case-local try/catch — no throw propagates'
         noExceptionThrown()
     }
 
@@ -82,10 +91,8 @@ class ErrorPathsSpec extends RuleHarnessSpec {
         noExceptionThrown()
     }
 
-    def "unknown condition type returns false (fail closed)"() {
-        expect:
-        script.evaluateCondition([type: 'absolutely_not_a_real_type']) == false
-    }
+    // Unknown condition type fail-closed coverage is already pinned by
+    // EvaluateConditionSpec. Dropping the duplicate here.
 
     def "unknown action type logs a warn and returns true (continue)"() {
         when:
@@ -98,7 +105,8 @@ class ErrorPathsSpec extends RuleHarnessSpec {
     def "set_mode missing the 'mode' field returns false (stops the chain)"() {
         given:
         atomicStateMap.actions = [
-            [type: 'set_mode'],  // missing mode field → returns false → break
+            // missing mode field → executeAction returns false → executeActionsFromIndex breaks its outer loop
+            [type: 'set_mode'],
             [type: 'device_command', deviceId: 1L, command: 'on']
         ]
         def target = Spy(TestDevice) { getId() >> 1 }

--- a/src/test/groovy/rules/ErrorPathsSpec.groovy
+++ b/src/test/groovy/rules/ErrorPathsSpec.groovy
@@ -1,0 +1,134 @@
+package rules
+
+import support.TestDevice
+
+/**
+ * Error-path coverage for the rule engine (#75). The engine is designed to
+ * fail closed and keep going — a malformed action or condition should not
+ * tear the whole rule down. This spec pins that behaviour for the cases
+ * primitive specs don't cover.
+ *
+ * Complements: {@link EvaluateComparisonSpec} (null/type-coercion branches)
+ * and {@link EvaluateConditionsSpec} (caught-exception → condition-miss).
+ */
+class ErrorPathsSpec extends RuleHarnessSpec {
+
+    def "action targeting a missing device logs a warning but does not stop execution"() {
+        given:
+        def present = Spy(TestDevice) { getId() >> 2 }
+        parent = new ErrorParent(devices: [2L: present])
+
+        and: 'first action targets a non-existent device; second hits a real one'
+        atomicStateMap.actions = [
+            [type: 'device_command', deviceId: 999L, command: 'on'],
+            [type: 'device_command', deviceId: 2L, command: 'off']
+        ]
+
+        when:
+        script.executeActions()
+
+        then: 'the missing-device branch warns + skips; the next action still fires'
+        1 * present.off()
+    }
+
+    def "a thrown exception inside a device command is caught and does not halt the loop"() {
+        given:
+        def flaky = Spy(TestDevice) {
+            getId() >> 1
+            on() >> { throw new RuntimeException("simulated device failure") }
+        }
+        def healthy = Spy(TestDevice) { getId() >> 2 }
+        parent = new ErrorParent(devices: [1L: flaky, 2L: healthy])
+
+        atomicStateMap.actions = [
+            [type: 'device_command', deviceId: 1L, command: 'on'],
+            [type: 'device_command', deviceId: 2L, command: 'on']
+        ]
+
+        when:
+        script.executeActions()
+
+        then: 'executeAction catches the throw; subsequent action runs'
+        1 * healthy.on()
+    }
+
+    def "set_thermostat catches per-setter failures without skipping remaining setters"() {
+        given: 'setHeatingSetpoint throws, but setThermostatMode is still called first'
+        def tstat = Spy(TestDevice) {
+            getId() >> 5
+            setHeatingSetpoint(_) >> { throw new RuntimeException("probe fail") }
+        }
+        parent = new ErrorParent(devices: [5L: tstat])
+
+        when:
+        script.executeAction([
+            type: 'set_thermostat', deviceId: 5L,
+            thermostatMode: 'cool', heatingSetpoint: 65, coolingSetpoint: 72
+        ])
+
+        then: 'mode was set before the throw; the outer catch swallows the exception'
+        1 * tstat.setThermostatMode('cool')
+        noExceptionThrown()
+    }
+
+    def "missing actions list in atomicState is treated as an empty list"() {
+        given: 'atomicState.actions is absent (not set on the map)'
+        assert !atomicStateMap.containsKey('actions')
+
+        when:
+        script.executeActions()
+
+        then: 'the `?: []` default short-circuits the loop body cleanly'
+        noExceptionThrown()
+    }
+
+    def "unknown condition type returns false (fail closed)"() {
+        expect:
+        script.evaluateCondition([type: 'absolutely_not_a_real_type']) == false
+    }
+
+    def "unknown action type logs a warn and returns true (continue)"() {
+        when:
+        def result = script.executeAction([type: 'absolutely_not_a_real_action'])
+
+        then: 'executeAction returns true so the outer loop continues'
+        result == true
+    }
+
+    def "set_mode missing the 'mode' field returns false (stops the chain)"() {
+        given:
+        atomicStateMap.actions = [
+            [type: 'set_mode'],  // missing mode field → returns false → break
+            [type: 'device_command', deviceId: 1L, command: 'on']
+        ]
+        def target = Spy(TestDevice) { getId() >> 1 }
+        parent = new ErrorParent(devices: [1L: target])
+
+        when:
+        script.executeActions()
+
+        then: 'the second action is NOT reached because set_mode returned false'
+        0 * target.on()
+    }
+
+    def "set_hsm missing the 'status' field returns false (stops the chain)"() {
+        given:
+        atomicStateMap.actions = [
+            [type: 'set_hsm'],
+            [type: 'device_command', deviceId: 1L, command: 'on']
+        ]
+        def target = Spy(TestDevice) { getId() >> 1 }
+        parent = new ErrorParent(devices: [1L: target])
+
+        when:
+        script.executeActions()
+
+        then:
+        0 * target.on()
+    }
+
+    static class ErrorParent {
+        Map<Long, TestDevice> devices = [:]
+        Object findDevice(id) { devices[(id as Long)] }
+    }
+}

--- a/src/test/groovy/rules/EvaluateConditionsSpec.groovy
+++ b/src/test/groovy/rules/EvaluateConditionsSpec.groovy
@@ -105,9 +105,66 @@ class EvaluateConditionsSpec extends RuleHarnessSpec {
         script.evaluateConditions() == false
     }
 
+    def "all-logic short-circuits: a false condition stops subsequent evaluations"() {
+        given: 'two device_state conditions — the first will miss'
+        def counting = new CountingParent()
+        parent = counting
+        atomicStateMap.conditions = [
+            [type: 'device_state', deviceId: 1L, attribute: 'switch',
+             operator: 'equals', value: 'on'],   // miss — device 1 has no entry
+            [type: 'device_state', deviceId: 2L, attribute: 'switch',
+             operator: 'equals', value: 'on']    // would hit, but should be skipped
+        ]
+        settingsMap.conditionLogic = 'all'
+
+        when:
+        def result = script.evaluateConditions()
+
+        then:
+        result == false
+        counting.lookups == [1L]  // no lookup for device 2 — proves short-circuit
+    }
+
+    def "any-logic short-circuits: a matching condition stops subsequent evaluations"() {
+        given:
+        def counting = new CountingParent(devices: [
+            1L: new support.TestDevice(id: 1, label: 'Match', attributeValues: [switch: 'on'])
+        ])
+        parent = counting
+        atomicStateMap.conditions = [
+            [type: 'device_state', deviceId: 1L, attribute: 'switch',
+             operator: 'equals', value: 'on'],   // hit
+            [type: 'device_state', deviceId: 2L, attribute: 'switch',
+             operator: 'equals', value: 'on']    // should be skipped
+        ]
+        settingsMap.conditionLogic = 'any'
+
+        when:
+        def result = script.evaluateConditions()
+
+        then:
+        result == true
+        counting.lookups == [1L]
+    }
+
     static class ThrowingParent {
         Object findDevice(id) {
             throw new RuntimeException("simulated findDevice failure")
+        }
+    }
+
+    /**
+     * Parent stub that records every findDevice(id) call in order — lets
+     * short-circuit tests assert the second condition's lookup never fires.
+     */
+    static class CountingParent {
+        Map<Long, support.TestDevice> devices = [:]
+        List<Long> lookups = []
+
+        Object findDevice(id) {
+            def key = (id as Long)
+            lookups << key
+            devices[key]
         }
     }
 }

--- a/src/test/groovy/rules/LoopGuardSpec.groovy
+++ b/src/test/groovy/rules/LoopGuardSpec.groovy
@@ -63,8 +63,8 @@ class LoopGuardSpec extends RuleHarnessSpec {
         appExecutor.getApp().settingsStore.ruleEnabled == false
 
         and: 'unsubscribe() and unschedule() both fire'
-        1 * appExecutor.unsubscribe()
-        1 * appExecutor.unschedule()
+        unsubscribeCount == 1
+        unscheduleCalls == [null]
 
         and: 'recentExecutions is cleared'
         atomicStateMap.recentExecutions == []

--- a/src/test/groovy/rules/LoopGuardSpec.groovy
+++ b/src/test/groovy/rules/LoopGuardSpec.groovy
@@ -26,9 +26,10 @@ class LoopGuardSpec extends RuleHarnessSpec {
     private static final long FIXED_NOW = 1234567890000L
 
     def "under threshold: rule executes and the exec timestamp is appended"() {
-        given:
+        given: 'seed ruleEnabled=true on the shared TestChildApp so we can assert it stays true'
         settingsMap.ruleEnabled = true
         settingsMap.ruleName = 'Rule Under Limit'
+        appExecutor.getApp().settingsStore.ruleEnabled = true
         parent = new LoopGuardParent(settings: [loopGuardMax: 30, loopGuardWindowSec: 60])
         atomicStateMap.conditions = []
         atomicStateMap.actions = []
@@ -37,12 +38,12 @@ class LoopGuardSpec extends RuleHarnessSpec {
         when:
         script.executeRule('test')
 
-        then: 'exec recorded, rule not disabled'
+        then: 'exec recorded, ruleEnabled untouched (auto-disable would flip it to false)'
         atomicStateMap.recentExecutions == [FIXED_NOW]
-        appExecutor.getApp().settingsStore.ruleEnabled != false
+        appExecutor.getApp().settingsStore.ruleEnabled == true
     }
 
-    def "at threshold: rule auto-disables and unsubscribes / unschedules"() {
+    def "at threshold: rule auto-disables, unsubscribes, unschedules, and emits mcpLoopGuard"() {
         given:
         settingsMap.ruleEnabled = true
         settingsMap.ruleName = 'Rule Over Limit'
@@ -62,18 +63,24 @@ class LoopGuardSpec extends RuleHarnessSpec {
         then: 'auto-disable writes ruleEnabled=false on the app settings'
         appExecutor.getApp().settingsStore.ruleEnabled == false
 
-        and: 'unsubscribe() and unschedule() both fire'
+        and: 'unsubscribe() and the blanket unschedule() both fire'
         unsubscribeCount == 1
-        unscheduleCalls == [null]
+        unscheduleAllCount == 1
 
         and: 'recentExecutions is cleared'
         atomicStateMap.recentExecutions == []
+
+        and: 'a public mcpLoopGuard location event is fired so other rules can subscribe'
+        sendLocationEventCalls.any {
+            it.name == 'mcpLoopGuard' && it.value == 'Rule Over Limit'
+        }
     }
 
     def "window pruning: out-of-window entries do not count toward the threshold"() {
         given:
         settingsMap.ruleEnabled = true
         settingsMap.ruleName = 'Rule Pruning'
+        appExecutor.getApp().settingsStore.ruleEnabled = true
         parent = new LoopGuardParent(settings: [loopGuardMax: 3, loopGuardWindowSec: 60])
         atomicStateMap.conditions = []
         atomicStateMap.actions = []
@@ -87,8 +94,8 @@ class LoopGuardSpec extends RuleHarnessSpec {
         when:
         script.executeRule('test')
 
-        then: 'rule still fires — old entries were pruned'
-        appExecutor.getApp().settingsStore.ruleEnabled != false
+        then: 'rule still fires — old entries were pruned, ruleEnabled stays true'
+        appExecutor.getApp().settingsStore.ruleEnabled == true
         // Pruned + one new entry → just [FIXED_NOW]
         atomicStateMap.recentExecutions == [FIXED_NOW]
     }

--- a/src/test/groovy/rules/LoopGuardSpec.groovy
+++ b/src/test/groovy/rules/LoopGuardSpec.groovy
@@ -1,0 +1,125 @@
+package rules
+
+/**
+ * Spec for hubitat-mcp-rule.groovy::executeRule loop-guard behaviour (see #75).
+ *
+ * The loop guard prevents a rule from stampeding (e.g. "switch A on" action
+ * triggers "switch A on" again). It reads {@code parent.settings.loopGuardMax}
+ * (default 30) and {@code loopGuardWindowSec} (default 60) and counts entries
+ * in {@code atomicState.recentExecutions} within the sliding window. When the
+ * count meets or exceeds the threshold, it auto-disables the rule via
+ * {@code app.updateSetting("ruleEnabled", false)}, then calls
+ * {@code unsubscribe()} / {@code unschedule()} / {@code notifyLoopGuard()}.
+ *
+ * {@code now()} is fixed at {@code 1234567890000L} by the harness, so the
+ * "within window" math works off that constant. Specs seed
+ * {@code recentExecutions} relative to that value.
+ *
+ * {@code app.updateSetting("ruleEnabled", false)} writes to the shared
+ * {@link support.TestChildApp}'s {@code settingsStore} map — NOT to
+ * {@code settingsMap}. Specs verify via
+ * {@code appExecutor.getApp().settingsStore.ruleEnabled == false}.
+ */
+class LoopGuardSpec extends RuleHarnessSpec {
+
+    // The harness's fixed mocked now(), used to construct in-window timestamps.
+    private static final long FIXED_NOW = 1234567890000L
+
+    def "under threshold: rule executes and the exec timestamp is appended"() {
+        given:
+        settingsMap.ruleEnabled = true
+        settingsMap.ruleName = 'Rule Under Limit'
+        parent = new LoopGuardParent(settings: [loopGuardMax: 30, loopGuardWindowSec: 60])
+        atomicStateMap.conditions = []
+        atomicStateMap.actions = []
+        atomicStateMap.recentExecutions = []
+
+        when:
+        script.executeRule('test')
+
+        then: 'exec recorded, rule not disabled'
+        atomicStateMap.recentExecutions == [FIXED_NOW]
+        appExecutor.getApp().settingsStore.ruleEnabled != false
+    }
+
+    def "at threshold: rule auto-disables and unsubscribes / unschedules"() {
+        given:
+        settingsMap.ruleEnabled = true
+        settingsMap.ruleName = 'Rule Over Limit'
+        parent = new LoopGuardParent(settings: [loopGuardMax: 3, loopGuardWindowSec: 60])
+        atomicStateMap.conditions = []
+        atomicStateMap.actions = []
+        // Three in-window exec timestamps == loopGuardMax
+        atomicStateMap.recentExecutions = [
+            FIXED_NOW - 10_000L,
+            FIXED_NOW - 5_000L,
+            FIXED_NOW - 1_000L
+        ]
+
+        when:
+        script.executeRule('test')
+
+        then: 'auto-disable writes ruleEnabled=false on the app settings'
+        appExecutor.getApp().settingsStore.ruleEnabled == false
+
+        and: 'unsubscribe() and unschedule() both fire'
+        1 * appExecutor.unsubscribe()
+        1 * appExecutor.unschedule()
+
+        and: 'recentExecutions is cleared'
+        atomicStateMap.recentExecutions == []
+    }
+
+    def "window pruning: out-of-window entries do not count toward the threshold"() {
+        given:
+        settingsMap.ruleEnabled = true
+        settingsMap.ruleName = 'Rule Pruning'
+        parent = new LoopGuardParent(settings: [loopGuardMax: 3, loopGuardWindowSec: 60])
+        atomicStateMap.conditions = []
+        atomicStateMap.actions = []
+        // Three old (outside 60s window) + zero in-window → count is 0, not 3
+        atomicStateMap.recentExecutions = [
+            FIXED_NOW - 120_000L,
+            FIXED_NOW - 90_000L,
+            FIXED_NOW - 70_000L
+        ]
+
+        when:
+        script.executeRule('test')
+
+        then: 'rule still fires — old entries were pruned'
+        appExecutor.getApp().settingsStore.ruleEnabled != false
+        // Pruned + one new entry → just [FIXED_NOW]
+        atomicStateMap.recentExecutions == [FIXED_NOW]
+    }
+
+    def "custom loopGuardMax from parent.settings is honoured"() {
+        given: 'a tight loopGuardMax of 2'
+        settingsMap.ruleEnabled = true
+        settingsMap.ruleName = 'Tight Limit'
+        parent = new LoopGuardParent(settings: [loopGuardMax: 2, loopGuardWindowSec: 60])
+        atomicStateMap.conditions = []
+        atomicStateMap.actions = []
+        atomicStateMap.recentExecutions = [
+            FIXED_NOW - 5_000L,
+            FIXED_NOW - 1_000L
+        ]
+
+        when:
+        script.executeRule('test')
+
+        then: 'threshold of 2 triggers auto-disable'
+        appExecutor.getApp().settingsStore.ruleEnabled == false
+    }
+
+    /**
+     * Minimal loop-guard parent. {@code settings} map carries loopGuardMax
+     * and loopGuardWindowSec; {@code getSelectedDevices()} returns an empty
+     * list so {@code notifyLoopGuard} can finish without NPEs when the
+     * guard trips.
+     */
+    static class LoopGuardParent {
+        Map<String, Object> settings = [:]
+        List getSelectedDevices() { [] }
+    }
+}

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -127,6 +127,12 @@ abstract class RuleHarnessSpec extends Specification {
         testLocation.sunrise = null
         testLocation.sunset = null
         testLocation.hsmStatus = null
+        // Clear TestChildApp.settingsStore so auto-disable writes from a
+        // prior feature's loop-guard trip don't leak forward. The Mock's
+        // `>> new TestChildApp(...)` is evaluated once at construction, so
+        // the same instance is returned every call — mutations persist
+        // across tests without an explicit reset.
+        appExecutor.getApp().settingsStore.clear()
         // Propagate unconditionally so the script's parent exactly matches
         // a freshly-reset `_parent` (null) on entry to each test.
         // eighty20results' sandbox installs a default InstalledAppWrapperImpl

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -63,6 +63,25 @@ abstract class RuleHarnessSpec extends Specification {
      */
     @Shared protected final TestLocation testLocation = new TestLocation()
 
+    // Call recorders for AppExecutor methods the rule engine dispatches
+    // through @Delegate. Spock's interaction verification (`1 * appExecutor.foo(...)`)
+    // on a @Shared mock declared in given:/then: doesn't work reliably —
+    // stubs only apply when installed in setupSpec. Tests assert on these
+    // lists instead of using Spock interactions. All are cleared in setup().
+    @Shared protected final List<List<Object>> runInCalls = []
+    @Shared protected final List<List<Object>> runOnceCalls = []
+    @Shared protected final List<String> unscheduleCalls = []
+    @Shared protected int unsubscribeCount = 0
+    @Shared protected final List<Map> sendLocationEventCalls = []
+    @Shared protected final List<List<Object>> httpGetCalls = []
+    @Shared protected final List<List<Object>> httpPostCalls = []
+
+    // Mutable @Shared fields reading from tests' given: blocks. The stub
+    // closures in setupSpec read these at invocation time.
+    @Shared protected Boolean stubTimeOfDayResult = false
+    @Shared protected Map<String, Date> stubSunriseSunset = null
+    @Shared protected Throwable stubHttpGetException = null
+
     // Per-feature backing field — each test gets its own instance, so
     // resetting _parent to null in setup() guarantees isolation without
     // having to @Shared the state.
@@ -97,6 +116,27 @@ abstract class RuleHarnessSpec extends Specification {
             _ * now() >> 1234567890000L
             _ * getLog() >> sharedLog
         }
+        // Permanent recording stubs for AppExecutor methods the rule engine
+        // dispatches via @Delegate. Tests assert on the recorded *Calls lists
+        // (Spock's `1 * appExecutor.foo(...)` verification on a @Shared mock
+        // from given:/then: doesn't work reliably — stubs must live here to
+        // take effect). Mutable @Shared fields (stubTimeOfDayResult etc.) are
+        // read at invocation time so tests can drive behaviour per-feature.
+        appExecutor.runIn(*_) >> { args -> runInCalls << (args as List) }
+        appExecutor.runOnce(*_) >> { args -> runOnceCalls << (args as List) }
+        appExecutor.unsubscribe() >> { unsubscribeCount++ }
+        appExecutor.unschedule() >> { unscheduleCalls << null }
+        appExecutor.unschedule(_ as String) >> { args -> unscheduleCalls << (args[0] as String) }
+        appExecutor.sendLocationEvent(_) >> { args -> sendLocationEventCalls << (args[0] as Map) }
+        appExecutor.httpGet(_, _) >> { args ->
+            httpGetCalls << (args as List)
+            if (stubHttpGetException) throw stubHttpGetException
+        }
+        appExecutor.httpPost(_, _) >> { args -> httpPostCalls << (args as List) }
+        appExecutor.timeOfDayIsBetween(_, _, _) >> { args -> stubTimeOfDayResult }
+        appExecutor.timeOfDayIsBetween(_, _, _, _) >> { args -> stubTimeOfDayResult }
+        appExecutor.getSunriseAndSunset(_) >> { args -> stubSunriseSunset }
+        appExecutor.getSunriseAndSunset() >> { stubSunriseSunset }
         def validator = new PassThroughAppValidator([
             Flags.DontValidatePreferences,
             Flags.DontValidateDefinition,
@@ -133,6 +173,18 @@ abstract class RuleHarnessSpec extends Specification {
         // the same instance is returned every call — mutations persist
         // across tests without an explicit reset.
         appExecutor.getApp().settingsStore.clear()
+        // Reset AppExecutor call recorders + stub-driver fields so they
+        // don't leak between feature methods.
+        runInCalls.clear()
+        runOnceCalls.clear()
+        unscheduleCalls.clear()
+        unsubscribeCount = 0
+        sendLocationEventCalls.clear()
+        httpGetCalls.clear()
+        httpPostCalls.clear()
+        stubTimeOfDayResult = false
+        stubSunriseSunset = null
+        stubHttpGetException = null
         // Propagate unconditionally so the script's parent exactly matches
         // a freshly-reset `_parent` (null) on entry to each test.
         // eighty20results' sandbox installs a default InstalledAppWrapperImpl

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -70,6 +70,11 @@ abstract class RuleHarnessSpec extends Specification {
     // lists instead of using Spock interactions. All are cleared in setup().
     @Shared protected final List<List<Object>> runInCalls = []
     @Shared protected final List<List<Object>> runOnceCalls = []
+    // Split to disambiguate no-arg `unschedule()` (blanket cancel, everything)
+    // from targeted `unschedule('handlerName')` — the engine uses both and
+    // lumping them together would let a regression swap one for the other
+    // without any assertion failing.
+    @Shared protected int unscheduleAllCount = 0
     @Shared protected final List<String> unscheduleCalls = []
     @Shared protected int unsubscribeCount = 0
     @Shared protected final List<Map> sendLocationEventCalls = []
@@ -125,7 +130,7 @@ abstract class RuleHarnessSpec extends Specification {
         appExecutor.runIn(*_) >> { args -> runInCalls << (args as List) }
         appExecutor.runOnce(*_) >> { args -> runOnceCalls << (args as List) }
         appExecutor.unsubscribe() >> { unsubscribeCount++ }
-        appExecutor.unschedule() >> { unscheduleCalls << null }
+        appExecutor.unschedule() >> { unscheduleAllCount++ }
         appExecutor.unschedule(_ as String) >> { args -> unscheduleCalls << (args[0] as String) }
         appExecutor.sendLocationEvent(_) >> { args -> sendLocationEventCalls << (args[0] as Map) }
         appExecutor.httpGet(_, _) >> { args ->
@@ -177,6 +182,7 @@ abstract class RuleHarnessSpec extends Specification {
         // don't leak between feature methods.
         runInCalls.clear()
         runOnceCalls.clear()
+        unscheduleAllCount = 0
         unscheduleCalls.clear()
         unsubscribeCount = 0
         sendLocationEventCalls.clear()

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -1,7 +1,6 @@
 package rules
 
 import me.biocomp.hubitat_ci.api.app_api.AppExecutor
-import me.biocomp.hubitat_ci.api.common_api.Location
 import me.biocomp.hubitat_ci.app.HubitatAppSandbox
 import me.biocomp.hubitat_ci.validation.Flags
 import spock.lang.Shared
@@ -9,6 +8,7 @@ import spock.lang.Specification
 import support.PassThroughAppValidator
 import support.PermissiveLog
 import support.TestChildApp
+import support.TestLocation
 
 /**
  * Loads hubitat-mcp-rule.groovy (the rule-engine child app — separate
@@ -54,6 +54,14 @@ abstract class RuleHarnessSpec extends Specification {
     @Shared protected final Map atomicStateMap = [:]
     // Must be non-empty at sandbox.run() time — see HarnessSpec.
     @Shared protected final Map settingsMap = [_harness: true]
+    /**
+     * Shared Location stub returned by the AppExecutor mock. Mutable fields
+     * (`mode`, `sunrise`, `sunset`, `hsmStatus`) are reset in {@code setup()}
+     * so per-test state does not leak across feature methods. Specs that
+     * need to drive these in {@code given:} set them directly on this
+     * instance (e.g. {@code testLocation.mode = 'Night'}).
+     */
+    @Shared protected final TestLocation testLocation = new TestLocation()
 
     // Per-feature backing field — each test gets its own instance, so
     // resetting _parent to null in setup() guarantees isolation without
@@ -81,13 +89,11 @@ abstract class RuleHarnessSpec extends Specification {
             // unconditionally; provide non-null stubs typed to the interface
             // Spock expects (raw Map returns trip a GroovyCastException).
             _ * getApp() >> new TestChildApp(id: 1L, label: 'TestRuleApp')
-            _ * getLocation() >> ([
-                getMode    : { -> 'Home' },
-                getCurrentMode: { -> null },
-                getModes   : { -> [] },
-                getName    : { -> 'TestLocation' },
-                getId      : { -> 1L }
-            ] as Location)
+            // Shared TestLocation — mutable fields (mode, sunrise, sunset,
+            // hsmStatus) reset in setup(), so specs can drive them per-test
+            // without the closure-based Map-as-Location trick from the original
+            // harness (which returned a fresh frozen view on every call).
+            _ * getLocation() >> testLocation
             _ * now() >> 1234567890000L
             _ * getLog() >> sharedLog
         }
@@ -114,6 +120,13 @@ abstract class RuleHarnessSpec extends Specification {
         atomicStateMap.clear()
         settingsMap.clear()
         settingsMap._harness = true
+        // Reset the shared TestLocation's mutable fields so a spec that mutates
+        // mode / sunrise / hsmStatus doesn't leak state into the next feature.
+        testLocation.setMode('Home')
+        testLocation.modeSetCalls.clear()
+        testLocation.sunrise = null
+        testLocation.sunset = null
+        testLocation.hsmStatus = null
         // Propagate unconditionally so the script's parent exactly matches
         // a freshly-reset `_parent` (null) on entry to each test.
         // eighty20results' sandbox installs a default InstalledAppWrapperImpl

--- a/src/test/groovy/rules/TriggerBreadthSpec.groovy
+++ b/src/test/groovy/rules/TriggerBreadthSpec.groovy
@@ -83,7 +83,7 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
     def "handleSunriseEvent fires the rule and reschedules the next sunrise"() {
         given: 'a future sunrise supplied via the mocked getSunriseAndSunset'
         def tomorrow = new Date(System.currentTimeMillis() + 86_400_000L)
-        _ * appExecutor.getSunriseAndSunset(_) >> [sunrise: tomorrow, sunset: tomorrow]
+        stubSunriseSunset = [sunrise: tomorrow, sunset: tomorrow]
 
         and:
         settingsMap.ruleEnabled = true
@@ -175,7 +175,9 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
         ])
 
         then:
-        1 * appExecutor.runIn(30L, 'checkDurationTrigger', _)
+        runInCalls.size() == 1
+        runInCalls[0][0] == 30L
+        runInCalls[0][1] == 'checkDurationTrigger'
         0 * target.on()
         atomicStateMap.durationTimers?.size() == 1
     }
@@ -268,7 +270,7 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
         ])
 
         then: 'no new timer scheduled, no rule fire'
-        0 * appExecutor.runIn(_, 'checkDurationTrigger', _)
+        runInCalls.findAll { it[1] == 'checkDurationTrigger' } == []
         0 * target.on()
     }
 

--- a/src/test/groovy/rules/TriggerBreadthSpec.groovy
+++ b/src/test/groovy/rules/TriggerBreadthSpec.groovy
@@ -9,9 +9,10 @@ import support.TestDevice
  * <ul>
  *   <li>Time-based triggers — {@code handleTimeEvent},
  *       {@code handleSunriseEvent}, {@code handleSunsetEvent}.
- *       Sun handlers reschedule via {@code runInMillis}; tests stub
- *       {@code getSunriseAndSunset()} to a future time so the rescheduler
- *       takes the happy path and the rule actions still fire.</li>
+ *       Sun handlers reschedule via {@code runOnce(sunDate, handlerName, ...)};
+ *       tests stub {@code getSunriseAndSunset()} to a future time so the
+ *       rescheduler takes the happy path and the rule actions still fire.
+ *       Reschedule is asserted via {@code runOnceCalls}.</li>
  *   <li>Multi-device {@code matchMode="all"} — the rule only fires when
  *       every device in {@code deviceIds} currently matches the target
  *       value (checked via {@code checkAllDevicesMatch}).</li>
@@ -96,8 +97,32 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
         when:
         script.handleSunriseEvent()
 
+        then: 'the rule fired and the next sunrise was rescheduled via runOnce'
+        1 * target.on()
+        runOnceCalls.size() == 1
+        runOnceCalls[0][1] == 'handleSunriseEvent'
+    }
+
+    def "handleSunsetEvent fires the rule and reschedules the next sunset"() {
+        given:
+        def tomorrow = new Date(System.currentTimeMillis() + 86_400_000L)
+        stubSunriseSunset = [sunrise: tomorrow, sunset: tomorrow]
+
+        and:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 1 }
+        parent = new TriggerParent(devices: [1L: target])
+
+        atomicStateMap.triggers = [[type: 'time', sunset: true, offset: 0]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 1L, command: 'on']]
+
+        when:
+        script.handleSunsetEvent()
+
         then:
         1 * target.on()
+        runOnceCalls.size() == 1
+        runOnceCalls[0][1] == 'handleSunsetEvent'
     }
 
     // -------- multi-device "all" matchMode --------
@@ -108,10 +133,7 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
         def a = new TestDevice(id: 10, label: 'A', attributeValues: [switch: 'on'])
         def b = new TestDevice(id: 11, label: 'B', attributeValues: [switch: 'on'])
         def target = Spy(TestDevice) { getId() >> 99 }
-        // Parent resolves deviceIds both by Long (evaluateCondition path) and by
-        // String (checkAllDevicesMatch uses devId.toString()).
-        parent = new StringOrLongTriggerParent(
-            devices: [10L: a, 11L: b, 99L: target])
+        parent = new TriggerParent(devices: [10L: a, 11L: b, 99L: target])
 
         atomicStateMap.triggers = [[
             type: 'device_event', deviceIds: ['10', '11'],
@@ -135,8 +157,7 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
         def a = new TestDevice(id: 10, label: 'A', attributeValues: [switch: 'on'])
         def b = new TestDevice(id: 11, label: 'B', attributeValues: [switch: 'off']) // lagging
         def target = Spy(TestDevice) { getId() >> 99 }
-        parent = new StringOrLongTriggerParent(
-            devices: [10L: a, 11L: b, 99L: target])
+        parent = new TriggerParent(devices: [10L: a, 11L: b, 99L: target])
 
         atomicStateMap.triggers = [[
             type: 'device_event', deviceIds: ['10', '11'],
@@ -226,6 +247,35 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
 
         then:
         0 * target.on()
+    }
+
+    def "checkDurationTrigger does not fire when the condition is no longer met; clears the timer"() {
+        given: 'timer exists, but the device now reads inactive instead of active'
+        settingsMap.ruleEnabled = true
+        def sensor = new TestDevice(id: 1, label: 'Motion',
+            attributeValues: [motion: 'inactive'])
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [1L: sensor, 99L: target])
+
+        def trigger = [type: 'device_event', deviceId: 1L,
+                       attribute: 'motion', value: 'active', duration: 30]
+        atomicStateMap.triggers = [trigger]
+        atomicStateMap.durationTimers = [
+            'duration_1_motion': [startTime: 0L, trigger: trigger]
+        ]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.checkDurationTrigger([
+            triggerKey: 'duration_1_motion',
+            deviceLabel: 'Motion', attribute: 'motion'
+        ])
+
+        then: 'no rule fire, and the timer is removed'
+        0 * target.on()
+        atomicStateMap.durationTimers == [:]
+        // durationFired stays empty — this path does not set the fired flag
+        !atomicStateMap.durationFired
     }
 
     def "duration trigger: does not re-fire while durationFired flag is set"() {
@@ -450,6 +500,32 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
         1 * target.on()
     }
 
+    def "per-trigger condition gate fails closed when the inline condition throws"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        // ThrowingTriggerParent.findDevice throws — the device_state condition
+        // will hit the try/catch inside evaluateTriggerCondition and return false.
+        parent = new ThrowingTriggerParent()
+
+        atomicStateMap.triggers = [[
+            type: 'device_event', deviceId: '1',
+            attribute: 'switch', value: 'on',
+            condition: [type: 'device_state', deviceId: 1L,
+                        attribute: 'switch', operator: 'equals', value: 'on']
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'off']]
+
+        when:
+        script.handleDeviceEvent([
+            device: [id: 1, label: 'Switch'],
+            name: 'switch', value: 'on'
+        ])
+
+        then: 'the caught exception yields false → rule does not fire'
+        0 * target.off()
+    }
+
     def "per-trigger condition gate allows execution when the inline condition passes"() {
         given:
         settingsMap.ruleEnabled = true
@@ -475,7 +551,12 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
         1 * target.off()
     }
 
-    /** findDevice coerces id to Long — works for trigger-action deviceId values. */
+    /**
+     * findDevice coerces id to Long. Handles numeric Strings (e.g. '10' from
+     * checkAllDevicesMatch's {@code devId.toString()} call site) via Groovy's
+     * {@code "10" as Long} conversion. Non-numeric strings would throw
+     * NumberFormatException — tests in this spec only use numeric IDs.
+     */
     static class TriggerParent {
         Map<Long, TestDevice> devices = [:]
         Map settings = [:]
@@ -483,17 +564,14 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
     }
 
     /**
-     * checkAllDevicesMatch passes {@code devId.toString()} to findDevice,
-     * so a pure Long-keyed parent misses. This stub coerces any input
-     * (String or Integer or Long) to Long before looking up.
+     * findDevice stub that always throws — used to exercise
+     * {@code evaluateTriggerCondition}'s catch branch (fail-closed on
+     * inline-condition evaluator exceptions).
      */
-    static class StringOrLongTriggerParent {
-        Map<Long, TestDevice> devices = [:]
+    static class ThrowingTriggerParent {
         Map settings = [:]
         Object findDevice(id) {
-            if (id == null) return null
-            try { return devices[(id.toString() as Long)] }
-            catch (NumberFormatException ignored) { return null }
+            throw new RuntimeException('simulated findDevice failure')
         }
     }
 }

--- a/src/test/groovy/rules/TriggerBreadthSpec.groovy
+++ b/src/test/groovy/rules/TriggerBreadthSpec.groovy
@@ -182,28 +182,6 @@ class TriggerBreadthSpec extends RuleHarnessSpec {
         atomicStateMap.durationTimers?.size() == 1
     }
 
-    def "duration trigger: timer-cancel path clears the timer when condition goes false"() {
-        given: 'a timer is already pending for this device/attribute'
-        settingsMap.ruleEnabled = true
-        atomicStateMap.triggers = [[
-            type: 'device_event', deviceId: '1',
-            attribute: 'motion', value: 'active', duration: 30
-        ]]
-        atomicStateMap.durationTimers = [
-            'duration_1_motion': [startTime: 0L, trigger: atomicStateMap.triggers[0]]
-        ]
-        atomicStateMap.actions = []
-
-        when: 'a mismatching event arrives (value is now inactive)'
-        script.handleDeviceEvent([
-            device: [id: 1, label: 'Motion'],
-            name: 'motion', value: 'inactive'
-        ])
-
-        then: 'the timer entry is removed'
-        atomicStateMap.durationTimers == [:]
-    }
-
     def "checkDurationTrigger fires the rule when the condition is still met"() {
         given: 'the trigger is stored in durationTimers as if a timer had been armed'
         settingsMap.ruleEnabled = true

--- a/src/test/groovy/rules/TriggerBreadthSpec.groovy
+++ b/src/test/groovy/rules/TriggerBreadthSpec.groovy
@@ -1,0 +1,519 @@
+package rules
+
+import support.TestDevice
+
+/**
+ * Breadth coverage for trigger-side behaviour beyond {@link HandleDeviceEventSpec}'s
+ * basic device-event matching. Covers (#75):
+ *
+ * <ul>
+ *   <li>Time-based triggers — {@code handleTimeEvent},
+ *       {@code handleSunriseEvent}, {@code handleSunsetEvent}.
+ *       Sun handlers reschedule via {@code runInMillis}; tests stub
+ *       {@code getSunriseAndSunset()} to a future time so the rescheduler
+ *       takes the happy path and the rule actions still fire.</li>
+ *   <li>Multi-device {@code matchMode="all"} — the rule only fires when
+ *       every device in {@code deviceIds} currently matches the target
+ *       value (checked via {@code checkAllDevicesMatch}).</li>
+ *   <li>Duration triggers — {@code handleDeviceEvent} schedules
+ *       {@code checkDurationTrigger} via {@code runIn}; the delayed
+ *       check re-validates the device state and fires the rule if still met.
+ *       Re-arm semantics verified: once a duration trigger fires, it is
+ *       gated by {@code atomicState.durationFired} until the condition
+ *       goes false again.</li>
+ *   <li>Per-trigger condition gates — {@code evaluateTriggerCondition}
+ *       blocks rule execution when the inline condition misses.</li>
+ * </ul>
+ *
+ * Handler entry points are called directly (bypassing subscribe()), so
+ * these specs do not exercise {@code subscribeToTriggers} registration.
+ */
+class TriggerBreadthSpec extends RuleHarnessSpec {
+
+    // -------- handleTimeEvent --------
+
+    def "handleTimeEvent fires the rule when enabled and a time trigger exists"() {
+        given:
+        settingsMap.ruleEnabled = true
+        settingsMap.ruleName = 'Test Rule'
+        def target = Spy(TestDevice) { getId() >> 1 }
+        parent = new TriggerParent(devices: [1L: target])
+
+        and:
+        atomicStateMap.triggers = [[type: 'time', time: '08:00']]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 1L, command: 'on']]
+
+        when:
+        script.handleTimeEvent()
+
+        then:
+        1 * target.on()
+    }
+
+    def "handleTimeEvent is a no-op when ruleEnabled is false"() {
+        given:
+        settingsMap.ruleEnabled = false
+        def target = Spy(TestDevice) { getId() >> 1 }
+        parent = new TriggerParent(devices: [1L: target])
+        atomicStateMap.triggers = [[type: 'time', time: '08:00']]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 1L, command: 'on']]
+
+        when:
+        script.handleTimeEvent()
+
+        then:
+        0 * target.on()
+    }
+
+    def "handleTimeEvent is a no-op when no matching time trigger is configured"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 1 }
+        parent = new TriggerParent(devices: [1L: target])
+        atomicStateMap.triggers = [[type: 'device_event', deviceId: '1', attribute: 'switch']]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 1L, command: 'on']]
+
+        when:
+        script.handleTimeEvent()
+
+        then:
+        0 * target.on()
+    }
+
+    def "handleSunriseEvent fires the rule and reschedules the next sunrise"() {
+        given: 'a future sunrise supplied via the mocked getSunriseAndSunset'
+        def tomorrow = new Date(System.currentTimeMillis() + 86_400_000L)
+        _ * appExecutor.getSunriseAndSunset(_) >> [sunrise: tomorrow, sunset: tomorrow]
+
+        and:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 1 }
+        parent = new TriggerParent(devices: [1L: target])
+
+        atomicStateMap.triggers = [[type: 'time', sunrise: true, offset: 0]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 1L, command: 'on']]
+
+        when:
+        script.handleSunriseEvent()
+
+        then:
+        1 * target.on()
+    }
+
+    // -------- multi-device "all" matchMode --------
+
+    def "matchMode='all' fires when every device in deviceIds currently matches"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def a = new TestDevice(id: 10, label: 'A', attributeValues: [switch: 'on'])
+        def b = new TestDevice(id: 11, label: 'B', attributeValues: [switch: 'on'])
+        def target = Spy(TestDevice) { getId() >> 99 }
+        // Parent resolves deviceIds both by Long (evaluateCondition path) and by
+        // String (checkAllDevicesMatch uses devId.toString()).
+        parent = new StringOrLongTriggerParent(
+            devices: [10L: a, 11L: b, 99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'device_event', deviceIds: ['10', '11'],
+            attribute: 'switch', value: 'on', matchMode: 'all'
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'off']]
+
+        when:
+        script.handleDeviceEvent([
+            device: [id: 10, label: 'A'],
+            name: 'switch', value: 'on'
+        ])
+
+        then:
+        1 * target.off()
+    }
+
+    def "matchMode='all' does not fire when one device still reports the wrong value"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def a = new TestDevice(id: 10, label: 'A', attributeValues: [switch: 'on'])
+        def b = new TestDevice(id: 11, label: 'B', attributeValues: [switch: 'off']) // lagging
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new StringOrLongTriggerParent(
+            devices: [10L: a, 11L: b, 99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'device_event', deviceIds: ['10', '11'],
+            attribute: 'switch', value: 'on', matchMode: 'all'
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'off']]
+
+        when: 'device A fires its event but B is still off'
+        script.handleDeviceEvent([
+            device: [id: 10, label: 'A'],
+            name: 'switch', value: 'on'
+        ])
+
+        then:
+        0 * target.off()
+    }
+
+    // -------- duration triggers --------
+
+    def "duration trigger schedules checkDurationTrigger via runIn (not immediate fire)"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'device_event', deviceId: '1',
+            attribute: 'motion', value: 'active', duration: 30
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handleDeviceEvent([
+            device: [id: 1, label: 'Motion'],
+            name: 'motion', value: 'active'
+        ])
+
+        then:
+        1 * appExecutor.runIn(30L, 'checkDurationTrigger', _)
+        0 * target.on()
+        atomicStateMap.durationTimers?.size() == 1
+    }
+
+    def "duration trigger: timer-cancel path clears the timer when condition goes false"() {
+        given: 'a timer is already pending for this device/attribute'
+        settingsMap.ruleEnabled = true
+        atomicStateMap.triggers = [[
+            type: 'device_event', deviceId: '1',
+            attribute: 'motion', value: 'active', duration: 30
+        ]]
+        atomicStateMap.durationTimers = [
+            'duration_1_motion': [startTime: 0L, trigger: atomicStateMap.triggers[0]]
+        ]
+        atomicStateMap.actions = []
+
+        when: 'a mismatching event arrives (value is now inactive)'
+        script.handleDeviceEvent([
+            device: [id: 1, label: 'Motion'],
+            name: 'motion', value: 'inactive'
+        ])
+
+        then: 'the timer entry is removed'
+        atomicStateMap.durationTimers == [:]
+    }
+
+    def "checkDurationTrigger fires the rule when the condition is still met"() {
+        given: 'the trigger is stored in durationTimers as if a timer had been armed'
+        settingsMap.ruleEnabled = true
+        settingsMap.ruleName = 'Duration Rule'
+        def sensor = new TestDevice(id: 1, label: 'Motion',
+            attributeValues: [motion: 'active'])
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [1L: sensor, 99L: target])
+
+        def trigger = [type: 'device_event', deviceId: 1L,
+                       attribute: 'motion', value: 'active', duration: 30]
+        atomicStateMap.triggers = [trigger]
+        atomicStateMap.durationTimers = [
+            'duration_1_motion': [startTime: 0L, trigger: trigger]
+        ]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.checkDurationTrigger([
+            triggerKey: 'duration_1_motion',
+            deviceLabel: 'Motion', attribute: 'motion'
+        ])
+
+        then:
+        1 * target.on()
+        atomicStateMap.durationFired['duration_1_motion'] == true
+    }
+
+    def "checkDurationTrigger does not fire when the timer has already been cancelled"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+        atomicStateMap.durationTimers = [:]  // no pending timer
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.checkDurationTrigger([
+            triggerKey: 'duration_1_motion',
+            deviceLabel: 'Motion', attribute: 'motion'
+        ])
+
+        then:
+        0 * target.on()
+    }
+
+    def "duration trigger: does not re-fire while durationFired flag is set"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'device_event', deviceId: '1',
+            attribute: 'motion', value: 'active', duration: 30
+        ]]
+        atomicStateMap.durationFired = ['duration_1_motion': true]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handleDeviceEvent([
+            device: [id: 1, label: 'Motion'],
+            name: 'motion', value: 'active'
+        ])
+
+        then: 'no new timer scheduled, no rule fire'
+        0 * appExecutor.runIn(_, 'checkDurationTrigger', _)
+        0 * target.on()
+    }
+
+    // -------- per-trigger condition gate --------
+
+    def "per-trigger condition gate blocks execution when the inline condition misses"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        // No local variable 'armed' → variable condition misses → gate fails.
+        atomicStateMap.localVariables = [:]
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'device_event', deviceId: '1',
+            attribute: 'switch', value: 'on',
+            condition: [type: 'variable', variableName: 'armed',
+                        operator: 'equals', value: 'true']
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'off']]
+
+        when:
+        script.handleDeviceEvent([
+            device: [id: 1, label: 'Switch'],
+            name: 'switch', value: 'on'
+        ])
+
+        then:
+        0 * target.off()
+    }
+
+    // -------- button / periodic / mode / HSM handlers --------
+
+    def "handleButtonEvent fires the rule when deviceId + action + buttonNumber all match"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'button_event', deviceId: '5', action: 'pushed', buttonNumber: 2
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handleButtonEvent([
+            device: [id: 5, label: 'Remote'],
+            name: 'pushed', value: '2'
+        ])
+
+        then:
+        1 * target.on()
+    }
+
+    def "handleButtonEvent ignores buttonNumber mismatch"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'button_event', deviceId: '5', action: 'pushed', buttonNumber: 2
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when: 'same device/action but a different button'
+        script.handleButtonEvent([
+            device: [id: 5, label: 'Remote'],
+            name: 'pushed', value: '3'
+        ])
+
+        then:
+        0 * target.on()
+    }
+
+    def "handleButtonEvent with null buttonNumber matches any button"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'button_event', deviceId: '5', action: 'pushed', buttonNumber: null
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handleButtonEvent([
+            device: [id: 5, label: 'Remote'],
+            name: 'pushed', value: '7'
+        ])
+
+        then:
+        1 * target.on()
+    }
+
+    def "handlePeriodicEvent fires a type='periodic' trigger"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[type: 'periodic']]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handlePeriodicEvent()
+
+        then:
+        1 * target.on()
+    }
+
+    def "handlePeriodicEvent is a no-op when no periodic trigger is configured"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[type: 'time', time: '08:00']]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handlePeriodicEvent()
+
+        then:
+        0 * target.on()
+    }
+
+    def "handleModeEvent matches toMode and updates state.previousMode"() {
+        given:
+        settingsMap.ruleEnabled = true
+        stateMap.previousMode = 'Home'
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'mode_change', toMode: 'Night'
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handleModeEvent([name: 'mode', value: 'Night'])
+
+        then:
+        1 * target.on()
+        stateMap.previousMode == 'Night'
+    }
+
+    def "handleModeEvent fromMode filter: non-matching previous mode blocks the fire"() {
+        given:
+        settingsMap.ruleEnabled = true
+        stateMap.previousMode = 'Night'  // trigger expects fromMode='Home'
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'mode_change', toMode: 'Away', fromMode: 'Home'
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handleModeEvent([name: 'mode', value: 'Away'])
+
+        then:
+        0 * target.on()
+        // state.previousMode is unconditionally updated even when the trigger doesn't fire
+        stateMap.previousMode == 'Away'
+    }
+
+    def "handleHsmEvent matches hsm_change triggers with a specific status"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[type: 'hsm_change', status: 'armedAway']]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handleHsmEvent([name: 'hsmStatus', value: 'armedAway'])
+
+        then:
+        1 * target.on()
+    }
+
+    def "handleHsmEvent with no status filter matches any HSM change"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[type: 'hsm_change']]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'on']]
+
+        when:
+        script.handleHsmEvent([name: 'hsmStatus', value: 'disarmed'])
+
+        then:
+        1 * target.on()
+    }
+
+    def "per-trigger condition gate allows execution when the inline condition passes"() {
+        given:
+        settingsMap.ruleEnabled = true
+        def target = Spy(TestDevice) { getId() >> 99 }
+        atomicStateMap.localVariables = [armed: 'true']
+        parent = new TriggerParent(devices: [99L: target])
+
+        atomicStateMap.triggers = [[
+            type: 'device_event', deviceId: '1',
+            attribute: 'switch', value: 'on',
+            condition: [type: 'variable', variableName: 'armed',
+                        operator: 'equals', value: 'true']
+        ]]
+        atomicStateMap.actions = [[type: 'device_command', deviceId: 99L, command: 'off']]
+
+        when:
+        script.handleDeviceEvent([
+            device: [id: 1, label: 'Switch'],
+            name: 'switch', value: 'on'
+        ])
+
+        then:
+        1 * target.off()
+    }
+
+    /** findDevice coerces id to Long — works for trigger-action deviceId values. */
+    static class TriggerParent {
+        Map<Long, TestDevice> devices = [:]
+        Map settings = [:]
+        Object findDevice(id) { devices[(id as Long)] }
+    }
+
+    /**
+     * checkAllDevicesMatch passes {@code devId.toString()} to findDevice,
+     * so a pure Long-keyed parent misses. This stub coerces any input
+     * (String or Integer or Long) to Long before looking up.
+     */
+    static class StringOrLongTriggerParent {
+        Map<Long, TestDevice> devices = [:]
+        Map settings = [:]
+        Object findDevice(id) {
+            if (id == null) return null
+            try { return devices[(id.toString() as Long)] }
+            catch (NumberFormatException ignored) { return null }
+        }
+    }
+}

--- a/src/test/groovy/support/TestDevice.groovy
+++ b/src/test/groovy/support/TestDevice.groovy
@@ -26,14 +26,57 @@ class TestDevice {
     // a list of maps like [[name: 'switch', value: 'on']].
     List currentStates = null
 
+    // Events returned by eventsSince(). Default [] keeps existing specs green;
+    // rule-engine device_was tests seed this with maps like
+    // [[name: 'switch', value: 'on'], ...] to drive the lookback check.
+    List events = []
+
     Object currentValue(String attr) {
         attributeValues[attr]
+    }
+
+    /**
+     * Stubbed device event history — rule engine's device_was condition
+     * filters by attribute and looks for recent value changes. Tests seed
+     * {@code events} with the history they want the condition to see.
+     * The {@code since} and {@code opts} params are ignored here (we return
+     * the full seeded list); filtering happens in the rule engine's own
+     * `.findAll { it.name == ... }` over the returned list.
+     */
+    List eventsSince(Date since, Map opts = null) {
+        return events
     }
 
     void on() { invokeCommand('on', []) }
     void off() { invokeCommand('off', []) }
     void setLevel(Integer level) { invokeCommand('setLevel', [level]) }
     void setLevel(Integer level, Integer duration) { invokeCommand('setLevel', [level, duration]) }
+
+    // Command surface used by rule-engine action specs (#75). Each delegates
+    // to invokeCommand so Spy(TestDevice) { 1 * setColor(_) } still works,
+    // and so any not-yet-mocked spec doesn't blow up on the dynamic dispatch
+    // `device."${action.command}"(...)` path the rule engine uses.
+    void setColor(Map colorMap) { invokeCommand('setColor', [colorMap]) }
+    void setColorTemperature(Integer temp) { invokeCommand('setColorTemperature', [temp]) }
+    void setColorTemperature(Integer temp, Integer level) { invokeCommand('setColorTemperature', [temp, level]) }
+    void lock() { invokeCommand('lock', []) }
+    void unlock() { invokeCommand('unlock', []) }
+    void deviceNotification(String msg) { invokeCommand('deviceNotification', [msg]) }
+    void setThermostatMode(String mode) { invokeCommand('setThermostatMode', [mode]) }
+    void setHeatingSetpoint(def value) { invokeCommand('setHeatingSetpoint', [value]) }
+    void setCoolingSetpoint(def value) { invokeCommand('setCoolingSetpoint', [value]) }
+    void setThermostatFanMode(String mode) { invokeCommand('setThermostatFanMode', [mode]) }
+    void setVolume(Integer volume) { invokeCommand('setVolume', [volume]) }
+    void speak(String msg) { invokeCommand('speak', [msg]) }
+    void open() { invokeCommand('open', []) }
+    void close() { invokeCommand('close', []) }
+    void setPosition(Integer position) { invokeCommand('setPosition', [position]) }
+    void setSpeed(String speed) { invokeCommand('setSpeed', [speed]) }
+
+    /** Capability check for capture_state action (filters which attrs to snapshot). */
+    boolean hasCapability(String cap) { capabilities?.contains(cap) }
+    /** Command-presence check for loop-guard notifyLoopGuard fallback. */
+    boolean hasCommand(String cmd) { supportedCommands?.contains(cmd) }
 
     /** Override via Spy or subclass to observe command dispatch. */
     void invokeCommand(String commandName, List args) {}

--- a/src/test/groovy/support/TestLocation.groovy
+++ b/src/test/groovy/support/TestLocation.groovy
@@ -10,19 +10,49 @@ import me.biocomp.hubitat_ci.api.common_api.Location
  * with default null/zero returns — tests override the handful of methods they care about
  * by constructing instances or assigning to `hub` directly.
  *
- * `hub` is typed as {@link Hub} so Groovy auto-generates a {@code Hub getHub()} that
- * satisfies the interface (a raw {@code def hub} generates {@code Object getHub()} and
- * fails to override the interface method). Tests assign a {@link TestHub} instance
- * with the fields their tool under test reads (e.g. {@code zwaveVersion}, {@code uptime}).
+ * Rule-engine specs (issue #75) additionally read/mutate {@code mode},
+ * {@code sunrise}, {@code sunset}, and {@code hsmStatus}. {@code hsmStatus} is
+ * not declared on HubitatCI's {@code Location} interface, but real Hubitat
+ * exposes it dynamically; Groovy property dispatch resolves the field on this
+ * class at runtime. The {@code set_mode} action calls {@code setMode(...)} on
+ * the Location, so setMode captures invocations into {@code modeSetCalls} for
+ * spec assertions without relying on Spock interaction counts on a
+ * delegated-property accessor.
+ *
+ * {@code hub} is typed as {@link Hub} so Groovy auto-generates a {@code Hub getHub()}
+ * that satisfies the interface (a raw {@code def hub} generates
+ * {@code Object getHub()} and fails to override the interface method). Tests assign
+ * a {@link TestHub} instance with the fields their tool under test reads (e.g.
+ * {@code zwaveVersion}, {@code uptime}).
  */
 @AutoImplement
 class TestLocation implements Location {
     /** Populated by tests; read by the server via `location.hub`. */
     Hub hub
 
-    // Common overrides with sensible defaults — tests can override per-instance
-    // via `metaClass.getMode = { -> 'Night' }` when they need to.
-    @Override String getMode() { 'Home' }
+    // Backing field for mode so getMode/setMode can be implemented explicitly
+    // (the interface declares both, and capturing setMode calls requires
+    // the hand-written setter below).
+    private String _mode = 'Home'
+
+    /** setMode() invocations recorded for set_mode action assertions. */
+    List<String> modeSetCalls = []
+
+    /** Mutable — specs assign in given: to drive sun_position / time-related logic. */
+    Date sunrise
+
+    /** Mutable — specs assign in given: to drive sun_position / time-related logic. */
+    Date sunset
+
+    /**
+     * Mutable. Not declared on the Location interface, but `location.hsmStatus`
+     * in the rule engine resolves via Groovy property dispatch on the concrete
+     * object, which finds this field.
+     */
+    String hsmStatus
+
+    @Override String getMode() { _mode }
+    @Override void setMode(String m) { _mode = m; modeSetCalls << m }
     @Override String getName() { 'TestLocation' }
     @Override Long getId() { 1L }
 }


### PR DESCRIPTION
## Summary
- Adds the rule-engine test coverage outlined in #75, building on primitive-specs PR #98 and the harness work in #100 / #104.
- 5 new spec classes + short-circuit additions to `EvaluateConditionsSpec` + additive harness extensions.
- ~75 Spock feature methods covering every trigger handler, condition type, action type, loop-guard path, and error path the rule engine exposes.

## Changes
Closes #75.

**New specs**
- `ConditionTypesSpec` — 12 non-primitive condition types: mode, time_range, days_of_week, sun_position, hsm_status, device_was, presence, lock, thermostat_mode, thermostat_state, illuminance, power.
- `ActionTypesSpec` — every non-primitive action type: toggle_device, set_level (clamp + duration overload), lock/unlock, set_color, set_color_temperature, activate_scene, send_notification, speak, set_valve, set_fan_speed, set_shade, set_thermostat, set_mode, set_hsm, set_local_variable, set_variable, variable_math (local + global + divide-by-zero), delay, cancel_delayed (all vs. specific), if_then_else, repeat (clamp), capture_state/restore_state, http_request (GET/POST/exception continuity), log, comment, unknown-type no-op.
- `TriggerBreadthSpec` — every rule-engine event handler: `handleTimeEvent`, `handleSunriseEvent` (stubbed `getSunriseAndSunset`), `handleButtonEvent` (deviceId+action+buttonNumber, mismatch, null-button wildcard), `handlePeriodicEvent` (match/no-match), `handleModeEvent` (toMode + fromMode + `state.previousMode` update), `handleHsmEvent` (status filter + wildcard), `matchMode="all"` multi-device, duration triggers (schedule + re-arm + timer-cancel), per-trigger condition gate.
- `LoopGuardSpec` — executeRule's threshold, window pruning, auto-disable writes `ruleEnabled=false` + calls `unsubscribe()`/`unschedule()`, custom `loopGuardMax` honoured.
- `ErrorPathsSpec` — missing-device warn+continue, thrown-command caught, `set_thermostat` per-setter failure swallowed, unknown condition/action types, set_mode/set_hsm missing-field stops the chain.

**Short-circuit additions** to `EvaluateConditionsSpec` with a `CountingParent` that records `findDevice` calls — verifies all-logic stops at first false and any-logic stops at first true.

**Harness extensions (additive)**
- `TestLocation` gains mutable `mode` / `sunrise` / `sunset` / `hsmStatus` fields + `setMode()` call log. `hsmStatus` isn't on HubitatCI's `Location` interface but Groovy property dispatch resolves it on the concrete object (real Hubitat exposes it the same way).
- `RuleHarnessSpec` shares a single `TestLocation` across the spec class; `setup()` resets its fields and `TestChildApp.settingsStore` (loop-guard auto-disable writes leak otherwise — `>> new TestChildApp(...)` is evaluated once at Mock construction).
- `TestDevice` grows the command surface the rule engine dispatches to (setColor, lock/unlock, deviceNotification, thermostat setters, valve/fan/shade, `hasCapability`/`hasCommand`). Each delegates to `invokeCommand` so existing `Spy(TestDevice) { 1 * foo() }` patterns still work.

## Testing
\`./gradlew test\` across the full suite via CI.

Note on boolean composition: #75 mentions NOT / precedence, but the engine implements neither — it's a flat condition list with a single \`all\`/\`any\` combinator (pinned in \`EvaluateConditionsSpec\`), so there's nothing separate to test.