### PR TITLE
test: backfill sunrise/sunset silent-failure fix + broader silent-device-not-found coverage (#76)

### DIFF
--- a/src/test/groovy/rules/RegressionsFromHistorySpec.groovy
+++ b/src/test/groovy/rules/RegressionsFromHistorySpec.groovy
@@ -129,6 +129,66 @@ class RegressionsFromHistorySpec extends RuleHarnessSpec {
     // via ThrowingParent. Not duplicated here — see the class-Javadoc
     // cross-reference above.
 
+    // --- silent device-not-found failures across 14 action types (commit
+    //     83aee5b — "Comprehensive debug logging overhaul - eliminate
+    //     silent failures", follow-up to v0.2.12 sunrise/sunset incident).
+    //
+    // Before the fix, an action targeting a non-existent device would
+    // either NPE on the device method call (caught by the outer
+    // executeAction try/catch and silently swallowed with no user-visible
+    // log) or fall through silently if the code happened to null-guard.
+    // The fix added an explicit `if (device) { ... } else { ruleLog("warn",
+    // "Action 'X' skipped: device not found (ID: N)") }` branch to 14
+    // action types.
+    //
+    // {@link ErrorPathsSpec} already pins this shape for {@code device_command}
+    // (missing-device action warns + execution continues). This feature
+    // method broadens the coverage to the other action types the commit
+    // named — each one must emit a warn-level {@code ruleLog} and must
+    // NOT throw, so the next action in the chain still runs.
+
+    def "missing-device action '#actionType' emits a warn ruleLog and lets the next action run"() {
+        given: 'a registered sibling device the next action will drive'
+        def sibling = Spy(TestDevice) { getId() >> 42 }
+        parent = new RepeatParent(devices: [42L: sibling])
+
+        and: 'capture every ruleLog emission from the rule engine'
+        def logCalls = []
+        script.metaClass.ruleLog = { String level, String message, Map extra = null ->
+            logCalls << [level: level, message: message]
+        }
+
+        and: 'action targeting missing-id 999 followed by a sibling-targeted action'
+        atomicStateMap.actions = [
+            missingAction,
+            [type: 'device_command', deviceId: 42L, command: 'on']
+        ]
+
+        when:
+        script.executeActions()
+
+        then: 'a warn-level log cites the action type AND the missing id'
+        logCalls.any {
+            it.level == 'warn' &&
+            it.message?.contains(actionType) &&
+            it.message?.contains('999')
+        }
+
+        and: 'the follow-up action still fires — no silent throw stopped the chain'
+        1 * sibling.on()
+
+        where:
+        actionType          | missingAction
+        'set_level'         | [type: 'set_level', deviceId: 999L, level: 50]
+        'set_color'         | [type: 'set_color', deviceId: 999L, hue: 100, saturation: 50, level: 75]
+        'toggle_device'     | [type: 'toggle_device', deviceId: 999L]
+        'lock'              | [type: 'lock', deviceId: 999L]
+        'unlock'            | [type: 'unlock', deviceId: 999L]
+        'speak'             | [type: 'speak', deviceId: 999L, message: 'hi']
+        'send_notification' | [type: 'send_notification', deviceId: 999L, message: 'hi']
+        'set_thermostat'    | [type: 'set_thermostat', deviceId: 999L, thermostatMode: 'cool']
+    }
+
     static class RepeatParent {
         Map<Long, TestDevice> devices = [:]
         Object findDevice(id) { devices[(id as Long)] }

--- a/src/test/groovy/rules/RegressionsFromHistorySpec.groovy
+++ b/src/test/groovy/rules/RegressionsFromHistorySpec.groovy
@@ -22,9 +22,14 @@ import support.TestDevice
  *       evaluator throw: {@link EvaluateConditionsSpec} pins both — the
  *       {@code all}/{@code any} short-circuit via CountingParent, and the
  *       throw-caught-as-miss path via ThrowingParent.</li>
- *   <li>v0.7.7 — {@code variable_math} double atomicState read:
- *       {@link ActionTypesSpec} pins the read-once/write-once shape through
- *       its {@code variable_math} tests.</li>
+ *   <li>v0.7.7 — {@code variable_math} arithmetic across operations:
+ *       {@link ActionTypesSpec} pins add/subtract/modulo/set/divide-by-zero/
+ *       scope=global through its {@code variable_math} tests. The specific
+ *       "read-once / write-once" cardinality that v0.7.7's fix targeted is
+ *       not directly asserted there (the existing tests would still pass
+ *       under a single-threaded double-read); adding a read-counting test
+ *       would be a reasonable follow-up but is out of scope for this
+ *       backfill.</li>
  *   <li>v0.1.5 — {@code capture_state}/{@code restore_state} across rules:
  *       {@link ActionTypesSpec} pins both the write path via
  *       {@code parent.saveCapturedState} and the read path via
@@ -106,8 +111,9 @@ class RegressionsFromHistorySpec extends RuleHarnessSpec {
     // order, a user whose rule defines a local variable called
     // {@code now} would see its value take over the built-in {@code %now%}
     // token — surprising and hard to debug. (The v0.7.6 "variable shadowing
-    // of now()" fix applied to a different code path; that's guarded by
-    // sandbox_lint.py and code review, not by this test.)
+    // of now()" fix was in a different code path — currently guarded by
+    // code review only, since sandbox_lint.py's rules don't cover variable
+    // shadowing.)
 
     def "built-in %now% token is resolved before the localVariables loop runs"() {
         given: 'a local variable named "now" whose value would collide with the built-in'
@@ -129,7 +135,7 @@ class RegressionsFromHistorySpec extends RuleHarnessSpec {
     // via ThrowingParent. Not duplicated here — see the class-Javadoc
     // cross-reference above.
 
-    // --- silent device-not-found failures across 14 action types (commit
+    // --- silent device-not-found failures across 13 action types (commit
     //     83aee5b — "Comprehensive debug logging overhaul - eliminate
     //     silent failures", follow-up to v0.2.12 sunrise/sunset incident).
     //
@@ -138,14 +144,19 @@ class RegressionsFromHistorySpec extends RuleHarnessSpec {
     // executeAction try/catch and silently swallowed with no user-visible
     // log) or fall through silently if the code happened to null-guard.
     // The fix added an explicit `if (device) { ... } else { ruleLog("warn",
-    // "Action 'X' skipped: device not found (ID: N)") }` branch to 14
-    // action types.
+    // "Action 'X' skipped: device not found (ID: N)") }` branch to every
+    // device-targeting action type.
     //
-    // {@link ErrorPathsSpec} already pins this shape for {@code device_command}
-    // (missing-device action warns + execution continues). This feature
-    // method broadens the coverage to the other action types the commit
-    // named — each one must emit a warn-level {@code ruleLog} and must
-    // NOT throw, so the next action in the chain still runs.
+    // {@link ErrorPathsSpec} already pins this shape for {@code device_command}.
+    // This feature method covers the remaining 13 action types the commit
+    // named (14 total minus device_command) — each must emit a warn-level
+    // {@code ruleLog} citing the specific action name and missing id, and
+    // must NOT throw, so the next action in the chain still runs.
+    //
+    // The warn-match assertion brackets the action name in single quotes
+    // (e.g. {@code "Action 'lock'"}) so a test for {@code lock} cannot pass
+    // against a cross-wired {@code unlock} message — same for
+    // {@code set_color} vs {@code set_color_temperature}.
 
     def "missing-device action '#actionType' emits a warn ruleLog and lets the next action run"() {
         given: 'a registered sibling device the next action will drive'
@@ -167,10 +178,10 @@ class RegressionsFromHistorySpec extends RuleHarnessSpec {
         when:
         script.executeActions()
 
-        then: 'a warn-level log cites the action type AND the missing id'
+        then: 'a warn-level log cites the exact action type AND the missing id'
         logCalls.any {
             it.level == 'warn' &&
-            it.message?.contains(actionType) &&
+            it.message?.contains("Action '${actionType}'") &&
             it.message?.contains('999')
         }
 
@@ -178,15 +189,22 @@ class RegressionsFromHistorySpec extends RuleHarnessSpec {
         1 * sibling.on()
 
         where:
-        actionType          | missingAction
-        'set_level'         | [type: 'set_level', deviceId: 999L, level: 50]
-        'set_color'         | [type: 'set_color', deviceId: 999L, hue: 100, saturation: 50, level: 75]
-        'toggle_device'     | [type: 'toggle_device', deviceId: 999L]
-        'lock'              | [type: 'lock', deviceId: 999L]
-        'unlock'            | [type: 'unlock', deviceId: 999L]
-        'speak'             | [type: 'speak', deviceId: 999L, message: 'hi']
-        'send_notification' | [type: 'send_notification', deviceId: 999L, message: 'hi']
-        'set_thermostat'    | [type: 'set_thermostat', deviceId: 999L, thermostatMode: 'cool']
+        actionType              | missingAction
+        'set_level'             | [type: 'set_level',             deviceId: 999L, level: 50]
+        'set_color'             | [type: 'set_color',             deviceId: 999L, hue: 100, saturation: 50, level: 75]
+        'set_color_temperature' | [type: 'set_color_temperature', deviceId: 999L, temperature: 3000, level: 50]
+        'toggle_device'         | [type: 'toggle_device',         deviceId: 999L]
+        'lock'                  | [type: 'lock',                  deviceId: 999L]
+        'unlock'                | [type: 'unlock',                deviceId: 999L]
+        'speak'                 | [type: 'speak',                 deviceId: 999L, message: 'hi']
+        'send_notification'     | [type: 'send_notification',     deviceId: 999L, message: 'hi']
+        'set_thermostat'        | [type: 'set_thermostat',        deviceId: 999L, thermostatMode: 'cool']
+        'set_valve'             | [type: 'set_valve',             deviceId: 999L, command: 'open']
+        'set_fan_speed'         | [type: 'set_fan_speed',         deviceId: 999L, speed: 'medium']
+        'set_shade'             | [type: 'set_shade',             deviceId: 999L, command: 'open']
+        // activate_scene uses sceneDeviceId, not deviceId — the warn log
+        // at hubitat-mcp-rule.groovy:3480 references the sceneDeviceId value.
+        'activate_scene'        | [type: 'activate_scene',        sceneDeviceId: 999L]
     }
 
     static class RepeatParent {

--- a/src/test/groovy/server/NormalizeTriggerSpec.groovy
+++ b/src/test/groovy/server/NormalizeTriggerSpec.groovy
@@ -1,0 +1,132 @@
+package server
+
+import support.ToolSpecBase
+
+/**
+ * Regression spec for hubitat-mcp-server.groovy::normalizeTrigger — the
+ * silent-failure fix (commit 2a6da11, v0.2.12 follow-up → v0.3.x) that
+ * addressed the "rule with a sunrise trigger never fires" bug.
+ *
+ * Root cause: rule-engine trigger handling only recognised the canonical
+ * shape {@code {type:'time', sunrise:true}} / {@code {type:'time', sunset:true}},
+ * but create_rule / update_rule accepted four additional shapes the LLM
+ * naturally emitted (e.g. {@code {type:'sunrise'}}, {@code {type:'time', time:'sunrise'}}).
+ * The rule saved, never threw, and then silently never fired — no log,
+ * no error, no hint. normalizeTrigger is the bridge that converts every
+ * accepted input shape into the canonical form before persistence.
+ *
+ * Pure function — testable without any AppExecutor wiring. These tests
+ * guard the five input shapes from the original bug report plus the
+ * passthrough of the canonical form.
+ */
+class NormalizeTriggerSpec extends ToolSpecBase {
+
+    def "converts {type: 'sunrise'} to the canonical {type: 'time', sunrise: true} shape"() {
+        when:
+        def out = script.normalizeTrigger([type: 'sunrise'])
+
+        then:
+        out.type == 'time'
+        out.sunrise == true
+        !out.containsKey('sunset')
+    }
+
+    def "converts {type: 'sunset'} to the canonical {type: 'time', sunset: true} shape"() {
+        when:
+        def out = script.normalizeTrigger([type: 'sunset'])
+
+        then:
+        out.type == 'time'
+        out.sunset == true
+        !out.containsKey('sunrise')
+    }
+
+    def "converts {type: 'sun', event: '#event'} to the canonical sunrise/sunset flag and drops the event field"() {
+        when:
+        def out = script.normalizeTrigger([type: 'sun', event: event])
+
+        then:
+        out.type == 'time'
+        out[event] == true
+        !out.containsKey('event')
+
+        where:
+        event << ['sunrise', 'sunset']
+    }
+
+    def "converts {type: 'time', time: '#event'} to the canonical sunrise/sunset flag and drops the time field"() {
+        when:
+        def out = script.normalizeTrigger([type: 'time', time: event])
+
+        then:
+        out.type == 'time'
+        out[event] == true
+        !out.containsKey('time')
+
+        where:
+        event << ['sunrise', 'sunset']
+    }
+
+    def "converts {type: 'time', sunEvent: 'sunrise', offsetMinutes: N} and renames offsetMinutes to offset"() {
+        when:
+        def out = script.normalizeTrigger([type: 'time', sunEvent: 'sunrise', offsetMinutes: 15])
+
+        then:
+        out.type == 'time'
+        out.sunrise == true
+        out.offset == 15
+        !out.containsKey('sunEvent')
+        !out.containsKey('offsetMinutes')
+    }
+
+    def "preserves an existing offset when normalising {type: 'time', sunEvent, offsetMinutes}"() {
+        given: 'caller already set a canonical `offset` — the legacy `offsetMinutes` should not overwrite it'
+        when:
+        def out = script.normalizeTrigger([type: 'time', sunEvent: 'sunset', offset: -30, offsetMinutes: 99])
+
+        then: 'canonical offset wins; offsetMinutes is dropped silently'
+        out.sunset == true
+        out.offset == -30
+        !out.containsKey('offsetMinutes')
+    }
+
+    def "passes a canonical {type: 'time', sunrise: true} trigger through unchanged"() {
+        given:
+        def input = [type: 'time', sunrise: true, offset: 10]
+
+        when:
+        def out = script.normalizeTrigger(input)
+
+        then:
+        out.type == 'time'
+        out.sunrise == true
+        out.offset == 10
+    }
+
+    def "does not mutate an unrelated trigger type"() {
+        given:
+        def input = [type: 'device_event', deviceId: 42, attribute: 'switch', value: 'on']
+
+        when:
+        def out = script.normalizeTrigger(input)
+
+        then: 'every field preserved — normalizeTrigger only rewrites time/sun shapes'
+        out.type == 'device_event'
+        out.deviceId == 42
+        out.attribute == 'switch'
+        out.value == 'on'
+    }
+
+    def "returns a fresh map — mutating the output does not affect the caller's input"() {
+        given:
+        def input = [type: 'sunrise']
+
+        when:
+        def out = script.normalizeTrigger(input)
+        out.sunrise = 'MUTATED'
+
+        then: 'the input map still has its original shape (no sunrise field yet)'
+        input.type == 'sunrise'
+        !input.containsKey('sunrise')
+    }
+}

--- a/src/test/groovy/server/NormalizeTriggerSpec.groovy
+++ b/src/test/groovy/server/NormalizeTriggerSpec.groovy
@@ -7,17 +7,22 @@ import support.ToolSpecBase
  * silent-failure fix (commit 2a6da11, v0.2.12 follow-up → v0.3.x) that
  * addressed the "rule with a sunrise trigger never fires" bug.
  *
- * Root cause: rule-engine trigger handling only recognised the canonical
- * shape {@code {type:'time', sunrise:true}} / {@code {type:'time', sunset:true}},
- * but create_rule / update_rule accepted four additional shapes the LLM
- * naturally emitted (e.g. {@code {type:'sunrise'}}, {@code {type:'time', time:'sunrise'}}).
- * The rule saved, never threw, and then silently never fired — no log,
- * no error, no hint. normalizeTrigger is the bridge that converts every
- * accepted input shape into the canonical form before persistence.
+ * Root cause: the rule engine only recognised the canonical shape
+ * {@code {type:'time', sunrise:true}} / {@code {type:'time', sunset:true}},
+ * but {@code create_rule} / {@code update_rule} persisted whatever the
+ * LLM emitted — and the LLM naturally emitted four additional shapes
+ * (e.g. {@code {type:'sunrise'}}, {@code {type:'time', time:'sunrise'}}).
+ * Rules saved under those shapes, never threw during save, and then
+ * silently never fired — no log, no error, no hint. normalizeTrigger
+ * is the server-side bridge that now coerces every accepted input
+ * shape to canonical form before persistence, so the rule engine only
+ * ever sees one shape.
  *
- * Pure function — testable without any AppExecutor wiring. These tests
- * guard the five input shapes from the original bug report plus the
- * passthrough of the canonical form.
+ * These tests guard the five input shapes from the original bug report
+ * plus the passthrough of the canonical form. normalizeTrigger itself
+ * reads no state, but we still extend {@link ToolSpecBase} for
+ * consistency with the other server specs (and so future additions
+ * don't have to re-wire the sandbox).
  */
 class NormalizeTriggerSpec extends ToolSpecBase {
 

--- a/src/test/groovy/server/RegressionsFromHistorySpec.groovy
+++ b/src/test/groovy/server/RegressionsFromHistorySpec.groovy
@@ -227,4 +227,93 @@ class RegressionsFromHistorySpec extends ToolSpecBase {
         script.normalizeCommandParams(['75']) == [75]
         script.normalizeCommandParams(['3.14']) == [3.14d]
     }
+
+    // --- toolUpdateItemCode optimistic-locking version mismatch (v0.4.6) ----
+    //
+    // {@code backupItemSource} keeps a 1-hour cache of the most recent
+    // backup manifest — within that window, it returns the cached
+    // manifest (with its cached {@code version}) without re-hitting
+    // the hub. Pre-v0.4.6, {@code toolUpdateItemCode} fed that cached
+    // version straight into the update POST's optimistic-locking
+    // field. If the user had made any change in the Hubitat UI between
+    // the first backup and the subsequent update call, the cached
+    // version was stale and the hub rejected the update with
+    // "Version does not match." The failure mode was obscure: the user
+    // had no visibility into the 1-hour cache and no way to force a
+    // refresh short of waiting it out.
+    //
+    // The fix (hubitat-mcp-server.groovy:6263-6276) fetches the version
+    // fresh from {@code /app/ajax/code} for source/sourceFile modes
+    // (resave mode already gets it for free from its own fetch), then
+    // falls back to the cached backup version only if the fresh fetch
+    // fails. These two tests pin both branches.
+
+    def "update_app_code uses the fresh version from the hub, not the stale backup-manifest cache (v0.4.6)"() {
+        given: 'a recent cached backup whose manifest carries a stale version=5'
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L
+        stateMap.itemBackupManifest = [app_50: [
+            type: 'app', id: '50',
+            fileName: 'mcp-backup-app-50.groovy',
+            version: 5,                                    // stale
+            timestamp: 1234567890000L - 60_000L,           // 1 minute ago — well inside the 1-hour window
+            sourceLength: 100
+        ]]
+
+        and: '/app/ajax/code returns version=12 — the current fresh value'
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 12, "source": "does-not-matter — this path only used for fresh version"}'
+        }
+
+        and: 'capture the version passed into the update POST'
+        def posted = [:]
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            posted.path = path
+            posted.body = body
+            [status: 200, location: null, data: '{"status": "success"}']
+        }
+
+        when:
+        def result = script.toolUpdateAppCode([appId: '50', source: 'new source', confirm: true])
+
+        then: 'update POST carries the fresh version=12, NOT the cached stale version=5'
+        posted.body.version == 12
+
+        and: 'the tool reports success using the fresh version'
+        result.success == true
+        result.previousVersion == 12
+    }
+
+    def "update_app_code falls back to the cached backup version when the fresh-fetch fails (v0.4.6)"() {
+        given: 'a recent cached backup with version=5 (stale, but the only thing we have)'
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L
+        stateMap.itemBackupManifest = [app_50: [
+            type: 'app', id: '50',
+            fileName: 'mcp-backup-app-50.groovy',
+            version: 5,
+            timestamp: 1234567890000L - 60_000L,
+            sourceLength: 100
+        ]]
+
+        and: '/app/ajax/code throws on the fresh-version attempt'
+        hubGet.register('/app/ajax/code') { params ->
+            throw new RuntimeException('simulated hub offline')
+        }
+
+        and: 'capture the version passed into the update POST'
+        def posted = [:]
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            posted.body = body
+            [status: 200, location: null, data: '{"status": "success"}']
+        }
+
+        when:
+        def result = script.toolUpdateAppCode([appId: '50', source: 'new source', confirm: true])
+
+        then: 'best-effort fallback — use the cached version=5 rather than failing outright'
+        posted.body.version == 5
+        result.success == true
+        result.previousVersion == 5
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #116. On rewalking the CHANGELOG / git history, two important silent-failure backfills were missing from that PR — both for bugs that shipped "silent" (no exception, no log, no user-visible signal), which is exactly the class of regression hardest to catch without dedicated tests.

## 1. Sunrise/sunset `normalizeTrigger` (commit 2a6da11, v0.2.12 follow-up → v0.3.x)

**The gnarly one.** Pre-fix, the rule engine only recognised the canonical sunrise/sunset trigger shape `{type:'time', sunrise:true}`, while `create_rule` / `update_rule` accepted four additional LLM-natural shapes (e.g. `{type:'sunrise'}`, `{type:'time', time:'sunrise'}`). Rules saved under those shapes silently never fired — no log, no error, no hint.

New file: `src/test/groovy/server/NormalizeTriggerSpec.groovy`

Tests cover:
- All five input shapes from the original bug report convert correctly.
- Canonical `{type:'time', sunrise:true}` passes through unchanged.
- Unrelated trigger types (`device_event`) are not mutated.
- `offsetMinutes` is renamed to `offset`; an existing canonical `offset` wins over a legacy `offsetMinutes` on the same input.
- Return value is a fresh map — mutating the output does not affect the caller's input (defends the `new LinkedHashMap(trigger)` clone at the top of the function).

## 2. Silent device-not-found coverage across 8 more action types (commit 83aee5b)

83aee5b — *"Comprehensive debug logging overhaul - eliminate silent failures"* — added `if (device) { ... } else { ruleLog("warn", ...) }` branches to 14 action types. Before the fix, any action targeting a missing device would NPE on the device method call, get swallowed by the outer `try/catch`, and silently skip with no log.

`ErrorPathsSpec` already pinned the `device_command` slice. This PR extends the guard to `set_level`, `set_color`, `toggle_device`, `lock`, `unlock`, `speak`, `send_notification`, and `set_thermostat` via a data-driven `@Unroll` feature method in `src/test/groovy/rules/RegressionsFromHistorySpec.groovy`.

For each type the test asserts:
- A warn-level `ruleLog` is emitted citing both the action type and the missing device id.
- The NEXT action in the chain still fires — no silent throw stopped execution.

`activate_scene` / `set_valve` / `set_fan_speed` / `set_shade` / `set_color_temperature` share the same shape and are implicitly covered by the same fix; adding them would be pure repetition.

## Scope notes

- The `v0.4.6` optimistic-locking-with-stale-backup-version fix (`toolUpdateItemCode`) is partially covered by existing tests in `ToolAppDriverCodeSpec` (the resave-mode test pins the fresh-version-from-parse path). A dedicated test stubbing `hubInternalGet` to return different versions on backup vs fresh fetch is a reasonable add but is a narrower regression than these two; leaving for a follow-up if needed.
- The `v0.2.2` "rules with `enabled=true` have no triggers/actions" bug was a Hubitat state-flush timing issue — the fix was swapping `state` → `atomicState` across the rule engine. Not reproducible at the unit level because the harness backs both through the same `atomicStateMap`.

## Test plan

- [ ] CI `./gradlew test` green with the new specs
- [ ] All new feature methods isolated (no state leaks) via the existing `HarnessSpec` / `RuleHarnessSpec` contract