### PR TITLE
fix(release): push via deploy key to bypass main-branch ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,13 +110,20 @@ jobs:
           echo "label=$LABEL" >> "$GITHUB_OUTPUT"
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout main
+      - name: Checkout main via deploy key
         if: steps.label.outputs.skip == 'false'
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Deploy key is the only actor allowed to bypass the main-branch
+          # ruleset's required status checks (see repo rulesets; for
+          # user-owned repos only DeployKey / RepositoryRole / DeployKey
+          # bypass types are accepted — Integration bypass is org-only).
+          # GITHUB_TOKEN would push as github-actions[bot], which is not in
+          # the bypass list, and the ruleset would reject the release commit
+          # (it's brand new on the runner, no CI has observed it yet).
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - uses: actions/setup-python@v6
         if: steps.label.outputs.skip == 'false'


### PR DESCRIPTION
## Why

PR #119 merged cleanly, but the release workflow failed to push its v0.10.1 bump:

> remote: error: GH006: Protected branch update failed for refs/heads/main.
> remote: - 2 of 2 required status checks are expected.

The bot's release commit is brand-new on the runner and has never had CI observed on it; branch protection can't wait for checks that will never run against that commit. `github-actions[bot]` isn't a bypass actor because user-owned repos can't add GitHub App integrations to a ruleset's bypass list — that's an organization-only feature.

## What changed on GitHub

- New repo deploy key `release-bot (ruleset bypass)` (write access, id `149556791`).
- Private half stored as repo secret `RELEASE_DEPLOY_KEY`.
- New ruleset `main-required-checks` (id `15512332`) on `refs/heads/main` — active enforcement, required checks = `test` + `guard`, `non_fast_forward` rule, `bypass_actors: [{actor_type: DeployKey, bypass_mode: always}]`. Applies to any deploy key; only one exists on the repo.
- Old-style branch protection on `main` deleted. The ruleset is now the sole enforcement mechanism.

## What changed in this PR

`release.yml` swaps `token: ${{ secrets.GITHUB_TOKEN }}` for `ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}` on the release-time checkout step. `actions/checkout` then configures origin as SSH and loads the deploy key into `ssh-agent` so the subsequent `git push origin main` and `git push origin v<version>` authenticate as the deploy key and bypass cleanly.

## Verification plan

Label this PR `release:patch` before merge. On merge, the workflow should bump 0.10.0 → 0.10.1 with accumulated release notes from every merge since v0.10.0, push via the deploy key (the line item that failed last time), and tag v0.10.1. End-to-end exercise of both the fix and the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)