### PR TITLE
fix(release): positive-match the skip cascade so recursion guard short-circuits cleanly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,12 @@ jobs:
       # regardless of where the merged code came from. We recover the PR
       # the merge commit came from via the commits-to-PRs API.
       - name: Resolve PR from merge commit
-        if: steps.precheck.outputs.skip != 'true'
+        # Positive-match cascade: `!= 'true'` evaluates TRUE for empty outputs,
+        # so a skipped upstream step would let this one run anyway. Using
+        # `== 'false'` only proceeds when the upstream explicitly signalled
+        # "don't skip" — empty (because upstream was skipped) correctly gates
+        # this step out.
+        if: steps.precheck.outputs.skip == 'false'
         id: pr
         env:
           SHA: ${{ github.sha }}
@@ -89,7 +94,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Determine release label
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.pr.outputs.skip == 'false'
         id: label
         env:
           LABELS_JSON: ${{ steps.pr.outputs.labels_json }}


### PR DESCRIPTION
## Why

v0.10.1 released correctly via the deploy-key bypass landed in #122, but the self-triggered workflow run that fired on the `chore(release): 0.10.1` push falsely reported failure. The recursion guard correctly set `skip=true` on the release-commit push, and "Resolve PR from merge commit" correctly skipped — but "Determine release label" ran anyway, then "Checkout main", "Setup Python", and finally `release_bump.py` exited 1 on empty env.

## Root cause

Each downstream step used `if: steps.<prev>.outputs.skip != 'true'`. A **skipped** upstream step has empty outputs; `empty != 'true'` evaluates to TRUE, so the next step runs. The skip signal gets swallowed on the first hop past a skipped step.

## Fix

Positive match: change `!= 'true'` → `== 'false'` on the two cascade steps that check upstream skip signals. Empty output fails the `== 'false'` check, so once any upstream skip fires the rest of the job correctly short-circuits. The later steps (`Checkout main`, `Setup Python`, `Bump version`, `Commit/tag/push`) already used `== 'false'` — only the first two cascade hops had the bug.

## Verification

Merge without a `release:*` label. The merge commit's release-workflow run should short-circuit at "Determine release label" (no release label on this PR). No spurious failure email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)