### PR TITLE
feat(rule-tools): redirect hint when caller passes a built-in RM rule id (addresses #118 Option A)

### DIFF
--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -245,17 +245,19 @@ Auto-backs up before modifying. Rapid edits within 1 hour preserve the original.
 - If the rule still exists, settings are replayed in place; if deleted, a fresh empty rule is recreated and the saved settings replayed onto it
 
 ### Hubitat Built-in Rule Redirect
-When `get_rule`, `export_rule`, `update_rule`, `delete_rule`, `test_rule`, or `clone_rule` fails
+When `custom_get_rule`, `custom_export_rule`, `custom_update_rule`, `custom_delete_rule`, `custom_test_rule`, or `custom_clone_rule` fails
 with "Rule not found", the error message may include a redirect hint if the ID belongs to a
 Hubitat built-in rule-like app (Rule Machine, Room Lighting, Basic Rules, Visual Rules Builder).
 
 Example redirect message:
 > "Rule 832 is a Hubitat built-in Rule-5.1 app. Use `manage_installed_apps -> get_app_config(appId=832)` to read its configuration."
 
-- Read verbs (`get_rule`, `export_rule`, `clone_rule`): points to `get_app_config` and notes these tools only handle MCP's own rule engine.
-- Write verbs (`update_rule`, `delete_rule`, `test_rule`): points to `get_app_config` for read-only inspection and notes that built-in rules cannot be programmatically modified via MCP.
+- Read verbs (`custom_get_rule`, `custom_export_rule`, `custom_clone_rule`): points to `get_app_config` and notes these tools only handle MCP's own rule engine.
+- Write verbs (`custom_update_rule`): points to `get_app_config` for inspection and `manage_native_rules_and_apps -> update_native_app` for programmatic modification (requires Built-in App Tools + Hub Admin Write).
+- Delete verb (`custom_delete_rule`): points to `manage_native_rules_and_apps -> delete_native_app` for programmatic deletion.
+- Test verb (`custom_test_rule`): points to `manage_native_rules_and_apps -> run_rm_rule` to trigger the rule.
 - The redirect check is best-effort: if the hub appsList call fails, a plain "Rule not found" message is returned with no secondary error.
-- `list_rules` and `create_rule` are not affected (they do not take a rule id as input).
+- `custom_list_rules` and `custom_create_rule` are not affected (they do not take a rule id as input).
 
 ---
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -255,7 +255,7 @@ Example redirect message:
 - Read verbs (`custom_get_rule`, `custom_export_rule`, `custom_clone_rule`): points to `get_app_config` and notes these tools only handle MCP's own rule engine.
 - Write verbs (`custom_update_rule`): points to `get_app_config` for inspection and `manage_native_rules_and_apps -> update_native_app` for programmatic modification (requires Built-in App Tools + Hub Admin Write).
 - Delete verb (`custom_delete_rule`): points to `manage_native_rules_and_apps -> delete_native_app` for programmatic deletion.
-- Test verb (`custom_test_rule`): points to `manage_native_rules_and_apps -> run_rm_rule` to trigger the rule.
+- Test verb (`custom_test_rule`): points to `manage_installed_apps -> get_app_config` for inspection. For Rule Machine rules specifically, the hint also includes a pointer to `manage_native_rules_and_apps -> run_rm_rule` to trigger them; non-RM rule-likes (Room Lighting, Basic Rules, Visual Rule Builder) receive only the `get_app_config` pointer because `run_rm_rule` routes through `RMUtils.sendAction` and is RM-only.
 - The redirect check is best-effort: if the hub appsList call fails, a plain "Rule not found" message is returned with no secondary error.
 - `custom_list_rules` and `custom_create_rule` are not affected (they do not take a rule id as input).
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -244,6 +244,19 @@ Auto-backs up before modifying. Rapid edits within 1 hour preserve the original.
 - Use `list_item_backups` to enumerate, `restore_item_backup` (in `manage_apps_drivers`) with the backupKey to roll back
 - If the rule still exists, settings are replayed in place; if deleted, a fresh empty rule is recreated and the saved settings replayed onto it
 
+### Hubitat Built-in Rule Redirect
+When `get_rule`, `export_rule`, `update_rule`, `delete_rule`, `test_rule`, or `clone_rule` fails
+with "Rule not found", the error message may include a redirect hint if the ID belongs to a
+Hubitat built-in rule-like app (Rule Machine, Room Lighting, Basic Rules, Visual Rules Builder).
+
+Example redirect message:
+> "Rule 832 is a Hubitat built-in Rule-5.1 app. Use `manage_installed_apps -> get_app_config(appId=832)` to read its configuration."
+
+- Read verbs (`get_rule`, `export_rule`, `clone_rule`): points to `get_app_config` and notes these tools only handle MCP's own rule engine.
+- Write verbs (`update_rule`, `delete_rule`, `test_rule`): points to `get_app_config` for read-only inspection and notes that built-in rules cannot be programmatically modified via MCP.
+- The redirect check is best-effort: if the hub appsList call fails, a plain "Rule not found" message is returned with no secondary error.
+- `list_rules` and `create_rule` are not affected (they do not take a rule id as input).
+
 ---
 
 ## File Manager

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -25,8 +25,6 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | `custom_create_rule` | Create a new automation rule. | None |
 | `custom_update_rule` | Update rule triggers, conditions, or actions. Also handles enable/disable via `enabled=true/false`. | None |
 
-> **Note:** `custom_get_rule`, `custom_update_rule`, and related `custom_*` tools only operate on MCP-native rules. Passing a Hubitat built-in rule id yields a redirect hint pointing to `manage_installed_apps` (read) or `manage_native_rules_and_apps` (write/delete/test).
-
 ### Device Management (1)
 
 | Tool | Description | Access Gate |

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -76,7 +76,7 @@ Rule administration: delete, test, export, import, and clone rules.
 | `custom_import_rule` | Import a rule from exported JSON. | None |
 | `custom_clone_rule` | Duplicate an existing rule. | None |
 
-> **Built-in rule redirect:** `custom_get_rule`, `custom_export_rule`, `custom_update_rule`, `custom_delete_rule`, `custom_test_rule`, and `custom_clone_rule` operate only on MCP-native rules. If you pass an id belonging to a Hubitat built-in rule (Rule Machine, Room Lighting, Basic Rules, Visual Rules), the error message includes a redirect hint pointing to `manage_installed_apps -> get_app_config(appId=<id>)` (read) or the appropriate `manage_native_rules_and_apps` tool (write/delete/test). This redirect fires only when Built-in App Tools are enabled. See `TOOL_GUIDE.md` "Hubitat Built-in Rule Redirect" for full details.
+> **Built-in rule redirect:** `custom_get_rule`, `custom_export_rule`, `custom_update_rule`, `custom_delete_rule`, `custom_test_rule`, and `custom_clone_rule` operate only on MCP-native rules. If you pass an id belonging to a Hubitat built-in rule (Rule Machine, Room Lighting, Basic Rules, Visual Rules), the error message includes a redirect hint pointing to `manage_installed_apps -> get_app_config(appId=<id>)` (read) or, for write and delete verbs, the appropriate `manage_native_rules_and_apps` CRUD tool. The test verb hint includes `run_rm_rule` only for Rule Machine rules; other built-in rule-likes receive `get_app_config` for inspection because `run_rm_rule` is RM-only. This redirect fires only when Built-in App Tools are enabled. See `TOOL_GUIDE.md` "Hubitat Built-in Rule Redirect" for full details.
 
 ### manage_hub_variables (4 tools)
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -25,7 +25,7 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | `custom_create_rule` | Create a new automation rule. | None |
 | `custom_update_rule` | Update rule triggers, conditions, or actions. Also handles enable/disable via `enabled=true/false`. | None |
 
-> **Note:** `get_rule` and `update_rule` only operate on MCP-native rules. Passing a Hubitat built-in rule id yields a redirect hint (see `manage_rules_admin` note below).
+> **Note:** `custom_get_rule`, `custom_update_rule`, and related `custom_*` tools only operate on MCP-native rules. Passing a Hubitat built-in rule id yields a redirect hint pointing to `manage_installed_apps` (read) or `manage_native_rules_and_apps` (write/delete/test).
 
 ### Device Management (1)
 
@@ -78,7 +78,7 @@ Rule administration: delete, test, export, import, and clone rules.
 | `custom_import_rule` | Import a rule from exported JSON. | None |
 | `custom_clone_rule` | Duplicate an existing rule. | None |
 
-> **Built-in rule redirect:** `get_rule`, `export_rule`, `update_rule`, `delete_rule`, `test_rule`, and `clone_rule` operate only on MCP-native rules. If you pass an id belonging to a Hubitat built-in rule (Rule Machine, Room Lighting, Basic Rules, Visual Rules), the error message includes a redirect hint pointing to `manage_installed_apps -> get_app_config(appId=<id>)`. This redirect fires only when Built-in App Tools are enabled. See `TOOL_GUIDE.md` "Hubitat Built-in Rule Redirect" for full details.
+> **Built-in rule redirect:** `custom_get_rule`, `custom_export_rule`, `custom_update_rule`, `custom_delete_rule`, `custom_test_rule`, and `custom_clone_rule` operate only on MCP-native rules. If you pass an id belonging to a Hubitat built-in rule (Rule Machine, Room Lighting, Basic Rules, Visual Rules), the error message includes a redirect hint pointing to `manage_installed_apps -> get_app_config(appId=<id>)` (read) or the appropriate `manage_native_rules_and_apps` tool (write/delete/test). This redirect fires only when Built-in App Tools are enabled. See `TOOL_GUIDE.md` "Hubitat Built-in Rule Redirect" for full details.
 
 ### manage_hub_variables (4 tools)
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -25,6 +25,8 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | `custom_create_rule` | Create a new automation rule. | None |
 | `custom_update_rule` | Update rule triggers, conditions, or actions. Also handles enable/disable via `enabled=true/false`. | None |
 
+> **Note:** `get_rule` and `update_rule` only operate on MCP-native rules. Passing a Hubitat built-in rule id yields a redirect hint (see `manage_rules_admin` note below).
+
 ### Device Management (1)
 
 | Tool | Description | Access Gate |
@@ -75,6 +77,8 @@ Rule administration: delete, test, export, import, and clone rules.
 | `custom_export_rule` | Export rule as portable JSON. | None |
 | `custom_import_rule` | Import a rule from exported JSON. | None |
 | `custom_clone_rule` | Duplicate an existing rule. | None |
+
+> **Built-in rule redirect:** `get_rule`, `export_rule`, `update_rule`, `delete_rule`, `test_rule`, and `clone_rule` operate only on MCP-native rules. If you pass an id belonging to a Hubitat built-in rule (Rule Machine, Room Lighting, Basic Rules, Visual Rules), the error message includes a redirect hint pointing to `manage_installed_apps -> get_app_config(appId=<id>)`. This redirect fires only when Built-in App Tools are enabled. See `TOOL_GUIDE.md` "Hubitat Built-in Rule Redirect" for full details.
 
 ### manage_hub_variables (4 tools)
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3307,13 +3307,16 @@ def toolTestRule(ruleId) {
  * verb-appropriate redirect hint string. Returns null on any failure (fetch error, parse error,
  * id not present, app not rule-like) so callers always get graceful fallback.
  *
- * Rule-like detection uses two complementary signals:
- *   1. classLocation from systemAppTypes[] (authoritative SDK string: ruleApp51, roomLightsApp, etc.)
- *   2. type string from the instance data (human-readable: "Rule-5.1", "Room Lights", etc.)
- * Either signal matching is sufficient.
+ * Rule-like detection uses the human-readable type string from the app's instance data
+ * (e.g. "Rule-5.1", "Room Lights", "Visual Rule Builder"). Fragment matching is case-insensitive
+ * substring: any type string containing a fragment from ruleTypeFragments is considered rule-like.
+ * The test verb additionally checks RM-specific fragments to gate the run_rm_rule pointer
+ * (RMUtils is RM-only and does not work for Room Lighting / Basic Rules / Visual Rules instances).
  *
  * @param ruleId  the ID to look up (String or numeric)
- * @param verb    "read" (get/export) or "write" (update/delete/test/clone) -- controls hint phrasing
+ * @param verb    controls hint phrasing: "read" (get/export; clone routes through export so it also uses read),
+ *                "write" (update -- catch-all for any future write verbs),
+ *                "delete" (delete), "test" (test -- RM-only run_rm_rule pointer; non-RM falls back to inspection)
  * @return        redirect hint String, or null if no redirect applies
  */
 private String findRuleAppRedirect(ruleId, String verb) {
@@ -3322,22 +3325,16 @@ private String findRuleAppRedirect(ruleId, String verb) {
     // operator has intentionally restricted built-in app visibility.
     if (!settings.enableBuiltinApp) return null
 
-    // Known classLocation values for rule-like built-in apps.
-    // ruleApp51 = Rule Machine 5.1, ruleApp50 = Rule Machine 5.0,
-    // ruleApp = Rule Machine 4.x (legacy), roomLightsApp = Room Lighting parent,
-    // roomLightsChildApp = Room Lighting instance, basicRulesApp = Basic Rules,
-    // vrb = Visual Rules Builder.
-    def ruleClassLocations = [
-        "ruleApp51", "ruleApp50", "ruleApp",
-        "roomLightsApp", "roomLightsChildApp",
-        "basicRulesApp", "vrb"
-    ] as Set
-
-    // Human-readable type-string fragments to match as a fallback when classLocation
-    // is unavailable (e.g., systemAppTypes absent from the firmware's appsList response).
+    // Type-string fragments that identify rule-like built-in apps. Matched case-insensitively
+    // as substrings of the app's type field. "visual rule" (singular) covers both
+    // "Visual Rule Builder" (child instances) and "Visual Rules Builder" (parent app).
     def ruleTypeFragments = [
-        "rule machine", "rule-5", "rule-4", "room light", "basic rules", "visual rules"
+        "rule machine", "rule-5", "rule-4", "room light", "basic rules", "visual rule"
     ]
+
+    // Subset of ruleTypeFragments that are RM-specific. run_rm_rule (RMUtils) only works for
+    // Rule Machine rules -- pointing Room Lighting / Basic Rules / VRB ids there would fail.
+    def rmTypeFragments = ["rule machine", "rule-5", "rule-4"]
 
     def idStr = ruleId?.toString()?.trim()
     if (!idStr || !idStr.isInteger()) return null
@@ -3346,57 +3343,39 @@ private String findRuleAppRedirect(ruleId, String verb) {
         def responseText = hubInternalGet("/hub2/appsList")
         if (!responseText) return null
 
-        def parsed
-        try {
-            parsed = new groovy.json.JsonSlurper().parseText(responseText)
-        } catch (Exception ignored) {
-            return null
-        }
-
+        def parsed = new groovy.json.JsonSlurper().parseText(responseText)
         if (!(parsed instanceof Map)) return null
 
-        // Build a classLocation lookup map from systemAppTypes[]: id -> classLocation.
-        def classLocationById = [:]
-        def systemTypes = parsed.systemAppTypes
-        if (systemTypes instanceof List) {
-            systemTypes.each { t ->
-                if (t instanceof Map && t.id != null && t.classLocation) {
-                    classLocationById[t.id.toString()] = t.classLocation.toString()
-                }
-            }
-        }
-
-        // Walk the apps[] tree with an early-exit DFS to find the app instance
-        // with matching id. Avoids building a full flat list when the target
-        // is found partway through a large app tree.
+        // Walk the apps[] tree with an early-exit iterative DFS to find the app instance
+        // with matching id. Iterative (explicit stack) avoids StackOverflowError on pathological
+        // hub responses with deeply-nested children (which would bypass the outer Exception catch).
         def foundData = null
-        def findInNodes
-        findInNodes = { List nodes ->
-            for (node in nodes) {
-                if (!(node instanceof Map)) continue
-                def d = node.data
-                if (d instanceof Map && d.id?.toString() == idStr) {
-                    foundData = d
-                    return true
-                }
-                if (node.children instanceof List && findInNodes(node.children)) return true
-            }
-            return false
-        }
         def apps = parsed.apps
         if (!(apps instanceof List)) return null
-        findInNodes(apps)
+        def stack = []
+        stack.addAll(apps)
+        while (!stack.isEmpty()) {
+            def node = stack.remove(0)
+            if (!(node instanceof Map)) continue
+            def d = node.data
+            if (d instanceof Map && d.id?.toString() == idStr) {
+                foundData = d
+                break
+            }
+            if (node.children instanceof List) {
+                stack.addAll(0, node.children)
+            }
+        }
         if (!foundData) return null
 
-        // Determine whether this app type is rule-like via classLocation or type string.
         def appTypeName = foundData.type?.toString() ?: "built-in app"
-        def appTypeId = foundData.appTypeId?.toString()
-        def classLoc = appTypeId ? classLocationById[appTypeId] : null
+        def appTypeNameLower = appTypeName.toLowerCase()
 
-        boolean isRuleLike = (classLoc && ruleClassLocations.contains(classLoc)) ||
-            ruleTypeFragments.any { frag -> appTypeName.toLowerCase().contains(frag) }
-
+        boolean isRuleLike = ruleTypeFragments.any { frag -> appTypeNameLower.contains(frag) }
         if (!isRuleLike) return null
+
+        // Is this app a Rule Machine instance? Gates the run_rm_rule pointer in the test-verb hint.
+        boolean isRmRule = rmTypeFragments.any { frag -> appTypeNameLower.contains(frag) }
 
         // Build verb-appropriate redirect hint.
         if (verb == "read") {
@@ -3406,22 +3385,32 @@ private String findRuleAppRedirect(ruleId, String verb) {
         } else if (verb == "delete") {
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                 "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
+                "`custom_delete_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +
                 "Use `manage_native_rules_and_apps -> delete_native_app(appId=${idStr}, confirm=true)` to delete it programmatically " +
                 "(requires Built-in App Tools + Hub Admin Write)."
         } else if (verb == "test") {
-            return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
-                "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
-                "Use `manage_native_rules_and_apps -> run_rm_rule(ruleId=${idStr})` to trigger it " +
-                "(requires Built-in App Tools)."
+            // run_rm_rule routes through RMUtils and is RM-only. Point non-RM rule-likes at get_app_config instead.
+            if (isRmRule) {
+                return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
+                    "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
+                    "`custom_test_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +
+                    "Use `manage_native_rules_and_apps -> run_rm_rule(ruleId=${idStr})` to trigger it " +
+                    "(requires Built-in App Tools)."
+            } else {
+                return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
+                    "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
+                    "`custom_test_rule` only handles MCP's own rule engine, not Hubitat built-in apps."
+            }
         } else {
-            // write (update_rule and any future write verbs)
+            // Catch-all for "write" verb (custom_update_rule) and any future write verbs.
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                 "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
+                "`custom_update_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +
                 "Use `manage_native_rules_and_apps -> update_native_app(appId=${idStr})` to modify it programmatically " +
                 "(requires Built-in App Tools + Hub Admin Write)."
         }
     } catch (Exception e) {
-        mcpLog("warn", "rules", "findRuleAppRedirect lookup failed for id ${idStr}: ${e.message ?: e.toString()}")
+        mcpLog("error", "rules", "findRuleAppRedirect lookup failed for id ${idStr}: ${e.message ?: e.toString()}")
         return null
     }
 }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3355,7 +3355,7 @@ private String findRuleAppRedirect(ruleId, String verb) {
         def stack = []
         stack.addAll(apps)
         while (!stack.isEmpty()) {
-            def node = stack.remove(0)
+            def node = stack.remove(stack.size() - 1)
             if (!(node instanceof Map)) continue
             def d = node.data
             if (d instanceof Map && d.id?.toString() == idStr) {
@@ -3363,7 +3363,7 @@ private String findRuleAppRedirect(ruleId, String verb) {
                 break
             }
             if (node.children instanceof List) {
-                stack.addAll(0, node.children)
+                stack.addAll(node.children)
             }
         }
         if (!foundData) return null
@@ -3403,6 +3403,9 @@ private String findRuleAppRedirect(ruleId, String verb) {
             }
         } else {
             // Catch-all for "write" verb (custom_update_rule) and any future write verbs.
+            if (verb != "write") {
+                mcpLog("debug", "rules", "findRuleAppRedirect: unrecognized verb '${verb}', defaulting to write-verb message")
+            }
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                 "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
                 "`custom_update_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3016,7 +3016,10 @@ def toolListRules() {
 def toolGetRule(ruleId) {
     def childApp = getChildAppById(ruleId)
     if (!childApp) {
-        throw new IllegalArgumentException("Rule not found: ${ruleId}")
+        def redirect = findRuleAppRedirect(ruleId, "read")
+        def msg = "Rule not found: ${ruleId}"
+        if (redirect) msg += ". ${redirect}"
+        throw new IllegalArgumentException(msg)
     }
 
     def ruleData = childApp.getRuleData()
@@ -3131,7 +3134,10 @@ def toolCreateRule(args) {
 def toolUpdateRule(ruleId, args, String customEngineMode = "full") {
     def childApp = getChildAppById(ruleId)
     if (!childApp) {
-        throw new IllegalArgumentException("Rule not found: ${ruleId}")
+        def redirect = findRuleAppRedirect(ruleId, "write")
+        def msg = "Rule not found: ${ruleId}"
+        if (redirect) msg += ". ${redirect}"
+        throw new IllegalArgumentException(msg)
     }
 
     // Read-only mode gate: only the 'enabled' field may be updated when the
@@ -3202,7 +3208,10 @@ def toolDeleteRule(args) {
 
     def childApp = getChildAppById(args.ruleId)
     if (!childApp) {
-        throw new IllegalArgumentException("Rule not found: ${args.ruleId}")
+        def redirect = findRuleAppRedirect(args.ruleId, "write")
+        def msg = "Rule not found: ${args.ruleId}"
+        if (redirect) msg += ". ${redirect}"
+        throw new IllegalArgumentException(msg)
     }
 
     def ruleName = childApp.getSetting("ruleName") ?: "Unnamed Rule"
@@ -3280,13 +3289,129 @@ def toolDeleteRule(args) {
 def toolTestRule(ruleId) {
     def childApp = getChildAppById(ruleId)
     if (!childApp) {
-        throw new IllegalArgumentException("Rule not found: ${ruleId}")
+        def redirect = findRuleAppRedirect(ruleId, "write")
+        def msg = "Rule not found: ${ruleId}"
+        if (redirect) msg += ". ${redirect}"
+        throw new IllegalArgumentException(msg)
     }
 
     return childApp.testRuleFromParent()
 }
 
 // ==================== RULE HELPERS ====================
+
+/**
+ * Best-effort check: given a numeric id that was not found as an MCP child-app rule, look it up
+ * in the hub's installed-app list (/hub2/appsList). If the id belongs to a known rule-like
+ * built-in (Rule Machine, Room Lighting, Basic Rules, Visual Rules Builder), return a
+ * verb-appropriate redirect hint string. Returns null on any failure (fetch error, parse error,
+ * id not present, app not rule-like) so callers always get graceful fallback.
+ *
+ * Rule-like detection uses two complementary signals:
+ *   1. classLocation from systemAppTypes[] (authoritative SDK string: ruleApp51, roomLightsApp, etc.)
+ *   2. type string from the instance data (human-readable: "Rule-5.1", "Room Lights", etc.)
+ * Either signal matching is sufficient.
+ *
+ * @param ruleId  the ID to look up (String or numeric)
+ * @param verb    "read" (get/export) or "write" (update/delete/test/clone) -- controls hint phrasing
+ * @return        redirect hint String, or null if no redirect applies
+ */
+private String findRuleAppRedirect(ruleId, String verb) {
+    // Soft gate: only enrich the error when Built-in App Tools are enabled.
+    // Prevents leaking that an app exists at this id (or its type) when the
+    // operator has intentionally restricted built-in app visibility.
+    if (!settings.enableBuiltinAppRead) return null
+
+    // Known classLocation values for rule-like built-in apps.
+    // ruleApp51 = Rule Machine 5.1, ruleApp50 = Rule Machine 5.0,
+    // ruleApp = Rule Machine 4.x (legacy), roomLightsApp = Room Lighting parent,
+    // roomLightsChildApp = Room Lighting instance, basicRulesApp = Basic Rules,
+    // vrb = Visual Rules Builder.
+    def ruleClassLocations = [
+        "ruleApp51", "ruleApp50", "ruleApp",
+        "roomLightsApp", "roomLightsChildApp",
+        "basicRulesApp", "vrb"
+    ] as Set
+
+    // Human-readable type-string fragments to match as a fallback when classLocation
+    // is unavailable (e.g., systemAppTypes absent from the firmware's appsList response).
+    def ruleTypeFragments = [
+        "rule machine", "rule-5", "rule-4", "room light", "basic rules", "visual rules"
+    ]
+
+    def idStr = ruleId?.toString()?.trim()
+    if (!idStr || !idStr.isInteger()) return null
+
+    try {
+        def responseText = hubInternalGet("/hub2/appsList")
+        if (!responseText) return null
+
+        def parsed
+        try {
+            parsed = new groovy.json.JsonSlurper().parseText(responseText)
+        } catch (Exception ignored) {
+            return null
+        }
+
+        if (!(parsed instanceof Map)) return null
+
+        // Build a classLocation lookup map from systemAppTypes[]: id -> classLocation.
+        def classLocationById = [:]
+        def systemTypes = parsed.systemAppTypes
+        if (systemTypes instanceof List) {
+            systemTypes.each { t ->
+                if (t instanceof Map && t.id != null && t.classLocation) {
+                    classLocationById[t.id.toString()] = t.classLocation.toString()
+                }
+            }
+        }
+
+        // Flatten the apps[] tree to find the app instance with matching id.
+        // Reuses the same flatten-and-search pattern as toolListInstalledApps.
+        def flat = []
+        def flatten
+        flatten = { List nodes ->
+            nodes?.each { node ->
+                if (!(node instanceof Map)) return
+                def d = node.data
+                if (d instanceof Map) flat << d
+                def children = node.children
+                if (children instanceof List) flatten(children)
+            }
+        }
+        def apps = parsed.apps
+        if (!(apps instanceof List)) return null
+        flatten(apps)
+
+        def foundData = flat.find { it?.id?.toString() == idStr }
+        if (!foundData) return null
+
+        // Determine whether this app type is rule-like via classLocation or type string.
+        def appTypeName = foundData.type?.toString() ?: "built-in app"
+        def appTypeId = foundData.appTypeId?.toString()
+        def classLoc = appTypeId ? classLocationById[appTypeId] : null
+
+        boolean isRuleLike = (classLoc && ruleClassLocations.contains(classLoc)) ||
+            ruleTypeFragments.any { frag -> appTypeName.toLowerCase().contains(frag) }
+
+        if (!isRuleLike) return null
+
+        // Build verb-appropriate redirect hint.
+        if (verb == "read") {
+            return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
+                "Use `manage_installed_apps -> get_app_config(appId=${idStr})` to read its configuration. " +
+                "`get_rule` and `export_rule` only handle MCP's own rule engine, not Hubitat built-in apps."
+        } else {
+            return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
+                "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
+                "Hubitat built-in rules cannot be programmatically modified via MCP at this time -- " +
+                "use the Hubitat Rule Machine UI for changes."
+        }
+    } catch (Exception e) {
+        mcpLog("warn", "rules", "findRuleAppRedirect lookup failed for id ${idStr}: ${e.message ?: e.toString()}")
+        return null
+    }
+}
 
 /**
  * Build a portable rule export object from rule data (excludes runtime state like id, lastTriggered, executionCount).
@@ -3313,7 +3438,10 @@ def toolExportRule(args) {
 
     def childApp = getChildAppById(args.ruleId)
     if (!childApp) {
-        throw new IllegalArgumentException("Rule not found: ${args.ruleId}")
+        def redirect = findRuleAppRedirect(args.ruleId, "read")
+        def msg = "Rule not found: ${args.ruleId}"
+        if (redirect) msg += ". ${redirect}"
+        throw new IllegalArgumentException(msg)
     }
 
     def ruleData = childApp.getRuleData()

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3366,24 +3366,26 @@ private String findRuleAppRedirect(ruleId, String verb) {
             }
         }
 
-        // Flatten the apps[] tree to find the app instance with matching id.
-        // Reuses the same flatten-and-search pattern as toolListInstalledApps.
-        def flat = []
-        def flatten
-        flatten = { List nodes ->
-            nodes?.each { node ->
-                if (!(node instanceof Map)) return
+        // Walk the apps[] tree with an early-exit DFS to find the app instance
+        // with matching id. Avoids building a full flat list when the target
+        // is found partway through a large app tree.
+        def foundData = null
+        def findInNodes
+        findInNodes = { List nodes ->
+            for (node in nodes) {
+                if (!(node instanceof Map)) continue
                 def d = node.data
-                if (d instanceof Map) flat << d
-                def children = node.children
-                if (children instanceof List) flatten(children)
+                if (d instanceof Map && d.id?.toString() == idStr) {
+                    foundData = d
+                    return true
+                }
+                if (node.children instanceof List && findInNodes(node.children)) return true
             }
+            return false
         }
         def apps = parsed.apps
         if (!(apps instanceof List)) return null
-        flatten(apps)
-
-        def foundData = flat.find { it?.id?.toString() == idStr }
+        findInNodes(apps)
         if (!foundData) return null
 
         // Determine whether this app type is rule-like via classLocation or type string.
@@ -3400,7 +3402,7 @@ private String findRuleAppRedirect(ruleId, String verb) {
         if (verb == "read") {
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                 "Use `manage_installed_apps -> get_app_config(appId=${idStr})` to read its configuration. " +
-                "`get_rule` and `export_rule` only handle MCP's own rule engine, not Hubitat built-in apps."
+                "`get_rule`, `export_rule`, and `clone_rule` only handle MCP's own rule engine, not Hubitat built-in apps."
         } else {
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                 "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3208,7 +3208,7 @@ def toolDeleteRule(args) {
 
     def childApp = getChildAppById(args.ruleId)
     if (!childApp) {
-        def redirect = findRuleAppRedirect(args.ruleId, "write")
+        def redirect = findRuleAppRedirect(args.ruleId, "delete")
         def msg = "Rule not found: ${args.ruleId}"
         if (redirect) msg += ". ${redirect}"
         throw new IllegalArgumentException(msg)
@@ -3289,7 +3289,7 @@ def toolDeleteRule(args) {
 def toolTestRule(ruleId) {
     def childApp = getChildAppById(ruleId)
     if (!childApp) {
-        def redirect = findRuleAppRedirect(ruleId, "write")
+        def redirect = findRuleAppRedirect(ruleId, "test")
         def msg = "Rule not found: ${ruleId}"
         if (redirect) msg += ". ${redirect}"
         throw new IllegalArgumentException(msg)
@@ -3320,7 +3320,7 @@ private String findRuleAppRedirect(ruleId, String verb) {
     // Soft gate: only enrich the error when Built-in App Tools are enabled.
     // Prevents leaking that an app exists at this id (or its type) when the
     // operator has intentionally restricted built-in app visibility.
-    if (!settings.enableBuiltinAppRead) return null
+    if (!settings.enableBuiltinApp) return null
 
     // Known classLocation values for rule-like built-in apps.
     // ruleApp51 = Rule Machine 5.1, ruleApp50 = Rule Machine 5.0,
@@ -3402,12 +3402,23 @@ private String findRuleAppRedirect(ruleId, String verb) {
         if (verb == "read") {
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                 "Use `manage_installed_apps -> get_app_config(appId=${idStr})` to read its configuration. " +
-                "`get_rule`, `export_rule`, and `clone_rule` only handle MCP's own rule engine, not Hubitat built-in apps."
-        } else {
+                "`custom_get_rule`, `custom_export_rule`, and `custom_clone_rule` only handle MCP's own rule engine, not Hubitat built-in apps."
+        } else if (verb == "delete") {
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                 "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
-                "Hubitat built-in rules cannot be programmatically modified via MCP at this time -- " +
-                "use the Hubitat Rule Machine UI for changes."
+                "Use `manage_native_rules_and_apps -> delete_native_app(appId=${idStr}, confirm=true)` to delete it programmatically " +
+                "(requires Built-in App Tools + Hub Admin Write)."
+        } else if (verb == "test") {
+            return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
+                "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
+                "Use `manage_native_rules_and_apps -> run_rm_rule(ruleId=${idStr})` to trigger it " +
+                "(requires Built-in App Tools)."
+        } else {
+            // write (update_rule and any future write verbs)
+            return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
+                "Use `manage_installed_apps -> get_app_config(appId=${idStr})` for read-only inspection. " +
+                "Use `manage_native_rules_and_apps -> update_native_app(appId=${idStr})` to modify it programmatically " +
+                "(requires Built-in App Tools + Hub Admin Write)."
         }
     } catch (Exception e) {
         mcpLog("warn", "rules", "findRuleAppRedirect lookup failed for id ${idStr}: ${e.message ?: e.toString()}")

--- a/src/test/groovy/server/RuleNotFoundRedirectSpec.groovy
+++ b/src/test/groovy/server/RuleNotFoundRedirectSpec.groovy
@@ -1,0 +1,406 @@
+package server
+
+import groovy.json.JsonOutput
+import support.TestChildApp
+import support.ToolSpecBase
+
+/**
+ * Spec for the Rule-not-found redirect feature (feat/rule-not-found-redirect).
+ *
+ * When an MCP-native rule tool (get_rule, export_rule, update_rule, delete_rule,
+ * test_rule, clone_rule) receives an id that does not belong to any MCP child-app
+ * rule, it calls findRuleAppRedirect() to check whether the id exists as a
+ * Hubitat built-in rule-like app. If so, the IllegalArgumentException includes
+ * a verb-appropriate redirect hint guiding the AI toward get_app_config.
+ *
+ * Coverage matrix per affected tool:
+ *   (a) Valid MCP-native rule id         -> no redirect; original behaviour unchanged
+ *   (b) Id is an RM rule (ruleApp51)     -> redirect hint in exception
+ *   (c) Id not found anywhere            -> generic "not found" (no redirect)
+ *   (d) Id is a non-rule-like built-in   -> no redirect (avoid false positives)
+ *   (e) /hub2/appsList fetch fails       -> graceful fallback, no secondary exception
+ *
+ * Shared helper scenarios (a/c/d/e) are tested once against toolGetRule since
+ * they exercise the shared findRuleAppRedirect helper. Per-tool tests cover
+ * the redirect hint phrasing (read vs write verb) and the gate/confirm checks
+ * that fire before the redirect path is reached (e.g. delete_rule confirm gate).
+ */
+class RuleNotFoundRedirectSpec extends ToolSpecBase {
+
+    // ------------------------------------------------------------------ helpers
+
+    /** Minimal appsList JSON with one app of the given classLocation. */
+    private static String appsListJson(int appId, String appType, String classLocation, int appTypeId = 1) {
+        JsonOutput.toJson([
+            systemAppTypes: [[id: appTypeId, name: appType, classLocation: classLocation]],
+            apps: [[
+                data: [id: appId, name: appType, type: appType, user: false,
+                       disabled: false, hidden: false, appTypeId: appTypeId],
+                children: []
+            ]]
+        ])
+    }
+
+    /** appsList JSON with no systemAppTypes (type-string fallback path). */
+    private static String appsListJsonNoTypes(int appId, String typeName) {
+        JsonOutput.toJson([
+            systemAppTypes: [],
+            apps: [[
+                data: [id: appId, name: typeName, type: typeName, user: false,
+                       disabled: false, hidden: false],
+                children: []
+            ]]
+        ])
+    }
+
+    /** appsList JSON with no matching app id (app absent). */
+    private static String appsListJsonEmpty() {
+        JsonOutput.toJson([systemAppTypes: [], apps: []])
+    }
+
+    // ================================================================ toolGetRule
+
+    def "get_rule (a) valid MCP rule id -- no redirect, returns rule data"() {
+        given: 'an existing MCP child-app rule'
+        def childApp = new TestChildApp(id: 42L, label: 'Motion Rule')
+        childApp.ruleData = [
+            name: 'Motion Rule', enabled: true,
+            triggers: [[type: 'time', time: '08:00']],
+            conditions: [], actions: [[type: 'delay', seconds: 1]],
+            localVariables: [:]
+        ]
+        childAppsList << childApp
+
+        when:
+        def result = script.toolGetRule('42')
+
+        then: 'rule data returned, no exception, no hub appsList call'
+        result.name == 'Motion Rule'
+        hubGet.calls.empty
+    }
+
+    def "get_rule (b) RM rule id (classLocation=ruleApp51) -- read-verb redirect in exception"() {
+        given: 'hub has appId 832 as a Rule Machine 5.1 rule'
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(832, 'Rule-5.1', 'ruleApp51')
+        }
+
+        when:
+        script.toolGetRule('832')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 832')
+        ex.message.contains('get_app_config(appId=832)')
+        ex.message.contains('get_rule')
+        ex.message.contains('export_rule')
+        // read-verb phrasing: should NOT contain write-verb phrasing
+        !ex.message.contains('cannot be programmatically modified')
+    }
+
+    def "get_rule (b2) type-string fallback -- Rule Machine name without systemAppTypes"() {
+        given: 'appsList has no systemAppTypes entries but type string matches'
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJsonNoTypes(900, 'Rule-5.1')
+        }
+
+        when:
+        script.toolGetRule('900')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 900')
+        ex.message.contains('get_app_config(appId=900)')
+    }
+
+    def "get_rule (b3) Room Lighting classLocation -- read-verb redirect"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(101, 'Room Lights', 'roomLightsApp')
+        }
+
+        when:
+        script.toolGetRule('101')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('get_app_config(appId=101)')
+    }
+
+    def "get_rule (c) id not found anywhere -- generic not found, no redirect"() {
+        given: 'hub appsList has no app with this id'
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
+
+        when:
+        script.toolGetRule('9999')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 9999')
+        !ex.message.contains('get_app_config')
+    }
+
+    def "get_rule (d) non-rule-like built-in app -- no redirect"() {
+        given: 'hub has appId 50 as Groups and Scenes (not rule-like)'
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(50, 'Groups and Scenes', 'groupsAndScenesApp')
+        }
+
+        when:
+        script.toolGetRule('50')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 50')
+        !ex.message.contains('get_app_config')
+    }
+
+    def "get_rule (e) appsList fetch throws -- graceful fallback, generic not found"() {
+        given: 'appsList endpoint is not registered (will throw IllegalStateException from mock)'
+        settingsMap.enableBuiltinAppRead = true
+        // HubInternalGetMock throws IllegalStateException for unregistered paths;
+        // findRuleAppRedirect must catch this and return null.
+        // Do NOT register /hub2/appsList here -- the mock's default throws.
+
+        when:
+        script.toolGetRule('777')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 777')
+        !ex.message.contains('get_app_config')
+    }
+
+    def "get_rule (e2) appsList returns empty string -- graceful fallback"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ -> '' }
+
+        when:
+        script.toolGetRule('888')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 888')
+        !ex.message.contains('get_app_config')
+    }
+
+    def "get_rule (e3) appsList returns non-JSON -- graceful fallback"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ -> 'not valid json' }
+
+        when:
+        script.toolGetRule('889')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 889')
+        !ex.message.contains('get_app_config')
+    }
+
+    def "get_rule (f) enableBuiltinAppRead disabled -- no redirect even if id is a built-in rule"() {
+        given: 'Built-in App Tools gate is OFF (default); helper must short-circuit without calling appsList'
+        // settingsMap.enableBuiltinAppRead is intentionally absent (falsy) -- this is the gate-off scenario
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(832, 'Rule-5.1', 'ruleApp51')
+        }
+
+        when:
+        script.toolGetRule('832')
+
+        then: 'generic not-found only -- no hint leaking app existence or type'
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 832')
+        !ex.message.contains('get_app_config')
+        // helper short-circuited: appsList endpoint should not have been called
+        hubGet.calls.empty
+    }
+
+    // ============================================================== toolExportRule
+
+    def "export_rule (b) RM rule id -- read-verb redirect in exception"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(500, 'Rule-5.0', 'ruleApp50')
+        }
+
+        when:
+        script.toolExportRule([ruleId: '500'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 500')
+        ex.message.contains('get_app_config(appId=500)')
+        ex.message.contains('get_rule')
+        ex.message.contains('export_rule')
+        !ex.message.contains('cannot be programmatically modified')
+    }
+
+    def "export_rule (c) id not found anywhere -- generic not found"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
+
+        when:
+        script.toolExportRule([ruleId: '1234'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 1234')
+        !ex.message.contains('get_app_config')
+    }
+
+    // ============================================================== toolUpdateRule
+
+    def "update_rule (b) RM rule id -- write-verb redirect in exception"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(300, 'Rule-5.1', 'ruleApp51')
+        }
+
+        when:
+        script.toolUpdateRule('300', [name: 'New Name'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 300')
+        ex.message.contains('get_app_config(appId=300)')
+        ex.message.contains('cannot be programmatically modified')
+        // write-verb phrasing: should NOT include the read-verb-exclusive phrase about
+        // get_rule / export_rule only handling MCP rules (mis-wiring 'read' verb would fail this)
+        !ex.message.contains('only handle MCP')
+    }
+
+    def "update_rule (c) id not found anywhere -- generic not found"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
+
+        when:
+        script.toolUpdateRule('9999', [name: 'X'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 9999')
+        !ex.message.contains('get_app_config')
+    }
+
+    // ============================================================== toolDeleteRule
+
+    def "delete_rule confirm gate fires before redirect check -- no appsList call"() {
+        when: 'no confirm param; gate should throw before rule lookup'
+        script.toolDeleteRule([ruleId: '300'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('confirm=true')
+        // appsList should NOT have been called -- confirm gate fires first
+        hubGet.calls.empty
+    }
+
+    def "delete_rule (b) RM rule id -- write-verb redirect in exception"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(400, 'Rule-5.1', 'ruleApp51')
+        }
+
+        when:
+        script.toolDeleteRule([ruleId: '400', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 400')
+        ex.message.contains('get_app_config(appId=400)')
+        ex.message.contains('cannot be programmatically modified')
+    }
+
+    def "delete_rule (c) id not found anywhere -- generic not found"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
+
+        when:
+        script.toolDeleteRule([ruleId: '9999', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 9999')
+        !ex.message.contains('get_app_config')
+    }
+
+    // =============================================================== toolTestRule
+
+    def "test_rule (b) RM rule id -- write-verb redirect in exception"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(600, 'Rule-5.1', 'ruleApp51')
+        }
+
+        when:
+        script.toolTestRule('600')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 600')
+        ex.message.contains('get_app_config(appId=600)')
+        ex.message.contains('cannot be programmatically modified')
+    }
+
+    def "test_rule (c) id not found anywhere -- generic not found"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
+
+        when:
+        script.toolTestRule('9999')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 9999')
+        !ex.message.contains('get_app_config')
+    }
+
+    // =============================================================== toolCloneRule
+
+    def "clone_rule (b) RM rule id -- redirect propagates from toolExportRule"() {
+        given: 'clone delegates to toolExportRule which checks the redirect'
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(700, 'Rule-5.1', 'ruleApp51')
+        }
+
+        when:
+        script.toolCloneRule([ruleId: '700'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 700')
+        ex.message.contains('get_app_config(appId=700)')
+        // export_rule is called internally by clone_rule, so read-verb phrasing applies
+        ex.message.contains('export_rule')
+    }
+
+    def "clone_rule (c) id not found anywhere -- generic not found"() {
+        given:
+        settingsMap.enableBuiltinAppRead = true
+        hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
+
+        when:
+        script.toolCloneRule([ruleId: '9999'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 9999')
+        !ex.message.contains('get_app_config')
+    }
+}

--- a/src/test/groovy/server/RuleNotFoundRedirectSpec.groovy
+++ b/src/test/groovy/server/RuleNotFoundRedirectSpec.groovy
@@ -95,6 +95,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         ex.message.contains('get_app_config(appId=832)')
         ex.message.contains('get_rule')
         ex.message.contains('export_rule')
+        ex.message.contains('clone_rule')
         // read-verb phrasing: should NOT contain write-verb phrasing
         !ex.message.contains('cannot be programmatically modified')
     }
@@ -240,6 +241,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         ex.message.contains('get_app_config(appId=500)')
         ex.message.contains('get_rule')
         ex.message.contains('export_rule')
+        ex.message.contains('clone_rule')
         !ex.message.contains('cannot be programmatically modified')
     }
 
@@ -388,6 +390,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         ex.message.contains('get_app_config(appId=700)')
         // export_rule is called internally by clone_rule, so read-verb phrasing applies
         ex.message.contains('export_rule')
+        ex.message.contains('clone_rule')
     }
 
     def "clone_rule (c) id not found anywhere -- generic not found"() {

--- a/src/test/groovy/server/RuleNotFoundRedirectSpec.groovy
+++ b/src/test/groovy/server/RuleNotFoundRedirectSpec.groovy
@@ -15,12 +15,13 @@ import support.ToolSpecBase
  *
  * Coverage matrix per affected tool:
  *   (a) Valid MCP-native rule id         -> no redirect; original behaviour unchanged
- *   (b) Id is an RM rule (ruleApp51)     -> redirect hint in exception
+ *   (b) Id is an RM rule (type=Rule-5.1) -> redirect hint in exception
  *   (c) Id not found anywhere            -> generic "not found" (no redirect)
  *   (d) Id is a non-rule-like built-in   -> no redirect (avoid false positives)
  *   (e) /hub2/appsList fetch fails       -> graceful fallback, no secondary exception
+ *   (f) enableBuiltinApp disabled        -> no redirect, no info-leak (gate-off scenario)
  *
- * Shared helper scenarios (a/c/d/e) are tested once against toolGetRule since
+ * Shared helper scenarios (a/c/d/e/f) are tested once against toolGetRule since
  * they exercise the shared findRuleAppRedirect helper. Per-tool tests cover
  * the redirect hint phrasing (read vs write verb) and the gate/confirm checks
  * that fire before the redirect path is reached (e.g. custom_delete_rule confirm gate).
@@ -29,24 +30,16 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
 
     // ------------------------------------------------------------------ helpers
 
-    /** Minimal appsList JSON with one app of the given classLocation. */
-    private static String appsListJson(int appId, String appType, String classLocation, int appTypeId = 1) {
-        JsonOutput.toJson([
-            systemAppTypes: [[id: appTypeId, name: appType, classLocation: classLocation]],
-            apps: [[
-                data: [id: appId, name: appType, type: appType, user: false,
-                       disabled: false, hidden: false, appTypeId: appTypeId],
-                children: []
-            ]]
-        ])
-    }
-
-    /** appsList JSON with no systemAppTypes (type-string fallback path). */
-    private static String appsListJsonNoTypes(int appId, String typeName) {
+    /**
+     * Minimal appsList JSON containing one app with the given type string.
+     * Rule-like detection in findRuleAppRedirect is purely type-string based;
+     * systemAppTypes is present (as real hub returns it) but not used by the helper.
+     */
+    private static String appsListJson(int appId, String appType) {
         JsonOutput.toJson([
             systemAppTypes: [],
             apps: [[
-                data: [id: appId, name: typeName, type: typeName, user: false,
+                data: [id: appId, name: appType, type: appType, user: false,
                        disabled: false, hidden: false],
                 children: []
             ]]
@@ -56,6 +49,25 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
     /** appsList JSON with no matching app id (app absent). */
     private static String appsListJsonEmpty() {
         JsonOutput.toJson([systemAppTypes: [], apps: []])
+    }
+
+    /**
+     * appsList JSON where the target app is a child nested under a parent app.
+     * Exercises the iterative DFS path that descends into children[].
+     */
+    private static String appsListJsonNested(int parentId, String parentType, int childId, String childType) {
+        JsonOutput.toJson([
+            systemAppTypes: [],
+            apps: [[
+                data: [id: parentId, name: parentType, type: parentType, user: false,
+                       disabled: false, hidden: false],
+                children: [[
+                    data: [id: childId, name: childType, type: childType, user: false,
+                           disabled: false, hidden: false],
+                    children: []
+                ]]
+            ]]
+        ])
     }
 
     // ================================================================ toolGetRule
@@ -79,11 +91,11 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         hubGet.calls.empty
     }
 
-    def "custom_get_rule (b) RM rule id (classLocation=ruleApp51) -- read-verb redirect in exception"() {
+    def "custom_get_rule (b) RM rule id (type=Rule-5.1) -- read-verb redirect in exception"() {
         given: 'hub has appId 832 as a Rule Machine 5.1 rule'
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJson(832, 'Rule-5.1', 'ruleApp51')
+            appsListJson(832, 'Rule-5.1')
         }
 
         when:
@@ -100,11 +112,11 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         !ex.message.contains('update_native_app')
     }
 
-    def "custom_get_rule (b2) type-string fallback -- Rule Machine name without systemAppTypes"() {
-        given: 'appsList has no systemAppTypes entries but type string matches'
+    def "custom_get_rule (b2) RM rule -- type string Rule Machine 5.1 also matches"() {
+        given: 'type string "Rule Machine 5.1" matches via "rule machine" fragment'
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJsonNoTypes(900, 'Rule-5.1')
+            appsListJson(900, 'Rule Machine 5.1')
         }
 
         when:
@@ -116,11 +128,11 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         ex.message.contains('get_app_config(appId=900)')
     }
 
-    def "custom_get_rule (b3) Room Lighting classLocation -- read-verb redirect"() {
+    def "custom_get_rule (b3) Room Lighting type string -- read-verb redirect"() {
         given:
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJson(101, 'Room Lights', 'roomLightsApp')
+            appsListJson(101, 'Room Lights')
         }
 
         when:
@@ -149,7 +161,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         given: 'hub has appId 50 as Groups and Scenes (not rule-like)'
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJson(50, 'Groups and Scenes', 'groupsAndScenesApp')
+            appsListJson(50, 'Groups and Scenes')
         }
 
         when:
@@ -209,7 +221,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         given: 'Built-in App Tools gate is OFF (default); helper must short-circuit without calling appsList'
         // settingsMap.enableBuiltinApp is intentionally absent (falsy) -- this is the gate-off scenario
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJson(832, 'Rule-5.1', 'ruleApp51')
+            appsListJson(832, 'Rule-5.1')
         }
 
         when:
@@ -223,13 +235,56 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         hubGet.calls.empty
     }
 
+    def "findRuleAppRedirect type '#typeName' fires redirect via fragment match"() {
+        given: 'each rule-like type string should trigger a redirect via fragment matching -- the only detection path'
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(200, typeName)
+        }
+
+        when:
+        script.toolGetRule('200')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('get_app_config(appId=200)')
+
+        where:
+        typeName                | _
+        'Rule Machine 5.1'      | _   // fragment: "rule machine"
+        'Rule-5.1'              | _   // fragment: "rule-5"
+        'Rule-5.0'              | _   // fragment: "rule-5"
+        'Rule-4.1'              | _   // fragment: "rule-4"
+        'Room Lights'           | _   // fragment: "room light"
+        'Room Lighting'         | _   // fragment: "room light"
+        'Basic Rules'           | _   // fragment: "basic rules"
+        'Visual Rules Builder'  | _   // fragment: "visual rule" (parent app, plural)
+        'Visual Rule Builder'   | _   // fragment: "visual rule" (child instance, singular -- live-firmware name)
+    }
+
+    def "findRuleAppRedirect nested child app -- DFS descends into children"() {
+        given: 'target app is nested under a parent (Room Lighting child instance pattern on live hub)'
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJsonNested(999, 'Room Lights', 201, 'Room Lights')
+        }
+
+        when:
+        script.toolGetRule('201')
+
+        then: 'redirect fires even though the app is not at the top level'
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 201')
+        ex.message.contains('get_app_config(appId=201)')
+    }
+
     // ============================================================== toolExportRule
 
     def "custom_export_rule (b) RM rule id -- read-verb redirect in exception"() {
         given:
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJson(500, 'Rule-5.0', 'ruleApp50')
+            appsListJson(500, 'Rule-5.0')
         }
 
         when:
@@ -266,7 +321,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         given:
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJson(300, 'Rule-5.1', 'ruleApp51')
+            appsListJson(300, 'Rule-5.1')
         }
 
         when:
@@ -277,9 +332,10 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         ex.message.contains('Rule not found: 300')
         ex.message.contains('get_app_config(appId=300)')
         ex.message.contains('update_native_app')
-        // write-verb phrasing: should NOT include the read-verb-exclusive phrase about
-        // custom_get_rule / custom_export_rule only handling MCP rules
-        !ex.message.contains('only handle MCP')
+        ex.message.contains('custom_update_rule')
+        // write-verb phrasing: custom_get_rule appears only in read-verb output (lists get/export/clone tools);
+        // its absence here confirms we are not emitting the read-verb hint by mistake.
+        !ex.message.contains('custom_get_rule')
     }
 
     def "custom_update_rule (c) id not found anywhere -- generic not found"() {
@@ -298,7 +354,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
 
     // ============================================================== toolDeleteRule
 
-    def "delete_rule confirm gate fires before redirect check -- no appsList call"() {
+    def "custom_delete_rule confirm gate fires before redirect check -- no appsList call"() {
         when: 'no confirm param; gate should throw before rule lookup'
         script.toolDeleteRule([ruleId: '300'])
 
@@ -313,7 +369,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         given:
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJson(400, 'Rule-5.1', 'ruleApp51')
+            appsListJson(400, 'Rule-5.1')
         }
 
         when:
@@ -324,6 +380,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         ex.message.contains('Rule not found: 400')
         ex.message.contains('get_app_config(appId=400)')
         ex.message.contains('delete_native_app')
+        ex.message.contains('custom_delete_rule')
     }
 
     def "custom_delete_rule (c) id not found anywhere -- generic not found"() {
@@ -342,11 +399,11 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
 
     // =============================================================== toolTestRule
 
-    def "custom_test_rule (b) RM rule id -- test-verb redirect in exception"() {
-        given:
+    def "custom_test_rule (b) RM rule id -- test-verb redirect includes run_rm_rule"() {
+        given: 'ruleApp51 is RM-specific -- run_rm_rule hint should appear'
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJson(600, 'Rule-5.1', 'ruleApp51')
+            appsListJson(600, 'Rule-5.1')
         }
 
         when:
@@ -357,6 +414,24 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         ex.message.contains('Rule not found: 600')
         ex.message.contains('get_app_config(appId=600)')
         ex.message.contains('run_rm_rule')
+        ex.message.contains('custom_test_rule')
+    }
+
+    def "custom_test_rule (b2) non-RM rule-like id -- test-verb redirect omits run_rm_rule"() {
+        given: 'roomLightsApp is not RM -- run_rm_rule (RMUtils) would fail; hint must not appear'
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { _ ->
+            appsListJson(601, 'Room Lights')
+        }
+
+        when:
+        script.toolTestRule('601')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Rule not found: 601')
+        ex.message.contains('get_app_config(appId=601)')
+        !ex.message.contains('run_rm_rule')
     }
 
     def "custom_test_rule (c) id not found anywhere -- generic not found"() {
@@ -379,7 +454,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         given: 'clone delegates to toolExportRule which checks the redirect'
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
-            appsListJson(700, 'Rule-5.1', 'ruleApp51')
+            appsListJson(700, 'Rule-5.1')
         }
 
         when:

--- a/src/test/groovy/server/RuleNotFoundRedirectSpec.groovy
+++ b/src/test/groovy/server/RuleNotFoundRedirectSpec.groovy
@@ -7,11 +7,11 @@ import support.ToolSpecBase
 /**
  * Spec for the Rule-not-found redirect feature (feat/rule-not-found-redirect).
  *
- * When an MCP-native rule tool (get_rule, export_rule, update_rule, delete_rule,
- * test_rule, clone_rule) receives an id that does not belong to any MCP child-app
- * rule, it calls findRuleAppRedirect() to check whether the id exists as a
- * Hubitat built-in rule-like app. If so, the IllegalArgumentException includes
- * a verb-appropriate redirect hint guiding the AI toward get_app_config.
+ * When an MCP-native rule tool (custom_get_rule, custom_export_rule, custom_update_rule,
+ * custom_delete_rule, custom_test_rule, custom_clone_rule) receives an id that does not
+ * belong to any MCP child-app rule, it calls findRuleAppRedirect() to check whether the
+ * id exists as a Hubitat built-in rule-like app. If so, the IllegalArgumentException
+ * includes a verb-appropriate redirect hint guiding the AI toward the right tool.
  *
  * Coverage matrix per affected tool:
  *   (a) Valid MCP-native rule id         -> no redirect; original behaviour unchanged
@@ -23,7 +23,7 @@ import support.ToolSpecBase
  * Shared helper scenarios (a/c/d/e) are tested once against toolGetRule since
  * they exercise the shared findRuleAppRedirect helper. Per-tool tests cover
  * the redirect hint phrasing (read vs write verb) and the gate/confirm checks
- * that fire before the redirect path is reached (e.g. delete_rule confirm gate).
+ * that fire before the redirect path is reached (e.g. custom_delete_rule confirm gate).
  */
 class RuleNotFoundRedirectSpec extends ToolSpecBase {
 
@@ -60,7 +60,7 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
 
     // ================================================================ toolGetRule
 
-    def "get_rule (a) valid MCP rule id -- no redirect, returns rule data"() {
+    def "custom_get_rule (a) valid MCP rule id -- no redirect, returns rule data"() {
         given: 'an existing MCP child-app rule'
         def childApp = new TestChildApp(id: 42L, label: 'Motion Rule')
         childApp.ruleData = [
@@ -79,9 +79,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         hubGet.calls.empty
     }
 
-    def "get_rule (b) RM rule id (classLocation=ruleApp51) -- read-verb redirect in exception"() {
+    def "custom_get_rule (b) RM rule id (classLocation=ruleApp51) -- read-verb redirect in exception"() {
         given: 'hub has appId 832 as a Rule Machine 5.1 rule'
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
             appsListJson(832, 'Rule-5.1', 'ruleApp51')
         }
@@ -93,16 +93,16 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         def ex = thrown(IllegalArgumentException)
         ex.message.contains('Rule not found: 832')
         ex.message.contains('get_app_config(appId=832)')
-        ex.message.contains('get_rule')
-        ex.message.contains('export_rule')
-        ex.message.contains('clone_rule')
-        // read-verb phrasing: should NOT contain write-verb phrasing
-        !ex.message.contains('cannot be programmatically modified')
+        ex.message.contains('custom_get_rule')
+        ex.message.contains('custom_export_rule')
+        ex.message.contains('custom_clone_rule')
+        // read-verb phrasing: should NOT contain write-verb pointer to update_native_app
+        !ex.message.contains('update_native_app')
     }
 
-    def "get_rule (b2) type-string fallback -- Rule Machine name without systemAppTypes"() {
+    def "custom_get_rule (b2) type-string fallback -- Rule Machine name without systemAppTypes"() {
         given: 'appsList has no systemAppTypes entries but type string matches'
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
             appsListJsonNoTypes(900, 'Rule-5.1')
         }
@@ -116,9 +116,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         ex.message.contains('get_app_config(appId=900)')
     }
 
-    def "get_rule (b3) Room Lighting classLocation -- read-verb redirect"() {
+    def "custom_get_rule (b3) Room Lighting classLocation -- read-verb redirect"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
             appsListJson(101, 'Room Lights', 'roomLightsApp')
         }
@@ -131,9 +131,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         ex.message.contains('get_app_config(appId=101)')
     }
 
-    def "get_rule (c) id not found anywhere -- generic not found, no redirect"() {
+    def "custom_get_rule (c) id not found anywhere -- generic not found, no redirect"() {
         given: 'hub appsList has no app with this id'
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
 
         when:
@@ -145,9 +145,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         !ex.message.contains('get_app_config')
     }
 
-    def "get_rule (d) non-rule-like built-in app -- no redirect"() {
+    def "custom_get_rule (d) non-rule-like built-in app -- no redirect"() {
         given: 'hub has appId 50 as Groups and Scenes (not rule-like)'
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
             appsListJson(50, 'Groups and Scenes', 'groupsAndScenesApp')
         }
@@ -161,9 +161,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         !ex.message.contains('get_app_config')
     }
 
-    def "get_rule (e) appsList fetch throws -- graceful fallback, generic not found"() {
+    def "custom_get_rule (e) appsList fetch throws -- graceful fallback, generic not found"() {
         given: 'appsList endpoint is not registered (will throw IllegalStateException from mock)'
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         // HubInternalGetMock throws IllegalStateException for unregistered paths;
         // findRuleAppRedirect must catch this and return null.
         // Do NOT register /hub2/appsList here -- the mock's default throws.
@@ -177,9 +177,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         !ex.message.contains('get_app_config')
     }
 
-    def "get_rule (e2) appsList returns empty string -- graceful fallback"() {
+    def "custom_get_rule (e2) appsList returns empty string -- graceful fallback"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ -> '' }
 
         when:
@@ -191,9 +191,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         !ex.message.contains('get_app_config')
     }
 
-    def "get_rule (e3) appsList returns non-JSON -- graceful fallback"() {
+    def "custom_get_rule (e3) appsList returns non-JSON -- graceful fallback"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ -> 'not valid json' }
 
         when:
@@ -205,9 +205,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         !ex.message.contains('get_app_config')
     }
 
-    def "get_rule (f) enableBuiltinAppRead disabled -- no redirect even if id is a built-in rule"() {
+    def "custom_get_rule (f) enableBuiltinApp disabled -- no redirect even if id is a built-in rule"() {
         given: 'Built-in App Tools gate is OFF (default); helper must short-circuit without calling appsList'
-        // settingsMap.enableBuiltinAppRead is intentionally absent (falsy) -- this is the gate-off scenario
+        // settingsMap.enableBuiltinApp is intentionally absent (falsy) -- this is the gate-off scenario
         hubGet.register('/hub2/appsList') { _ ->
             appsListJson(832, 'Rule-5.1', 'ruleApp51')
         }
@@ -225,9 +225,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
 
     // ============================================================== toolExportRule
 
-    def "export_rule (b) RM rule id -- read-verb redirect in exception"() {
+    def "custom_export_rule (b) RM rule id -- read-verb redirect in exception"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
             appsListJson(500, 'Rule-5.0', 'ruleApp50')
         }
@@ -239,15 +239,16 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         def ex = thrown(IllegalArgumentException)
         ex.message.contains('Rule not found: 500')
         ex.message.contains('get_app_config(appId=500)')
-        ex.message.contains('get_rule')
-        ex.message.contains('export_rule')
-        ex.message.contains('clone_rule')
-        !ex.message.contains('cannot be programmatically modified')
+        ex.message.contains('custom_get_rule')
+        ex.message.contains('custom_export_rule')
+        ex.message.contains('custom_clone_rule')
+        // read-verb phrasing: should NOT contain write-verb pointer to update_native_app
+        !ex.message.contains('update_native_app')
     }
 
-    def "export_rule (c) id not found anywhere -- generic not found"() {
+    def "custom_export_rule (c) id not found anywhere -- generic not found"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
 
         when:
@@ -261,9 +262,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
 
     // ============================================================== toolUpdateRule
 
-    def "update_rule (b) RM rule id -- write-verb redirect in exception"() {
+    def "custom_update_rule (b) RM rule id -- write-verb redirect in exception"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
             appsListJson(300, 'Rule-5.1', 'ruleApp51')
         }
@@ -275,15 +276,15 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         def ex = thrown(IllegalArgumentException)
         ex.message.contains('Rule not found: 300')
         ex.message.contains('get_app_config(appId=300)')
-        ex.message.contains('cannot be programmatically modified')
+        ex.message.contains('update_native_app')
         // write-verb phrasing: should NOT include the read-verb-exclusive phrase about
-        // get_rule / export_rule only handling MCP rules (mis-wiring 'read' verb would fail this)
+        // custom_get_rule / custom_export_rule only handling MCP rules
         !ex.message.contains('only handle MCP')
     }
 
-    def "update_rule (c) id not found anywhere -- generic not found"() {
+    def "custom_update_rule (c) id not found anywhere -- generic not found"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
 
         when:
@@ -308,9 +309,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         hubGet.calls.empty
     }
 
-    def "delete_rule (b) RM rule id -- write-verb redirect in exception"() {
+    def "custom_delete_rule (b) RM rule id -- write-verb redirect in exception"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
             appsListJson(400, 'Rule-5.1', 'ruleApp51')
         }
@@ -322,12 +323,12 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         def ex = thrown(IllegalArgumentException)
         ex.message.contains('Rule not found: 400')
         ex.message.contains('get_app_config(appId=400)')
-        ex.message.contains('cannot be programmatically modified')
+        ex.message.contains('delete_native_app')
     }
 
-    def "delete_rule (c) id not found anywhere -- generic not found"() {
+    def "custom_delete_rule (c) id not found anywhere -- generic not found"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
 
         when:
@@ -341,9 +342,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
 
     // =============================================================== toolTestRule
 
-    def "test_rule (b) RM rule id -- write-verb redirect in exception"() {
+    def "custom_test_rule (b) RM rule id -- test-verb redirect in exception"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
             appsListJson(600, 'Rule-5.1', 'ruleApp51')
         }
@@ -355,12 +356,12 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         def ex = thrown(IllegalArgumentException)
         ex.message.contains('Rule not found: 600')
         ex.message.contains('get_app_config(appId=600)')
-        ex.message.contains('cannot be programmatically modified')
+        ex.message.contains('run_rm_rule')
     }
 
-    def "test_rule (c) id not found anywhere -- generic not found"() {
+    def "custom_test_rule (c) id not found anywhere -- generic not found"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
 
         when:
@@ -374,9 +375,9 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
 
     // =============================================================== toolCloneRule
 
-    def "clone_rule (b) RM rule id -- redirect propagates from toolExportRule"() {
+    def "custom_clone_rule (b) RM rule id -- redirect propagates from toolExportRule"() {
         given: 'clone delegates to toolExportRule which checks the redirect'
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ ->
             appsListJson(700, 'Rule-5.1', 'ruleApp51')
         }
@@ -388,14 +389,14 @@ class RuleNotFoundRedirectSpec extends ToolSpecBase {
         def ex = thrown(IllegalArgumentException)
         ex.message.contains('Rule not found: 700')
         ex.message.contains('get_app_config(appId=700)')
-        // export_rule is called internally by clone_rule, so read-verb phrasing applies
-        ex.message.contains('export_rule')
-        ex.message.contains('clone_rule')
+        // toolExportRule is called internally by toolCloneRule, so read-verb phrasing applies
+        ex.message.contains('custom_export_rule')
+        ex.message.contains('custom_clone_rule')
     }
 
-    def "clone_rule (c) id not found anywhere -- generic not found"() {
+    def "custom_clone_rule (c) id not found anywhere -- generic not found"() {
         given:
-        settingsMap.enableBuiltinAppRead = true
+        settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { _ -> appsListJsonEmpty() }
 
         when:

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -2427,6 +2427,31 @@ Tools in this section have mixed gate requirements. `list_installed_apps` and `g
 
 **Expected**: AI uses the Rule Machine app ID discovered in setup, then calls `manage_installed_apps(tool='list_app_pages', args={appId: <discovered_id>})`. Returns a `pages` list with a single entry `{name: 'mainPage', role: 'primary'}` plus a `note` confirming rules are single-page. AI explains there is only one page (mainPage) and no sub-pages are available.
 
+### T219 — get_rule on a Rule Machine rule ID (redirect hint)
+
+```json
+{
+  "setup_prompt": "Built-in App Tools is enabled. Use list_rm_rules or list_installed_apps to find an existing Rule Machine rule and note its app ID (not an MCP rule ID).",
+  "test_prompt": "Call get_rule with the Rule Machine app ID you just found and tell me what error message you receive.",
+  "teardown_prompt": "No teardown needed."
+}
+```
+
+**Expected**: `get_rule` throws `IllegalArgumentException` containing both "Rule not found: <id>" and a redirect hint like:
+> "Rule <id> is a Hubitat built-in Rule-5.1 app. Use `manage_installed_apps -> get_app_config(appId=<id>)` to read its configuration."
+
+AI should:
+1. Report the full error including the redirect hint
+2. Recognize that `get_rule` only handles MCP's own rule engine
+3. Follow the hint by calling `manage_installed_apps(tool='get_app_config', args={appId: <id>})` to read the rule's configuration
+
+This scenario validates that an agent landing on the wrong tool is efficiently redirected to the correct one in a single round-trip rather than wasting 3-4 tool calls.
+
+**Failure modes to flag:**
+- AI receives a redirect hint but ignores it and keeps calling `get_rule` variants
+- AI receives "Rule not found" with no redirect hint (suggests `enableBuiltinAppRead` is disabled and the `/hub2/appsList` lookup couldn't run -- check hub settings)
+- AI follows the hint successfully but reports confusion about read vs write capabilities
+
 ---
 
 ## Section 12: Developer Mode Tests

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -2427,29 +2427,29 @@ Tools in this section have mixed gate requirements. `list_installed_apps` and `g
 
 **Expected**: AI uses the Rule Machine app ID discovered in setup, then calls `manage_installed_apps(tool='list_app_pages', args={appId: <discovered_id>})`. Returns a `pages` list with a single entry `{name: 'mainPage', role: 'primary'}` plus a `note` confirming rules are single-page. AI explains there is only one page (mainPage) and no sub-pages are available.
 
-### T219 — get_rule on a Rule Machine rule ID (redirect hint)
+### T219 — custom_get_rule on a Rule Machine rule ID (redirect hint)
 
 ```json
 {
   "setup_prompt": "Built-in App Tools is enabled. Use list_rm_rules or list_installed_apps to find an existing Rule Machine rule and note its app ID (not an MCP rule ID).",
-  "test_prompt": "Call get_rule with the Rule Machine app ID you just found and tell me what error message you receive.",
+  "test_prompt": "Call custom_get_rule with the Rule Machine app ID you just found and tell me what error message you receive.",
   "teardown_prompt": "No teardown needed."
 }
 ```
 
-**Expected**: `get_rule` throws `IllegalArgumentException` containing both "Rule not found: <id>" and a redirect hint like:
+**Expected**: `custom_get_rule` throws `IllegalArgumentException` containing both "Rule not found: <id>" and a redirect hint like:
 > "Rule <id> is a Hubitat built-in Rule-5.1 app. Use `manage_installed_apps -> get_app_config(appId=<id>)` to read its configuration."
 
 AI should:
 1. Report the full error including the redirect hint
-2. Recognize that `get_rule` only handles MCP's own rule engine
+2. Recognize that `custom_get_rule` only handles MCP's own rule engine
 3. Follow the hint by calling `manage_installed_apps(tool='get_app_config', args={appId: <id>})` to read the rule's configuration
 
 This scenario validates that an agent landing on the wrong tool is efficiently redirected to the correct one in a single round-trip rather than wasting 3-4 tool calls.
 
 **Failure modes to flag:**
-- AI receives a redirect hint but ignores it and keeps calling `get_rule` variants
-- AI receives "Rule not found" with no redirect hint (suggests `enableBuiltinAppRead` is disabled and the `/hub2/appsList` lookup couldn't run -- check hub settings)
+- AI receives a redirect hint but ignores it and keeps calling `custom_get_rule` variants
+- AI receives "Rule not found" with no redirect hint (suggests `enableBuiltinApp` is disabled and the `/hub2/appsList` lookup couldn't run -- check hub settings)
 - AI follows the hint successfully but reports confusion about read vs write capabilities
 
 ---

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -119,6 +119,12 @@ RULES = [
         "message": "HubAction only valid in drivers, not apps",
         "severity": "error",
     },
+    {
+        "id": "SANDBOX-012",
+        "pattern": r"\bnew\s+(?:java\s*\.\s*util\s*\.\s*)?ArrayDeque\s*\(",
+        "message": "ArrayDeque instantiation blocked in Hubitat sandbox at parse time -- use Groovy list literal `[]` (LinkedList-backed; supports addLast/removeLast for LIFO semantics)",
+        "severity": "error",
+    },
 ]
 
 # ---------------------------------------------------------------------------
@@ -631,6 +637,31 @@ SELF_TEST_CASES = [
         "Bare $Locale.default in an interpolation is flagged",
         'log.info "loc=$Locale.default"',
         [("SANDBOX-002", True)],
+    ),
+    (
+        "new ArrayDeque() (no-arg constructor) is flagged",
+        "def stack = new ArrayDeque()",
+        [("SANDBOX-012", True)],
+    ),
+    (
+        "new ArrayDeque(collection) is flagged",
+        "def stack = new ArrayDeque(apps)",
+        [("SANDBOX-012", True)],
+    ),
+    (
+        "new java.util.ArrayDeque() fully-qualified is flagged",
+        "def stack = new java.util.ArrayDeque()",
+        [("SANDBOX-012", True)],
+    ),
+    (
+        "Groovy list literal `[]` is NOT flagged (the safe alternative)",
+        "def stack = []",
+        [("SANDBOX-012", False)],
+    ),
+    (
+        "new LinkedList() is NOT flagged (LinkedList is sandbox-allowed)",
+        "def stack = new LinkedList()",
+        [("SANDBOX-012", False)],
     ),
 ]
 


### PR DESCRIPTION
## Summary

Addresses #118 **Option A** — when a caller passes a rule id that belongs to a Hubitat built-in rule app (Rule Machine, Room Lighting, Basic Rules, Visual Rule Builder) to an MCP-native rule tool (`custom_get_rule`, `custom_export_rule`, `custom_update_rule`, `custom_delete_rule`, `custom_test_rule`, `custom_clone_rule`), the "Rule not found" error now includes a verb-specific redirect hint pointing at the appropriate native tool.

Read verbs cite `manage_installed_apps → get_app_config(appId=<id>)` for inspection. Write verbs (post-#134 rebase) point at the matching native CRUD: `custom_update_rule → update_native_app(appId, ...)`, `custom_delete_rule → delete_native_app(appId, confirm=true)`, `custom_test_rule → run_rm_rule(ruleId)`. `custom_clone_rule` and `custom_export_rule` direct callers at `get_app_config` for read-only inspection (no native equivalent for cloning a built-in rule today).

Scope-commitment anchor: kingpanther13/Hubitat-local-MCP-server#118 (comment-4316325580). Phase 2 Option D (`readConfigVia` hint on `custom_list_rules` response) and Option B (`get_rm_rule` thin wrapper) remain in your #120 Phase 2 plan.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

New helper `findRuleAppRedirect(ruleId, verb)` in the rule helpers section:

1. **Soft-gates on `enableBuiltinApp`** — returns null before any hub fetch when the gate is off, so plain "Rule not found: <id>" is the observable message in that posture (no information leak via the error side channel).
2. Fetches `/hub2/appsList`, walks the apps tree with iterative DFS to find the matching id (Round-2 refactor — replaces a recursive closure for stack-depth safety on large hubs).
3. Classifies the found node by case-insensitive substring match against a curated list of built-in-rule type-name fragments: `"rule machine"`, `"rule-5"`, `"rule-4"`, `"room light"`, `"basic rules"`, `"visual rule"`. The `"visual rule"` (singular) fragment matches both `"Visual Rule Builder"` (child instance) and `"Visual Rules Builder"` (parent app).
4. Returns a verb-tailored redirect string. Read verbs cite `get_app_config`. Write verbs cite the appropriate native CRUD tool from the post-#134 surface.
5. Returns null on any fetch / parse / classification failure — caller's existing plain-"Rule not found" behavior is preserved. Best-effort diagnostic enrichment, never changes the thrown exception class.

`custom_clone_rule` inherits the redirect via its delegation to `custom_export_rule` — no separate call site needed.

Closes #118 (Option A only — Options B, C, D remain in #120 Phase 2 per your bundling plan).

## Release Notes

- Custom rule tools (`custom_get_rule`, `custom_test_rule`, `custom_export_rule`, `custom_clone_rule`, `custom_update_rule`, `custom_delete_rule`) now return a redirect hint when called with a rule id that belongs to a Hubitat built-in rule app (Rule Machine, Room Lighting, Basic Rules, Visual Rule Builder).
- Read verbs point at `manage_installed_apps → get_app_config`. Write verbs point at the matching native CRUD tool under `manage_native_rules_and_apps`.
- New MCP-app-side toggle `enableBuiltinApp` (off by default) gates the helper — keeps the "no information leak" posture for sites that prefer the plain error.

## Testing

`RuleNotFoundRedirectSpec` — **32/32 PASS** across the 6 verb tools × scenarios:

- (a) Valid MCP-native rule id → no redirect, existing error path unchanged
- (b) Unknown id exists as RM rule (`type: Rule-5.1`) → read-verb redirect with backtick-quoted tool names
- (b2) Rule Machine 5.0 / 4.x type-name variants
- (b3) Room Lighting type string matches via `"room light"` fragment
- (b4) Basic Rules type string matches via `"basic rules"` fragment
- (b5) Visual Rule Builder (singular, child instance) matches via `"visual rule"` fragment
- (b6) Visual Rules Builder (plural, parent app) also matches via `"visual rule"` fragment
- (c) Unknown id doesn't exist anywhere → generic "Rule not found" (no redirect)
- (d) Unknown id exists as non-rule-like built-in (e.g., Groups and Scenes, HPM) → no redirect (false-positive guard)
- (e / e2 / e3) `/hub2/appsList` fetch throws / returns empty / returns non-JSON → graceful null return, generic not-found
- (f) `enableBuiltinApp=false` → short-circuits before any `hubGet` call (asserted via `hubGet.calls.empty`)

Parallel test blocks for `custom_clone_rule`, `custom_delete_rule`, `custom_export_rule`, `custom_test_rule`, `custom_update_rule` covering both the redirect-fires case and the write-verb-specific phrasing.

**Live-hub validation on test hub (firmware 2.5.0.126):**

| Rule id | App type | Expected | Observed |
|---|---|---|---|
| 724 | `Rule-5.1` (RM child) | redirect | ✅ Rule Machine 5.1 redirect, points at `update_native_app` for write |
| 725 | `Visual Rule Builder` (VRB child, singular) | redirect | ✅ matches via `"visual rule"` fragment |
| 216 | `Rule Machine` (RM parent) | redirect | ✅ matches via `"rule machine"` fragment |
| 5 | `Visual Rules Builder` (VRB parent, plural) | redirect | ✅ matches via `"visual rule"` fragment |
| 37 | `Hubitat Package Manager` (non-rule) | plain "Rule not found" | ✅ no redirect, false-positive guard holds |

Earlier zero-context Sonnet validations on firmware 2.4.4.156 (4 blind agents — A1/A2/A3/A4): each redirect-firing agent read and acted on the hint on the first encounter, landed on `get_app_config` directly, produced complete rule summaries. Tool-call count reduced from 3-4 wasted calls (pre-redirect) to 1 corrective call (post-redirect).

`tests/sandbox_lint.py` — clean (0 errors, 0 warnings). New SANDBOX-012 rule added in round-2 catches `new java.util.ArrayDeque(...)` (sandbox-blocked at parse time; surfaced when an iteration refactor hit it).

## Checklist

- [x] Unit tests added for any new MCP tools (RuleNotFoundRedirectSpec, 32 scenarios)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally and on CI
- [x] Live-hub BAT tests updated (T219 in `tests/BAT-v2.md`)
- [x] Documentation updated (`TOOL_GUIDE.md` redirect-helper section, `agent-skill/hubitat-mcp/tool-reference.md`)

## Scope that's explicitly NOT in this PR

- **Option B** (`get_rm_rule(ruleId)` thin wrapper under `manage_rule_machine`) — yours under #120 Phase 2
- **Option D** (`readConfigVia` hint on `custom_list_rules` response) — yours under #120 Phase 2
- **Option C** (structured parsed RM output) — deferred per your direction unless a concrete use case surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
