### PR TITLE
feat: optional flat tool-list mode (toggle off category gateways)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 89 tools total — 22 core tools are always visible, while 67 additional tools are organized behind 12 domain-named gateways to keep the tool list manageable.
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 89 tools total — 22 core tools are always visible, while 67 additional tools are organized behind 12 domain-named gateways to keep the tool list manageable. If your client handles long tool lists well, you can disable the gateways via the **Consolidate tools behind category gateways** setting and every tool is exposed individually instead. (Counts here describe the shipped catalog; the runtime count on `tools/list` varies based on enabled settings.)
 
 ## Requirements
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -18,9 +18,9 @@ All safety gates (Hub Admin Read/Write, confirm, backup checks) are preserved �
 
 Gateways exist because most MCP clients struggle with long tool lists. Some clients now ship their own progressive-disclosure layer (deferred tools, built-in BM25 search, etc.) and don't need ours. For those, the **Consolidate tools behind category gateways** setting in the app preferences can be turned off — `tools/list` then advertises every tool individually and `search_tools` is suppressed because it's only useful for navigating gateway-hidden tools.
 
-Default is **ON** (gateways enabled). Existing installations keep the gateway behavior on update.
+When the toggle is off, the dispatch contract still holds: every gateway sub-tool already has its own case in `executeTool()`, so a flat-mode client calling `list_rooms` directly hits the same handler as a gateway-mode client calling `manage_rooms` with `tool: "list_rooms"`. If a stale or cached client tries to call a gateway name (e.g. `manage_rooms`) while the toggle is off, the server returns a soft `isError` pointing at the underlying sub-tools rather than silently servicing the call with a gateway-shaped response.
 
-> The 89/34 counts above describe the shipped catalog. Runtime `tools/list` size varies based on settings — the Built-in App Tools, Custom Rule Engine, and gateway toggles all add or remove entries.
+Default is **ON** (gateways enabled). Existing installations keep the gateway behavior on update. Counts here describe the shipped catalog; runtime `tools/list` size varies based on enabled settings (Built-in App Tools, Custom Rule Engine, and the gateway toggle all add or remove entries).
 
 ## Device Authorization (CRITICAL)
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -14,6 +14,14 @@ As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used 
 
 All safety gates (Hub Admin Read/Write, confirm, backup checks) are preserved — they are enforced in the handler functions, not the dispatch layer.
 
+### Disabling Gateways (Flat Tool List)
+
+Gateways exist because most MCP clients struggle with long tool lists. Some clients now ship their own progressive-disclosure layer (deferred tools, built-in BM25 search, etc.) and don't need ours. For those, the **Consolidate tools behind category gateways** setting in the app preferences can be turned off — `tools/list` then advertises every tool individually and `search_tools` is suppressed because it's only useful for navigating gateway-hidden tools.
+
+Default is **ON** (gateways enabled). Existing installations keep the gateway behavior on update.
+
+> The 89/34 counts above describe the shipped catalog. Runtime `tools/list` size varies based on settings — the Built-in App Tools, Custom Rule Engine, and gateway toggles all add or remove entries.
+
 ## Device Authorization (CRITICAL)
 
 **Exact match rule:**

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -168,7 +168,7 @@ def mainPage() {
                   description: "Controls the legacy MCP-managed rule engine (custom_* tools). OFF + Built-in App Tools ON = read-only mode: custom_list_rules, custom_get_rule, custom_update_rule(enabled only), custom_test_rule, custom_get_rule_diagnostics are visible; create/delete/export/import/clone are hidden. OFF + Built-in App Tools OFF = all custom_* tools hidden. ON = all custom_* tools shown (full mode). The native Hubitat Rule Machine (Built-in App Tools toggle) is independent of this. Note: Hubitat firmware upgrades may briefly reset Boolean toggles -- verify this stays OFF after each firmware upgrade if you've migrated to native Rule Machine.",
                   defaultValue: false, submitOnChange: true
             input "useGateways", "bool", title: "Consolidate tools behind category gateways",
-                  description: "When ON (default): tools are organized behind domain-named category gateways so tools/list stays compact for clients that struggle with long tool lists. When OFF: every tool is exposed individually as a top-level MCP tool and search_tools is hidden. Most LLM clients perform better with the gateway list; turn this off only if your client has its own progressive-disclosure / tool-search layer.",
+                  description: "When ON (default): tools are organized behind domain-named category gateways so tools/list stays compact for clients that struggle with long tool lists. When OFF: every tool is exposed individually as a top-level MCP tool and search_tools is hidden because its only purpose is finding tools hidden behind gateways. Most LLM clients perform better with the gateway list; turn this off only if your client has its own progressive-disclosure / tool-search layer. Note: other toggles (Built-in App Tools, Custom Rule Engine) also add or remove entries from tools/list independently of this setting.",
                   defaultValue: true
             input "mcpLogLevel", "enum", title: "MCP Debug Log Level",
                   description: "Controls MCP-accessible debug logs (default: errors only)",
@@ -827,25 +827,11 @@ def handleGateway(gatewayName, toolName, toolArgs) {
     return executeTool(toolName, safeArgs)
 }
 
-// Returns tool definitions visible to the MCP client. Default: 22 core tools + gateway
-// entries. When useGateways is explicitly false, every tool is advertised individually
-// and search_tools is dropped — it only helps navigate gateway-hidden tools.
-//
-// Toggle-based hides (apply in BOTH flat and gateway modes — when a feature toggle is off,
-// its tools are completely REMOVED from tools/list, not just gated at call time):
-//   enableBuiltinApp=false  → hides list_installed_apps, get_device_in_use_by, list_rm_rules,
-//                              run_rm_rule, pause_rm_rule, resume_rm_rule, set_rm_rule_boolean,
-//                              create_native_app, update_native_app, delete_native_app
-//   enableCustomRuleEngine=false AND enableBuiltinApp=false → hides all 10 custom_* tools
-//   enableCustomRuleEngine=false AND enableBuiltinApp=true  → read-only subset shown:
-//     visible: custom_list_rules, custom_get_rule, custom_update_rule (enabled only),
-//              custom_test_rule, custom_get_rule_diagnostics
-//     hidden:  custom_create_rule, custom_delete_rule, custom_export_rule,
-//              custom_import_rule, custom_clone_rule
-//   enableCustomRuleEngine=true → all 10 custom_* tools shown (full mode)
-//   useGateways=false → tools/list is flat (every tool individually) and search_tools is hidden.
-//                        Null (never saved) means existing installs keep gateway behavior; only
-//                        an explicit false flips to flat mode.
+// When a feature toggle is off, its tools are REMOVED from tools/list — not just gated
+// at call time. The hide rules live in the biTools / customEngineMode blocks below;
+// useGateways=false additionally flattens the catalog (every tool individually) and
+// hides search_tools, whose only purpose is finding gateway-hidden tools. Null/unset
+// useGateways preserves gateway behavior so existing installs are unaffected on update.
 def getToolDefinitions() {
     def builtinAppOn = settings.enableBuiltinApp == true
     def customEngineOn = settings.enableCustomRuleEngine == true
@@ -887,9 +873,17 @@ def getToolDefinitions() {
     // Flat mode: every tool advertised individually under its real name; search_tools
     // is dropped because it only helps navigate gateway-hidden tools.
     if (settings.useGateways == false) {
-        return getAllToolDefinitions().findAll {
-            it.name != 'search_tools' && !hideByName.contains(it.name)
+        def all = getAllToolDefinitions()
+        def filtered = all.findAll { it.name != 'search_tools' && !hideByName.contains(it.name) }
+        // Loud guard: if search_tools is ever renamed/removed, the prose ("search_tools is
+        // hidden in flat mode") becomes a lie and the filter silently no-ops. Fail visibly.
+        if (!all.any { it.name == 'search_tools' }) {
+            throw new IllegalStateException(
+                "Flat-mode filter expected to drop 'search_tools' but it was not found in " +
+                "getAllToolDefinitions(). Update getToolDefinitions() if the tool was renamed."
+            )
         }
+        return filtered
     }
 
     def gatewayConfig = getGatewayConfig()
@@ -2586,6 +2580,24 @@ def executeTool(toolName, args) {
         case "manage_installed_apps":
         case "manage_native_rules_and_apps":
         case "manage_mcp_self":
+            // Flat-mode guard: gateways are not advertised on tools/list when useGateways=false,
+            // so a gateway-name call here is almost certainly a stale/cached client. Returning
+            // the gateway catalog would silently contradict the user's intent — fail loud with
+            // a hint pointing at the real sub-tools instead.
+            if (settings.useGateways == false) {
+                // Filter the hint against the live flat catalog so we don't recommend tools
+                // that other toggles (Built-in App / Custom Rule Engine) have also hidden.
+                def visibleNames = getToolDefinitions()*.name as Set
+                def subTools = (getGatewayConfig()[toolName]?.tools ?: []).findAll { visibleNames.contains(it) }
+                def hint = subTools
+                    ? "Call the underlying tool directly: ${subTools.join(', ')}. Refresh tools/list to see the flat catalog."
+                    : "All sub-tools of this gateway are also disabled by other server toggles (Built-in App Tools / Custom Rule Engine). Enable those toggles or refresh tools/list."
+                return [
+                    isError: true,
+                    error: "Gateway tool '${toolName}' is disabled — useGateways is OFF in this server's preferences.",
+                    hint: hint
+                ]
+            }
             return handleGateway(toolName, args.tool, args.args)
 
         default:

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -167,6 +167,9 @@ def mainPage() {
             input "enableCustomRuleEngine", "bool", title: "Enable Custom Rule Engine (legacy)",
                   description: "Controls the legacy MCP-managed rule engine (custom_* tools). OFF + Built-in App Tools ON = read-only mode: custom_list_rules, custom_get_rule, custom_update_rule(enabled only), custom_test_rule, custom_get_rule_diagnostics are visible; create/delete/export/import/clone are hidden. OFF + Built-in App Tools OFF = all custom_* tools hidden. ON = all custom_* tools shown (full mode). The native Hubitat Rule Machine (Built-in App Tools toggle) is independent of this. Note: Hubitat firmware upgrades may briefly reset Boolean toggles -- verify this stays OFF after each firmware upgrade if you've migrated to native Rule Machine.",
                   defaultValue: false, submitOnChange: true
+            input "useGateways", "bool", title: "Consolidate tools behind category gateways",
+                  description: "When ON (default): tools are organized behind domain-named category gateways so tools/list stays compact for clients that struggle with long tool lists. When OFF: every tool is exposed individually as a top-level MCP tool and search_tools is hidden. Most LLM clients perform better with the gateway list; turn this off only if your client has its own progressive-disclosure / tool-search layer.",
+                  defaultValue: true
             input "mcpLogLevel", "enum", title: "MCP Debug Log Level",
                   description: "Controls MCP-accessible debug logs (default: errors only)",
                   options: ["debug": "Debug (verbose)", "info": "Info (normal)", "warn": "Warnings only", "error": "Errors only (recommended)"],
@@ -824,9 +827,9 @@ def handleGateway(gatewayName, toolName, toolArgs) {
     return executeTool(toolName, safeArgs)
 }
 
-// Returns tool definitions visible to the MCP client. Default: 22 core tools + 11 gateway
+// Returns tool definitions visible to the MCP client. Default: 22 core tools + gateway
 // entries. When useGateways is explicitly false, every tool is advertised individually
-// (~82 entries) and search_tools is dropped — it only helps navigate gateway-hidden tools.
+// and search_tools is dropped — it only helps navigate gateway-hidden tools.
 //
 // Toggle-based hides (apply in BOTH flat and gateway modes — when a feature toggle is off,
 // its tools are completely REMOVED from tools/list, not just gated at call time):
@@ -840,6 +843,9 @@ def handleGateway(gatewayName, toolName, toolArgs) {
 //     hidden:  custom_create_rule, custom_delete_rule, custom_export_rule,
 //              custom_import_rule, custom_clone_rule
 //   enableCustomRuleEngine=true → all 10 custom_* tools shown (full mode)
+//   useGateways=false → tools/list is flat (every tool individually) and search_tools is hidden.
+//                        Null (never saved) means existing installs keep gateway behavior; only
+//                        an explicit false flips to flat mode.
 def getToolDefinitions() {
     def builtinAppOn = settings.enableBuiltinApp == true
     def customEngineOn = settings.enableCustomRuleEngine == true

--- a/src/test/groovy/server/GatewayToggleSpec.groovy
+++ b/src/test/groovy/server/GatewayToggleSpec.groovy
@@ -1,0 +1,122 @@
+package server
+
+import support.ToolSpecBase
+
+/**
+ * Spec for the `useGateways` setting on getToolDefinitions().
+ *
+ * Default + null + true: tools/list returns the consolidated catalog
+ * (22 core + 11 gateway entries). Explicit false: tools/list returns
+ * every tool individually and search_tools is hidden because its only
+ * purpose is mapping a query to a hidden sub-tool's gateway.
+ *
+ * Dispatch is unchanged in either mode — every gateway sub-tool already
+ * has its own case in executeTool(), so a flat-mode client calling
+ * `list_rooms` directly hits the same handler as a gateway-mode client
+ * calling `manage_rooms` with `tool: "list_rooms"`.
+ */
+class GatewayToggleSpec extends ToolSpecBase {
+
+    def "default (no setting saved): tools/list contains gateway entries and hides proxied sub-tools"() {
+        when:
+        def tools = script.getToolDefinitions()
+        def names = tools*.name as Set
+
+        then: 'gateway entries appear'
+        names.contains('manage_rooms')
+        names.contains('manage_files')
+        names.contains('manage_logs')
+
+        and: 'sub-tools that live behind a gateway are NOT top-level'
+        !names.contains('list_rooms')
+        !names.contains('list_files')
+        !names.contains('get_hub_logs')
+
+        and: 'core tools still appear'
+        names.contains('list_devices')
+        names.contains('get_device')
+        names.contains('search_tools')
+    }
+
+    def "useGateways=true: same as default"() {
+        given:
+        settingsMap.useGateways = true
+
+        when:
+        def names = script.getToolDefinitions()*.name as Set
+
+        then:
+        names.contains('manage_rooms')
+        !names.contains('list_rooms')
+        names.contains('search_tools')
+    }
+
+    def "useGateways=false: every tool advertised individually, gateway entries gone, search_tools hidden"() {
+        given:
+        settingsMap.useGateways = false
+
+        when:
+        def tools = script.getToolDefinitions()
+        def names = tools*.name as Set
+
+        then: 'no gateway entries on tools/list'
+        !names.contains('manage_rooms')
+        !names.contains('manage_files')
+        !names.contains('manage_logs')
+        !names.contains('manage_diagnostics')
+        !names.contains('manage_rules_admin')
+        !names.contains('manage_rule_machine')
+
+        and: 'every previously-proxied sub-tool is now top-level'
+        names.contains('list_rooms')
+        names.contains('get_room')
+        names.contains('list_files')
+        names.contains('get_hub_logs')
+        names.contains('get_zwave_details')
+        names.contains('list_rm_rules')
+
+        and: 'core tools still appear'
+        names.contains('list_devices')
+        names.contains('get_device')
+        names.contains('create_rule')
+
+        and: 'search_tools is suppressed in flat mode (its purpose is finding tools hidden behind gateways)'
+        !names.contains('search_tools')
+
+        and: 'every entry has the MCP tool shape'
+        tools.every {
+            it.name instanceof String && !it.name.isEmpty() &&
+            it.description instanceof String && !it.description.isEmpty() &&
+            it.inputSchema instanceof Map
+        }
+    }
+
+    def "useGateways=false: count is the full tool inventory minus search_tools"() {
+        given:
+        settingsMap.useGateways = false
+
+        when:
+        def flatNames = script.getToolDefinitions()*.name as Set
+        def allNames = script.getAllToolDefinitions()*.name as Set
+
+        then: 'flat-mode list equals all tools minus search_tools (no gateway entries leaked in, no tools dropped)'
+        flatNames == (allNames - 'search_tools')
+    }
+
+    def "useGateways=false: dispatch still works for a sub-tool called by its real name"() {
+        // The whole point of the toggle is that flat-mode clients call sub-tools directly.
+        // executeTool routes every sub-tool by name (no gateway prefix needed) — this pins
+        // that contract.
+        given:
+        settingsMap.useGateways = false
+        script.metaClass.getRooms = { ->
+            [[id: 1L, name: 'Living Room']]
+        }
+
+        when:
+        def result = script.executeTool('list_rooms', [:])
+
+        then:
+        result.rooms*.name == ['Living Room']
+    }
+}

--- a/src/test/groovy/server/GatewayToggleSpec.groovy
+++ b/src/test/groovy/server/GatewayToggleSpec.groovy
@@ -1,20 +1,10 @@
 package server
 
+import spock.lang.Unroll
 import support.ToolSpecBase
 
-/**
- * Spec for the `useGateways` setting on getToolDefinitions().
- *
- * Default + null + true: tools/list returns the consolidated catalog
- * (22 core + 11 gateway entries). Explicit false: tools/list returns
- * every tool individually and search_tools is hidden because its only
- * purpose is mapping a query to a hidden sub-tool's gateway.
- *
- * Dispatch is unchanged in either mode — every gateway sub-tool already
- * has its own case in executeTool(), so a flat-mode client calling
- * `list_rooms` directly hits the same handler as a gateway-mode client
- * calling `manage_rooms` with `tool: "list_rooms"`.
- */
+// Spec for `useGateways`. Other feature toggles are enabled per-test so the
+// gateway filter is the only narrowing.
 class GatewayToggleSpec extends ToolSpecBase {
 
     def "default (no setting saved): tools/list contains gateway entries and hides proxied sub-tools"() {
@@ -38,22 +28,23 @@ class GatewayToggleSpec extends ToolSpecBase {
         names.contains('search_tools')
     }
 
-    def "useGateways=true: same as default"() {
+    def "default (null) and explicit useGateways=true produce identical tool lists"() {
         given:
-        settingsMap.useGateways = true
+        def defaultNames = script.getToolDefinitions()*.name as Set
 
         when:
-        def names = script.getToolDefinitions()*.name as Set
+        settingsMap.useGateways = true
+        def explicitTrueNames = script.getToolDefinitions()*.name as Set
 
         then:
-        names.contains('manage_rooms')
-        !names.contains('list_rooms')
-        names.contains('search_tools')
+        explicitTrueNames == defaultNames
     }
 
     def "useGateways=false: every tool advertised individually, gateway entries gone, search_tools hidden"() {
-        given:
+        given: 'gateways off; the feature toggles whose tools we expect to see are on'
         settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
 
         when:
         def tools = script.getToolDefinitions()
@@ -65,7 +56,8 @@ class GatewayToggleSpec extends ToolSpecBase {
         !names.contains('manage_logs')
         !names.contains('manage_diagnostics')
         !names.contains('manage_rules_admin')
-        !names.contains('manage_rule_machine')
+        !names.contains('manage_native_rules_and_apps')
+        !names.contains('manage_mcp_self')
 
         and: 'every previously-proxied sub-tool is now top-level'
         names.contains('list_rooms')
@@ -78,7 +70,7 @@ class GatewayToggleSpec extends ToolSpecBase {
         and: 'core tools still appear'
         names.contains('list_devices')
         names.contains('get_device')
-        names.contains('create_rule')
+        names.contains('custom_create_rule')
 
         and: 'search_tools is suppressed in flat mode (its purpose is finding tools hidden behind gateways)'
         !names.contains('search_tools')
@@ -91,22 +83,71 @@ class GatewayToggleSpec extends ToolSpecBase {
         }
     }
 
-    def "useGateways=false: count is the full tool inventory minus search_tools"() {
-        given:
+    def "useGateways=false: catalog equals all tools minus search_tools (no leaks, no drops)"() {
+        given: 'all feature toggles on so the gateway-filter is the only narrowing'
         settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
 
         when:
         def flatNames = script.getToolDefinitions()*.name as Set
         def allNames = script.getAllToolDefinitions()*.name as Set
 
-        then: 'flat-mode list equals all tools minus search_tools (no gateway entries leaked in, no tools dropped)'
+        then:
         flatNames == (allNames - 'search_tools')
     }
 
+    @Unroll
+    def "useGateways=false: gateway sub-tool '#subTool' is dispatchable by its real name"() {
+        // Pins the load-bearing claim that every gateway sub-tool already has a top-level
+        // case in executeTool(). Adding a new sub-tool to getGatewayConfig() without a
+        // matching case here would silently break flat mode for that whole gateway.
+        given:
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        try {
+            script.executeTool(subTool, [:])
+        } catch (IllegalArgumentException e) {
+            // Tool-side validation IAE (missing required args, bad ID, etc.) is fine — it
+            // means dispatch reached the handler. Only a default-case fallthrough is fatal.
+            assert !e.message.startsWith("Unknown tool: ${subTool}"),
+                   "executeTool fell through to default for sub-tool '${subTool}' — missing case in switch"
+        } catch (Exception ignored) {
+            // Hub-side failures (NPE on null devices etc.) also indicate dispatch reached
+            // the handler. Pass.
+        }
+
+        then:
+        notThrown(AssertionError)
+
+        where:
+        subTool << [
+            'custom_delete_rule', 'custom_test_rule', 'custom_export_rule', 'custom_import_rule', 'custom_clone_rule',
+            'list_variables', 'get_variable', 'set_variable', 'delete_variable',
+            'list_rooms', 'get_room', 'create_room', 'delete_room', 'rename_room',
+            'reboot_hub', 'shutdown_hub', 'delete_device',
+            'list_hub_apps', 'list_hub_drivers', 'get_app_source', 'get_driver_source',
+            'list_item_backups', 'get_item_backup',
+            'install_app', 'install_driver', 'update_app_code', 'update_driver_code',
+            'delete_app', 'delete_driver', 'restore_item_backup',
+            'get_hub_logs', 'get_device_history', 'get_performance_stats', 'get_hub_jobs',
+            'get_debug_logs', 'clear_debug_logs', 'set_log_level', 'get_logging_status',
+            'get_set_hub_metrics', 'get_memory_history', 'force_garbage_collection',
+            'device_health_check', 'custom_get_rule_diagnostics',
+            'get_zwave_details', 'get_zigbee_details', 'zwave_repair',
+            'list_captured_states', 'delete_captured_state', 'clear_captured_states',
+            'list_files', 'read_file', 'write_file', 'delete_file',
+            'list_installed_apps', 'get_device_in_use_by', 'get_app_config', 'list_app_pages',
+            'list_rm_rules', 'run_rm_rule', 'pause_rm_rule', 'resume_rm_rule', 'set_rm_rule_boolean',
+            'create_native_app', 'update_native_app', 'delete_native_app', 'check_rule_health',
+            'update_mcp_settings'
+        ]
+    }
+
     def "useGateways=false: dispatch still works for a sub-tool called by its real name"() {
-        // The whole point of the toggle is that flat-mode clients call sub-tools directly.
-        // executeTool routes every sub-tool by name (no gateway prefix needed) — this pins
-        // that contract.
         given:
         settingsMap.useGateways = false
         script.metaClass.getRooms = { ->
@@ -118,5 +159,103 @@ class GatewayToggleSpec extends ToolSpecBase {
 
         then:
         result.rooms*.name == ['Living Room']
+    }
+
+    def "useGateways=false: calling a gateway name returns isError pointing at sub-tools"() {
+        given:
+        settingsMap.useGateways = false
+
+        when:
+        def result = script.executeTool('manage_rooms', [tool: 'list_rooms', args: [:]])
+
+        then:
+        result.isError == true
+        result.error.contains('manage_rooms')
+        result.error.contains('disabled')
+        result.hint.contains('list_rooms')
+        result.hint.contains('rename_room')
+    }
+
+    def "useGateways=true (default): calling a gateway name still dispatches normally"() {
+        given:
+        script.metaClass.getRooms = { ->
+            [[id: 1L, name: 'Living Room']]
+        }
+
+        when:
+        def result = script.executeTool('manage_rooms', [tool: 'list_rooms', args: [:]])
+
+        then:
+        result.isError != true
+        result.rooms*.name == ['Living Room']
+    }
+
+    def "useGateways=false + enableBuiltinApp=false: built-in-app tools still hidden in the flat catalog"() {
+        // Pins that the flat-mode branch reuses hideByName — a refactor that splits
+        // hide-list construction out of the gateway-mode path would silently leak
+        // list_rm_rules / create_native_app etc. into flat mode.
+        given:
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = false
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def names = script.getToolDefinitions()*.name as Set
+
+        then: 'built-in-app tools are removed from the flat catalog, not just from gateway entries'
+        !names.contains('list_rm_rules')
+        !names.contains('create_native_app')
+        !names.contains('list_installed_apps')
+        !names.contains('check_rule_health')
+
+        and: 'tools that do not depend on enableBuiltinApp are still present'
+        names.contains('get_app_config')
+        names.contains('list_devices')
+    }
+
+    def "useGateways=false + enableCustomRuleEngine=false (readonly): write-side custom_* tools hidden"() {
+        // Same shape as the enableBuiltinApp test, but for the readonly customEngineMode
+        // path: read tools stay visible, write/structural tools are removed.
+        given:
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = false
+
+        when:
+        def names = script.getToolDefinitions()*.name as Set
+
+        then: 'write/structural custom_* tools are removed'
+        !names.contains('custom_create_rule')
+        !names.contains('custom_delete_rule')
+        !names.contains('custom_export_rule')
+        !names.contains('custom_import_rule')
+        !names.contains('custom_clone_rule')
+
+        and: 'read-side custom_* tools remain'
+        names.contains('custom_list_rules')
+        names.contains('custom_get_rule')
+        names.contains('custom_test_rule')
+        names.contains('custom_get_rule_diagnostics')
+    }
+
+    def "useGateways=false + builtin/custom both off: gateway-name hint omits hidden sub-tools"() {
+        // The flat-mode guard's hint must filter through hideByName — telling a stale
+        // client to call list_rm_rules when it's also disabled by enableBuiltinApp=false
+        // would just trade one error for another.
+        given:
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = false
+        settingsMap.enableCustomRuleEngine = false
+
+        when: 'every sub-tool of manage_native_rules_and_apps is hidden by enableBuiltinApp=false'
+        def result = script.executeTool('manage_native_rules_and_apps', [tool: 'list_rm_rules', args: [:]])
+
+        then: 'guard fires, hint does not name any of the hidden sub-tools'
+        result.isError == true
+        !result.hint.contains('list_rm_rules')
+        !result.hint.contains('create_native_app')
+
+        and: 'hint mentions the responsible toggles instead'
+        result.hint.contains('Built-in App Tools') || result.hint.contains('Custom Rule Engine')
     }
 }

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -85,6 +85,36 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         }
     }
 
+    def "tools/list with useGateways=false returns the flat catalog through the JSON-RPC envelope"() {
+        given: 'feature toggles on so the JSON-RPC envelope returns the full flat catalog'
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+        mcpDriver.pushBody([jsonrpc: '2.0', id: 50, method: 'tools/list', params: [:]])
+
+        when:
+        script.handleMcpRequest()
+
+        then:
+        def response = mcpDriver.parseResponseJson()
+        response.jsonrpc == '2.0'
+        response.id == 50
+        def names = response.result.tools*.name as Set
+
+        and: 'gateway entries gone, sub-tools surface, search_tools suppressed'
+        !names.contains('manage_rooms')
+        !names.contains('manage_files')
+        !names.contains('search_tools')
+        names.contains('list_rooms')
+        names.contains('list_files')
+        names.contains('list_devices')
+
+        and: 'feature-toggle-gated tools also surface (proves the envelope returns the full flat catalog, not just the cores)'
+        names.contains('list_rm_rules')
+        names.contains('list_installed_apps')
+        names.contains('custom_create_rule')
+    }
+
     def "tools/call list_rooms flows through render with an MCP content envelope"() {
         given: 'a stubbed getRooms returning a deterministic list'
         script.metaClass.getRooms = { ->


### PR DESCRIPTION
## Summary

- New `useGateways` preference (default **ON**) that lets users opt out of the category-gateway proxy. When OFF, every tool is advertised individually on `tools/list` and `search_tools` is hidden because it only exists to navigate gateway-hidden tools.
- Default behaviour is unchanged — existing installs see no diff after update; the toggle only kicks in when explicitly flipped to off.
- No changes to `executeTool()` were needed: every gateway sub-tool already has a top-level case, so flat-mode dispatch is automatic.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- `hubitat-mcp-server.groovy`
  - `mainPage()` Settings section: new `useGateways` bool input (default `true`) with helper text explaining the trade-off.
  - `getToolDefinitions()`: when `settings.useGateways == false`, returns the full flat catalog (minus `search_tools`, minus anything hidden by the existing Built-in App / Custom Rule Engine toggles). Null/unset preserves the existing gateway list so updates don't surprise anyone.
  - `executeTool()` switch: when a stale client calls a gateway name (e.g. `manage_rooms`) while flat mode is on, returns a soft `isError` pointing at the underlying sub-tools (filtered against the visible catalog so it never recommends sub-tools other toggles have hidden) instead of silently servicing a gateway-shaped response.
- `src/test/groovy/server/GatewayToggleSpec.groovy` (new): default / null / explicit-true / explicit-false coverage, parametrized sweep over all 67 gateway sub-tools confirming top-level dispatch in flat mode, interaction tests for `useGateways=false × enableBuiltinApp=false` and `× customEngineMode=readonly`, and the gateway-name flat-mode guard from both sides.
- `src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy`: integration test pinning the JSON-RPC `tools/list` envelope returns the full flat catalog (not just core tools) when `useGateways=false` and feature toggles are on.
- `README.md`, `TOOL_GUIDE.md`: notes on the new setting, when to use it, and a static-counts disclaimer (shipped catalog vs. runtime size).

### Why opt out?

Some LLM clients now ship their own progressive-disclosure layer — deferred tools, built-in BM25 search across the tool catalog, etc. (Claude is one example.) For users on those clients our gateway pattern duplicates work the client already does and gets in the way of the client's native tool discovery. The toggle gives them a clean opt-out without changing the default for everyone else.

Gateway-mode is still the right default for clients that don't have built-in tool search, which is most of them today.

## Release Notes

- New optional **Consolidate tools behind category gateways** setting (default ON, no change for existing installs)
  - Turn OFF if your MCP client has its own tool search / progressive disclosure (e.g. Claude with deferred tools) — every MCP tool is then exposed individually on `tools/list`
  - When OFF, `search_tools` is hidden because its only job is finding gateway-hidden tools
  - Stale clients calling a gateway name after you flip OFF receive a friendly error pointing at the real sub-tools to call

## Testing

- `./gradlew test` — full suite green (940 tests, 0 failures, includes the expanded `GatewayToggleSpec` + new dispatch integration test).
- `python tests/sandbox_lint.py` — 0 errors / 0 warnings.
- Live-hub smoke test on the rebased branch: read-only tools (`list_rooms`, `list_rm_rules`, `get_set_hub_metrics`) all returned cleanly, `create_native_app` built a BAT-flat-mode rule with trigger + action fully committed (`health.ok=true`), `delete_native_app` cleaned it up.
- Spec coverage:
  - Default (no setting saved) → consolidated 22 core + 12 gateway list, sub-tools hidden, `search_tools` present.
  - `useGateways=true` → set-equal to default.
  - `useGateways=false` → no gateway entries, every previously-proxied sub-tool top-level, `search_tools` suppressed, MCP tool shape valid, set-equals `getAllToolDefinitions() - search_tools` (with feature toggles on).
  - `useGateways=false × enableBuiltinApp=false` → built-in-app tools stay hidden in the flat catalog, not just behind gateway entries.
  - `useGateways=false × customEngineMode=readonly` → write-side `custom_*` tools hidden, read-side present.
  - Gateway-name flat-mode guard fires for stale clients; hint omits sub-tools that other toggles also hide.

## Checklist

- [x] **Unit tests added for any new MCP tools** (no new MCP tools; the `useGateways` toggle is a listing-layer behaviour and is covered by `GatewayToggleSpec` + `HandleMcpRequestDispatchSpec`)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally
- [x] Live-hub BAT tests updated if tool behaviour changed — verified live on the rebased branch (read + write smoke)
- [x] Documentation updated if user-facing behaviour or tool surface changed
