### PR TITLE
feat: add clone_native_app via Hubitat appCloner

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -704,7 +704,7 @@ def getGatewayConfig() {
         ],
         manage_native_rules_and_apps: [
             description: "WHEN TO USE: this is the right path for any user who says 'create a rule machine rule,' 'make a Hubitat rule,' or wants the rule visible in Hubitat's Rule Machine app list / web UI. Use this for default rule-creation requests. The custom_* MCP rule engine (separate surface) is only appropriate when the user EXPLICITLY wants a sandbox MCP-managed rule that does not appear in Hubitat's UI -- uncommon outside power-user / testing scenarios. QUICK FLOW for a default rule create: (1) create_native_app(appType='rule_machine', name='...', confirm=true) returns appId. (2) update_native_app(appId=N, addTrigger={capability:'Certain Time (and optional date)', time:'A specific time', atTime:'17:00'}, confirm=true). (3) update_native_app(appId=N, addAction={capability:'log', message:'...'}, confirm=true). Three calls. Each call returns settingsApplied so you can confirm the rule baked. Native rules + apps (RM rules, Room Lighting, Button Controllers, Basic Rules, Notifier, Groups+Scenes, Visual Rules -- any classic SmartApp). Two surfaces: (1) RMUtils-based runtime control for RM rules (list/run/pause/resume/setBoolean -- RM-specific because RMUtils is RM-only); (2) admin-layer CRUD that works uniformly across ALL classic SmartApps via /installedapp/* (create/update/delete by appId). Writes snapshot before every change; restore via the unified list_item_backups + restore_item_backup tools in manage_apps_drivers. Completely separate from the MCP custom rule engine (custom_* tools). Requires Built-in App Tools enabled; CRUD additionally requires Hub Admin Write. Verification protocol: write operations on RM 5.1 are asynchronous; if a response indicates a hard failure (success: false) or a partial state needing repair (partial: true, or non-empty settingsSkipped), the hub may have applied the change post-response despite the reported status -- verify via get_app_config(appId=N) and inspect persisted settings before retrying.",
-            tools: ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "check_rule_health"],
+            tools: ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "clone_native_app", "check_rule_health"],
             summaries: [
                 list_rm_rules: "List all Rule Machine rules (RM 4.x + 5.x) with IDs and labels (uses RMUtils — RM only)",
                 run_rm_rule: "Trigger an RM rule lifecycle verb. Args: ruleId, action (rule/actions/stop/start, default rule). rule/actions use RMUtils; stop/start toggle the stopRule button (start also resets private boolean).",
@@ -714,6 +714,7 @@ def getGatewayConfig() {
                 create_native_app: "Create a new empty native automation app (RM rule by default; expand via _appTypeRegistry for Room Lighting / Button Controllers / etc.). Args: appType (default rule_machine), name, confirm. Returns appId — use update_native_app next to populate.",
                 update_native_app: "Modify any classic native app: write settings (multiple=true contract automatic), click a page-transition button, or use a high-level structured shortcut (addTrigger / addAction / addRequiredExpression / addTriggers / addActions / replaceActions / removeAction / clearActions / moveAction / removeTrigger / modifyTrigger / walkStep). Auto-backs-up first. Args: appId, settings|button|<shortcut>, pageName (opt), stateAttribute (opt), confirm",
                 delete_native_app: "Delete any classic native app (soft by default, force=true for hard). Auto-backs-up first. Args: appId, force (opt), confirm",
+                clone_native_app: "Clone an existing rule/app via Hubitat's first-party appCloner. Cheaper than creating from scratch + walking the wizard. Args: sourceAppId, newName (opt), confirm. Returns newAppId.",
                 check_rule_health: "Inspect a rule for broken state (label *BROKEN*, **Broken Trigger** markers, configPage errors, multiple-flag corruption). Args: appId. Returns {ok, issues, ...}. Auto-attached to update_native_app responses too."
             ],
             searchHints: [
@@ -725,6 +726,7 @@ def getGatewayConfig() {
                 create_native_app: "create new native rule machine room lighting button controller basic rule notifier scene group automation app",
                 update_native_app: "modify edit change native rule machine room lighting button controller basic rule notifier app trigger action condition setting",
                 delete_native_app: "remove delete destroy native rule machine room lighting button controller basic rule notifier app",
+                clone_native_app: "copy duplicate clone existing rule app appCloner template surgical edit",
                 check_rule_health: "broken validate inspect rule health diagnostic broken trigger broken action multiple flag corruption"
             ]
         ],
@@ -844,12 +846,12 @@ def getToolDefinitions() {
     def hideGatewaySubTools = [:].withDefault { [] as Set }
 
     if (!builtinAppOn) {
-        def biTools = ["list_installed_apps", "get_device_in_use_by", "list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "check_rule_health"]
+        def biTools = ["list_installed_apps", "get_device_in_use_by", "list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "clone_native_app", "check_rule_health"]
         biTools.each { hideByName << it }
         // Sub-tool removal from gateways (when in gateway mode):
-        //   manage_native_rules_and_apps: ALL 9 sub-tools require enableBuiltinApp → empty gateway → drops entirely
+        //   manage_native_rules_and_apps: ALL 10 sub-tools require enableBuiltinApp → empty gateway → drops entirely
         //   manage_installed_apps: 2/4 sub-tools require enableBuiltinApp; the other 2 (get_app_config, list_app_pages) only need Hub Admin Read
-        hideGatewaySubTools["manage_native_rules_and_apps"] = ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "check_rule_health"] as Set
+        hideGatewaySubTools["manage_native_rules_and_apps"] = ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "clone_native_app", "check_rule_health"] as Set
         hideGatewaySubTools["manage_installed_apps"] = ["list_installed_apps", "get_device_in_use_by"] as Set
     }
     if (customEngineMode == "off") {
@@ -2344,6 +2346,25 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
             ]
         ],
         [
+            name: "clone_native_app",
+            description: """Clone any classic native automation app (RM rule, Room Lighting, Button Controller, Basic Rule, Notifier, etc.) using Hubitat's first-party appCloner. Lower-overhead alternative to creating from scratch + walking the wizard for every field — clone an existing rule that has the shape you want, then surgically edit a few fields via update_native_app.
+
+The clone preserves the full rule shape including state.actNdx, conditions, expressions, IF/THEN/ELSE positional arrays — things the wizard-driving path can't easily reconstruct from a spec. Pair with a small library of template rules to cover most user intents.
+
+Endpoint: GET /installedapp/sysAppApi/appCloner/app/<sourceAppId> (no body), then walk appCloner's wizard via update_native_app calls. Returns newAppId and the cloner's appId in case the caller wants to inspect/cancel it.
+
+Requires Built-in App Tools enabled + Hub Admin Write + confirm=true.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    sourceAppId: [type: "integer", description: "Installed-app ID of the rule/app to clone."],
+                    newName: [type: "string", description: "Label for the new cloned app. If omitted, the cloner picks a default like 'Source-Label (clone)'."],
+                    confirm: [type: "boolean", description: "Must be true."]
+                ],
+                required: ["sourceAppId", "confirm"]
+            ]
+        ],
+        [
             name: "check_rule_health",
             description: """Inspect a rule's current state and return a structured health report — the LLM uses this to detect broken rules without having to investigate via curl. Surfaces:
 
@@ -2561,6 +2582,7 @@ def executeTool(toolName, args) {
         case "create_native_app": return toolCreateNativeApp(args)
         case "update_native_app": return toolUpdateNativeApp(args)
         case "delete_native_app": return toolDeleteNativeApp(args)
+        case "clone_native_app": return toolCloneNativeApp(args)
         case "check_rule_health": return toolCheckRuleHealth(args)
 
         // Tool Guide
@@ -16474,6 +16496,123 @@ def toolCheckRuleHealth(args) {
 }
 
 /**
+ * clone_native_app — wraps Hubitat's first-party appCloner system app.
+ *
+ * Wire format verified live by hooking the cloner UI's XHRs:
+ *
+ *   1. GET /installedapp/sysAppApi/appCloner/app/<sourceAppId> → 302
+ *      Location: /apps/api/<clonerInstanceId>/app/<sourceAppId>?access_token=…
+ *      A transient cloner instance is created with the source rule loaded
+ *      into its state. We only need the instance ID from the Location.
+ *   2. POST /installedapp/btn  with form fields:
+ *        id=<clonerInstanceId>
+ *        name=cloneRuleButton
+ *        settings[cloneRuleButton]=clicked
+ *        cloneRuleButton.type=button
+ *      Hub clones the source as a new sibling under the same parent,
+ *      naming it "Clone of <sourceLabel>". The POST blocks until the
+ *      clone is fully committed (can take >30s for large rules).
+ *   3. Optional rename: update_native_app(newAppId, settings={origLabel:…})
+ *
+ * The button name `cloneRuleButton` is NOT discoverable via
+ * /installedapp/configure/json/<clonerId>/main — that endpoint returns
+ * a stripped page object missing the dynamic Export/Clone buttons. The
+ * names are hardcoded since they're stable for this system app.
+ */
+def toolCloneNativeApp(args) {
+    requireBuiltinApp()
+    requireHubAdminWrite(args?.confirm as Boolean)
+    if (args?.sourceAppId == null) throw new IllegalArgumentException("sourceAppId is required")
+    def sourceAppId = normalizeRuleId(args.sourceAppId)
+    def newName = args?.newName?.toString()?.trim()
+
+    // Snapshot pre-clone children so we can identify the new app afterward.
+    def sourceCfg
+    try { sourceCfg = _rmFetchConfigJson(sourceAppId) } catch (Exception ignored) { sourceCfg = null }
+    if (!sourceCfg?.app) {
+        throw new IllegalArgumentException("Source app ${sourceAppId} not found")
+    }
+    def parentAppId = sourceCfg.app.parentAppId as Integer
+    def preCloneChildIds = [] as Set
+    if (parentAppId) {
+        def parentCfg = _rmFetchConfigJson(parentAppId)
+        preCloneChildIds = ((parentCfg?.childApps ?: []) as List).collect { (it.id as Integer) } as Set
+    }
+
+    // Step 1: hit appCloner's entry point. Hub responds with a 302 whose
+    // Location header carries the cloner instance ID.
+    def entryResp
+    try {
+        entryResp = hubInternalGetRaw("/installedapp/sysAppApi/appCloner/app/${sourceAppId}")
+    } catch (Exception e) {
+        throw new IllegalStateException("appCloner entry failed for source ${sourceAppId}: ${e.message}. The source app may not exist or appCloner may be unavailable.")
+    }
+    def clonerLocation = entryResp?.location
+    if (!clonerLocation) {
+        throw new IllegalStateException("appCloner entry returned no Location header for source ${sourceAppId} (status=${entryResp?.status})")
+    }
+    // Two observed Location shapes:
+    //   /apps/api/<clonerId>/app/<sourceId>?access_token=…    (current — preferred)
+    //   /installedapp/configure/<clonerId>                     (legacy)
+    def clonerAppId = null
+    def m1 = (clonerLocation =~ /\/apps\/api\/(\d+)\//)
+    if (m1.find()) {
+        clonerAppId = m1[0][1] as Integer
+    } else {
+        def m2 = (clonerLocation =~ /\/installedapp\/configure\/(\d+)/)
+        if (m2.find()) clonerAppId = m2[0][1] as Integer
+    }
+    if (clonerAppId == null) {
+        throw new IllegalStateException("Unexpected appCloner Location: ${clonerLocation}")
+    }
+
+    // Step 2: click cloneRuleButton. Hardcoded button name — see header
+    // comment for why introspection doesn't work for this system app.
+    // _rmClickAppButton POSTs to /installedapp/btn with the right shape;
+    // the call blocks until the clone is committed server-side.
+    _rmClickAppButton(clonerAppId, "cloneRuleButton")
+
+    // Step 3: discover the new app id. The clone appears as a new child of
+    // the source's parent. Diff against the pre-clone snapshot to find it.
+    def newAppId = null
+    if (parentAppId) {
+        def parentCfg = _rmFetchConfigJson(parentAppId)
+        def afterIds = ((parentCfg?.childApps ?: []) as List).collect { (it.id as Integer) }
+        def added = afterIds.findAll { !preCloneChildIds.contains(it) }
+        if (added.size() == 1) {
+            newAppId = added[0]
+        } else if (added.size() > 1) {
+            // Multiple new apps somehow; pick the one whose label looks like a clone of the source.
+            def srcLabel = sourceCfg?.app?.label?.toString() ?: ""
+            def candidates = (parentCfg.childApps as List).findAll { added.contains(it.id as Integer) }
+            def match = candidates.find { (it.label?.toString() ?: "").contains(srcLabel) || (it.label?.toString() ?: "").startsWith("Clone of") }
+            newAppId = (match?.id ?: candidates*.id.max()) as Integer
+        }
+    }
+
+    // Step 4: optional rename via update_native_app on the new clone.
+    if (newAppId && newName) {
+        try {
+            def newSchema = _rmCollectInputSchema(_rmFetchConfigJson(newAppId)?.configPage)
+            _rmUpdateAppSettings(newAppId, [origLabel: newName], newSchema)
+            _rmClickAppButton(newAppId, "updateRule")
+        } catch (Exception e) {
+            mcpLog("warn", "rm-native", "clone_native_app: rename failed for new app ${newAppId}: ${e.message}")
+        }
+    }
+
+    return [
+        success: newAppId != null,
+        sourceAppId: sourceAppId,
+        clonerAppId: clonerAppId,
+        newAppId: newAppId,
+        note: newAppId
+            ? "Cloned source ${sourceAppId} → new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
+            : "Clone button clicked but no new child app appeared under parent ${parentAppId}. The clone may have failed silently — check Hubitat logs."
+    ]
+}
+
+/**
  * Internal: replay an RM rule snapshot. Called by the unified
  * restore_item_backup tool when entry.type == "rm-rule". Two paths:
  *   - Rule still exists: settings re-applied in place (no new rule created).
@@ -17135,7 +17274,7 @@ Tools in the manage_installed_apps and manage_native_rules_and_apps gateways hav
   - Returns curated page directory for known app types (HPM, RM 5.x, Room Lighting, Mode Manager) plus an introspected primary page for unknown app types
   - Cuts the page-name guessing cycle for multi-page apps. Especially useful for HPM which exposes multiple sub-pages (prefPkgUninstall / prefPkgModify / prefPkgInstall / prefPkgMatchUp) for different operations.
 
-**manage_native_rules_and_apps (9 tools) — read, trigger, AND full CRUD on native RM rules:**
+**manage_native_rules_and_apps (10 tools) — read, trigger, AND full CRUD on native RM rules:**
 
 RMUtils-based control surface (Built-in App Tools gate only):
 - **list_rm_rules** — enumerate Rule Machine rules (RM 4.x + 5.x combined, deduplicated by id)
@@ -17150,6 +17289,7 @@ Native CRUD (hub admin-layer, additionally requires Hub Admin Write):
 - **create_native_app** — create a new empty classic SmartApp (RM 5.1 by default; appType enum covers rule_machine / button_controller / groups_scenes / notifier / visual_rule). Args: appType (default rule_machine), name, confirm. Returns appId. Call update_native_app afterward to populate; or pass triggers=[...] / actions=[...] arrays to populate in one call.
 - **update_native_app** — modify any classic SmartApp. Two raw modes (settings (Map) OR button (String)) plus 14 structured shortcuts (addTrigger, addTriggers, addAction, addActions, addRequiredExpression, addLocalVariable, removeAction, clearActions, replaceActions, moveAction, removeTrigger, modifyTrigger, patches, walkStep). Args: appId + one of those shortcut keys, plus optional pageName, stateAttribute, confirm. Auto-backs-up before writing; emits the multiple=true 3-field capability contract automatically. removeTrigger={index:N} deletes a trigger; modifyTrigger={index:N, mods:{state:'...'}} changes the state field of an existing trigger (capability/deviceIds changes require removeTrigger + addTrigger).
 - **delete_native_app** — soft delete (default; refuses if children exist) or force=true. Args: appId, force, confirm. Auto-backs-up before deleting.
+- **clone_native_app** — clone any classic SmartApp via Hubitat's first-party appCloner system app. Args: sourceAppId, newName (opt), confirm. Returns newAppId. Useful as a lower-overhead alternative to building a rule from scratch — clone a template that already has the right shape, then surgically edit fields via update_native_app.
 - **check_rule_health** — read-only health check on any installed app. Args: appId. Returns ok / configPageError / brokenMarkers / multipleFlagPoison / issues.
 
 For READING an RM rule's current state, use **get_app_config** in the manage_installed_apps gateway — it works on any installed app including RM rules and returns the same configPage shape that update_native_app expects to see.

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -2347,19 +2347,14 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
         ],
         [
             name: "clone_native_app",
-            description: """Clone any classic native automation app (RM rule, Room Lighting, Button Controller, Basic Rule, Notifier, etc.) using Hubitat's first-party appCloner. Lower-overhead alternative to creating from scratch + walking the wizard for every field — clone an existing rule that has the shape you want, then surgically edit a few fields via update_native_app.
-
-The clone preserves the full rule shape including state.actNdx, conditions, expressions, and IF/THEN/ELSE positional arrays — things the wizard-driving path can't easily reconstruct from a spec. Pair with a small library of template rules to cover most user intents.
-
-Endpoint: GET /installedapp/sysAppApi/appCloner/app/<sourceAppId> (302), then POST /installedapp/btn (cloneRuleButton). The click is fired with a short read timeout because the hub blocks the response until the clone is fully committed server-side (which can take minutes for large rules); we then poll the source's parent.childApps to discover the new appId. Returns newAppId on success, or pending=true with a note to re-check via list_installed_apps if the poll budget runs out.
-
-Requires Built-in App Tools enabled + Hub Admin Write + confirm=true.""",
+            description: """Clone any classic native automation app (RM rule, Room Lighting, Button Controller, Basic Rule, Notifier, etc.) using Hubitat's first-party appCloner. Preserves the full rule shape (conditions, expressions, IF/THEN/ELSE positional arrays) — much cheaper than rebuilding from a spec. Pair with a library of template rules + update_native_app for surgical edits. Async: the clone POST is fired with a short read timeout and we poll the source's parent.childApps for the new appId. Returns newAppId on success, or pending=true if the poll budget runs out (re-check via list_installed_apps). Requires Built-in App Tools enabled + Hub Admin Write + confirm=true.""",
             inputSchema: [
                 type: "object",
                 properties: [
                     sourceAppId: [type: "integer", description: "Installed-app ID of the rule/app to clone."],
                     newName: [type: "string", description: "Label for the new cloned app. If omitted, the cloner picks a default like 'Clone of <source-label>'."],
                     timeoutSec: [type: "integer", description: "Total polling budget in seconds for the new child app to appear after the clone fires. Default 60. Increase for very large rules."],
+                    pollIntervalMs: [type: "integer", description: "Polling interval in milliseconds. Default 500. Mostly a tuning knob for tests + very-fast hubs."],
                     confirm: [type: "boolean", description: "Must be true."]
                 ],
                 required: ["sourceAppId", "confirm"]
@@ -10003,10 +9998,9 @@ private Map _rmClickAppButton(Integer appId, String buttonName, String stateAttr
             // whole call here.
         }
     }
-    // timeoutSec lets callers (currently only clone_native_app) shorten the
-    // socket-read timeout when the hub blocks the response until a slow
-    // server-side job completes. Default null = use hubInternalPostForm's
-    // built-in 420s default to preserve every existing caller's behavior.
+    // Optional shorter socket-read timeout for callers where the hub blocks
+    // the response on a slow server-side job. Default null preserves the
+    // 420s built-in for every existing caller.
     def resp = (timeoutSec != null)
         ? hubInternalPostForm("/installedapp/btn", body, timeoutSec)
         : hubInternalPostForm("/installedapp/btn", body)
@@ -16505,28 +16499,10 @@ def toolCheckRuleHealth(args) {
 /**
  * clone_native_app — wraps Hubitat's first-party appCloner system app.
  *
- * Wire format verified live by hooking the cloner UI's XHRs:
- *
- *   1. GET /installedapp/sysAppApi/appCloner/app/<sourceAppId> → 302
- *      Location: /apps/api/<clonerInstanceId>/app/<sourceAppId>?access_token=…
- *      A transient cloner instance is created with the source rule loaded
- *      into its state. We only need the instance ID from the Location.
- *   2. POST /installedapp/btn  with form fields:
- *        id=<clonerInstanceId>
- *        name=cloneRuleButton
- *        settings[cloneRuleButton]=clicked
- *        cloneRuleButton.type=button
- *      Hub clones the source as a new sibling under the same parent,
- *      naming it "Clone of <sourceLabel>". The POST does not return until
- *      the clone is fully committed server-side, which can take minutes
- *      for rules with many settings — so we issue it with a short read
- *      timeout and treat any timeout as "in flight, keep polling".
- *   3. Optional rename via origLabel write + updateRule on the new clone.
- *
- * The button name `cloneRuleButton` is NOT discoverable via
- * /installedapp/configure/json/<clonerId>/main — that endpoint returns
- * a stripped page object missing the dynamic Export/Clone buttons. The
- * name is hardcoded since it's stable for this system app.
+ * The cloneRuleButton POST blocks until the clone is fully committed
+ * server-side (tens of seconds for big rules), so the click fires with
+ * a short read timeout and the new child id is discovered by polling
+ * the source's parent.childApps.
  */
 def toolCloneNativeApp(args) {
     requireBuiltinApp()
@@ -16537,27 +16513,46 @@ def toolCloneNativeApp(args) {
     int overallTimeoutSec = (args?.timeoutSec ?: 60) as Integer
     int pollIntervalMs = (args?.pollIntervalMs ?: 500) as Integer
     int clickTimeoutSec = 5
+    int maxConsecutivePollFailures = 5
     long deadline = now() + (overallTimeoutSec * 1000L)
 
-    // Snapshot pre-clone children so we can identify the new app after the clone fires.
     def sourceCfg
-    try { sourceCfg = _rmFetchConfigJson(sourceAppId) } catch (Exception ignored) { sourceCfg = null }
-    if (!sourceCfg?.app) {
-        throw new IllegalArgumentException("Source app ${sourceAppId} not found")
+    try {
+        sourceCfg = _rmFetchConfigJson(sourceAppId)
+    } catch (Exception sourceFetchErr) {
+        // Log the real reason — auth/network/parse failures otherwise
+        // collapse into the same generic "not found" error below.
+        mcpLog("warn", "rm-native", "clone_native_app: source ${sourceAppId} config fetch failed: ${sourceFetchErr.message}")
+        sourceCfg = null
     }
-    def parentAppId = sourceCfg.app.parentAppId as Integer
+    if (!sourceCfg?.app) {
+        throw new IllegalArgumentException("Source app ${sourceAppId} not found or unreadable")
+    }
+    Integer parentAppId = null
+    try {
+        parentAppId = sourceCfg.app.parentAppId != null ? (sourceCfg.app.parentAppId.toString() as Integer) : null
+    } catch (NumberFormatException nfe) {
+        mcpLog("warn", "rm-native", "clone_native_app: source ${sourceAppId} parentAppId is not numeric: ${sourceCfg.app.parentAppId}")
+    }
+
+    // Snapshot pre-clone children as STRING ids — Hubitat childApp ids are
+    // numeric in practice but the project convention (CLAUDE.md) is to
+    // compare ids as strings to avoid NumberFormatException on edge cases.
     def preCloneChildIds = [] as Set
-    if (parentAppId) {
+    boolean snapshotIncomplete = false
+    if (parentAppId != null) {
         try {
             def parentCfg = _rmFetchConfigJson(parentAppId)
-            preCloneChildIds = ((parentCfg?.childApps ?: []) as List).collect { (it.id as Integer) } as Set
+            preCloneChildIds = ((parentCfg?.childApps ?: []) as List).collect { it?.id?.toString() }.findAll { it != null } as Set
         } catch (Exception preExc) {
-            mcpLog("debug", "rm-native", "clone_native_app: pre-clone parent ${parentAppId} fetch failed: ${preExc.message}")
+            // If the snapshot is empty AND polling later sees children, every
+            // existing child looks "added" and we may misidentify the clone.
+            // Surface this as a flag so callers know the answer is heuristic.
+            snapshotIncomplete = true
+            mcpLog("warn", "rm-native", "clone_native_app: pre-clone parent ${parentAppId} fetch failed: ${preExc.message}. Setting snapshotIncomplete=true; new-child detection may misidentify a pre-existing app.")
         }
     }
 
-    // Step 1: hit appCloner's entry point. Hub responds with a 302 whose
-    // Location header carries the cloner instance ID.
     def entryResp
     try {
         entryResp = hubInternalGetRaw("/installedapp/sysAppApi/appCloner/app/${sourceAppId}")
@@ -16568,65 +16563,66 @@ def toolCloneNativeApp(args) {
     if (!clonerLocation) {
         throw new IllegalStateException("appCloner entry returned no Location header for source ${sourceAppId} (status=${entryResp?.status})")
     }
-    // Two observed Location shapes:
-    //   /apps/api/<clonerId>/app/<sourceId>?access_token=…    (current — preferred)
-    //   /installedapp/configure/<clonerId>                     (legacy)
-    def clonerAppId = null
-    def m1 = (clonerLocation =~ /\/apps\/api\/(\d+)\//)
-    if (m1.find()) {
-        clonerAppId = m1[0][1] as Integer
-    } else {
-        def m2 = (clonerLocation =~ /\/installedapp\/configure\/(\d+)/)
-        if (m2.find()) clonerAppId = m2[0][1] as Integer
-    }
+    // Two Location shapes seen across firmwares: /apps/api/<id>/... (current)
+    // and /installedapp/configure/<id> (older). Either yields the cloner id.
+    def m = (clonerLocation =~ /\/(?:apps\/api|installedapp\/configure)\/(\d+)/)
+    Integer clonerAppId = m.find() ? (m[0][1] as Integer) : null
     if (clonerAppId == null) {
         throw new IllegalStateException("Unexpected appCloner Location: ${clonerLocation}")
     }
 
-    // Step 2: fire the cloneRuleButton click with a short read timeout.
-    // The hub processes the clone server-side regardless of whether we
-    // wait for the response — so we don't, and instead poll for the new
-    // child to appear. This unblocks the MCP loop for clones that take
-    // multiple minutes to commit.
+    // Fire the cloneRuleButton click with a short read timeout. The button
+    // name `cloneRuleButton` is NOT discoverable via /installedapp/configure/
+    // json/<clonerId>/main (system-app pages are stripped of dynamic
+    // buttons) but is stable for the appCloner system app.
     def clickError = null
     try {
         _rmClickAppButton(clonerAppId, "cloneRuleButton", null, null, clickTimeoutSec)
     } catch (Exception e) {
         clickError = e.message
-        mcpLog("debug", "rm-native", "clone_native_app: click POST returned/timed out after ${clickTimeoutSec}s — polling parent ${parentAppId} for new child (${clickError})")
+        def msg = (clickError ?: "").toLowerCase()
+        boolean isTimeout = msg.contains("timed out") || msg.contains("timeout") || msg.contains("read timed out")
+        def level = isTimeout ? "debug" : "warn"
+        mcpLog(level, "rm-native", "clone_native_app: click POST ${isTimeout ? "timed out (expected for slow clones)" : "failed (non-timeout)"} after ${clickTimeoutSec}s; polling parent ${parentAppId} for new child anyway: ${clickError}")
     }
 
-    // Step 3: poll parent.childApps for the new clone. Returns as soon as
-    // a previously-unseen child appears, or when the overall budget runs out.
-    def newAppId = null
+    Integer newAppId = null
     int pollAttempts = 0
-    while (parentAppId != null && now() < deadline && newAppId == null) {
+    int consecutivePollFailures = 0
+    String lastPollError = null
+    boolean pollAborted = false
+    while (parentAppId != null && now() < deadline && newAppId == null && !pollAborted) {
         pollAttempts++
         try {
             def parentCfg = _rmFetchConfigJson(parentAppId)
-            def afterIds = ((parentCfg?.childApps ?: []) as List).collect { (it.id as Integer) }
+            consecutivePollFailures = 0
+            def afterIds = ((parentCfg?.childApps ?: []) as List).collect { it?.id?.toString() }.findAll { it != null }
             def added = afterIds.findAll { !preCloneChildIds.contains(it) }
             if (added.size() == 1) {
-                newAppId = added[0]
+                newAppId = added[0] as Integer
             } else if (added.size() > 1) {
-                // Multiple new children appeared. Prefer the one whose label
-                // matches the cloner's "Clone of <source-label>" pattern, then
-                // any label containing the source label, else the highest id.
+                // Multiple new children: prefer "Clone of <label>" prefix,
+                // then any label containing the source label, else max id.
                 def srcLabel = sourceCfg?.app?.label?.toString() ?: ""
-                def candidates = (parentCfg.childApps as List).findAll { added.contains(it.id as Integer) }
+                def candidates = (parentCfg.childApps as List).findAll { added.contains(it?.id?.toString()) }
                 def match = candidates.find { (it.label?.toString() ?: "").startsWith("Clone of") } ?:
                             candidates.find { srcLabel && (it.label?.toString() ?: "").contains(srcLabel) }
-                newAppId = (match?.id ?: candidates*.id.max()) as Integer
+                newAppId = (match?.id ?: candidates.collect { it.id as Integer }.max()) as Integer
             }
         } catch (Exception pollExc) {
-            mcpLog("debug", "rm-native", "clone_native_app: poll #${pollAttempts} parent ${parentAppId} fetch failed: ${pollExc.message}")
+            consecutivePollFailures++
+            lastPollError = pollExc.message
+            mcpLog("debug", "rm-native", "clone_native_app: poll #${pollAttempts} parent ${parentAppId} fetch failed (${consecutivePollFailures} consecutive): ${pollExc.message}")
+            if (consecutivePollFailures >= maxConsecutivePollFailures) {
+                pollAborted = true
+                mcpLog("warn", "rm-native", "clone_native_app: aborting polling after ${consecutivePollFailures} consecutive parent-fetch failures (last: ${lastPollError})")
+            }
         }
-        if (newAppId == null && now() < deadline) pauseExecution(pollIntervalMs)
+        if (newAppId == null && !pollAborted && now() < deadline) pauseExecution(pollIntervalMs)
     }
 
-    // Step 4: optional rename via origLabel write + updateRule on the new clone.
     def renameError = null
-    if (newAppId && newName) {
+    if (newAppId != null && newName) {
         try {
             def newSchema = _rmCollectInputSchema(_rmFetchConfigJson(newAppId)?.configPage)
             _rmUpdateAppSettings(newAppId, [origLabel: newName], newSchema)
@@ -16647,10 +16643,15 @@ def toolCloneNativeApp(args) {
             note: "Cloned source ${sourceAppId} -> new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
         ]
         if (renameError) result.renameError = renameError
+        if (clickError) result.clickError = clickError
+        if (snapshotIncomplete) result.snapshotIncomplete = true
         return result
     }
 
-    return [
+    def note = parentAppId != null
+        ? "Clone fired but no new child app appeared under parent ${parentAppId} within ${overallTimeoutSec}s${pollAborted ? " (polling aborted after ${consecutivePollFailures} consecutive fetch failures)" : ""}. The hub may still be processing — re-check via list_installed_apps shortly."
+        : "Clone fired but source ${sourceAppId} has no parentAppId, so we cannot poll for the new child. Re-check via list_installed_apps shortly."
+    def result = [
         success: false,
         pending: true,
         sourceAppId: sourceAppId,
@@ -16658,8 +16659,11 @@ def toolCloneNativeApp(args) {
         newAppId: null,
         pollAttempts: pollAttempts,
         clickError: clickError,
-        note: "Clone fired but no new child app appeared under parent ${parentAppId} within ${overallTimeoutSec}s. The hub may still be processing the clone — re-check via list_installed_apps shortly. If it never appears, check Hubitat logs."
+        note: note
     ]
+    if (lastPollError) result.lastPollError = lastPollError
+    if (snapshotIncomplete) result.snapshotIncomplete = true
+    return result
 }
 
 /**

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -2349,16 +2349,17 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
             name: "clone_native_app",
             description: """Clone any classic native automation app (RM rule, Room Lighting, Button Controller, Basic Rule, Notifier, etc.) using Hubitat's first-party appCloner. Lower-overhead alternative to creating from scratch + walking the wizard for every field — clone an existing rule that has the shape you want, then surgically edit a few fields via update_native_app.
 
-The clone preserves the full rule shape including state.actNdx, conditions, expressions, IF/THEN/ELSE positional arrays — things the wizard-driving path can't easily reconstruct from a spec. Pair with a small library of template rules to cover most user intents.
+The clone preserves the full rule shape including state.actNdx, conditions, expressions, and IF/THEN/ELSE positional arrays — things the wizard-driving path can't easily reconstruct from a spec. Pair with a small library of template rules to cover most user intents.
 
-Endpoint: GET /installedapp/sysAppApi/appCloner/app/<sourceAppId> (no body), then walk appCloner's wizard via update_native_app calls. Returns newAppId and the cloner's appId in case the caller wants to inspect/cancel it.
+Endpoint: GET /installedapp/sysAppApi/appCloner/app/<sourceAppId> (302), then POST /installedapp/btn (cloneRuleButton). The click is fired with a short read timeout because the hub blocks the response until the clone is fully committed server-side (which can take minutes for large rules); we then poll the source's parent.childApps to discover the new appId. Returns newAppId on success, or pending=true with a note to re-check via list_installed_apps if the poll budget runs out.
 
 Requires Built-in App Tools enabled + Hub Admin Write + confirm=true.""",
             inputSchema: [
                 type: "object",
                 properties: [
                     sourceAppId: [type: "integer", description: "Installed-app ID of the rule/app to clone."],
-                    newName: [type: "string", description: "Label for the new cloned app. If omitted, the cloner picks a default like 'Source-Label (clone)'."],
+                    newName: [type: "string", description: "Label for the new cloned app. If omitted, the cloner picks a default like 'Clone of <source-label>'."],
+                    timeoutSec: [type: "integer", description: "Total polling budget in seconds for the new child app to appear after the clone fires. Default 60. Increase for very large rules."],
                     confirm: [type: "boolean", description: "Must be true."]
                 ],
                 required: ["sourceAppId", "confirm"]
@@ -9971,7 +9972,7 @@ private Integer _rmCreateChildApp(Integer parentAppId, String namespace = "hubit
  * Pass pageName for sub-page wizard buttons (hasAll on selectTriggers,
  * actionDone on selectActions, etc.) so the form-context fields fire.
  */
-private Map _rmClickAppButton(Integer appId, String buttonName, String stateAttribute = null, String pageName = null) {
+private Map _rmClickAppButton(Integer appId, String buttonName, String stateAttribute = null, String pageName = null, Integer timeoutSec = null) {
     def body = [
         id: appId.toString(),
         name: buttonName,
@@ -10002,7 +10003,13 @@ private Map _rmClickAppButton(Integer appId, String buttonName, String stateAttr
             // whole call here.
         }
     }
-    def resp = hubInternalPostForm("/installedapp/btn", body)
+    // timeoutSec lets callers (currently only clone_native_app) shorten the
+    // socket-read timeout when the hub blocks the response until a slow
+    // server-side job completes. Default null = use hubInternalPostForm's
+    // built-in 420s default to preserve every existing caller's behavior.
+    def resp = (timeoutSec != null)
+        ? hubInternalPostForm("/installedapp/btn", body, timeoutSec)
+        : hubInternalPostForm("/installedapp/btn", body)
     if (resp?.status != null && resp.status >= 400) {
         throw new IllegalArgumentException("Button click '${buttonName}' on app ${appId} failed: status=${resp.status}")
     }
@@ -16510,14 +16517,16 @@ def toolCheckRuleHealth(args) {
  *        settings[cloneRuleButton]=clicked
  *        cloneRuleButton.type=button
  *      Hub clones the source as a new sibling under the same parent,
- *      naming it "Clone of <sourceLabel>". The POST blocks until the
- *      clone is fully committed (can take >30s for large rules).
- *   3. Optional rename: update_native_app(newAppId, settings={origLabel:…})
+ *      naming it "Clone of <sourceLabel>". The POST does not return until
+ *      the clone is fully committed server-side, which can take minutes
+ *      for rules with many settings — so we issue it with a short read
+ *      timeout and treat any timeout as "in flight, keep polling".
+ *   3. Optional rename via origLabel write + updateRule on the new clone.
  *
  * The button name `cloneRuleButton` is NOT discoverable via
  * /installedapp/configure/json/<clonerId>/main — that endpoint returns
  * a stripped page object missing the dynamic Export/Clone buttons. The
- * names are hardcoded since they're stable for this system app.
+ * name is hardcoded since it's stable for this system app.
  */
 def toolCloneNativeApp(args) {
     requireBuiltinApp()
@@ -16525,8 +16534,12 @@ def toolCloneNativeApp(args) {
     if (args?.sourceAppId == null) throw new IllegalArgumentException("sourceAppId is required")
     def sourceAppId = normalizeRuleId(args.sourceAppId)
     def newName = args?.newName?.toString()?.trim()
+    int overallTimeoutSec = (args?.timeoutSec ?: 60) as Integer
+    int pollIntervalMs = (args?.pollIntervalMs ?: 500) as Integer
+    int clickTimeoutSec = 5
+    long deadline = now() + (overallTimeoutSec * 1000L)
 
-    // Snapshot pre-clone children so we can identify the new app afterward.
+    // Snapshot pre-clone children so we can identify the new app after the clone fires.
     def sourceCfg
     try { sourceCfg = _rmFetchConfigJson(sourceAppId) } catch (Exception ignored) { sourceCfg = null }
     if (!sourceCfg?.app) {
@@ -16535,8 +16548,12 @@ def toolCloneNativeApp(args) {
     def parentAppId = sourceCfg.app.parentAppId as Integer
     def preCloneChildIds = [] as Set
     if (parentAppId) {
-        def parentCfg = _rmFetchConfigJson(parentAppId)
-        preCloneChildIds = ((parentCfg?.childApps ?: []) as List).collect { (it.id as Integer) } as Set
+        try {
+            def parentCfg = _rmFetchConfigJson(parentAppId)
+            preCloneChildIds = ((parentCfg?.childApps ?: []) as List).collect { (it.id as Integer) } as Set
+        } catch (Exception preExc) {
+            mcpLog("debug", "rm-native", "clone_native_app: pre-clone parent ${parentAppId} fetch failed: ${preExc.message}")
+        }
     }
 
     // Step 1: hit appCloner's entry point. Hub responds with a 302 whose
@@ -16566,49 +16583,82 @@ def toolCloneNativeApp(args) {
         throw new IllegalStateException("Unexpected appCloner Location: ${clonerLocation}")
     }
 
-    // Step 2: click cloneRuleButton. Hardcoded button name — see header
-    // comment for why introspection doesn't work for this system app.
-    // _rmClickAppButton POSTs to /installedapp/btn with the right shape;
-    // the call blocks until the clone is committed server-side.
-    _rmClickAppButton(clonerAppId, "cloneRuleButton")
-
-    // Step 3: discover the new app id. The clone appears as a new child of
-    // the source's parent. Diff against the pre-clone snapshot to find it.
-    def newAppId = null
-    if (parentAppId) {
-        def parentCfg = _rmFetchConfigJson(parentAppId)
-        def afterIds = ((parentCfg?.childApps ?: []) as List).collect { (it.id as Integer) }
-        def added = afterIds.findAll { !preCloneChildIds.contains(it) }
-        if (added.size() == 1) {
-            newAppId = added[0]
-        } else if (added.size() > 1) {
-            // Multiple new apps somehow; pick the one whose label looks like a clone of the source.
-            def srcLabel = sourceCfg?.app?.label?.toString() ?: ""
-            def candidates = (parentCfg.childApps as List).findAll { added.contains(it.id as Integer) }
-            def match = candidates.find { (it.label?.toString() ?: "").contains(srcLabel) || (it.label?.toString() ?: "").startsWith("Clone of") }
-            newAppId = (match?.id ?: candidates*.id.max()) as Integer
-        }
+    // Step 2: fire the cloneRuleButton click with a short read timeout.
+    // The hub processes the clone server-side regardless of whether we
+    // wait for the response — so we don't, and instead poll for the new
+    // child to appear. This unblocks the MCP loop for clones that take
+    // multiple minutes to commit.
+    def clickError = null
+    try {
+        _rmClickAppButton(clonerAppId, "cloneRuleButton", null, null, clickTimeoutSec)
+    } catch (Exception e) {
+        clickError = e.message
+        mcpLog("debug", "rm-native", "clone_native_app: click POST returned/timed out after ${clickTimeoutSec}s — polling parent ${parentAppId} for new child (${clickError})")
     }
 
-    // Step 4: optional rename via update_native_app on the new clone.
+    // Step 3: poll parent.childApps for the new clone. Returns as soon as
+    // a previously-unseen child appears, or when the overall budget runs out.
+    def newAppId = null
+    int pollAttempts = 0
+    while (parentAppId != null && now() < deadline && newAppId == null) {
+        pollAttempts++
+        try {
+            def parentCfg = _rmFetchConfigJson(parentAppId)
+            def afterIds = ((parentCfg?.childApps ?: []) as List).collect { (it.id as Integer) }
+            def added = afterIds.findAll { !preCloneChildIds.contains(it) }
+            if (added.size() == 1) {
+                newAppId = added[0]
+            } else if (added.size() > 1) {
+                // Multiple new children appeared. Prefer the one whose label
+                // matches the cloner's "Clone of <source-label>" pattern, then
+                // any label containing the source label, else the highest id.
+                def srcLabel = sourceCfg?.app?.label?.toString() ?: ""
+                def candidates = (parentCfg.childApps as List).findAll { added.contains(it.id as Integer) }
+                def match = candidates.find { (it.label?.toString() ?: "").startsWith("Clone of") } ?:
+                            candidates.find { srcLabel && (it.label?.toString() ?: "").contains(srcLabel) }
+                newAppId = (match?.id ?: candidates*.id.max()) as Integer
+            }
+        } catch (Exception pollExc) {
+            mcpLog("debug", "rm-native", "clone_native_app: poll #${pollAttempts} parent ${parentAppId} fetch failed: ${pollExc.message}")
+        }
+        if (newAppId == null && now() < deadline) pauseExecution(pollIntervalMs)
+    }
+
+    // Step 4: optional rename via origLabel write + updateRule on the new clone.
+    def renameError = null
     if (newAppId && newName) {
         try {
             def newSchema = _rmCollectInputSchema(_rmFetchConfigJson(newAppId)?.configPage)
             _rmUpdateAppSettings(newAppId, [origLabel: newName], newSchema)
             _rmClickAppButton(newAppId, "updateRule")
         } catch (Exception e) {
+            renameError = e.message
             mcpLog("warn", "rm-native", "clone_native_app: rename failed for new app ${newAppId}: ${e.message}")
         }
     }
 
+    if (newAppId != null) {
+        def result = [
+            success: true,
+            sourceAppId: sourceAppId,
+            clonerAppId: clonerAppId,
+            newAppId: newAppId,
+            pollAttempts: pollAttempts,
+            note: "Cloned source ${sourceAppId} -> new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
+        ]
+        if (renameError) result.renameError = renameError
+        return result
+    }
+
     return [
-        success: newAppId != null,
+        success: false,
+        pending: true,
         sourceAppId: sourceAppId,
         clonerAppId: clonerAppId,
-        newAppId: newAppId,
-        note: newAppId
-            ? "Cloned source ${sourceAppId} → new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
-            : "Clone button clicked but no new child app appeared under parent ${parentAppId}. The clone may have failed silently — check Hubitat logs."
+        newAppId: null,
+        pollAttempts: pollAttempts,
+        clickError: clickError,
+        note: "Clone fired but no new child app appeared under parent ${parentAppId} within ${overallTimeoutSec}s. The hub may still be processing the clone — re-check via list_installed_apps shortly. If it never appears, check Hubitat logs."
     ]
 }
 

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -2122,6 +2122,321 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.issues.any { it.toString().toLowerCase().contains("broken") }
     }
 
+    // ---------- clone_native_app ----------
+    // The clone tool wraps Hubitat's appCloner system app. Wire format:
+    //   1. GET /installedapp/sysAppApi/appCloner/app/<sourceId> -> 302
+    //      Location: /apps/api/<clonerId>/app/<sourceId>?access_token=...
+    //   2. POST /installedapp/btn  name=cloneRuleButton, settings[cloneRuleButton]=clicked,
+    //      cloneRuleButton.type=button, id=<clonerId>
+    //   3. New child app appears under sourceApp.parentAppId — diff
+    //      parent.childApps before/after to discover its id.
+    //
+    // Clone POST blocks server-side until commit (minutes for big rules), so
+    // the tool fires it with a 5s read timeout and polls for the new child.
+    // Tests pass pollIntervalMs=1 to keep the polling loop fast.
+
+    private String cloneSourceConfigJson(int sourceId, int parentId, String label = "Src") {
+        JsonOutput.toJson([
+            app: [id: sourceId, label: label, parentAppId: parentId, name: "Rule-5.1", trueLabel: label, installed: true],
+            configPage: [name: "mainPage", title: "Edit Rule", install: true, error: null, sections: []],
+            settings: [:],
+            childApps: []
+        ])
+    }
+
+    private String cloneParentConfigJson(int parentId, List children) {
+        JsonOutput.toJson([
+            app: [id: parentId, label: "RM"],
+            configPage: [name: "mainPage", title: "Rule Machine", install: true, error: null, sections: []],
+            settings: [:],
+            childApps: children
+        ])
+    }
+
+    def "clone_native_app requires confirm=true"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolCloneNativeApp([sourceAppId: 100])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("SAFETY CHECK FAILED")
+    }
+
+    def "clone_native_app throws when sourceAppId is missing"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolCloneNativeApp([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains("sourceappid")
+    }
+
+    def "clone_native_app throws when source app not found"() {
+        given:
+        enableHubAdminWrite()
+        // Empty response triggers _rmFetchConfigJson's "Empty response" branch,
+        // which the tool catches and converts to a clean "Source app N not found".
+        hubGet.register('/installedapp/configure/json/999') { params -> "" }
+
+        when:
+        script.toolCloneNativeApp([sourceAppId: 999, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("999")
+        ex.message.toLowerCase().contains("not found")
+    }
+
+    def "clone_native_app throws when appCloner returns no Location header"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Src") }
+        hubGet.register('/installedapp/configure/json/21') { params -> cloneParentConfigJson(21, [[id: 100, label: "Src"]]) }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 200, location: null, data: ""]
+        }
+
+        when:
+        script.toolCloneNativeApp([sourceAppId: 100, confirm: true])
+
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.message.toLowerCase().contains("no location")
+    }
+
+    def "clone_native_app throws when appCloner Location format is unrecognized"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Src") }
+        hubGet.register('/installedapp/configure/json/21') { params -> cloneParentConfigJson(21, [[id: 100, label: "Src"]]) }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/totally/unexpected/url/shape", data: ""]
+        }
+
+        when:
+        script.toolCloneNativeApp([sourceAppId: 100, confirm: true])
+
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.message.toLowerCase().contains("unexpected")
+    }
+
+    def "clone_native_app golden path: fires click POST and finds new appId via polling"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Source Rule") }
+        int parentCalls = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentCalls++
+            // First call = pre-clone snapshot (just the source). Subsequent =
+            // new clone has appeared.
+            parentCalls <= 1
+                ? cloneParentConfigJson(21, [[id: 100, label: "Source Rule"]])
+                : cloneParentConfigJson(21, [[id: 100, label: "Source Rule"], [id: 250, label: "Clone of Source Rule"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100?access_token=abc", data: ""]
+        }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body, timeout: t]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true, pollIntervalMs: 1])
+
+        then: "tool succeeds with new appId discovered via polling"
+        result.success == true
+        result.sourceAppId == 100
+        result.clonerAppId == 4242
+        result.newAppId == 250
+        result.pollAttempts >= 1
+
+        and: "click POST was sent with cloneRuleButton form contract + short read timeout"
+        def click = posts.find { it.path == "/installedapp/btn" && it.body?.name == "cloneRuleButton" }
+        click != null
+        click.body["settings[cloneRuleButton]"] == "clicked"
+        click.body["cloneRuleButton.type"] == "button"
+        click.body.id == "4242"
+        click.timeout == 5
+    }
+
+    def "clone_native_app survives click POST timeout and still finds new appId via polling"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Source") }
+        int parentCalls = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentCalls++
+            parentCalls <= 1
+                ? cloneParentConfigJson(21, [[id: 100, label: "Source"]])
+                : cloneParentConfigJson(21, [[id: 100, label: "Source"], [id: 300, label: "Clone of Source"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/777/app/100", data: ""]
+        }
+        // Simulate the click POST blocking past the short read timeout — production
+        // hub would throw SocketTimeoutException; the tool must tolerate any
+        // exception here and continue to polling.
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            throw new RuntimeException("simulated SocketTimeoutException after ${t}s")
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true, pollIntervalMs: 1])
+
+        then:
+        result.success == true
+        result.newAppId == 300
+        result.clonerAppId == 777
+    }
+
+    def "clone_native_app multi-candidate disambiguation prefers 'Clone of <label>' match"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Foo Rule") }
+        int pc = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            pc++
+            pc <= 1
+                ? cloneParentConfigJson(21, [[id: 100, label: "Foo Rule"]])
+                : cloneParentConfigJson(21, [
+                    [id: 100, label: "Foo Rule"],
+                    [id: 401, label: "Some unrelated rule"],
+                    [id: 402, label: "Clone of Foo Rule"]
+                  ])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true, pollIntervalMs: 1])
+
+        then:
+        result.success == true
+        result.newAppId == 402
+    }
+
+    def "clone_native_app rename: writes origLabel + clicks updateRule on the new clone"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Src") }
+        int pc = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            pc++
+            pc <= 1
+                ? cloneParentConfigJson(21, [[id: 100, label: "Src"]])
+                : cloneParentConfigJson(21, [[id: 100, label: "Src"], [id: 500, label: "Clone of Src"]])
+        }
+        // Stub the rename helpers so the test stays focused on the clone tool's
+        // dispatch contract rather than the full _rmUpdateAppSettings chain
+        // (which has its own dedicated tests above).
+        def rmUpdates = []
+        script.metaClass._rmCollectInputSchema = { Map cp -> [origLabel: [name: "origLabel", type: "text"]] }
+        script.metaClass._rmUpdateAppSettings = { Integer appId, Map sMap, Map schema ->
+            rmUpdates << [appId: appId, settings: sMap]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, newName: "My Renamed Clone", confirm: true, pollIntervalMs: 1])
+
+        then: "clone succeeded with the renamed clone id"
+        result.success == true
+        result.newAppId == 500
+        result.note?.contains("renamed to 'My Renamed Clone'")
+
+        and: "rename routed origLabel through _rmUpdateAppSettings on the new clone"
+        rmUpdates.size() == 1
+        rmUpdates[0].appId == 500
+        rmUpdates[0].settings == [origLabel: "My Renamed Clone"]
+
+        and: "updateRule click also fired on new clone (so the rename is committed)"
+        def updateClick = posts.find { it.path == "/installedapp/btn" && it.body?.name == "updateRule" && it.body?.id == "500" }
+        updateClick != null
+    }
+
+    def "clone_native_app returns pending=true when source has no parentAppId (cannot poll)"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params ->
+            JsonOutput.toJson([
+                app: [id: 100, label: "Orphan"],   // no parentAppId
+                configPage: [name: "mainPage", title: "Rule", install: true, error: null, sections: []],
+                settings: [:],
+                childApps: []
+            ])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true])
+
+        then: "no parent to poll = pending result + no new appId discovered"
+        result.success == false
+        result.pending == true
+        result.newAppId == null
+        result.pollAttempts == 0
+        result.clonerAppId == 4242
+    }
+
+    def "clone_native_app rename failure soft-warns and returns success with renameError"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Src") }
+        int pc = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            pc++
+            pc <= 1
+                ? cloneParentConfigJson(21, [[id: 100, label: "Src"]])
+                : cloneParentConfigJson(21, [[id: 100, label: "Src"], [id: 600, label: "Clone of Src"]])
+        }
+        // Force the post-clone configPage fetch (used by _rmCollectInputSchema)
+        // to throw so the rename branch hits its catch block.
+        hubGet.register('/installedapp/configure/json/600') { params ->
+            throw new RuntimeException("simulated config fetch failure for new clone")
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, newName: "Foo", confirm: true, pollIntervalMs: 1])
+
+        then: "clone itself succeeded, rename failure is surfaced but non-fatal"
+        result.success == true
+        result.newAppId == 600
+        result.renameError != null
+        result.renameError.toString().length() > 0
+    }
+
     // ---------- post-write verification heuristic itself ----------
     // The silent-rejection / verification-fetch-failed paths are load-bearing
     // for the entire write-bookkeeping subsystem. Without these tests, a

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -2339,15 +2339,21 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
                 ? cloneParentConfigJson(21, [[id: 100, label: "Src"]])
                 : cloneParentConfigJson(21, [[id: 100, label: "Src"], [id: 500, label: "Clone of Src"]])
         }
-        // Stub the rename helpers so the test stays focused on the clone tool's
-        // dispatch contract rather than the full _rmUpdateAppSettings chain
-        // (which has its own dedicated tests above).
-        def rmUpdates = []
-        script.metaClass._rmCollectInputSchema = { Map cp -> [origLabel: [name: "origLabel", type: "text"]] }
-        script.metaClass._rmUpdateAppSettings = { Integer appId, Map sMap, Map schema ->
-            rmUpdates << [appId: appId, settings: sMap]
-            [status: 200, location: null, data: '{"status":"success"}']
+        // The rename branch fetches the new clone's configPage to collect a
+        // schema, then posts origLabel through the real _rmUpdateAppSettings
+        // chain — register the configure/json + statusJson endpoints so the
+        // post-write multiple-flag verification has data to inspect.
+        hubGet.register('/installedapp/configure/json/500') { params ->
+            JsonOutput.toJson([
+                app: [id: 500, label: "Clone of Src", name: "Rule-5.1", trueLabel: "Clone of Src", installed: true],
+                configPage: [name: "mainPage", title: "Edit Rule", install: true, error: null, sections: [
+                    [title: "", input: [[name: "origLabel", type: "text"]]]
+                ]],
+                settings: [:],
+                childApps: []
+            ])
         }
+        hubGet.register('/installedapp/statusJson/500') { params -> statusJson(500) }
         script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
             [status: 302, location: "/apps/api/4242/app/100", data: ""]
         }
@@ -2365,10 +2371,11 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.newAppId == 500
         result.note?.contains("renamed to 'My Renamed Clone'")
 
-        and: "rename routed origLabel through _rmUpdateAppSettings on the new clone"
-        rmUpdates.size() == 1
-        rmUpdates[0].appId == 500
-        rmUpdates[0].settings == [origLabel: "My Renamed Clone"]
+        and: "origLabel write POSTed to /installedapp/update/json with id=500"
+        def labelWrite = posts.find { it.path == "/installedapp/update/json" && it.body?.id == "500" }
+        labelWrite != null
+        labelWrite.body["settings[origLabel]"] == "My Renamed Clone"
+        labelWrite.body["origLabel.type"] == "text"
 
         and: "updateRule click also fired on new clone (so the rename is committed)"
         def updateClick = posts.find { it.path == "/installedapp/btn" && it.body?.name == "updateRule" && it.body?.id == "500" }

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -82,10 +82,15 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
     // Minimal RM rule config JSON. Schema inputs drive _rmBuildSettingsBody's
     // 3-field group logic, so tests shape the sections/inputs as needed.
-    private String ruleConfigJson(int ruleId, String label = "BAT-RM-test", List inputs = []) {
+    // parentAppId is optional and used by the clone_native_app specs which
+    // need a source rule attached to its RM parent so the polling path can
+    // discover the new clone via parent.childApps diffing.
+    private String ruleConfigJson(int ruleId, String label = "BAT-RM-test", List inputs = [], Integer parentAppId = null) {
+        def app = [id: ruleId, name: "Rule-5.1", label: label, trueLabel: label, installed: true,
+                   appType: [name: "Rule-5.1", namespace: "hubitat"]]
+        if (parentAppId != null) app.parentAppId = parentAppId
         JsonOutput.toJson([
-            app: [id: ruleId, name: "Rule-5.1", label: label, trueLabel: label, installed: true,
-                  appType: [name: "Rule-5.1", namespace: "hubitat"]],
+            app: app,
             configPage: [name: "mainPage", title: "Edit Rule", install: true, error: null, sections: [
                 [title: "", input: inputs]
             ]],
@@ -2135,15 +2140,6 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     // the tool fires it with a 5s read timeout and polls for the new child.
     // Tests pass pollIntervalMs=1 to keep the polling loop fast.
 
-    private String cloneSourceConfigJson(int sourceId, int parentId, String label = "Src") {
-        JsonOutput.toJson([
-            app: [id: sourceId, label: label, parentAppId: parentId, name: "Rule-5.1", trueLabel: label, installed: true],
-            configPage: [name: "mainPage", title: "Edit Rule", install: true, error: null, sections: []],
-            settings: [:],
-            childApps: []
-        ])
-    }
-
     private String cloneParentConfigJson(int parentId, List children) {
         JsonOutput.toJson([
             app: [id: parentId, label: "RM"],
@@ -2196,7 +2192,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     def "clone_native_app throws when appCloner returns no Location header"() {
         given:
         enableHubAdminWrite()
-        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Src") }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
         hubGet.register('/installedapp/configure/json/21') { params -> cloneParentConfigJson(21, [[id: 100, label: "Src"]]) }
         script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
             [status: 200, location: null, data: ""]
@@ -2213,7 +2209,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     def "clone_native_app throws when appCloner Location format is unrecognized"() {
         given:
         enableHubAdminWrite()
-        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Src") }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
         hubGet.register('/installedapp/configure/json/21') { params -> cloneParentConfigJson(21, [[id: 100, label: "Src"]]) }
         script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
             [status: 302, location: "/totally/unexpected/url/shape", data: ""]
@@ -2230,7 +2226,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     def "clone_native_app golden path: fires click POST and finds new appId via polling"() {
         given:
         enableHubAdminWrite()
-        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Source Rule") }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Source Rule", [], 21) }
         int parentCalls = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             parentCalls++
@@ -2271,7 +2267,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     def "clone_native_app survives click POST timeout and still finds new appId via polling"() {
         given:
         enableHubAdminWrite()
-        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Source") }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Source", [], 21) }
         int parentCalls = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             parentCalls++
@@ -2301,7 +2297,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     def "clone_native_app multi-candidate disambiguation prefers 'Clone of <label>' match"() {
         given:
         enableHubAdminWrite()
-        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Foo Rule") }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Foo Rule", [], 21) }
         int pc = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             pc++
@@ -2331,7 +2327,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     def "clone_native_app rename: writes origLabel + clicks updateRule on the new clone"() {
         given:
         enableHubAdminWrite()
-        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Src") }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
         int pc = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             pc++
@@ -2385,14 +2381,8 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     def "clone_native_app returns pending=true when source has no parentAppId (cannot poll)"() {
         given:
         enableHubAdminWrite()
-        hubGet.register('/installedapp/configure/json/100') { params ->
-            JsonOutput.toJson([
-                app: [id: 100, label: "Orphan"],   // no parentAppId
-                configPage: [name: "mainPage", title: "Rule", install: true, error: null, sections: []],
-                settings: [:],
-                childApps: []
-            ])
-        }
+        // ruleConfigJson with parentAppId=null (default) omits the field entirely.
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Orphan") }
         script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
             [status: 302, location: "/apps/api/4242/app/100", data: ""]
         }
@@ -2414,7 +2404,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     def "clone_native_app rename failure soft-warns and returns success with renameError"() {
         given:
         enableHubAdminWrite()
-        hubGet.register('/installedapp/configure/json/100') { params -> cloneSourceConfigJson(100, 21, "Src") }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
         int pc = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             pc++
@@ -2442,6 +2432,129 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.newAppId == 600
         result.renameError != null
         result.renameError.toString().length() > 0
+    }
+
+    def "clone_native_app handles the legacy /installedapp/configure/N Location shape"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
+        int pc = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            pc++
+            pc <= 1
+                ? cloneParentConfigJson(21, [[id: 100, label: "Src"]])
+                : cloneParentConfigJson(21, [[id: 100, label: "Src"], [id: 700, label: "Clone of Src"]])
+        }
+        // Older firmware returns the cloner instance via /installedapp/configure/<id>
+        // instead of the newer /apps/api/<id>/app/<sourceId>?access_token=… shape.
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/installedapp/configure/9999", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true, pollIntervalMs: 1])
+
+        then:
+        result.success == true
+        result.clonerAppId == 9999
+        result.newAppId == 700
+    }
+
+    def "clone_native_app multi-candidate fallback picks max id when no label match"() {
+        given:
+        enableHubAdminWrite()
+        // Source has an empty label, so the contains-source-label fallback can't
+        // match either — exercises the final candidates*.id.max() branch.
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "", [], 21) }
+        int pc = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            pc++
+            pc <= 1
+                ? cloneParentConfigJson(21, [[id: 100, label: ""]])
+                : cloneParentConfigJson(21, [
+                    [id: 100, label: ""],
+                    [id: 401, label: "rule-x"],
+                    [id: 402, label: "rule-y"]
+                  ])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true, pollIntervalMs: 1])
+
+        then: "no Clone-of-prefix and no source-label-contains match — fall back to max id"
+        result.success == true
+        result.newAppId == 402
+    }
+
+    def "clone_native_app pre-clone parent fetch failure sets snapshotIncomplete=true but still finds clone"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
+        int parentCalls = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentCalls++
+            // Pre-clone snapshot fetch (call #1) throws; subsequent polling
+            // calls return the post-clone state. With the snapshot empty, both
+            // the source AND the clone look "added" — multi-candidate logic
+            // disambiguates via the "Clone of" prefix.
+            if (parentCalls == 1) {
+                throw new RuntimeException("simulated transient parent fetch failure during pre-clone snapshot")
+            }
+            cloneParentConfigJson(21, [[id: 100, label: "Src"], [id: 800, label: "Clone of Src"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true, pollIntervalMs: 1])
+
+        then: "clone still discovered via Clone-of-prefix tiebreak; snapshotIncomplete flag surfaced"
+        result.success == true
+        result.newAppId == 800
+        result.snapshotIncomplete == true
+    }
+
+    def "clone_native_app polling tolerates a transient parent fetch failure mid-loop"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
+        int parentCalls = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentCalls++
+            // Call #1 = pre-clone snapshot (succeeds). Call #2 = first poll, throws.
+            // Call #3 = recovery, returns the new clone. Verifies the loop's
+            // catch block doesn't abort the iteration.
+            if (parentCalls == 1) return cloneParentConfigJson(21, [[id: 100, label: "Src"]])
+            if (parentCalls == 2) throw new RuntimeException("simulated transient parent fetch failure mid-poll")
+            cloneParentConfigJson(21, [[id: 100, label: "Src"], [id: 900, label: "Clone of Src"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true, pollIntervalMs: 1])
+
+        then: "transient mid-poll error swallowed; subsequent poll finds the clone"
+        result.success == true
+        result.newAppId == 900
+        result.pollAttempts >= 2
     }
 
     // ---------- post-write verification heuristic itself ----------


### PR DESCRIPTION
## Summary

- Adds `clone_native_app` to the `manage_native_rules_and_apps` gateway — clones any classic SmartApp (RM rule, Room Lighting, Button Controller, Basic Rule, Notifier, Group, Scene, etc.) by driving Hubitat's first-party `appCloner` system app.
- Lower-overhead alternative to `create_native_app` + walking the wizard — preserves the full rule shape (state.actNdx, conditions, expressions, IF/THEN/ELSE positional arrays) that the wizard-driving path can't easily reconstruct from a spec.
- Spun off from #134 (now merged); rebased clean onto current main — single commit, +145/-5 in `hubitat-mcp-server.groovy`.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- New tool `clone_native_app(sourceAppId, newName?, confirm)` — wraps Hubitat's `/installedapp/sysAppApi/appCloner/app/<id>` + `/installedapp/btn` (`cloneRuleButton`) wire format.
- Registers the tool in `manage_native_rules_and_apps` (now 10 sub-tools), `biTools`, `hideGatewaySubTools`, and the `executeTool` dispatch.
- Discovers the new `appId` by snapshotting `parent.childApps` before the clone and diffing after.
- Optional rename via `update_native_app(origLabel=...)` after the clone is committed.
- Requires `Built-in App Tools` enabled + `Hub Admin Write` + `confirm=true`.

Part of #120.

## Release Notes

- New `clone_native_app` tool under `manage_native_rules_and_apps` — clone any classic Hubitat automation app (RM rule, Room Lighting, Button Controller, Basic Rule, Notifier, etc.) without rebuilding it from scratch.
  - Returns `newAppId` so you can immediately surgical-edit the clone via `update_native_app`.
  - Preserves the full rule shape including conditions, expressions, and IF/THEN/ELSE positional arrays.
  - Optional `newName` argument renames the clone in one call.
- Requires the existing `Enable Built-in App Tools` toggle plus `Hub Admin Write` + `confirm=true`, same gating as `delete_native_app`.

## Testing

- Unit tests: forthcoming in this PR (Spock specs in `ToolRmNativeCrudSpec`).
- Live-hub: verified end-to-end against firmware 2.5.0.x — clone of an RM 5.1 rule lands as a sibling under the source's parent labelled `Clone of <source-label>`, and the optional rename writes through `origLabel`.
- Wire format probe (also in tests/wizard_probe matrix):
  - `GET /installedapp/sysAppApi/appCloner/app/<sourceId>` -> 302, `Location: /apps/api/<clonerId>/app/<sourceId>?access_token=...`
  - `POST /installedapp/btn` with `name=cloneRuleButton, settings[cloneRuleButton]=clicked, cloneRuleButton.type=button, id=<clonerId>` triggers the actual clone

## Checklist

- [ ] **Unit tests added for any new MCP tools** (in progress this PR — Spock specs in `ToolRmNativeCrudSpec`)
- [ ] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
- [ ] Documentation updated if user-facing behaviour or tool surface changed