### PR TITLE
fix(manage_virtual_device): rename "Virtual Presence Sensor" enum entry to "Virtual Presence"

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -397,7 +397,7 @@ Virtual devices are managed via the unified `manage_virtual_device` tool (action
 - **`getChildDevices()`** returns only child *devices* (not child apps/rules — those use `getChildApps()`)
 - **`deleteChildDevice(dni)`** removes by device network ID
 - Auto-generated DNIs use format `mcp-virtual-<hex-timestamp>-<hex-random>` with retry logic to avoid collisions
-- Supports 15 built-in virtual device types: Virtual Switch, Virtual Button, Virtual Contact Sensor, Virtual Motion Sensor, Virtual Presence Sensor, Virtual Lock, Virtual Temperature Sensor, Virtual Humidity Sensor, Virtual Dimmer, Virtual RGBW Light, Virtual Shade, Virtual Garage Door Opener, Virtual Water Sensor, Virtual Omni Sensor, Virtual Fan Controller
+- Supports 15 built-in virtual device types: Virtual Switch, Virtual Button, Virtual Contact Sensor, Virtual Motion Sensor, Virtual Presence, Virtual Lock, Virtual Temperature Sensor, Virtual Humidity Sensor, Virtual Dimmer, Virtual RGBW Light, Virtual Shade, Virtual Garage Door Opener, Virtual Water Sensor, Virtual Omni Sensor, Virtual Fan Controller
 - Requires Hub Admin Write access (with backup verification) for create/delete operations
 
 #### update_device Tool

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -90,7 +90,7 @@ When using `manage_virtual_device` (action: "create"), these types are available
 | Virtual Button | pushable button | Triggering automations |
 | Virtual Contact Sensor | open/closed | Simulate door/window state |
 | Virtual Motion Sensor | active/inactive | Simulate motion detection |
-| Virtual Presence Sensor | present/not present | Presence simulation |
+| Virtual Presence | present/not present | Presence simulation |
 | Virtual Lock | lock/unlock | Lock state simulation |
 | Virtual Temperature Sensor | numeric temp | Temperature reporting |
 | Virtual Humidity Sensor | numeric humidity | Humidity reporting |

--- a/agent-skill/hubitat-mcp/safety-guide.md
+++ b/agent-skill/hubitat-mcp/safety-guide.md
@@ -93,7 +93,7 @@ ALL Hub Admin Write tools require these steps in order:
 - Use `manage_virtual_device` with `action="create"` or `action="delete"` for MCP-managed virtual devices
 - Do NOT use `delete_device` for virtual devices created by MCP
 - Virtual devices created by MCP are automatically accessible to all device tools
-- 15 supported types: Virtual Switch, Button, Contact Sensor, Motion Sensor, Presence Sensor, Lock, Temperature Sensor, Humidity Sensor, Dimmer, RGBW Light, Shade, Garage Door Opener, Water Sensor, Omni Sensor, Fan Controller
+- 15 supported types: Virtual Switch, Button, Contact Sensor, Motion Sensor, Presence, Lock, Temperature Sensor, Humidity Sensor, Dimmer, RGBW Light, Shade, Garage Door Opener, Water Sensor, Omni Sensor, Fan Controller
 
 ---
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1315,7 +1315,7 @@ action="delete": Provide deviceNetworkId of device to delete. Use list_virtual_d
                 properties: [
                     action: [type: "string", description: "Operation to perform", enum: ["create", "delete"]],
                     deviceType: [type: "string", description: "Virtual device driver type (required for create)",
-                        enum: ["Virtual Switch", "Virtual Button", "Virtual Contact Sensor", "Virtual Motion Sensor", "Virtual Presence Sensor", "Virtual Lock", "Virtual Temperature Sensor", "Virtual Humidity Sensor", "Virtual Dimmer", "Virtual RGBW Light", "Virtual Shade", "Virtual Garage Door Opener", "Virtual Water Sensor", "Virtual Omni Sensor", "Virtual Fan Controller"]],
+                        enum: ["Virtual Switch", "Virtual Button", "Virtual Contact Sensor", "Virtual Motion Sensor", "Virtual Presence", "Virtual Lock", "Virtual Temperature Sensor", "Virtual Humidity Sensor", "Virtual Dimmer", "Virtual RGBW Light", "Virtual Shade", "Virtual Garage Door Opener", "Virtual Water Sensor", "Virtual Omni Sensor", "Virtual Fan Controller"]],
                     deviceLabel: [type: "string", description: "Display label (required for create)"],
                     deviceNetworkId: [type: "string", description: "Device network ID. Auto-generated for create if omitted. REQUIRED for delete."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true to confirm the operation."]
@@ -7014,7 +7014,7 @@ def toolManageVirtualDevice(args) {
     }
     switch (action) {
         case "create":
-            if (!args.deviceType) throw new IllegalArgumentException("deviceType is required for action='create'. Supported types: Virtual Switch, Virtual Button, Virtual Contact Sensor, Virtual Motion Sensor, Virtual Presence Sensor, Virtual Lock, Virtual Temperature Sensor, Virtual Humidity Sensor, Virtual Dimmer, Virtual RGBW Light, Virtual Shade, Virtual Garage Door Opener, Virtual Water Sensor, Virtual Omni Sensor, Virtual Fan Controller.")
+            if (!args.deviceType) throw new IllegalArgumentException("deviceType is required for action='create'. Supported types: Virtual Switch, Virtual Button, Virtual Contact Sensor, Virtual Motion Sensor, Virtual Presence, Virtual Lock, Virtual Temperature Sensor, Virtual Humidity Sensor, Virtual Dimmer, Virtual RGBW Light, Virtual Shade, Virtual Garage Door Opener, Virtual Water Sensor, Virtual Omni Sensor, Virtual Fan Controller.")
             if (!args.deviceLabel) throw new IllegalArgumentException("deviceLabel is required for action='create'.")
             return toolCreateVirtualDevice(args)
         case "delete":
@@ -7038,7 +7038,7 @@ def toolCreateVirtualDevice(args) {
     // Validate device type against supported list
     def supportedTypes = [
         "Virtual Switch", "Virtual Button", "Virtual Contact Sensor",
-        "Virtual Motion Sensor", "Virtual Presence Sensor", "Virtual Lock",
+        "Virtual Motion Sensor", "Virtual Presence", "Virtual Lock",
         "Virtual Temperature Sensor", "Virtual Humidity Sensor", "Virtual Dimmer",
         "Virtual RGBW Light", "Virtual Shade", "Virtual Garage Door Opener",
         "Virtual Water Sensor", "Virtual Omni Sensor", "Virtual Fan Controller"
@@ -8662,7 +8662,7 @@ All Hub Admin Write tools require these steps:
 | Virtual Button | pushable button | Triggering automations |
 | Virtual Contact Sensor | open/closed | Simulate door/window |
 | Virtual Motion Sensor | active/inactive | Simulate motion |
-| Virtual Presence Sensor | present/not present | Presence simulation |
+| Virtual Presence | present/not present | Presence simulation |
 | Virtual Lock | lock/unlock | Lock state simulation |
 | Virtual Temperature Sensor | numeric temp | Temperature reporting |
 | Virtual Humidity Sensor | numeric humidity | Humidity reporting |

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1315,7 +1315,7 @@ action="delete": Provide deviceNetworkId of device to delete. Use list_virtual_d
                 properties: [
                     action: [type: "string", description: "Operation to perform", enum: ["create", "delete"]],
                     deviceType: [type: "string", description: "Virtual device driver type (required for create)",
-                        enum: ["Virtual Switch", "Virtual Button", "Virtual Contact Sensor", "Virtual Motion Sensor", "Virtual Presence", "Virtual Lock", "Virtual Temperature Sensor", "Virtual Humidity Sensor", "Virtual Dimmer", "Virtual RGBW Light", "Virtual Shade", "Virtual Garage Door Opener", "Virtual Water Sensor", "Virtual Omni Sensor", "Virtual Fan Controller"]],
+                        enum: getSupportedVirtualDeviceTypes()],
                     deviceLabel: [type: "string", description: "Display label (required for create)"],
                     deviceNetworkId: [type: "string", description: "Device network ID. Auto-generated for create if omitted. REQUIRED for delete."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true to confirm the operation."]
@@ -7014,7 +7014,7 @@ def toolManageVirtualDevice(args) {
     }
     switch (action) {
         case "create":
-            if (!args.deviceType) throw new IllegalArgumentException("deviceType is required for action='create'. Supported types: Virtual Switch, Virtual Button, Virtual Contact Sensor, Virtual Motion Sensor, Virtual Presence, Virtual Lock, Virtual Temperature Sensor, Virtual Humidity Sensor, Virtual Dimmer, Virtual RGBW Light, Virtual Shade, Virtual Garage Door Opener, Virtual Water Sensor, Virtual Omni Sensor, Virtual Fan Controller.")
+            if (!args.deviceType) throw new IllegalArgumentException("deviceType is required for action='create'. Supported types: ${getSupportedVirtualDeviceTypes().join(', ')}.")
             if (!args.deviceLabel) throw new IllegalArgumentException("deviceLabel is required for action='create'.")
             return toolCreateVirtualDevice(args)
         case "delete":
@@ -7023,6 +7023,22 @@ def toolManageVirtualDevice(args) {
         default:
             throw new IllegalArgumentException("Unknown action '${action}'. Use 'create' or 'delete'.")
     }
+}
+
+// Single source of truth for virtual device types supported by manage_virtual_device.
+// Referenced from (a) the deviceType enum in the tool schema, (b) the
+// IllegalArgumentException error message thrown when deviceType is missing,
+// and (c) the validation list inside toolCreateVirtualDevice. Keep these three
+// sites in sync via this helper to prevent the kind of single-element mismatch
+// fixed in PR #144 (Virtual Presence Sensor → Virtual Presence).
+def getSupportedVirtualDeviceTypes() {
+    [
+        "Virtual Switch", "Virtual Button", "Virtual Contact Sensor",
+        "Virtual Motion Sensor", "Virtual Presence", "Virtual Lock",
+        "Virtual Temperature Sensor", "Virtual Humidity Sensor", "Virtual Dimmer",
+        "Virtual RGBW Light", "Virtual Shade", "Virtual Garage Door Opener",
+        "Virtual Water Sensor", "Virtual Omni Sensor", "Virtual Fan Controller"
+    ]
 }
 
 def toolCreateVirtualDevice(args) {
@@ -7035,14 +7051,8 @@ def toolCreateVirtualDevice(args) {
     if (!deviceType) throw new IllegalArgumentException("deviceType is required")
     if (!deviceLabel) throw new IllegalArgumentException("deviceLabel is required")
 
-    // Validate device type against supported list
-    def supportedTypes = [
-        "Virtual Switch", "Virtual Button", "Virtual Contact Sensor",
-        "Virtual Motion Sensor", "Virtual Presence", "Virtual Lock",
-        "Virtual Temperature Sensor", "Virtual Humidity Sensor", "Virtual Dimmer",
-        "Virtual RGBW Light", "Virtual Shade", "Virtual Garage Door Opener",
-        "Virtual Water Sensor", "Virtual Omni Sensor", "Virtual Fan Controller"
-    ]
+    // Validate device type against supported list (see getSupportedVirtualDeviceTypes)
+    def supportedTypes = getSupportedVirtualDeviceTypes()
     if (!supportedTypes.contains(deviceType)) {
         throw new IllegalArgumentException("Unsupported device type: '${deviceType}'. Supported types: ${supportedTypes.join(', ')}")
     }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -7025,12 +7025,8 @@ def toolManageVirtualDevice(args) {
     }
 }
 
-// Single source of truth for virtual device types supported by manage_virtual_device.
-// Referenced from (a) the deviceType enum in the tool schema, (b) the
-// IllegalArgumentException error message thrown when deviceType is missing,
-// and (c) the validation list inside toolCreateVirtualDevice. Keep these three
-// sites in sync via this helper to prevent the kind of single-element mismatch
-// fixed in PR #144 (Virtual Presence Sensor → Virtual Presence).
+// Single source of truth: the tool-schema enum, the missing-arg error,
+// and the create-time validator must all agree on this list.
 def getSupportedVirtualDeviceTypes() {
     [
         "Virtual Switch", "Virtual Button", "Virtual Contact Sensor",
@@ -7051,7 +7047,6 @@ def toolCreateVirtualDevice(args) {
     if (!deviceType) throw new IllegalArgumentException("deviceType is required")
     if (!deviceLabel) throw new IllegalArgumentException("deviceLabel is required")
 
-    // Validate device type against supported list (see getSupportedVirtualDeviceTypes)
     def supportedTypes = getSupportedVirtualDeviceTypes()
     if (!supportedTypes.contains(deviceType)) {
         throw new IllegalArgumentException("Unsupported device type: '${deviceType}'. Supported types: ${supportedTypes.join(', ')}")

--- a/tests/BAT-rm-native-crud.md
+++ b/tests/BAT-rm-native-crud.md
@@ -343,7 +343,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 ```json
 {
-  "setup_prompt": "Create BAT virtual devices: 'BAT-Motion-CS' (Virtual Motion Sensor) and 'BAT-Presence-CS' (Virtual Presence Sensor). Record IDs.",
+  "setup_prompt": "Create BAT virtual devices: 'BAT-Motion-CS' (Virtual Motion Sensor) and 'BAT-Presence-CS' (Virtual Presence). Record IDs.",
   "test_prompt": "Create 'BAT-RM-Cond+AndStays' where BAT-Motion-CS becoming active is BOTH a conditional trigger (condition: BAT-Presence-CS is present) AND an and-stays trigger (must stay active for 60 seconds). Verify both flags are set on the same trigger entry after round-trip.",
   "teardown_prompt": "Delete the rule and remove both virtual devices."
 }
@@ -427,7 +427,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 ```json
 {
-  "setup_prompt": "Create BAT virtual devices: 'BAT-Presence-1' (Virtual Presence Sensor) and 'BAT-PowerSource-1' (any device with powerSource attribute, or skip if unavailable). Record IDs.",
+  "setup_prompt": "Create BAT virtual devices: 'BAT-Presence-1' (Virtual Presence) and 'BAT-PowerSource-1' (any device with powerSource attribute, or skip if unavailable). Record IDs.",
   "test_prompt": "Create 'BAT-RM-Presence PowerSource' with: (1) BAT-Presence-1 arrives, (2) BAT-PowerSource-1 switches to battery (away from mains). Verify both triggers are captured with correct capabilities.",
   "teardown_prompt": "Delete the rule and remove the devices."
 }


### PR DESCRIPTION
## What

Single-character-class fix: change the deviceType enum entry `"Virtual Presence Sensor"` to `"Virtual Presence"` in `manage_virtual_device`, plus the matching documentation/error-message references and 2 BAT test scenarios.

## Context

Filed ahead of the CI workflow work for #77 (test-hub-as-E2E-target). Promised in https://github.com/kingpanther13/Hubitat-local-MCP-server/issues/77#issuecomment-4367455680 — landing this small fix first so that `manage_virtual_device` works for the full enum surface before CI starts exercising device creation. Not a blocker for #77 in general; just the sequencing I committed to.

## Why

The string `"Virtual Presence Sensor"` doesn't match any actual built-in Hubitat driver. Hubitat's real driver name is `"Virtual Presence"` (no "Sensor" suffix). When `manage_virtual_device action="create" deviceType="Virtual Presence Sensor"` runs, Hubitat's `addDevice()` throws a generic `java.lang.Exception` ("An unexpected error occurred") because the driver name is unrecognized, and the MCP gateway bubbles that up opaquely:

```
Streamable HTTP error: Error POSTing to endpoint:
{"error":true,"type":"java.lang.Exception","message":"An unexpected error occurred."}
```

Verified by inspecting the Add Device wizard search on a live test hub (firmware 2.5.0.126):

- search `"Virtual Presence Sensor"` → "No results found"
- search `"Presence"` → returns `Virtual Presence` + `Virtual Presence with Switch`

Spot-checked the other 14 enum entries against the Add Device wizard search; all match Hubitat's actual driver names. Only Presence was off.

## Files changed

| File | Change |
|---|---|
| `hubitat-mcp-server.groovy` | enum array (line 1318), error-message string (7017), internal type list (7041), doc table (8665) |
| `SKILL.md` | supported-types prose (line 400) |
| `TOOL_GUIDE.md` | virtual-device table (line 93) |
| `tests/BAT-rm-native-crud.md` | 2 BAT scenarios (lines 346, 430) that previously created devices with the wrong name and presumably failed silently |

## Verification

- Sandbox lint: clean (0 errors, 0 warnings)
- Live-deployed cherry-pick to test hub running PR #134 codeline → `manage_virtual_device action="create" deviceType="Virtual Presence" deviceLabel="_CI_VerifyFix_Presence"` returned `success:true` with `typeName: "Virtual Presence"`, capabilities `["Sensor", "PresenceSensor"]`, commands `["arrived", "departed"]`. Pre-fix this consistently failed with the opaque java.lang.Exception. Test device deleted post-verification.

- **Zero-context Sonnet validation**: a fresh-context agent given only the natural-language task "add a virtual presence sensor for CI testing" (no knowledge of this fix or the enum mismatch) intuited `deviceType="Virtual Presence Sensor"` first (matching the user's natural phrasing). Got a clear error: `Unsupported device type: 'Virtual Presence Sensor'. Supported types: ..., Virtual Presence, ...`. Recovered with 1 retry to `deviceType="Virtual Presence"` → success. Total flow: 8 tool calls (1 retry), single conversational pass, no user intervention.

- **Stale-cache note**: the agent's MCP client had cached the OLD schema (still showing `"Virtual Presence Sensor"` in the enum) from before the deploy. Server-side validator already had the new behavior. This will self-correct for clients that restart their MCP connection after this PR merges; not a blocker.

Pre-fix vs post-fix error UX:

| | Pre-fix | Post-fix |
|---|---|---|
| Error type | `java.lang.Exception` | `Invalid params -32602` |
| Error message | "An unexpected error occurred" | "Unsupported device type: 'X'. Supported types: ..." |
| Debuggable? | No | Yes — full enum list inline |
| Recovery | Manual codebase dig | 1 retry with the listed name |

## Scope notes

- No tool surface change (same tool name, same args, same response shape).
- No version bump (per fork policy — version is a release-cut decision).
- No new tests; the existing 2 BAT scenarios are corrected so they'll actually work.

Branch is rooted directly at `upstream/main` (not stacked on PR #134). Independent and safe to merge in either order.
