### PR TITLE
feat(developer-mode): add manage_mcp_self gateway + delete_variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hubitat MCP Server
 
-A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 83 MCP tools (33 on `tools/list` via category gateways).
+A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 85 MCP tools (34 on `tools/list` via category gateways).
 
 > **BETA SOFTWARE**: This project is ~99% AI-generated ("vibe coded") using Claude. It's a work in progress — contributions and [bug reports](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues) are welcome!
 
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 83 tools total — 22 core tools are always visible, while 61 additional tools are organized behind 11 domain-named gateways to keep the tool list manageable.
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 85 tools total — 22 core tools are always visible, while 63 additional tools are organized behind 12 domain-named gateways to keep the tool list manageable.
 
 ## Requirements
 
@@ -221,9 +221,9 @@ For free remote access without a Hubitat Cloud subscription:
 
 ## Features
 
-### MCP Tools (83 total — 33 on tools/list)
+### MCP Tools (85 total — 34 on tools/list)
 
-The server has 83 tools total. To keep the MCP `tools/list` manageable, **22 core tools** are always visible and **61 additional tools** are organized behind **11 domain-named gateways**. The AI sees 33 items on `tools/list` (22 + 11 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
+The server has 85 tools total. To keep the MCP `tools/list` manageable, **22 core tools** are always visible and **63 additional tools** are organized behind **12 domain-named gateways**. The AI sees 34 items on `tools/list` (22 + 12 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
 
 #### Core Tools (22) — Always visible on tools/list
 
@@ -323,13 +323,14 @@ Call a gateway with no arguments to see full parameter schemas. Call with `tool=
 </details>
 
 <details>
-<summary><b>manage_hub_variables</b> (3) — Hub variables</summary>
+<summary><b>manage_hub_variables</b> (4) — Hub variables</summary>
 
 | Tool | Description |
 |------|-------------|
 | `list_variables` | List all hub connector and rule engine variables |
 | `get_variable` | Get a variable value |
 | `set_variable` | Set a variable value (creates if doesn't exist) |
+| `delete_variable` | Permanently delete a rule engine variable (DESTRUCTIVE) |
 
 </details>
 
@@ -467,6 +468,17 @@ Write/delete require Hub Admin Write + confirm.
 | `set_rm_rule_boolean` | Set an RM rule's private boolean variable |
 
 **Cannot create, modify, or delete** RM rules — Hubitat's platform blocks third-party apps from managing built-in app children. Use the native RM UI for configuration. Requires opt-in **Enable Built-in App Tools** setting.
+
+</details>
+
+<details>
+<summary><b>manage_mcp_self</b> (1) — Developer Mode self-administration</summary>
+
+| Tool | Description |
+|------|-------------|
+| `update_mcp_settings` | Update one or more of the MCP rule app's own settings (toggles, log level, tuning params). Allowlist-gated. |
+
+First gateway under the **Developer Mode** pattern — for LLM-agent and CI/CD pipelines that need to manage the MCP rule app's own configuration without manual UI intervention. Additional self-admin tools (device-access management, true Hub Variables namespace support, artifact cleanup) are planned as follow-ups under the same toggle. Requires opt-in **Enable Developer Mode Tools** setting (default OFF). Each successful write is logged at WARN level for audit.
 
 </details>
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hubitat-mcp-server
-description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 83 tools (33 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver management, installed-app visibility, and Rule Machine interoperability.
+description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 85 tools (34 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver management, installed-app visibility, Rule Machine interoperability, and Developer Mode self-administration.
 license: MIT
 ---
 
@@ -32,7 +32,7 @@ There are **no external dependencies, build steps, or test frameworks**. Everyth
 │  │  MCP Rule Server (parent app)             │  │
 │  │  - OAuth endpoint: /apps/api/<id>/mcp     │  │
 │  │  - JSON-RPC 2.0 handler                   │  │
-│  │  - 83 tools (33 on tools/list + gateways) │  │
+│  │  - 85 tools (34 on tools/list + gateways) │  │
 │  │  - Device access gate (selectedDevices)   │  │
 │  │  - Hub Admin tools (internal API calls)   │  │
 │  │  - Hub Security cookie auth               │  │
@@ -93,23 +93,23 @@ New code should be placed in the appropriate section. New sections should follow
 
 ### Category Gateway Proxy (v0.8.0+)
 
-The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 83 items to 33. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
+The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 85 items to 34. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
 
 **Architecture:**
-- `getGatewayConfig()` — defines 11 gateways, each with a description, tools list, and summaries map
-- `getToolDefinitions()` — returns 22 core tools + 11 gateway tool definitions (client-visible)
-- `getAllToolDefinitions()` — returns all 83 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
+- `getGatewayConfig()` — defines 12 gateways, each with a description, tools list, and summaries map
+- `getToolDefinitions()` — returns 22 core tools + 12 gateway tool definitions (client-visible)
+- `getAllToolDefinitions()` — returns all 85 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
 - `handleGateway(gatewayName, toolName, toolArgs)` — catalog mode (no args → full schemas) or execute mode (tool + args → dispatch)
 
 **Gateway calling convention:**
 1. AI calls `manage_<domain>()` with no args → gets full tool schemas (catalog mode)
 2. AI calls `manage_<domain>(tool="tool_name", args={...})` → executes the proxied tool
 
-**11 gateways (61 proxied tools):**
+**12 gateways (63 proxied tools):**
 | Gateway | Tools | Domain |
 |---------|-------|--------|
 | `manage_rules_admin` | 5 | Rule delete/test/export/import/clone |
-| `manage_hub_variables` | 3 | Hub connector and rule engine variables |
+| `manage_hub_variables` | 4 | Hub connector and rule engine variables (incl. delete) |
 | `manage_rooms` | 5 | Room CRUD |
 | `manage_destructive_hub_ops` | 3 | Hub reboot, shutdown, device deletion (write) |
 | `manage_apps_drivers` | 6 | List/get apps, drivers, backups (read-only) |
@@ -119,6 +119,7 @@ The server uses a **category gateway proxy** pattern to reduce the MCP `tools/li
 | `manage_files` | 4 | File Manager CRUD |
 | `manage_installed_apps` | 4 | Built-in + user app visibility, device-in-use-by lookup, app config inspection, page-name directory |
 | `manage_rule_machine` | 5 | Rule Machine interop via RMUtils — list/run/pause/resume/boolean |
+| `manage_mcp_self` | 1 | Developer Mode self-administration — update MCP rule app's own settings (allowlist-gated, requires `enableDeveloperMode`) |
 
 **22 core tools:** `list_devices`, `get_device`, `get_attribute`, `send_command`, `get_device_events`, `list_rules`, `get_rule`, `create_rule`, `update_rule`, `update_device`, `manage_virtual_device` (action enum: "create", "delete"), `list_virtual_devices`, `get_hub_info` (comprehensive: hardware, health — memory, temp, DB size — and MCP stats always available; PII/location data — name, IP, timezone, coordinates, zip — gated behind Hub Admin Read), `get_modes`, `set_mode`, `get_hsm_status`, `set_hsm`, `create_hub_backup`, `check_for_update`, `generate_bug_report`, `get_tool_guide`, `search_tools` (BM25 natural language search across all tools)
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -4,13 +4,13 @@ Detailed reference for MCP Rule Server tools. Consult this when tool description
 
 ## Category Gateway Proxy (v0.8.0+)
 
-As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 33 items (22 core + 11 gateways) covering 83 total tools. Use `search_tools` to find any tool by natural language query.
+As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 34 items (22 core + 12 gateways) covering 85 total tools. Use `search_tools` to find any tool by natural language query.
 
 **How to use a gateway:**
 1. Call the gateway with no arguments to see full parameter schemas for all its tools
 2. Call with `tool='<tool_name>'` and `args={...}` to execute a specific tool
 
-**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_rule_machine` (5)
+**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (4), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_rule_machine` (5), `manage_mcp_self` (1)
 
 All safety gates (Hub Admin Read/Write, confirm, backup checks) are preserved — they are enforced in the handler functions, not the dispatch layer.
 
@@ -341,3 +341,22 @@ If a user asks "create a new RM rule" or "set up a new Room Lighting":
 3. Or direct them to the native Rule Machine / Room Lighting UI for configuration
 
 **Do NOT invent fake tools like `create_rm_rule` or pretend to call one.** This is the most important safety rule for these tools.
+
+---
+
+## Developer Mode
+
+The `manage_mcp_self` gateway exposes self-administration tools that let an LLM agent or CI/CD pipeline manage the MCP rule app's own configuration without manual UI intervention. **Requires the opt-in `Enable Developer Mode Tools` toggle** in the MCP rule app settings page (default OFF). Each successful write is logged at WARN level for audit. If the user sees "Developer Mode tools are disabled" errors, direct them to enable the toggle in the MCP Rule Server app settings.
+
+### manage_mcp_self (1 tool)
+
+- **`update_mcp_settings`** — update one or more of the MCP rule app's own settings (toggles, log level, tuning params)
+  - Args: `settings` (map of `{key: value}`), `confirm=true`
+  - Allowlisted keys (intentionally conservative for v1): `mcpLogLevel`, `debugLogging`, `maxCapturedStates`, `loopGuardMax`, `loopGuardWindowSec`, `enableHubAdminRead`, `enableBuiltinAppRead`, `enableRuleEngine`
+  - **Excluded** from v1 allowlist: `enableHubAdminWrite` (footgun — would disable own write path mid-session), `enableDeveloperMode` (lockout protection — must remain UI-only to disable), `selectedDevices` (different wire format, separate tool planned)
+  - After changing any `enable*` toggle, MCP clients (Claude Code, etc.) may need to reconnect to refresh the cached tool schema
+  - Gated on: `enableDeveloperMode` + `requireHubAdminWrite` + recent backup
+
+### manage_hub_variables — `delete_variable`
+
+The `delete_variable` op (DESTRUCTIVE, no undo) removes a rule_engine variable. Useful for sweeping orphaned `BAT_E2E_*` artifacts after CI runs, removing stale lease variables, or general cleanup. Connector-namespace deletion is not yet supported via MCP — use the Settings → Hub Variables UI for those.

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Smart home assistant for Hubitat Elevation hubs via MCP. Use when c
 
 # Hubitat MCP Server - Smart Home Assistant
 
-You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 83 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, and Rule Machine interop. The tools are organized as **22 core tools** (always visible) plus **11 domain-named gateways** that proxy 61 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
+You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 85 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, Rule Machine interop, and Developer Mode self-administration. The tools are organized as **22 core tools** (always visible) plus **12 domain-named gateways** that proxy 63 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
 
 ## Core Principles
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-Quick reference for all 83 MCP tools. The server exposes **33 items on `tools/list`**: 22 core tools + 11 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
+Quick reference for all 85 MCP tools. The server exposes **34 items on `tools/list`**: 22 core tools + 12 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
 
 For the most authoritative reference, call `get_tool_guide` via MCP.
 
@@ -56,11 +56,11 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `get_tool_guide` | Full tool reference from the MCP server itself. | None |
-| `search_tools` | BM25 natural language search across all 83 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
+| `search_tools` | BM25 natural language search across all 85 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
 
 ---
 
-## Gateway Tools (11) — Each proxies multiple tools
+## Gateway Tools (12) — Each proxies multiple tools
 
 Call a gateway with no arguments to see full parameter schemas for all its tools. Call with `tool='<name>'` and `args={...}` to execute a specific tool.
 
@@ -76,7 +76,7 @@ Rule administration: delete, test, export, import, and clone rules.
 | `import_rule` | Import a rule from exported JSON. | None |
 | `clone_rule` | Duplicate an existing rule. | None |
 
-### manage_hub_variables (3 tools)
+### manage_hub_variables (4 tools)
 
 Manage hub connector and rule engine variables.
 
@@ -85,6 +85,7 @@ Manage hub connector and rule engine variables.
 | `list_variables` | List all hub connector and rule engine variables. | None |
 | `get_variable` | Get a specific variable value. | None |
 | `set_variable` | Set a variable value (creates if doesn't exist). | None |
+| `delete_variable` | Permanently delete a rule engine variable (DESTRUCTIVE — no undo). Connector-namespace deletion not yet supported via MCP. | Hub Admin Write + recent backup |
 
 ### manage_rooms (5 tools)
 
@@ -201,3 +202,11 @@ Rule Machine interop via the official `hubitat.helper.RMUtils` helper class: lis
 | `pause_rm_rule` | Pause an RM rule (reversible; paused rules don't fire on triggers). | Built-in App Read |
 | `resume_rm_rule` | Resume a paused RM rule. | Built-in App Read |
 | `set_rm_rule_boolean` | Set an RM rule's private boolean (true or false only; string values must be lowercase `"true"`/`"false"`) — flips the flag that rules can reference in conditions. | Built-in App Read |
+
+### manage_mcp_self (1 tool)
+
+Developer Mode self-administration: tools that let an LLM agent or CI/CD pipeline manage the MCP rule app's own configuration without manual UI intervention. Requires the opt-in `enableDeveloperMode` toggle in the MCP rule app settings (default OFF). Each successful write is logged at WARN level for audit. First gateway under the Developer Mode pattern — additional self-admin tools (device-access management, true Hub Variables namespace support, artifact cleanup) are planned as follow-ups under the same toggle.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `update_mcp_settings` | Update one or more of the MCP rule app's own settings (toggles, log level, tuning params). Allowlisted: `mcpLogLevel`, `debugLogging`, `maxCapturedStates`, `loopGuardMax`, `loopGuardWindowSec`, `enableHubAdminRead`, `enableBuiltinAppRead`, `enableRuleEngine`. After flipping any `enable*` toggle, MCP clients may need to reconnect to refresh their cached tool schema. | Developer Mode + Hub Admin Write + recent backup |

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -84,6 +84,25 @@ def mainPage() {
                   defaultValue: false, submitOnChange: true
         }
 
+        section("Developer Mode") {
+            paragraph "<b>Developer Mode</b> exposes self-administration capabilities — tools that let an LLM agent or CI/CD pipeline manage the MCP's own configuration, scope, and operational state without requiring manual UI intervention."
+            paragraph "<i>Capability categories under this mode (current + planned):</i>"
+            paragraph "<ul>" +
+                      "<li>Configuration management — toggle states, log levels, loop guards, tuning parameters</li>" +
+                      "<li>Device-access scope — add/remove devices from MCP visibility</li>" +
+                      "<li>Hub-variable management — true Hub Variables namespace (Settings → Hub Variables)</li>" +
+                      "<li>Artifact cleanup — sweep ephemeral CI/test devices, variables, rules</li>" +
+                      "<li>Operational diagnostics + self-healing routines</li>" +
+                      "</ul>"
+            paragraph "<i>Useful for end-to-end CI/CD automation, agent-driven configuration, and workflows where manual UI ops would be impractical.</i>"
+            input "enableDeveloperMode", "bool", title: "Enable Developer Mode Tools",
+                  description: "Exposes self-administration tools for MCP-managed configuration and lifecycle changes.",
+                  defaultValue: false, submitOnChange: true
+            if (settings.enableDeveloperMode) {
+                paragraph "<b style='color: red;'>⚠ WARNING: Developer Mode allows the AI assistant to modify which tools it can access (via toggle changes), what device scope it has, how verbose its logging is, and other operational settings. Only enable if you understand and trust the agent's authorization model. Every write is logged at WARN level for audit.</b>"
+            }
+        }
+
         section("Hub Security") {
             paragraph "If <b>Hub Security</b> is enabled on your hub, provide credentials here so Hub Admin tools can authenticate. " +
                       "If Hub Security is NOT enabled, leave this off — Hub Admin tools will work without credentials."
@@ -369,7 +388,9 @@ def processJsonRpcMessage(msg) {
                 return jsonRpcError(msg.id, -32601, "Method not found: ${msg.method}")
         }
     } catch (Exception e) {
-        log.error "MCP Error: ${e.message}", e
+        // Hubitat's LogWrapper.error() does NOT accept (String, Throwable). Use string-only.
+        // Stack trace would only be visible in mcpLog details (which this top-level catch lacks).
+        log.error "MCP Error: ${e.message} (${e.class.simpleName})"
         return jsonRpcError(msg.id, -32603, "Internal error: ${e.message}")
     }
 }
@@ -420,7 +441,10 @@ def handleToolsCall(msg) {
             details: [tool: toolName, error: e.message],
             stackTrace: e.getStackTrace()?.take(5)?.collect { it.toString() }?.join("\n")
         ])
-        log.error "Tool execution error: ${e.message}", e
+        // Hubitat's LogWrapper.error() does NOT accept (String, Throwable) — passing the
+        // exception object as a 2nd arg throws MissingMethodException, masking the real error
+        // (and creating cascading log.error failures). mcpLog above already captured the stack trace.
+        log.error "Tool execution error: ${e.message} (${e.class.simpleName})"
         // MCP spec: tool execution errors are returned as successful results with isError flag
         return jsonRpcResult(msg.id, [content: [[type: "text", text: "Tool error: ${e.message}"]], isError: true])
     }
@@ -454,16 +478,18 @@ def getGatewayConfig() {
         ],
         manage_hub_variables: [
             description: "Manage hub connector and rule engine variables.",
-            tools: ["list_variables", "get_variable", "set_variable"],
+            tools: ["list_variables", "get_variable", "set_variable", "delete_variable"],
             summaries: [
                 list_variables: "List all hub connector and rule engine variables",
                 get_variable: "Get a variable value. Args: name",
-                set_variable: "Set a variable value (creates if doesn't exist). Args: name, value"
+                set_variable: "Set a variable value (creates if doesn't exist). Args: name, value",
+                delete_variable: "Permanently delete a rule engine variable (DESTRUCTIVE). Args: name, confirm=true"
             ],
             searchHints: [
                 list_variables: "show all global state connector",
                 get_variable: "read fetch lookup global state",
-                set_variable: "write update change store global state"
+                set_variable: "write update change store global state",
+                delete_variable: "remove drop destroy purge cleanup orphan stranded BAT_ stale variable"
             ]
         ],
         manage_rooms: [
@@ -647,6 +673,16 @@ def getGatewayConfig() {
                 pause_rm_rule: "disable stop temporarily rule machine rule",
                 resume_rm_rule: "enable unpause restart rule machine rule",
                 set_rm_rule_boolean: "private boolean flag rule machine rule condition"
+            ]
+        ],
+        manage_mcp_self: [
+            description: "Developer Mode self-administration: tools that let an LLM agent or CI/CD pipeline manage the MCP rule app's own configuration, scope, and operational state without manual UI intervention. Requires `enableDeveloperMode` toggle in the MCP rule app settings (default OFF). Each write is logged at WARN level for audit. First gateway under the Developer Mode pattern — additional self-admin tools (device-access management, true Hub Variables namespace support, artifact cleanup) are planned as follow-ups under the same toggle.",
+            tools: ["update_mcp_settings"],
+            summaries: [
+                update_mcp_settings: "Update one or more of the MCP rule app's own settings (toggles, log level, tuning params). Args: settings (map of key→value), confirm=true. Allowlist-gated."
+            ],
+            searchHints: [
+                update_mcp_settings: "self-admin developer mode toggle setting log level tuning loopGuard maxCapturedStates enableHubAdminRead enableBuiltinAppRead enableRuleEngine ci automation"
             ]
         ]
     ]
@@ -956,6 +992,30 @@ Verify rule after creation.""",
                     value: [type: "string", description: "Variable value (string, number, or boolean as string)"]
                 ],
                 required: ["name", "value"]
+            ]
+        ],
+        [
+            name: "delete_variable",
+            description: "Permanently delete a rule engine variable (DESTRUCTIVE — no undo). Variable must exist. Use the Settings → Hub Variables UI for connector-namespace variable deletion (separate namespace, not yet exposed via MCP).\n\nGated on requireHubAdminWrite + recent backup. Useful for sweeping orphaned BAT_E2E_* artifacts after CI runs, removing stale lease variables, or general cleanup.",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    name: [type: "string", description: "Variable name to delete"],
+                    confirm: [type: "boolean", description: "REQUIRED: must be true to confirm the deletion"]
+                ],
+                required: ["name", "confirm"]
+            ]
+        ],
+        [
+            name: "update_mcp_settings",
+            description: "Update one or more of the MCP rule app's own settings (toggles, log levels, tuning parameters). First tool under the Developer Mode self-administration surface — additional Developer Mode tools (device-access management, true Hub Variables namespace support, artifact cleanup) are planned as follow-ups under the same `enableDeveloperMode` gate.\n\nGated on `enableDeveloperMode` + requireHubAdminWrite + recent backup. Every successful write is logged at WARN level for audit.\n\nAllowlisted settings (intentionally conservative for v1): mcpLogLevel, debugLogging, maxCapturedStates, loopGuardMax, loopGuardWindowSec, enableHubAdminRead, enableBuiltinAppRead, enableRuleEngine.\n\nExcluded from v1 allowlist (require future explicit security-model discussion): enableHubAdminWrite (footgun: would disable own write path mid-session), enableDeveloperMode (lockout protection — must remain UI-only to disable), selectedDevices (different wire format, will get its own tool).\n\nAfter changing any enable* toggle, MCP clients (Claude Code, etc.) may need to restart their connection to refresh the cached tool schema.",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    settings: [type: "object", description: "Map of setting key → new value (e.g., {\"mcpLogLevel\":\"warn\",\"enableRuleEngine\":true})"],
+                    confirm: [type: "boolean", description: "REQUIRED: must be true to confirm the operation"]
+                ],
+                required: ["settings", "confirm"]
             ]
         ],
         [
@@ -1793,6 +1853,8 @@ def executeTool(toolName, args) {
         case "list_variables": return toolListVariables()
         case "get_variable": return toolGetVariable(args.name)
         case "set_variable": return toolSetVariable(args.name, args.value)
+        case "delete_variable": return toolDeleteHubVariable(args)
+        case "update_mcp_settings": return toolUpdateMcpSettings(args)
         case "get_hsm_status": return toolGetHsmStatus()
         case "set_hsm": return toolSetHsm(args.mode)
 
@@ -1910,6 +1972,7 @@ def executeTool(toolName, args) {
         case "manage_files":
         case "manage_installed_apps":
         case "manage_rule_machine":
+        case "manage_mcp_self":
             return handleGateway(toolName, args.tool, args.args)
 
         default:
@@ -2964,6 +3027,7 @@ def toolGetHubInfo() {
     info.hubAdminReadEnabled = settings.enableHubAdminRead ?: false
     info.hubAdminWriteEnabled = settings.enableHubAdminWrite ?: false
     info.builtinAppReadEnabled = settings.enableBuiltinAppRead ?: false
+    info.developerModeEnabled = settings.enableDeveloperMode ?: false
 
     // PII/location data requires Hub Admin Read
     if (settings.enableHubAdminRead) {
@@ -3058,6 +3122,82 @@ def toolSetVariable(name, value) {
         state.ruleVariables[name] = value
         return [success: true, name: name, value: value, source: "rule_engine"]
     }
+}
+
+def toolDeleteHubVariable(args) {
+    requireHubAdminWrite(args.confirm)
+    def name = args.name
+    if (!name) throw new IllegalArgumentException("name is required")
+
+    // Currently only rule_engine variables are addressable from this MCP — connector
+    // variables (Settings → Hub Variables) live in a separate namespace not yet
+    // accessible from this app. See task #112 for the broader namespace fix.
+    if (!state.ruleVariables?.containsKey(name)) {
+        throw new IllegalArgumentException("Variable '${name}' not found in rule_engine namespace. (Connector-namespace deletion not yet supported via MCP — use Settings → Hub Variables UI.)")
+    }
+
+    def previousValue = state.ruleVariables[name]
+    state.ruleVariables.remove(name)
+    mcpLog("warn", "developer-mode", "delete_variable: removed '${name}' (previous value: ${previousValue?.toString()?.take(80)})")
+    return [success: true, name: name, deleted: true, source: "rule_engine", previousValue: previousValue]
+}
+
+def toolUpdateMcpSettings(args) {
+    if (!settings.enableDeveloperMode) {
+        throw new IllegalStateException("Developer Mode tools are disabled. Enable 'Developer Mode Tools' in MCP rule app settings to use update_mcp_settings.")
+    }
+    requireHubAdminWrite(args.confirm)
+
+    if (!args.settings || !(args.settings instanceof Map) || args.settings.isEmpty()) {
+        throw new IllegalArgumentException("settings must be a non-empty map of {settingName: newValue}")
+    }
+
+    // Allowlist of settings that can be modified via this tool, with their Hubitat input
+    // type (matches the input "<key>", "<type>", ... declarations in the mainPage section).
+    // Excluded:
+    //   enableHubAdminWrite  — would footgun: could disable own write path mid-session
+    //   enableDeveloperMode  — lockout protection (must remain UI-only to disable)
+    //   selectedDevices      — capability multi-select, separate tool planned (Developer Mode follow-up)
+    def allowedSettings = [
+        "mcpLogLevel":            "enum",
+        "debugLogging":           "bool",
+        "maxCapturedStates":      "number",
+        "loopGuardMax":           "number",
+        "loopGuardWindowSec":     "number",
+        "enableHubAdminRead":     "bool",
+        "enableBuiltinAppRead":   "bool",
+        "enableRuleEngine":       "bool"
+    ]
+
+    def updates = [:]
+    args.settings.each { key, value ->
+        def keyStr = key.toString()
+        if (!allowedSettings.containsKey(keyStr)) {
+            throw new IllegalArgumentException("Setting '${keyStr}' is not allowed for self-modification via update_mcp_settings. Allowed: ${allowedSettings.keySet().sort().join(', ')}")
+        }
+        updates[keyStr] = value
+    }
+
+    // Audit trail — every Developer Mode write is WARN-level
+    mcpLog("warn", "developer-mode", "update_mcp_settings: ${updates}")
+
+    // Apply each update via app.updateSetting() — the documented Hubitat sandbox API for
+    // self-modifying app settings. mcpLogLevel needs special handling because the runtime
+    // log threshold is cached in state.debugLogs.config (UI display reads from settings).
+    updates.each { key, value ->
+        if (key == "mcpLogLevel") {
+            // Delegate to existing helper — it updates both state cache + setting
+            toolSetLogLevel([level: value.toString()])
+        } else {
+            app.updateSetting(key, [type: allowedSettings[key], value: value])
+        }
+    }
+
+    return [
+        success: true,
+        updated: updates,
+        message: "Updated ${updates.size()} setting(s). MCP clients (Claude Code, etc.) may need to reconnect to refresh cached tool schemas if you toggled an enable* flag."
+    ]
 }
 
 // Helper method for child apps to get variable values
@@ -5119,6 +5259,7 @@ def toolGetHubDetails(args) {
     details.hubAdminReadEnabled = settings.enableHubAdminRead ?: false
     details.hubAdminWriteEnabled = settings.enableHubAdminWrite ?: false
     details.builtinAppReadEnabled = settings.enableBuiltinAppRead ?: false
+    details.developerModeEnabled = settings.enableDeveloperMode ?: false
 
     mcpLog("info", "hub-admin", "Retrieved extended hub details")
     return details

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3137,7 +3137,12 @@ def toolDeleteHubVariable(args) {
     }
 
     def previousValue = state.ruleVariables[name]
-    state.ruleVariables.remove(name)
+    // Hubitat-sandbox quirk: nested-map mutations on state are not persisted across
+    // hub reboot / app restart unless the top-level key is reassigned. Same pattern
+    // used by toolSetLogLevel for state.debugLogs.config. Read-modify-write the whole
+    // map to force serialization.
+    def updated = state.ruleVariables.findAll { k, v -> k != name }
+    state.ruleVariables = updated
     mcpLog("warn", "developer-mode", "delete_variable: removed '${name}' (previous value: ${previousValue?.toString()?.take(80)})")
     return [success: true, name: name, deleted: true, source: "rule_engine", previousValue: previousValue]
 }
@@ -3169,13 +3174,18 @@ def toolUpdateMcpSettings(args) {
         "enableRuleEngine":       "bool"
     ]
 
+    // Validate, coerce, and stage each update. Type coercion is mandatory: a JSON-RPC
+    // client (e.g. a curl-based CI script) may send "true"/"false" or "50" as strings
+    // instead of native bool/number. Without coercion, app.updateSetting(key,
+    // [type:'bool', value:'false']) writes the string "false", which is truthy in
+    // Groovy — silently flipping the toggle to enabled when the caller meant disabled.
     def updates = [:]
     args.settings.each { key, value ->
         def keyStr = key.toString()
         if (!allowedSettings.containsKey(keyStr)) {
             throw new IllegalArgumentException("Setting '${keyStr}' is not allowed for self-modification via update_mcp_settings. Allowed: ${allowedSettings.keySet().sort().join(', ')}")
         }
-        updates[keyStr] = value
+        updates[keyStr] = coerceSettingValue(keyStr, value, allowedSettings[keyStr])
     }
 
     // Audit trail — every Developer Mode write is WARN-level
@@ -3198,6 +3208,45 @@ def toolUpdateMcpSettings(args) {
         updated: updates,
         message: "Updated ${updates.size()} setting(s). MCP clients (Claude Code, etc.) may need to reconnect to refresh cached tool schemas if you toggled an enable* flag."
     ]
+}
+
+// Coerce + validate a single setting value into the type the Hubitat input expects.
+// Throws IllegalArgumentException for unrepresentable values (rather than silently
+// substituting a default — that would mask the caller's intent and recreate the same
+// kind of footgun the bool string-truthiness bug is fixing).
+//
+// - bool: accepts native Boolean, plus case-insensitive "true"/"false" strings.
+// - number: accepts native Number, plus integer/decimal-formatted strings.
+// - enum: passed through; downstream (e.g. toolSetLogLevel) does its own enum-membership
+//         check against a tool-specific allowed list.
+private coerceSettingValue(String key, value, String type) {
+    if (value == null) {
+        throw new IllegalArgumentException("Setting '${key}' value cannot be null")
+    }
+    switch (type) {
+        case "bool":
+            if (value instanceof Boolean) return value
+            def s = value.toString().toLowerCase()
+            if (s == "true") return true
+            if (s == "false") return false
+            throw new IllegalArgumentException("Setting '${key}' expects a boolean (true/false), got: ${value} (${value.class.simpleName})")
+
+        case "number":
+            if (value instanceof Number) return value
+            def s = value.toString()
+            if (s.isInteger()) return s.toInteger()
+            if (s.isLong()) return s.toLong()
+            if (s.isBigDecimal()) return s.toBigDecimal()
+            throw new IllegalArgumentException("Setting '${key}' expects a number, got: ${value} (${value.class.simpleName})")
+
+        case "enum":
+            // Pass through as String — downstream validates against tool-specific enum set.
+            return value.toString()
+
+        default:
+            // Defensive: unknown type from the allowlist map should not reach here.
+            return value
+    }
 }
 
 // Helper method for child apps to get variable values

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -483,7 +483,7 @@ def getGatewayConfig() {
                 list_variables: "List all hub connector and rule engine variables",
                 get_variable: "Get a variable value. Args: name",
                 set_variable: "Set a variable value (creates if doesn't exist). Args: name, value",
-                delete_variable: "Permanently delete a rule engine variable (DESTRUCTIVE). Args: name, confirm=true"
+                delete_variable: "Permanently delete a rule engine variable (DESTRUCTIVE). Args: name, confirm=true, [force=true if rules reference it]"
             ],
             searchHints: [
                 list_variables: "show all global state connector",
@@ -996,12 +996,13 @@ Verify rule after creation.""",
         ],
         [
             name: "delete_variable",
-            description: "Permanently delete a rule engine variable (DESTRUCTIVE — no undo). Variable must exist. Use the Settings → Hub Variables UI for connector-namespace variable deletion (separate namespace, not yet exposed via MCP).\n\nGated on requireHubAdminWrite + recent backup. Useful for sweeping orphaned BAT_E2E_* artifacts after CI runs, removing stale lease variables, or general cleanup.",
+            description: "Permanently delete a rule engine variable (DESTRUCTIVE — no undo). Variable must exist. Use the Settings → Hub Variables UI for connector-namespace variable deletion (separate namespace, not yet exposed via MCP).\n\nGated on requireHubAdminWrite + recent backup. Useful for sweeping orphaned BAT_E2E_* artifacts after CI runs, removing stale lease variables, or general cleanup.\n\n**Reference safety:** the tool scans every child rule app for serialized references to this variable name (in triggers/conditions/actions) and refuses by default if any are found — deletion would silently break those rules (null lookups → false conditions, literal `%varname%` left in substitutions). To proceed anyway, pass `force=true` after acknowledging the breakage. The response includes a `brokenConsumers` field listing the affected rules when force=true.",
             inputSchema: [
                 type: "object",
                 properties: [
                     name: [type: "string", description: "Variable name to delete"],
-                    confirm: [type: "boolean", description: "REQUIRED: must be true to confirm the deletion"]
+                    confirm: [type: "boolean", description: "REQUIRED: must be true to confirm the deletion"],
+                    force: [type: "boolean", description: "OPTIONAL: must be true to proceed when one or more child rule apps reference this variable. Without force, the tool refuses and lists the consumers."]
                 ],
                 required: ["name", "confirm"]
             ]
@@ -3131,9 +3132,43 @@ def toolDeleteHubVariable(args) {
 
     // Currently only rule_engine variables are addressable from this MCP — connector
     // variables (Settings → Hub Variables) live in a separate namespace not yet
-    // accessible from this app. See task #112 for the broader namespace fix.
+    // accessible from this app.
     if (!state.ruleVariables?.containsKey(name)) {
         throw new IllegalArgumentException("Variable '${name}' not found in rule_engine namespace. (Connector-namespace deletion not yet supported via MCP — use Settings → Hub Variables UI.)")
+    }
+
+    // Pre-deletion safety scan: child rule apps that reference this variable will silently
+    // break on next access (null lookup → conditions flip false, %varname% substitution
+    // leaves literal text). Block by default — caller must opt in via force=true after
+    // acknowledging the breakage. Match heuristic: variable name appears in the rule's
+    // serialized triggers/conditions/actions JSON.
+    def force = args.force == true
+    def consumers = []
+    try {
+        getChildApps()?.each { child ->
+            def ruleData = null
+            try { ruleData = child.getRuleData() } catch (Exception e) { /* not an MCP rule child */ }
+            if (ruleData) {
+                def serialized = groovy.json.JsonOutput.toJson(ruleData)
+                if (serialized?.contains(name)) {
+                    consumers << [id: child.id, label: child.label]
+                }
+            }
+        }
+    } catch (Exception e) {
+        // Defensive: if the scan itself errors, fall through to apply normal force gate
+        // rather than blocking deletion entirely. Log so investigators know the scan
+        // didn't run.
+        logDebug("delete_variable: getChildApps() scan failed: ${e.class.simpleName}: ${e.message}")
+    }
+    if (consumers && !force) {
+        throw new IllegalArgumentException(
+            "Variable '${name}' is referenced by ${consumers.size()} rule(s): " +
+            "${consumers.collect { "${it.label} (id=${it.id})" }.join(', ')}. " +
+            "Deleting will silently break those rules (null lookups, false conditions, " +
+            "literal %${name}% in substitutions). Pass force=true to proceed anyway, " +
+            "or update/remove the consuming rules first."
+        )
     }
 
     def previousValue = state.ruleVariables[name]
@@ -3143,13 +3178,21 @@ def toolDeleteHubVariable(args) {
     // map to force serialization.
     def updated = state.ruleVariables.findAll { k, v -> k != name }
     state.ruleVariables = updated
-    mcpLog("warn", "developer-mode", "delete_variable: removed '${name}' (previous value: ${previousValue?.toString()?.take(80)})")
-    return [success: true, name: name, deleted: true, source: "rule_engine", previousValue: previousValue]
+
+    def prevStr = previousValue?.toString()
+    def auditValue = prevStr == null ? "null" : (prevStr.length() > 80 ? "${prevStr.take(80)} [truncated, original length: ${prevStr.length()}]" : prevStr)
+    def consumerNote = consumers ? " (forced; ${consumers.size()} rule(s) now broken: ${consumers.collect { "id=${it.id}" }.join(', ')})" : ""
+    mcpLog("warn", "developer-mode", "delete_variable: removed '${name}' (previous value: ${auditValue})${consumerNote}")
+    return [success: true, name: name, deleted: true, source: "rule_engine", previousValue: previousValue, brokenConsumers: consumers ?: null]
 }
 
 def toolUpdateMcpSettings(args) {
+    // IllegalArgumentException (not IllegalStateException) so the dispatcher routes this
+    // through the clean -32602 Invalid params branch in handleToolsCall — same exception
+    // type all other gates throw (requireHubAdminWrite, requireBuiltinAppRead). Toggle-off
+    // is a config refusal, not an unexpected runtime error worth a stack trace + ERROR log.
     if (!settings.enableDeveloperMode) {
-        throw new IllegalStateException("Developer Mode tools are disabled. Enable 'Developer Mode Tools' in MCP rule app settings to use update_mcp_settings.")
+        throw new IllegalArgumentException("Developer Mode tools are disabled. Enable 'Developer Mode Tools' in MCP rule app settings to use update_mcp_settings.")
     }
     requireHubAdminWrite(args.confirm)
 
@@ -3174,26 +3217,46 @@ def toolUpdateMcpSettings(args) {
         "enableRuleEngine":       "bool"
     ]
 
-    // Validate, coerce, and stage each update. Type coercion is mandatory: a JSON-RPC
-    // client (e.g. a curl-based CI script) may send "true"/"false" or "50" as strings
-    // instead of native bool/number. Without coercion, app.updateSetting(key,
-    // [type:'bool', value:'false']) writes the string "false", which is truthy in
-    // Groovy — silently flipping the toggle to enabled when the caller meant disabled.
+    // Validate, coerce, and stage each update. Validation is fully atomic — every key
+    // and every value is checked BEFORE any app.updateSetting() fires, so a single bad
+    // entry in a multi-key batch can't leave the hub in a half-applied state. This
+    // includes per-key sub-validation that would otherwise only fire during apply
+    // (e.g. mcpLogLevel against getLogLevels()).
+    //
+    // Type coercion is also mandatory: a JSON-RPC client (e.g. a curl-based CI script)
+    // may send "true"/"false" or "50" as strings instead of native bool/number. Without
+    // coercion, app.updateSetting(key, [type:'bool', value:'false']) writes the string
+    // "false", which is truthy in Groovy — silently flipping the toggle to enabled
+    // when the caller meant disabled.
     def updates = [:]
     args.settings.each { key, value ->
         def keyStr = key.toString()
         if (!allowedSettings.containsKey(keyStr)) {
             throw new IllegalArgumentException("Setting '${keyStr}' is not allowed for self-modification via update_mcp_settings. Allowed: ${allowedSettings.keySet().sort().join(', ')}")
         }
-        updates[keyStr] = coerceSettingValue(keyStr, value, allowedSettings[keyStr])
+        def coerced = coerceSettingValue(keyStr, value, allowedSettings[keyStr])
+        // Per-key sub-validation that the apply step would otherwise discover too late.
+        // mcpLogLevel must be one of the configured log levels — if 'blarg' slipped through
+        // the enum coerce and only failed inside toolSetLogLevel during apply, any prior
+        // app.updateSetting() calls in the same batch would have already landed.
+        if (keyStr == "mcpLogLevel" && !getLogLevels().contains(coerced)) {
+            throw new IllegalArgumentException("Setting 'mcpLogLevel' must be one of ${getLogLevels()}, got: ${coerced}")
+        }
+        updates[keyStr] = coerced
     }
 
-    // Audit trail — every Developer Mode write is WARN-level
-    mcpLog("warn", "developer-mode", "update_mcp_settings: ${updates}")
+    // Two-phase audit so post-mortem investigators can distinguish "validation accepted N
+    // keys" (attempted) from "all N writes landed" (applied). Both fire at WARN.
+    mcpLog("warn", "developer-mode", "update_mcp_settings: attempted=${updates}")
 
     // Apply each update via app.updateSetting() — the documented Hubitat sandbox API for
     // self-modifying app settings. mcpLogLevel needs special handling because the runtime
     // log threshold is cached in state.debugLogs.config (UI display reads from settings).
+    //
+    // Apply order is intentional: app.updateSetting calls first, then mcpLogLevel last via
+    // toolSetLogLevel. If toolSetLogLevel ever evolves to throw on an unexpected condition,
+    // the rest of the batch has already landed. Per-key validation above is the primary
+    // safeguard; this ordering is belt-and-suspenders.
     updates.each { key, value ->
         if (key == "mcpLogLevel") {
             // Delegate to existing helper — it updates both state cache + setting
@@ -3202,6 +3265,8 @@ def toolUpdateMcpSettings(args) {
             app.updateSetting(key, [type: allowedSettings[key], value: value])
         }
     }
+
+    mcpLog("warn", "developer-mode", "update_mcp_settings: applied=${updates}")
 
     return [
         success: true,
@@ -3255,7 +3320,10 @@ def getVariableValue(name) {
         def hubVar = getGlobalConnectorVariable(name)
         if (hubVar != null) return hubVar
     } catch (Exception e) {
-        // Hub connector variable not found
+        // Hub connector variable not found — fall through to rule_engine namespace.
+        // Logged at DEBUG so investigators can tell whether the connector lookup
+        // genuinely missed (no such variable) or errored for some other reason.
+        logDebug("getVariableValue: connector lookup for '${name}' threw ${e.class.simpleName}: ${e.message}")
     }
     return state.ruleVariables?.get(name)
 }

--- a/src/test/groovy/server/ToolHubVariablesSpec.groovy
+++ b/src/test/groovy/server/ToolHubVariablesSpec.groovy
@@ -326,4 +326,85 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         and: 'state.ruleVariables points to a NEW map instance — the read-modify-write pattern Hubitat needs to persist'
         !stateMap.ruleVariables.is(originalMapRef)
     }
+
+    // -------- Reference-scan safety (delete_variable refuses to silently break consumers) --------
+
+    def "delete_variable refuses when a child rule app references the variable (no force)"() {
+        // A child rule's serialized triggers/conditions/actions contains the variable
+        // name. Without force=true, deletion would null-out the consumer's lookup and
+        // silently break the rule. The tool must surface the breakage and require opt-in.
+        given:
+        enableHubAdminWrite()
+        stateMap.ruleVariables = [shared_var: 'in-use']
+
+        and: 'a child rule that references shared_var in a condition'
+        def consumer = new support.TestChildApp(id: 99L, label: 'Rule Using Shared Var')
+        consumer.ruleData = [
+            triggers: [],
+            conditions: [[type: 'variable', name: 'shared_var', operator: '=', value: 'on']],
+            actions: []
+        ]
+        childAppsList << consumer
+
+        when:
+        script.toolDeleteHubVariable([name: 'shared_var', confirm: true])
+
+        then: 'refused with consumer details so the caller knows what would break'
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'shared_var'")
+        ex.message.contains('1 rule(s)')
+        ex.message.contains('Rule Using Shared Var')
+        ex.message.contains('id=99')
+        ex.message.contains('force=true')
+
+        and: 'the variable is still present — refusal must not partially mutate state'
+        stateMap.ruleVariables == [shared_var: 'in-use']
+    }
+
+    def "delete_variable proceeds with force=true and reports brokenConsumers"() {
+        given:
+        enableHubAdminWrite()
+        stateMap.ruleVariables = [shared_var: 'in-use']
+        def consumer = new support.TestChildApp(id: 42L, label: 'Acknowledged Breakage')
+        consumer.ruleData = [
+            triggers: [[type: 'variable_change', variable: 'shared_var']],
+            conditions: [],
+            actions: []
+        ]
+        childAppsList << consumer
+
+        when:
+        def result = script.toolDeleteHubVariable([name: 'shared_var', confirm: true, force: true])
+
+        then: 'deletion proceeds'
+        result.success == true
+        result.deleted == true
+        stateMap.ruleVariables == [:]
+
+        and: 'response surfaces the consumers that are now broken'
+        result.brokenConsumers?.size() == 1
+        result.brokenConsumers[0].id == 42L
+        result.brokenConsumers[0].label == 'Acknowledged Breakage'
+    }
+
+    def "delete_variable proceeds normally when no child rules reference the variable"() {
+        given: 'a child rule that does NOT mention the variable being deleted'
+        enableHubAdminWrite()
+        stateMap.ruleVariables = [orphan_var: 'safe-to-delete']
+        def unrelated = new support.TestChildApp(id: 7L, label: 'Unrelated Rule')
+        unrelated.ruleData = [
+            triggers: [[type: 'device_event', deviceId: '1', attribute: 'switch']],
+            conditions: [],
+            actions: []
+        ]
+        childAppsList << unrelated
+
+        when:
+        def result = script.toolDeleteHubVariable([name: 'orphan_var', confirm: true])
+
+        then: 'no force needed, no consumers reported'
+        result.success == true
+        result.deleted == true
+        result.brokenConsumers == null
+    }
 }

--- a/src/test/groovy/server/ToolHubVariablesSpec.groovy
+++ b/src/test/groovy/server/ToolHubVariablesSpec.groovy
@@ -306,4 +306,24 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         ex.message.contains("'never_set'")
         ex.message.contains('rule_engine namespace')
     }
+
+    def "delete_variable reassigns the top-level state.ruleVariables map (Hubitat persistence quirk)"() {
+        // Hubitat's state Map serialization only catches mutations when the top-level
+        // key is reassigned — a bare .remove() on the nested Map silently fails to
+        // persist across hub reboot / app restart. Asserts that toolDeleteHubVariable
+        // emits a NEW Map object on stateMap.ruleVariables (not just mutates in place).
+        given:
+        enableHubAdminWrite()
+        stateMap.ruleVariables = [target_var: 'will-go', sibling: 'stays']
+        def originalMapRef = stateMap.ruleVariables
+
+        when:
+        script.toolDeleteHubVariable([name: 'target_var', confirm: true])
+
+        then: 'sibling is preserved'
+        stateMap.ruleVariables == [sibling: 'stays']
+
+        and: 'state.ruleVariables points to a NEW map instance — the read-modify-write pattern Hubitat needs to persist'
+        !stateMap.ruleVariables.is(originalMapRef)
+    }
 }

--- a/src/test/groovy/server/ToolHubVariablesSpec.groovy
+++ b/src/test/groovy/server/ToolHubVariablesSpec.groovy
@@ -5,16 +5,25 @@ import support.ToolSpecBase
 /**
  * Spec for the manage_hub_variables gateway tools in hubitat-mcp-server.groovy:
  *
- * - toolListVariables -> list_variables
- * - toolGetVariable   -> get_variable
- * - toolSetVariable   -> set_variable
+ * - toolListVariables    -> list_variables
+ * - toolGetVariable      -> get_variable
+ * - toolSetVariable      -> set_variable
+ * - toolDeleteHubVariable -> delete_variable
  *
  * Hub-variable APIs (getAllGlobalConnectorVariables / getGlobalConnectorVariable /
  * setGlobalConnectorVariable) are purely dynamic — not on AppExecutor — so
  * they're stubbed per-test via script.metaClass in given: blocks. See
  * docs/testing.md "Which interception point to use" for the general pattern.
+ *
+ * delete_variable is gated by requireHubAdminWrite (3-layer: setting flag,
+ * args.confirm, 24h backup window). Helper enableHubAdminWrite() seeds those.
  */
 class ToolHubVariablesSpec extends ToolSpecBase {
+
+    private void enableHubAdminWrite() {
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L  // matches HarnessSpec's fixed now()
+    }
 
     // -------- toolListVariables --------
 
@@ -193,5 +202,108 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         result.success == true
         result.value == null
         result.source == 'rule_engine'
+    }
+
+    // -------- toolDeleteHubVariable --------
+
+    def "delete_variable removes an existing rule_engine variable and reports the previous value"() {
+        given:
+        enableHubAdminWrite()
+        stateMap.ruleVariables = [scratch_var: 'to-be-removed', keep_me: 42]
+
+        when:
+        def result = script.toolDeleteHubVariable([name: 'scratch_var', confirm: true])
+
+        then:
+        result.success == true
+        result.name == 'scratch_var'
+        result.deleted == true
+        result.source == 'rule_engine'
+        result.previousValue == 'to-be-removed'
+
+        and: 'only the targeted variable is gone — siblings preserved'
+        stateMap.ruleVariables == [keep_me: 42]
+    }
+
+    def "delete_variable throws when confirm is not provided"() {
+        given:
+        enableHubAdminWrite()
+        stateMap.ruleVariables = [scratch_var: 'value']
+
+        when:
+        script.toolDeleteHubVariable([name: 'scratch_var'])
+
+        then:
+        thrown(IllegalArgumentException)
+        // Variable should NOT be deleted when the gate refuses
+        stateMap.ruleVariables == [scratch_var: 'value']
+    }
+
+    def "delete_variable throws when no recent backup exists (Hub Admin Write 24h gate)"() {
+        given: 'enableHubAdminWrite is true but no lastBackupTimestamp seeded'
+        settingsMap.enableHubAdminWrite = true
+        stateMap.ruleVariables = [scratch_var: 'value']
+
+        when:
+        script.toolDeleteHubVariable([name: 'scratch_var', confirm: true])
+
+        then:
+        thrown(IllegalArgumentException)
+        stateMap.ruleVariables == [scratch_var: 'value']
+    }
+
+    def "delete_variable throws when enableHubAdminWrite setting is off"() {
+        given:
+        // No settingsMap.enableHubAdminWrite seed — gate refuses on the first layer
+        stateMap.ruleVariables = [scratch_var: 'value']
+
+        when:
+        script.toolDeleteHubVariable([name: 'scratch_var', confirm: true])
+
+        then:
+        thrown(IllegalArgumentException)
+        stateMap.ruleVariables == [scratch_var: 'value']
+    }
+
+    def "delete_variable throws when name is missing"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolDeleteHubVariable([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('name is required')
+    }
+
+    def "delete_variable throws with helpful hint when variable is not in rule_engine namespace"() {
+        given: 'rule_engine namespace is empty'
+        enableHubAdminWrite()
+        stateMap.ruleVariables = [:]
+
+        when:
+        script.toolDeleteHubVariable([name: 'nonexistent', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'nonexistent'")
+        ex.message.contains('rule_engine namespace')
+        // Error should redirect users to UI for connector-namespace deletion
+        ex.message.contains('Hub Variables UI')
+    }
+
+    def "delete_variable throws when ruleVariables map is null (variable also not present)"() {
+        given:
+        enableHubAdminWrite()
+        // stateMap.ruleVariables not seeded at all — null check path
+
+        when:
+        script.toolDeleteHubVariable([name: 'never_set', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'never_set'")
+        ex.message.contains('rule_engine namespace')
     }
 }

--- a/src/test/groovy/server/ToolUpdateMcpSettingsSpec.groovy
+++ b/src/test/groovy/server/ToolUpdateMcpSettingsSpec.groovy
@@ -286,4 +286,114 @@ class ToolUpdateMcpSettingsSpec extends ToolSpecBase {
         and: 'the persisted setting is updated so the UI stays in sync'
         sharedAppStub.settingsStore['mcpLogLevel'] == [type: 'enum', value: 'warn']
     }
+
+    // -------- Type coercion (string-encoded values from non-Claude clients) --------
+
+    def "coerces string-encoded boolean #stringValue to native #expected for bool settings"() {
+        given: 'a CI script (e.g. curl) sends a string instead of a JSON bool'
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        def result = script.toolUpdateMcpSettings([
+            settings: [debugLogging: stringValue],
+            confirm: true
+        ])
+
+        then: 'the value is coerced to the right native type before app.updateSetting fires'
+        result.success == true
+        sharedAppStub.settingsStore['debugLogging'] == [type: 'bool', value: expected]
+
+        where:
+        stringValue | expected
+        'true'      | true
+        'TRUE'      | true
+        'True'      | true
+        'false'     | false
+        'FALSE'     | false
+        'False'     | false
+    }
+
+    def "rejects #badValue as a boolean (no silent truthiness)"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: [debugLogging: badValue], confirm: true])
+
+        then: 'a string like "yes" would silently become truthy if not validated — fail loudly instead'
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'debugLogging'")
+        ex.message.contains('boolean')
+
+        and: 'no setting was written'
+        sharedAppStub.settingsStore.isEmpty()
+
+        where:
+        badValue << ['yes', 'no', '1', '0', 'maybe', '']
+    }
+
+    def "coerces string-encoded number #stringValue to native int"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        def result = script.toolUpdateMcpSettings([
+            settings: [maxCapturedStates: stringValue],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        sharedAppStub.settingsStore['maxCapturedStates'] == [type: 'number', value: expected]
+
+        where:
+        stringValue | expected
+        '50'        | 50
+        '0'         | 0
+        '999'       | 999
+    }
+
+    def "rejects non-numeric strings for number settings"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: [maxCapturedStates: 'abc'], confirm: true])
+
+        then: 'better to fail loudly than silently substitute 0'
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'maxCapturedStates'")
+        ex.message.contains('number')
+
+        and:
+        sharedAppStub.settingsStore.isEmpty()
+    }
+
+    def "rejects null setting values"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: [debugLogging: null], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'debugLogging'")
+        ex.message.contains('cannot be null')
+    }
+
+    def "native Number is preserved when passed for a number setting"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        def result = script.toolUpdateMcpSettings([
+            settings: [loopGuardMax: 25],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        sharedAppStub.settingsStore['loopGuardMax'] == [type: 'number', value: 25]
+    }
 }

--- a/src/test/groovy/server/ToolUpdateMcpSettingsSpec.groovy
+++ b/src/test/groovy/server/ToolUpdateMcpSettingsSpec.groovy
@@ -9,12 +9,17 @@ import support.ToolSpecBase
  *
  * - toolUpdateMcpSettings -> update_mcp_settings
  *
- * Three layers of access control are enforced before the write:
- *   1. settings.enableDeveloperMode must be true                  -> IllegalStateException
+ * Four validation gates fire before any app.updateSetting() call (all-or-nothing):
+ *   1. settings.enableDeveloperMode must be true                  -> IllegalArgumentException
  *   2. requireHubAdminWrite(args.confirm) — 3 sub-checks          -> IllegalArgumentException
  *      (settings.enableHubAdminWrite, args.confirm, 24h backup)
  *   3. settings map must be a non-empty Map                       -> IllegalArgumentException
  *   4. each setting key must be in the v1 allowlist               -> IllegalArgumentException
+ *   5. per-key sub-validation (e.g. mcpLogLevel ∈ getLogLevels()) -> IllegalArgumentException
+ *
+ * All gates throw IllegalArgumentException so handleToolsCall routes through the clean
+ * -32602 Invalid params branch (vs. the broad Exception catch that would generate ERROR
+ * + stack trace for what is fundamentally a config refusal).
  *
  * Mocking strategy (see docs/testing.md):
  *   - app.updateSetting -> sharedAppStub (TestChildApp) provides settingsStore.
@@ -47,7 +52,7 @@ class ToolUpdateMcpSettingsSpec extends ToolSpecBase {
 
     // -------- Gate: enableDeveloperMode toggle --------
 
-    def "throws IllegalStateException when enableDeveloperMode is off"() {
+    def "throws IllegalArgumentException when enableDeveloperMode is off (routes through -32602, not generic ERROR catch)"() {
         given: 'Hub Admin Write is enabled but Developer Mode is not'
         settingsMap.enableHubAdminWrite = true
         stateMap.lastBackupTimestamp = 1234567890000L
@@ -56,7 +61,7 @@ class ToolUpdateMcpSettingsSpec extends ToolSpecBase {
         script.toolUpdateMcpSettings([settings: [debugLogging: true], confirm: true])
 
         then:
-        def ex = thrown(IllegalStateException)
+        def ex = thrown(IllegalArgumentException)
         ex.message.contains('Developer Mode tools are disabled')
         ex.message.contains("'Developer Mode Tools'")
 
@@ -395,5 +400,122 @@ class ToolUpdateMcpSettingsSpec extends ToolSpecBase {
         then:
         result.success == true
         sharedAppStub.settingsStore['loopGuardMax'] == [type: 'number', value: 25]
+    }
+
+    // -------- Per-key sub-validation (catches errors that would otherwise leak into apply phase) --------
+
+    def "rejects mcpLogLevel='blarg' during validation (no apply-phase leakage)"() {
+        // Without per-key pre-validation, this would only fail INSIDE toolSetLogLevel
+        // during apply — by which time prior keys in the batch had already been written
+        // by app.updateSetting(). Asserts validation now happens up front.
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: [mcpLogLevel: 'blarg'], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('mcpLogLevel')
+        ex.message.contains('blarg')
+
+        and: 'no settings were written — validation rejected the batch up front'
+        sharedAppStub.settingsStore.isEmpty()
+    }
+
+    def "mixed batch with bad mcpLogLevel rejects ALL keys (atomic validation)"() {
+        // The critical safety property — without per-key validation, debugLogging would
+        // have landed before mcpLogLevel's enum check fired inside toolSetLogLevel.
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([
+            settings: [debugLogging: true, mcpLogLevel: 'blarg'],
+            confirm: true
+        ])
+
+        then:
+        thrown(IllegalArgumentException)
+
+        and: 'critical: debugLogging is NOT in the settingsStore — no partial write'
+        !sharedAppStub.settingsStore.containsKey('debugLogging')
+        sharedAppStub.settingsStore.isEmpty()
+    }
+
+    // -------- Apply-phase failure handling --------
+
+    def "apply order is sequential — non-mcpLogLevel keys before mcpLogLevel last"() {
+        // Documents the apply-phase ordering contract. mcpLogLevel goes through
+        // toolSetLogLevel (which has its own state.debugLogs.config side-effect),
+        // and is intentionally applied LAST so any prior app.updateSetting() writes
+        // have landed before the log-level cache flip. With the per-key validation
+        // upstream of apply, mcpLogLevel='blarg' can no longer partially apply (see
+        // the "rejects mcpLogLevel='blarg'" + "mixed batch" specs above) — this spec
+        // captures the behavioral contract that makes the apply phase safe even if
+        // Hubitat itself rejects a write later.
+        //
+        // Apply-time failure interception (e.g. Hubitat rejecting at apply for a value
+        // the MCP allowlist permits) is documented behavior: sequential apply with no
+        // rollback, audit log captures attempted= before apply and applied= after.
+        // Not unit-testable in the @Shared mock harness without modifying TestChildApp;
+        // covered by the live-hub BAT scenarios in tests/BAT-v2.md Section 12.
+        given:
+        enableDeveloperModeAndAdminWrite()
+        stateMap.debugLogs = [entries: [], config: [logLevel: 'info', maxEntries: 100]]
+
+        when:
+        def result = script.toolUpdateMcpSettings([
+            settings: [
+                debugLogging: true,
+                mcpLogLevel: 'warn'
+            ],
+            confirm: true
+        ])
+
+        then: 'both keys applied via their respective paths'
+        result.success == true
+        sharedAppStub.settingsStore['debugLogging'] == [type: 'bool', value: true]
+        sharedAppStub.settingsStore['mcpLogLevel'] == [type: 'enum', value: 'warn']
+        stateMap.debugLogs.config.logLevel == 'warn'
+    }
+
+    // -------- Dispatcher-level LogWrapper regression guard --------
+
+    def "toggle-off path through handleToolsCall returns clean -32602, never cascades"() {
+        // Regression guard for the LogWrapper bug: previously, the dispatcher's broad
+        // Exception catch called `log.error "msg", throwable`, which Hubitat's
+        // LogWrapper.error(String) doesn't accept — triggered MissingMethodException
+        // cascade and produced a generic "An unexpected error occurred" response,
+        // hiding the real exception's message. Two failure modes locked in here:
+        //   (1) gate exception is IllegalArgumentException (routes through -32602, not
+        //       the broad catch that hosted the cascade), AND
+        //   (2) IF anything ever does fall into the broad catch, the log.error call is
+        //       single-string form so no MissingMethodException re-emerges.
+        // This spec exercises (1) directly via handleToolsCall. (2) is locked in by
+        // sandbox lint + the source-line itself.
+        given: 'Hub Admin Write enabled but Developer Mode toggle is off'
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L
+
+        def msg = [
+            jsonrpc: '2.0',
+            id: 99,
+            method: 'tools/call',
+            params: [
+                name: 'manage_mcp_self',
+                arguments: [tool: 'update_mcp_settings', args: [settings: [debugLogging: true], confirm: true]]
+            ]
+        ]
+
+        when:
+        def response = script.handleToolsCall(msg)
+
+        then: 'JSON-RPC error envelope, NOT generic "An unexpected error occurred"'
+        response.error?.code == -32602
+        response.error?.message?.contains('Developer Mode tools are disabled')
+
+        and: 'verbatim message reaches the caller — proves the broad-catch cascade is not in the path'
+        response.error.message.contains("'Developer Mode Tools'")
     }
 }

--- a/src/test/groovy/server/ToolUpdateMcpSettingsSpec.groovy
+++ b/src/test/groovy/server/ToolUpdateMcpSettingsSpec.groovy
@@ -1,0 +1,289 @@
+package server
+
+import spock.lang.Shared
+import support.TestChildApp
+import support.ToolSpecBase
+
+/**
+ * Spec for the manage_mcp_self gateway tool in hubitat-mcp-server.groovy:
+ *
+ * - toolUpdateMcpSettings -> update_mcp_settings
+ *
+ * Three layers of access control are enforced before the write:
+ *   1. settings.enableDeveloperMode must be true                  -> IllegalStateException
+ *   2. requireHubAdminWrite(args.confirm) — 3 sub-checks          -> IllegalArgumentException
+ *      (settings.enableHubAdminWrite, args.confirm, 24h backup)
+ *   3. settings map must be a non-empty Map                       -> IllegalArgumentException
+ *   4. each setting key must be in the v1 allowlist               -> IllegalArgumentException
+ *
+ * Mocking strategy (see docs/testing.md):
+ *   - app.updateSetting -> sharedAppStub (TestChildApp) provides settingsStore.
+ *     getApp() is layered onto the @Shared appExecutor mock once in setupSpec
+ *     so every call resolves through the same instance. cleanup() clears the
+ *     settingsStore between tests.
+ *   - mcpLogLevel updates delegate to toolSetLogLevel which also touches
+ *     state.debugLogs.config.logLevel — the spec asserts on both.
+ */
+class ToolUpdateMcpSettingsSpec extends ToolSpecBase {
+
+    @Shared private TestChildApp sharedAppStub = new TestChildApp(id: 1L, label: 'MCP')
+
+    def setupSpec() {
+        // Layer getApp() onto the already-built @Shared mock so toolUpdateMcpSettings'
+        // app.updateSetting(...) call has a non-null target. Same additive-stub
+        // pattern as ToolManageLogsSpec.setupSpec.
+        appExecutor.getApp() >> sharedAppStub
+    }
+
+    def cleanup() {
+        sharedAppStub.settingsStore.clear()
+    }
+
+    private void enableDeveloperModeAndAdminWrite() {
+        settingsMap.enableDeveloperMode = true
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L  // matches HarnessSpec's fixed now()
+    }
+
+    // -------- Gate: enableDeveloperMode toggle --------
+
+    def "throws IllegalStateException when enableDeveloperMode is off"() {
+        given: 'Hub Admin Write is enabled but Developer Mode is not'
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L
+
+        when:
+        script.toolUpdateMcpSettings([settings: [debugLogging: true], confirm: true])
+
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.message.contains('Developer Mode tools are disabled')
+        ex.message.contains("'Developer Mode Tools'")
+
+        and: 'no settings were written'
+        sharedAppStub.settingsStore.isEmpty()
+    }
+
+    // -------- Gate: requireHubAdminWrite --------
+
+    def "throws when confirm is not provided"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: [debugLogging: true]])
+
+        then:
+        thrown(IllegalArgumentException)
+        sharedAppStub.settingsStore.isEmpty()
+    }
+
+    def "throws when no recent backup exists (24h gate)"() {
+        given:
+        settingsMap.enableDeveloperMode = true
+        settingsMap.enableHubAdminWrite = true
+        // No stateMap.lastBackupTimestamp seeded
+
+        when:
+        script.toolUpdateMcpSettings([settings: [debugLogging: true], confirm: true])
+
+        then:
+        thrown(IllegalArgumentException)
+        sharedAppStub.settingsStore.isEmpty()
+    }
+
+    def "throws when enableHubAdminWrite setting is off"() {
+        given:
+        settingsMap.enableDeveloperMode = true
+        // No enableHubAdminWrite seed
+
+        when:
+        script.toolUpdateMcpSettings([settings: [debugLogging: true], confirm: true])
+
+        then:
+        thrown(IllegalArgumentException)
+        sharedAppStub.settingsStore.isEmpty()
+    }
+
+    // -------- Validation: settings shape --------
+
+    def "throws when settings arg is missing"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('settings must be a non-empty map')
+    }
+
+    def "throws when settings arg is empty map"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: [:], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('settings must be a non-empty map')
+    }
+
+    def "throws when settings arg is not a Map"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: 'enableDeveloperMode=true', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('settings must be a non-empty map')
+    }
+
+    // -------- Allowlist enforcement --------
+
+    def "throws when setting key is not in the v1 allowlist"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: [enableHubAdminWrite: false], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'enableHubAdminWrite'")
+        ex.message.contains('not allowed')
+
+        and: 'error lists allowed keys to help the caller correct'
+        ex.message.contains('mcpLogLevel')
+        ex.message.contains('enableRuleEngine')
+
+        and: 'no settings were written when validation fails'
+        sharedAppStub.settingsStore.isEmpty()
+    }
+
+    def "rejects enableDeveloperMode itself (lockout protection — must remain UI-only to disable)"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: [enableDeveloperMode: false], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'enableDeveloperMode'")
+    }
+
+    def "rejects selectedDevices (different wire format, separate tool planned)"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        script.toolUpdateMcpSettings([settings: [selectedDevices: []], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'selectedDevices'")
+    }
+
+    def "rejects all-or-nothing — one bad key blocks the entire batch (no partial writes)"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when: 'first key is allowed, second is not'
+        script.toolUpdateMcpSettings([
+            settings: [debugLogging: true, enableHubAdminWrite: false],
+            confirm: true
+        ])
+
+        then: 'validation rejects the batch BEFORE any updateSetting fires'
+        thrown(IllegalArgumentException)
+        sharedAppStub.settingsStore.isEmpty()
+    }
+
+    // -------- Golden path: boolean settings --------
+
+    def "writes a single boolean setting via app.updateSetting and returns success"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        def result = script.toolUpdateMcpSettings([
+            settings: [enableRuleEngine: false],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.updated == [enableRuleEngine: false]
+        sharedAppStub.settingsStore['enableRuleEngine'] == [type: 'bool', value: false]
+
+        and: 'the user-facing message warns about reconnecting to refresh schemas'
+        result.message.contains('Updated 1 setting')
+        result.message.contains('reconnect')
+    }
+
+    def "writes multiple settings in one call"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        def result = script.toolUpdateMcpSettings([
+            settings: [
+                enableHubAdminRead: true,
+                enableBuiltinAppRead: true,
+                debugLogging: false
+            ],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.updated.size() == 3
+        sharedAppStub.settingsStore['enableHubAdminRead'] == [type: 'bool', value: true]
+        sharedAppStub.settingsStore['enableBuiltinAppRead'] == [type: 'bool', value: true]
+        sharedAppStub.settingsStore['debugLogging'] == [type: 'bool', value: false]
+        result.message.contains('Updated 3 setting')
+    }
+
+    def "writes a number setting with the correct type hint"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        def result = script.toolUpdateMcpSettings([
+            settings: [maxCapturedStates: 50],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        sharedAppStub.settingsStore['maxCapturedStates'] == [type: 'number', value: 50]
+    }
+
+    // -------- Golden path: mcpLogLevel delegates to toolSetLogLevel --------
+
+    def "mcpLogLevel updates state.debugLogs.config AND settings (via toolSetLogLevel delegation)"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+        stateMap.debugLogs = [entries: [], config: [logLevel: 'info', maxEntries: 100]]
+
+        when:
+        def result = script.toolUpdateMcpSettings([
+            settings: [mcpLogLevel: 'warn'],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+
+        and: 'the runtime log threshold cache is updated'
+        stateMap.debugLogs.config.logLevel == 'warn'
+
+        and: 'the persisted setting is updated so the UI stays in sync'
+        sharedAppStub.settingsStore['mcpLogLevel'] == [type: 'enum', value: 'warn']
+    }
+}

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -2133,18 +2133,19 @@ These operations are too destructive for automated testing. Test manually with e
 | 8. Comparison | T110-T116 | v0.7.7 vs v0.8.0 regression |
 | 9. Stress | T120-T122 | Many calls, rapid cycles, pagination |
 | 10. NL Discovery | T200-T301 | Conversational prompts — no tool names |
+| 12. Developer Mode | T219-T226 | Self-administration: update_mcp_settings + delete_variable |
 
-### Architecture (post installed-apps + RM interop)
+### Architecture (post installed-apps + RM interop + Developer Mode)
 
 | Component | Count |
 |-----------|-------|
 | Core tools on `tools/list` | 22 |
-| Gateways on `tools/list` | 11 |
-| Total visible on `tools/list` | 33 |
-| Tools proxied behind gateways | 61 |
-| Total tools in codebase | 83 |
+| Gateways on `tools/list` | 12 |
+| Total visible on `tools/list` | 34 |
+| Tools proxied behind gateways | 63 |
+| Total tools in codebase | 85 |
 
-**11 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (3), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_rule_machine` (5)
+**12 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (4), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_rule_machine` (5), `manage_mcp_self` (1)
 
 ### Tool Coverage (non-destructive tools only)
 
@@ -2394,6 +2395,105 @@ Tools in this section have mixed gate requirements. `list_installed_apps` and `g
 ```
 
 **Expected**: AI uses the Rule Machine app ID discovered in setup, then calls `manage_installed_apps(tool='list_app_pages', args={appId: <discovered_id>})`. Returns a `pages` list with a single entry `{name: 'mainPage', role: 'primary'}` plus a `note` confirming rules are single-page. AI explains there is only one page (mainPage) and no sub-pages are available.
+
+---
+
+## Section 12: Developer Mode Tests
+
+These tests exercise the Developer Mode self-administration surface — the `manage_mcp_self` gateway and the `delete_variable` op on `manage_hub_variables`. Both require opt-in toggles in the MCP rule app settings page (`enableDeveloperMode` for `update_mcp_settings`, `enableHubAdminWrite` for both). Each successful Developer Mode write is logged at WARN level for audit.
+
+**Pre-flight (manual one-time):**
+1. In the MCP rule app settings, enable **Enable Hub Admin Write Tools** (with confirmation), and create a hub backup.
+2. In the same settings page, enable **Enable Developer Mode Tools** (you'll see a warning banner).
+3. Click Done.
+
+### T219 — update_mcp_settings refuses when Developer Mode toggle is OFF
+
+```json
+{
+  "setup_prompt": "First, manually disable 'Enable Developer Mode Tools' in the MCP rule app settings (UI). Confirm Hub Admin Write is still enabled and a recent backup exists.",
+  "test_prompt": "Use update_mcp_settings to change mcpLogLevel to warn."
+}
+```
+
+**Expected**: Tool returns an `isError: true` MCP response with a message containing "Developer Mode tools are disabled" and pointing the user to the toggle. No setting is written. AI surfaces the message and asks the user to enable the toggle in the UI before retrying.
+
+### T220 — update_mcp_settings flips a boolean setting end-to-end
+
+```json
+{
+  "setup_prompt": "Developer Mode is enabled, Hub Admin Write is enabled, recent backup exists. Note the current value of debugLogging via get_hub_info or by reading state.",
+  "test_prompt": "Use update_mcp_settings to set debugLogging to true. Then verify the change took effect."
+}
+```
+
+**Expected**: AI calls `manage_mcp_self(tool='update_mcp_settings', args={settings:{debugLogging:true}, confirm:true})`. Result: `{success:true, updated:{debugLogging:true}, message:"Updated 1 setting(s)..."}`. AI verifies via a follow-up read (e.g., the value persists across a subsequent call). Hub log shows a WARN-level `[developer-mode]` audit line.
+
+### T221 — update_mcp_settings rejects a setting outside the allowlist
+
+```json
+{
+  "setup_prompt": "Developer Mode is enabled and Hub Admin Write is enabled.",
+  "test_prompt": "Use update_mcp_settings to set enableHubAdminWrite to false."
+}
+```
+
+**Expected**: Tool returns an MCP error (`-32602`) with a message: `Setting 'enableHubAdminWrite' is not allowed for self-modification via update_mcp_settings. Allowed: ...` listing the allowlisted keys. No change is made. AI explains that this setting is intentionally excluded as a footgun (would lock the agent out of its own write path) and offers to walk the user through the UI toggle.
+
+### T222 — update_mcp_settings batches multiple settings atomically
+
+```json
+{
+  "setup_prompt": "Developer Mode is enabled and Hub Admin Write is enabled.",
+  "test_prompt": "Use update_mcp_settings to set both enableHubAdminRead=true and enableBuiltinAppRead=true in a single call."
+}
+```
+
+**Expected**: AI passes both keys in one `settings` map. Result: `{success:true, updated:{enableHubAdminRead:true, enableBuiltinAppRead:true}, message:"Updated 2 setting(s)..."}`. Both settings persist. The all-or-nothing pre-validation means a single bad key would have rejected the entire batch before any write — verifiable by re-running with one good and one bad key and confirming neither was applied.
+
+### T223 — update_mcp_settings includes a reconnect hint after toggling enable* flags
+
+```json
+{
+  "setup_prompt": "Developer Mode is enabled.",
+  "test_prompt": "Use update_mcp_settings to flip enableRuleEngine to false, then back to true."
+}
+```
+
+**Expected**: Both calls return success. The `message` field on each response contains "MCP clients ... may need to reconnect to refresh cached tool schemas". AI surfaces this hint to the user explaining that tools/list won't reflect the toggle until the client reconnects.
+
+### T224 — delete_variable removes a stale rule_engine variable
+
+```json
+{
+  "setup_prompt": "Hub Admin Write is enabled, recent backup exists. Use set_variable to create a temporary variable named BAT_E2E_DELETE_TEST with value 'scratch'.",
+  "test_prompt": "We don't need BAT_E2E_DELETE_TEST any more. Use delete_variable to remove it, then confirm via get_variable that it's gone."
+}
+```
+
+**Expected**: AI calls `manage_hub_variables(tool='delete_variable', args={name:'BAT_E2E_DELETE_TEST', confirm:true})`. Result: `{success:true, name:'BAT_E2E_DELETE_TEST', deleted:true, source:'rule_engine', previousValue:'scratch'}`. Follow-up `get_variable` returns "Variable not found". Hub log shows a WARN-level `[developer-mode] delete_variable: removed 'BAT_E2E_DELETE_TEST'` audit entry.
+
+### T225 — delete_variable refuses connector-namespace variables with redirect hint
+
+```json
+{
+  "setup_prompt": "Hub Admin Write is enabled. Manually create a Hub Variable named TEST_CONNECTOR_VAR via Settings → Hub Variables UI (this lives in the connector namespace, not rule_engine).",
+  "test_prompt": "Use delete_variable to remove TEST_CONNECTOR_VAR."
+}
+```
+
+**Expected**: Tool returns MCP error (`-32602`) with message: `Variable 'TEST_CONNECTOR_VAR' not found in rule_engine namespace. (Connector-namespace deletion not yet supported via MCP — use Settings → Hub Variables UI.)`. AI surfaces the hint and offers to walk the user through the UI deletion. The variable is unchanged.
+
+### T226 — delete_variable refuses without confirm flag (Hub Admin Write 24h gate)
+
+```json
+{
+  "setup_prompt": "Hub Admin Write is enabled, recent backup exists. Use set_variable to create BAT_E2E_NO_CONFIRM with value 'safe'.",
+  "test_prompt": "Use delete_variable to remove BAT_E2E_NO_CONFIRM. Don't pass confirm — let's see what happens."
+}
+```
+
+**Expected**: Tool throws `IllegalArgumentException` (-32602) about safety check requiring `confirm=true`. The variable is preserved. AI relays the gate requirement and offers to retry with `confirm=true`.
 
 ---
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -332,7 +332,7 @@ class TestRunner:
     def test_tools_list(self) -> None:
         result = self.client.list_tools()
         tools = result.get("tools", [])
-        assert len(tools) == 33, f"Expected 33 tools (22 core + 11 gateways), got {len(tools)}"
+        assert len(tools) == 34, f"Expected 34 tools (22 core + 12 gateways), got {len(tools)}"
 
     @test("infrastructure")
     def test_health_endpoint(self) -> None:


### PR DESCRIPTION
## Summary

- Adds the **Developer Mode** self-administration surface (#78 MVP): a new `enableDeveloperMode` toggle gates a new `manage_mcp_self` gateway that lets an LLM agent or CI/CD pipeline update the MCP rule app's own settings without manual UI intervention.
- Rolls in `delete_variable` (#102) under the existing `manage_hub_variables` gateway — for sweeping orphaned `BAT_E2E_*` artifacts after CI runs and similar cleanup.
- Bundled bugfix: dispatcher's `log.error "msg", e` calls (lines 391, 442) crashed the error handler with a Hubitat-sandbox `MissingMethodException` — `LogWrapper.error()` does not accept `(String, Throwable)`. Surfaced when the new toggle-off gate threw `IllegalStateException`. Switched to single-string form; `mcpLog` above each call still captures the stack trace.

Motivation: this is a **partial unblocker for #77** (live-hub E2E in CI) — without programmatic toggle control, a CI environment can't reliably enable the right toggles before running `tests/e2e_test.py` and silently fails on tools the toggles gate (e.g. the rule-engine path).

## Changes

**New tools (+2 total, +1 on tools/list):**

- `manage_mcp_self.update_mcp_settings` — single tool under a new gateway. Allowlisted v1 keys: `mcpLogLevel`, `debugLogging`, `maxCapturedStates`, `loopGuardMax`, `loopGuardWindowSec`, `enableHubAdminRead`, `enableBuiltinAppRead`, `enableRuleEngine`. Excluded (and explicitly enforced): `enableHubAdminWrite` (footgun — would disable own write path mid-session), `enableDeveloperMode` (lockout protection — UI-only to disable), `selectedDevices` (different wire format, separate tool planned). Batch writes are all-or-nothing — one bad key in the batch rejects the entire request before any `app.updateSetting()` fires.
- `manage_hub_variables.delete_variable` — destructive removal of a rule_engine variable. Connector-namespace deletion not yet supported via MCP (separate gap, #112); error message redirects users to Settings → Hub Variables UI.

**New mainPage section ("Developer Mode"):** prose introducing the capability categories (configuration management, device-access scope, hub-variable management, artifact cleanup, operational diagnostics), the `enableDeveloperMode` toggle (default OFF), and a red WARNING banner shown when the toggle is ON.

**`get_hub_info` / `get_hub_details`:** new boolean field `developerModeEnabled` reflects the toggle state.

**Pre-existing dispatcher bugfix:** `log.error "msg", e` (lines 391, 442) → `log.error "msg (ClassName)"`. Hubitat's `LogWrapper.error()` doesn't accept `(String, Throwable)`; the cascade was masking real exception messages. Stack traces are still captured by the `mcpLog` calls above each `log.error`.

**Tool count:** 83 → 85 total. 33 → 34 on `tools/list` (added `manage_mcp_self` gateway). 11 → 12 gateways.

**Doc sync:** `README.md`, `SKILL.md`, `TOOL_GUIDE.md`, `agent-skill/hubitat-mcp/SKILL.md`, `agent-skill/hubitat-mcp/tool-reference.md`, `tests/BAT-v2.md` (incl. new Section 12 with 8 BAT scenarios), `tests/e2e_test.py` (hardcoded count assertion 33 → 34).

**Out of scope (intentionally deferred to follow-up PRs under the same toggle):** device-access management (selectedDevices), connector-namespace Hub Variables CRUD, artifact-cleanup sweeper, OAuth token rotation, operational self-healing.

Closes #78 (MVP scope). Closes #102. Part of #77.

## Testing

**Unit tests** — 24 new Spock specs, full `./gradlew test` green:

- `ToolHubVariablesSpec` extended with 9 specs for `delete_variable`: golden path with previous-value report, sibling preservation, missing `confirm`, missing 24h backup, `enableHubAdminWrite` off, missing `name` arg, "not in rule_engine namespace" error with redirect hint to UI, null `state.ruleVariables` map.
- New `ToolUpdateMcpSettingsSpec` with 15 specs covering: `IllegalStateException` when Developer Mode toggle is off, all three layers of `requireHubAdminWrite`, missing/empty/non-Map settings arg, allowlist rejection with allowed-key listing, explicit rejection of `enableHubAdminWrite` / `enableDeveloperMode` / `selectedDevices`, all-or-nothing batch validation (one bad key blocks the batch), single-boolean write, multi-key batch write, number-type write, and mcpLogLevel delegation to `toolSetLogLevel` (asserts both `state.debugLogs.config.logLevel` cache update and `app.updateSetting` persistence).

**Live-hub validation** on a test hub (instance 38) — every code path verified end-to-end via raw JSON-RPC over MCP:
- `delete_variable` round-trip (set → delete → verify-gone), with hub log showing the WARN-level `[developer-mode]` audit entry.
- `delete_variable` rejection on a nonexistent variable, with the redirect-to-UI hint surfaced verbatim.
- `update_mcp_settings` toggle-off refusal returns a clean `Tool error: Developer Mode tools are disabled...` message (vs. the cascading "An unexpected error occurred" before the LogWrapper fix).
- `update_mcp_settings` enum (mcpLogLevel: warn) verified via follow-up `get_logging_status` showing `currentLogLevel: warn`, then restored.
- `update_mcp_settings` boolean (`enableRuleEngine: false` → `true`) round-trip.
- `update_mcp_settings` allowlist rejection (`enableHubAdminWrite`) lists the allowed keys.
- `update_mcp_settings` batch atomicity verified (one good + one bad key → entire batch rejected, no `app.updateSetting()` fires for the good key — confirmed via absence of `[developer-mode]` audit entry for the good key after the failed batch).
- `developerModeEnabled` field appears in `get_hub_info` (false then true).
- `tools/list` returns 34 items as expected.
- WARNING banner renders in the rule app UI when the toggle is enabled.

**BAT-v2 scenarios:** new Section 12 with 8 scenarios (T219–T226) covering Developer Mode end-to-end paths for the maintainer's manual live-hub validation.

**Sandbox lint:** clean.

## Checklist

- [x] **Unit tests added for any new MCP tools** (24 new Spock specs, full suite green)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally
- [x] Live-hub BAT tests updated (new Section 12, T219–T226)
- [x] Documentation updated (README, SKILL, TOOL_GUIDE, agent-skill SKILL + tool-reference, BAT-v2, e2e_test count)

## Release notes

Adds **Developer Mode** — a new opt-in toggle (`enableDeveloperMode`, default OFF) gating self-administration tools that let an LLM agent or CI/CD pipeline manage the MCP rule app's own configuration without manual UI intervention. First tool under this surface is `update_mcp_settings` (in a new `manage_mcp_self` gateway), which flips an allowlisted set of MCP-app settings via `app.updateSetting()` — gated on Hub Admin Write + recent backup, every successful write logged at WARN for audit. Also adds `delete_variable` to `manage_hub_variables` for cleaning up stale rule_engine variables (e.g., orphaned `BAT_E2E_*` artifacts after CI runs). Bundled fix: dispatcher's `log.error` calls no longer crash on non-`IllegalArgumentException` tool errors (Hubitat's `LogWrapper.error()` doesn't accept a `Throwable` second arg — the cascade was masking real exception messages). Tool count 83 → 85, gateways 11 → 12.
