### PR TITLE
ci(hub-e2e): self-configuring CI workflow against test hub (closes #77)

### DIFF
--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -46,7 +46,9 @@ if [ -n "$CURRENT" ]; then
   CURRENT_BY="$(echo "$CURRENT" | jq -r '.by // ""' 2>/dev/null || echo "")"
   CURRENT_UNTIL="$(echo "$CURRENT" | jq -r '.until // 0' 2>/dev/null || echo 0)"
   if [ "$CURRENT_UNTIL" -gt "$NOW_MS" ] && [ "$CURRENT_BY" != "$BY" ]; then
-    echo "::error::Test hub leased by '$CURRENT_BY' until $(date -u -d "@$((CURRENT_UNTIL / 1000))" +%FT%TZ). Aborting."
+    UNTIL_EPOCH=$((CURRENT_UNTIL / 1000))
+    UNTIL_TS=$(python3 -c "import datetime; print(datetime.datetime.utcfromtimestamp(${UNTIL_EPOCH}).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+    echo "::error::Test hub leased by '$CURRENT_BY' until ${UNTIL_TS}. Aborting."
     exit 1
   fi
 fi
@@ -72,4 +74,6 @@ if [ "$AFTER_BY" != "$BY" ]; then
   exit 1
 fi
 
-echo "Lease acquired: by=$BY, until=$(date -u -d "@$((EXPIRES_MS / 1000))" +%FT%TZ) (${LEASE_DURATION_MIN} min TTL)"
+EXPIRES_EPOCH=$((EXPIRES_MS / 1000))
+EXPIRES_TS=$(python3 -c "import datetime; print(datetime.datetime.utcfromtimestamp(${EXPIRES_EPOCH}).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+echo "Lease acquired: by=$BY, until=${EXPIRES_TS} (${LEASE_DURATION_MIN} min TTL)"

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -16,7 +16,8 @@ set -euo pipefail
 BY="${1:?Usage: $0 <by-identifier>}"
 : "${MCP_URL:?MCP_URL env var required (full cloud OAuth URL with access_token)}"
 
-NOW_MS=$(($(date +%s%N) / 1000000))
+# Portable epoch milliseconds (date +%s%N is GNU-only — fails on BSD/macOS).
+NOW_MS=$(python3 -c 'import time; print(int(time.time() * 1000))')
 LEASE_DURATION_MIN=30
 EXPIRES_MS=$((NOW_MS + LEASE_DURATION_MIN * 60 * 1000))
 VERIFY_SLEEP_S=2

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Acquire test hub lease for a CI run.
+#
+# Usage:  lease_acquire.sh <by-identifier>
+# Env:    MCP_URL — full cloud OAuth URL with access_token
+#
+# Exits 0 on successful claim. Exits 1 if the lease is held by someone else
+# (active and not us), or if the post-write race-check fails.
+#
+# Lease shape (JSON, written into Hubitat Hub Variable `_TEST_HUB_LEASED_BY`):
+#   {"by":"<who>","since":<epoch_ms>,"until":<epoch_ms>}
+# Empty string = released. See protocol in CLAUDE.md / issue #77 for context.
+
+set -euo pipefail
+
+BY="${1:?Usage: $0 <by-identifier>}"
+: "${MCP_URL:?MCP_URL env var required (full cloud OAuth URL with access_token)}"
+
+NOW_MS=$(($(date +%s%N) / 1000000))
+LEASE_DURATION_MIN=30
+EXPIRES_MS=$((NOW_MS + LEASE_DURATION_MIN * 60 * 1000))
+VERIFY_SLEEP_S=2
+
+mcp_call() {
+  curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
+    -H "Content-Type: application/json" \
+    -d "$1"
+}
+
+get_lease_value() {
+  mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"manage_hub_variables","arguments":{"tool":"get_variable","args":{"name":"_TEST_HUB_LEASED_BY"}}}}' \
+    | jq -r '.result.content[0].text' \
+    | jq -r '.value // ""'
+}
+
+set_lease_value() {
+  # Arg is the JSON-stringified value (already double-quoted + escaped).
+  local value_json="$1"
+  mcp_call "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"manage_hub_variables\",\"arguments\":{\"tool\":\"set_variable\",\"args\":{\"name\":\"_TEST_HUB_LEASED_BY\",\"value\":${value_json}}}}}" >/dev/null
+}
+
+CURRENT="$(get_lease_value)"
+
+if [ -n "$CURRENT" ]; then
+  CURRENT_BY="$(echo "$CURRENT" | jq -r '.by // ""' 2>/dev/null || echo "")"
+  CURRENT_UNTIL="$(echo "$CURRENT" | jq -r '.until // 0' 2>/dev/null || echo 0)"
+  if [ "$CURRENT_UNTIL" -gt "$NOW_MS" ] && [ "$CURRENT_BY" != "$BY" ]; then
+    echo "::error::Test hub leased by '$CURRENT_BY' until $(date -u -d "@$((CURRENT_UNTIL / 1000))" +%FT%TZ). Aborting."
+    exit 1
+  fi
+fi
+
+# Build the lease JSON, then JSON-stringify it for the set_variable arg.
+CLAIM_JSON="$(jq -nc \
+  --arg  by    "$BY" \
+  --argjson since "$NOW_MS" \
+  --argjson until "$EXPIRES_MS" \
+  '{by: $by, since: $since, until: $until}')"
+CLAIM_AS_STRING="$(printf '%s' "$CLAIM_JSON" | jq -Rs .)"
+
+set_lease_value "$CLAIM_AS_STRING"
+
+# Post-write race-check: re-read after a short delay. If "by" isn't us,
+# someone else's claim landed last and stole the lease — abort.
+sleep "$VERIFY_SLEEP_S"
+AFTER="$(get_lease_value)"
+AFTER_BY="$(echo "$AFTER" | jq -r '.by // ""' 2>/dev/null || echo "")"
+
+if [ "$AFTER_BY" != "$BY" ]; then
+  echo "::error::Lease stolen by '$AFTER_BY' before our verify check. Aborting."
+  exit 1
+fi
+
+echo "Lease acquired: by=$BY, until=$(date -u -d "@$((EXPIRES_MS / 1000))" +%FT%TZ) (${LEASE_DURATION_MIN} min TTL)"

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -47,7 +47,7 @@ if [ -n "$CURRENT" ]; then
   CURRENT_UNTIL="$(echo "$CURRENT" | jq -r '.until // 0' 2>/dev/null || echo 0)"
   if [ "$CURRENT_UNTIL" -gt "$NOW_MS" ] && [ "$CURRENT_BY" != "$BY" ]; then
     UNTIL_EPOCH=$((CURRENT_UNTIL / 1000))
-    UNTIL_TS=$(python3 -c "import datetime; print(datetime.datetime.utcfromtimestamp(${UNTIL_EPOCH}).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+    UNTIL_TS=$(python3 -c "import datetime; print(datetime.datetime.fromtimestamp(${UNTIL_EPOCH}, datetime.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'))")
     echo "::error::Test hub leased by '$CURRENT_BY' until ${UNTIL_TS}. Aborting."
     exit 1
   fi
@@ -75,5 +75,5 @@ if [ "$AFTER_BY" != "$BY" ]; then
 fi
 
 EXPIRES_EPOCH=$((EXPIRES_MS / 1000))
-EXPIRES_TS=$(python3 -c "import datetime; print(datetime.datetime.utcfromtimestamp(${EXPIRES_EPOCH}).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+EXPIRES_TS=$(python3 -c "import datetime; print(datetime.datetime.fromtimestamp(${EXPIRES_EPOCH}, datetime.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'))")
 echo "Lease acquired: by=$BY, until=${EXPIRES_TS} (${LEASE_DURATION_MIN} min TTL)"

--- a/.github/scripts/lease_release.sh
+++ b/.github/scripts/lease_release.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Release test hub lease (write empty string to `_TEST_HUB_LEASED_BY`).
+#
+# Env: MCP_URL — full cloud OAuth URL with access_token.
+#
+# Always exits 0 even if the release call fails — the lease has a 30-min
+# TTL safety net, and this script runs in `if: always()` workflow steps
+# where a non-zero exit would mask the real test failure.
+
+set -uo pipefail
+
+: "${MCP_URL:?MCP_URL env var required}"
+
+if curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"manage_hub_variables","arguments":{"tool":"set_variable","args":{"name":"_TEST_HUB_LEASED_BY","value":""}}}}' \
+    >/dev/null; then
+  echo "Lease released."
+else
+  echo "::warning::Lease release failed — relying on 30-min TTL to clear it."
+fi

--- a/.github/scripts/mcp_restore_env.sh
+++ b/.github/scripts/mcp_restore_env.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Restore the test hub's MCP settings to whatever mcp_setup_env.sh captured
+# pre-run. Tolerant of missing pre-state file (early-exit no-op) so it can
+# safely live in an `if: always()` workflow step alongside lease release.
+#
+# Usage:  mcp_restore_env.sh
+# Env:    MCP_URL — full cloud OAuth URL with access_token
+#         RUNNER_TEMP — GHA-provided temp dir; falls back to /tmp
+
+set -euo pipefail
+
+: "${MCP_URL:?MCP_URL env var required (full cloud OAuth URL with access_token)}"
+PRE_STATE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_state.json"
+
+if [ ! -f "$PRE_STATE_FILE" ]; then
+  echo "No pre-state file at $PRE_STATE_FILE — setup likely failed before capture. Skipping restore."
+  exit 0
+fi
+
+PRE_STATE="$(cat "$PRE_STATE_FILE")"
+echo "Restoring pre-run state: $PRE_STATE"
+
+# update_mcp_settings expects a Map<key, value>. The pre-state file is
+# already in the right shape — wrap it in the tool's argument envelope.
+SETTINGS_PAYLOAD="$(jq -nc --argjson s "$PRE_STATE" '{settings: $s, confirm: true}')"
+RPC_BODY="$(jq -nc --argjson p "$SETTINGS_PAYLOAD" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"manage_mcp_self",arguments:{tool:"update_mcp_settings",args:$p}}}')"
+
+curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -d "$RPC_BODY" \
+  | jq -e '.result.content[0].text | fromjson | .success == true' >/dev/null
+
+echo "Test environment restored from pre-run state."

--- a/.github/scripts/mcp_setup_env.sh
+++ b/.github/scripts/mcp_setup_env.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Configure the test hub for E2E by enabling the toggles tests/e2e_test.py
+# depends on. Captures pre-run state to a file so mcp_restore_env.sh can
+# put things back the way they were.
+#
+# Usage:  mcp_setup_env.sh
+# Env:    MCP_URL — full cloud OAuth URL with access_token
+#         RUNNER_TEMP — GHA-provided temp dir; falls back to /tmp
+#
+# Toggles enabled (all in update_mcp_settings allowlist):
+#   - enableRuleEngine     (create_rule / update_rule / delete_rule paths)
+#   - enableHubAdminRead   (get_hub_info PII fields, list_hub_apps, etc.)
+#   - enableBuiltinAppRead (list_installed_apps, list_rm_rules)
+#
+# Not touched here:
+#   - enableHubAdminWrite — excluded from update_mcp_settings allowlist by
+#     design (footgun: would let the agent disable its own write path
+#     mid-session). Must be enabled manually in the MCP rule app UI before
+#     any write-bearing test can pass.
+#   - enableDeveloperMode — same lockout protection. Must be on in the UI
+#     before this script can call update_mcp_settings at all (script aborts
+#     with a focused error if it isn't).
+
+set -euo pipefail
+
+: "${MCP_URL:?MCP_URL env var required (full cloud OAuth URL with access_token)}"
+PRE_STATE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_state.json"
+
+mcp_call() {
+  curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
+    -H "Content-Type: application/json" \
+    -d "$1"
+}
+
+# Pull the toggle state from get_hub_info. The settings-visibility block on
+# lines 3026+ of hubitat-mcp-server.groovy exposes these fields without
+# requiring Hub Admin Read.
+PRE_INFO_JSON="$(mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_hub_info","arguments":{}}}' \
+  | jq -r '.result.content[0].text')"
+
+DEV_MODE="$(echo "$PRE_INFO_JSON" | jq -r '.developerModeEnabled // false')"
+if [ "$DEV_MODE" != "true" ]; then
+  echo "::error::Developer Mode is OFF on the test hub. Enable 'Enable Developer Mode Tools' in the MCP rule app settings (default OFF) so update_mcp_settings can configure the test environment."
+  exit 1
+fi
+
+PRE_RULE_ENGINE="$(echo "$PRE_INFO_JSON"  | jq -r '.ruleEngineEnabled  // true')"
+PRE_HUB_READ="$(echo    "$PRE_INFO_JSON"  | jq -r '.hubAdminReadEnabled  // false')"
+PRE_BUILTIN_READ="$(echo "$PRE_INFO_JSON" | jq -r '.builtinAppReadEnabled // false')"
+
+jq -nc \
+  --argjson re  "$PRE_RULE_ENGINE" \
+  --argjson hr  "$PRE_HUB_READ" \
+  --argjson br  "$PRE_BUILTIN_READ" \
+  '{enableRuleEngine: $re, enableHubAdminRead: $hr, enableBuiltinAppRead: $br}' \
+  > "$PRE_STATE_FILE"
+
+echo "Captured pre-run state -> $PRE_STATE_FILE"
+cat "$PRE_STATE_FILE"
+
+# Enable everything E2E needs in a single batch. update_mcp_settings is
+# atomic — a single bad key would block the whole batch.
+mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"manage_mcp_self","arguments":{"tool":"update_mcp_settings","args":{"settings":{"enableRuleEngine":true,"enableHubAdminRead":true,"enableBuiltinAppRead":true},"confirm":true}}}}' \
+  | jq -e '.result.content[0].text | fromjson | .success == true' >/dev/null
+
+echo "Test environment configured: enableRuleEngine=true, enableHubAdminRead=true, enableBuiltinAppRead=true"

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -1,0 +1,98 @@
+name: Hub E2E (test hub)
+
+# End-to-end tests against a real Hubitat hub provided by @level99
+# (see issue #77 + the GitHub secret LEVEL99_TEST_HUB_MCP_URL).
+#
+# Failure mode: ADVISORY only. Hub flakiness must not block PR merges,
+# so this workflow is intentionally not added to branch protection's
+# required-checks. Treat it as a signal, not a gate.
+
+on:
+  pull_request:
+    branches: [main]
+    # Skip when only docs / non-test files change. Cuts CI cost on
+    # README-only / SKILL-only PRs that can't break the hub-side surface.
+    paths:
+      - 'hubitat-mcp-server.groovy'
+      - 'hubitat-mcp-rule.groovy'
+      - 'tests/e2e_test.py'
+      - '.github/workflows/hub-e2e.yml'
+      - '.github/scripts/lease_acquire.sh'
+      - '.github/scripts/lease_release.sh'
+  workflow_dispatch: {}
+
+# Serialize concurrent runs against the shared test hub. Don't cancel
+# in-progress — they hold the lease and need to release it cleanly via
+# the `if: always()` cleanup step. A cancelled run that leaves a
+# stranded lease will eventually expire via the 30-min TTL, but it's
+# better to let things finish and release explicitly.
+concurrency:
+  group: hub-e2e
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    # Must match the lease duration in lease_acquire.sh so the job can't
+    # outlive the lease and let another run trample state mid-test.
+    timeout-minutes: 30
+
+    env:
+      MCP_URL: ${{ secrets.LEVEL99_TEST_HUB_MCP_URL }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install requests
+
+      - name: Verify MCP_URL secret is present + mask token
+        run: |
+          if [ -z "$MCP_URL" ]; then
+            echo "::error::LEVEL99_TEST_HUB_MCP_URL secret is empty or missing on this repo. Cannot proceed."
+            exit 1
+          fi
+          # Defensive masking — secrets are auto-masked, but URL parsing
+          # below can split the token out into a separate string that
+          # isn't recognized as the original secret value. Force-mask.
+          TOKEN="$(echo "$MCP_URL" | sed -nE 's|.*access_token=(.*)|\1|p')"
+          if [ -n "$TOKEN" ]; then
+            echo "::add-mask::$TOKEN"
+          fi
+
+      - name: Parse MCP_URL into HUBITAT_* env vars
+        # tests/e2e_test.py expects these three env vars (see its docstring).
+        # MCP_URL format: https://cloud.hubitat.com/api/<UUID>/apps/<APPID>/mcp?access_token=<TOKEN>
+        run: |
+          BASE=$(echo "$MCP_URL"  | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\1|')
+          APPID=$(echo "$MCP_URL" | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\2|')
+          TOKEN=$(echo "$MCP_URL" | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\3|')
+          {
+            echo "HUBITAT_HUB_URL=$BASE"
+            echo "HUBITAT_APP_ID=$APPID"
+            echo "HUBITAT_ACCESS_TOKEN=$TOKEN"
+          } >> "$GITHUB_ENV"
+
+      - name: Acquire test hub lease
+        run: bash .github/scripts/lease_acquire.sh "ci-run-${{ github.run_id }}"
+
+      - name: Run E2E tests
+        run: python tests/e2e_test.py
+
+      - name: Cleanup BAT_E2E_ artifacts
+        if: always()
+        # Defensive — e2e_test.py cleans up after itself in the happy path,
+        # but a crashed run can strand virtual devices / rules / variables
+        # under the BAT_E2E_ prefix. This sweeps anything left over.
+        run: python tests/e2e_test.py --cleanup-only
+
+      - name: Release test hub lease
+        if: always()
+        run: bash .github/scripts/lease_release.sh

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -21,7 +21,11 @@ on:
       - '.github/scripts/lease_release.sh'
       - '.github/scripts/mcp_setup_env.sh'
       - '.github/scripts/mcp_restore_env.sh'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to test (blank = current ref)'
+        required: false
 
 # Serialize concurrent runs against the shared test hub. Don't cancel
 # in-progress — they hold the lease and need to release it cleanly via
@@ -47,6 +51,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || github.ref }}
 
       - name: Check secret availability + skip if absent
         # Two cases where MCP_URL is empty (and we want to skip silently
@@ -95,6 +101,12 @@ jobs:
         # tests/e2e_test.py expects these three env vars (see its docstring).
         # MCP_URL format: https://cloud.hubitat.com/api/<UUID>/apps/<APPID>/mcp?access_token=<TOKEN>
         run: |
+          # Note: regional cloud endpoints (e.g. eu.cloud.hubitat.com) are not yet supported —
+          # update the regex if Hubitat adds them.
+          if [[ ! "$MCP_URL" =~ ^https://cloud\.hubitat\.com/api/[^/]+/apps/[0-9]+/mcp\?access_token=.+$ ]]; then
+            echo "::error::MCP_URL does not match the expected cloud-endpoint shape — refusing to parse a malformed value into HUBITAT_* env vars."
+            exit 1
+          fi
           BASE=$(echo "$MCP_URL"  | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\1|')
           APPID=$(echo "$MCP_URL" | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\2|')
           TOKEN=$(echo "$MCP_URL" | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\3|')

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -19,6 +19,8 @@ on:
       - '.github/workflows/hub-e2e.yml'
       - '.github/scripts/lease_acquire.sh'
       - '.github/scripts/lease_release.sh'
+      - '.github/scripts/mcp_setup_env.sh'
+      - '.github/scripts/mcp_restore_env.sh'
   workflow_dispatch: {}
 
 # Serialize concurrent runs against the shared test hub. Don't cancel
@@ -83,6 +85,14 @@ jobs:
       - name: Acquire test hub lease
         run: bash .github/scripts/lease_acquire.sh "ci-run-${{ github.run_id }}"
 
+      - name: Configure test environment (capture pre-state + enable toggles)
+        # Captures enableRuleEngine / enableHubAdminRead / enableBuiltinAppRead
+        # to $RUNNER_TEMP/mcp_pre_state.json, then enables all three so the
+        # tests can exercise the rule engine + hub admin read paths regardless
+        # of the test hub's prior toggle state. Refuses if Developer Mode
+        # itself is off (UI-only to enable).
+        run: bash .github/scripts/mcp_setup_env.sh
+
       - name: Run E2E tests
         run: python tests/e2e_test.py
 
@@ -92,6 +102,12 @@ jobs:
         # but a crashed run can strand virtual devices / rules / variables
         # under the BAT_E2E_ prefix. This sweeps anything left over.
         run: python tests/e2e_test.py --cleanup-only
+
+      - name: Restore test environment (settings back to pre-run state)
+        if: always()
+        # Tolerant of missing pre-state file (early-exit no-op) so a setup
+        # failure before capture doesn't propagate here.
+        run: bash .github/scripts/mcp_restore_env.sh
 
       - name: Release test hub lease
         if: always()

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -48,28 +48,50 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check secret availability + skip if absent
+        # Two cases where MCP_URL is empty (and we want to skip silently
+        # rather than fail red):
+        #   - PRs from forks: GitHub's security policy strips secrets from
+        #     fork-PR workflow runs, even when the secret is set on the
+        #     upstream repo. The job runs but the env var is empty.
+        #   - Secret intentionally not configured (no donated test hub,
+        #     maintainer-private fork without test infra).
+        # The fork-dispatch path (workflow_dispatch from level99's fork)
+        # DOES have access to the secret, so this gate doesn't block the
+        # intended "run via fork dispatch" use case.
+        # GitHub doesn't allow `secrets` in job-level `if:` conditions, so
+        # the check happens here as a step output and gates everything below.
+        id: gate
+        run: |
+          if [ -z "$MCP_URL" ]; then
+            echo "::notice::LEVEL99_TEST_HUB_MCP_URL secret not available — skipping E2E (expected on fork PRs and on repos without the test hub configured)"
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/setup-python@v6
+        if: steps.gate.outputs.available == 'true'
         with:
           python-version: '3.x'
 
       - name: Install Python dependencies
+        if: steps.gate.outputs.available == 'true'
         run: pip install requests
 
-      - name: Verify MCP_URL secret is present + mask token
+      - name: Mask access token in subsequent log lines
+        if: steps.gate.outputs.available == 'true'
+        # Secrets are auto-masked, but the URL parsing below can split the
+        # token out into a separate string that isn't recognized as the
+        # original secret value. Force-mask.
         run: |
-          if [ -z "$MCP_URL" ]; then
-            echo "::error::LEVEL99_TEST_HUB_MCP_URL secret is empty or missing on this repo. Cannot proceed."
-            exit 1
-          fi
-          # Defensive masking — secrets are auto-masked, but URL parsing
-          # below can split the token out into a separate string that
-          # isn't recognized as the original secret value. Force-mask.
           TOKEN="$(echo "$MCP_URL" | sed -nE 's|.*access_token=(.*)|\1|p')"
           if [ -n "$TOKEN" ]; then
             echo "::add-mask::$TOKEN"
           fi
 
       - name: Parse MCP_URL into HUBITAT_* env vars
+        if: steps.gate.outputs.available == 'true'
         # tests/e2e_test.py expects these three env vars (see its docstring).
         # MCP_URL format: https://cloud.hubitat.com/api/<UUID>/apps/<APPID>/mcp?access_token=<TOKEN>
         run: |
@@ -83,9 +105,11 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Acquire test hub lease
+        if: steps.gate.outputs.available == 'true'
         run: bash .github/scripts/lease_acquire.sh "ci-run-${{ github.run_id }}"
 
       - name: Configure test environment (capture pre-state + enable toggles)
+        if: steps.gate.outputs.available == 'true'
         # Captures enableRuleEngine / enableHubAdminRead / enableBuiltinAppRead
         # to $RUNNER_TEMP/mcp_pre_state.json, then enables all three so the
         # tests can exercise the rule engine + hub admin read paths regardless
@@ -94,21 +118,22 @@ jobs:
         run: bash .github/scripts/mcp_setup_env.sh
 
       - name: Run E2E tests
+        if: steps.gate.outputs.available == 'true'
         run: python tests/e2e_test.py
 
       - name: Cleanup BAT_E2E_ artifacts
-        if: always()
+        if: always() && steps.gate.outputs.available == 'true'
         # Defensive — e2e_test.py cleans up after itself in the happy path,
         # but a crashed run can strand virtual devices / rules / variables
         # under the BAT_E2E_ prefix. This sweeps anything left over.
         run: python tests/e2e_test.py --cleanup-only
 
       - name: Restore test environment (settings back to pre-run state)
-        if: always()
+        if: always() && steps.gate.outputs.available == 'true'
         # Tolerant of missing pre-state file (early-exit no-op) so a setup
         # failure before capture doesn't propagate here.
         run: bash .github/scripts/mcp_restore_env.sh
 
       - name: Release test hub lease
-        if: always()
+        if: always() && steps.gate.outputs.available == 'true'
         run: bash .github/scripts/lease_release.sh

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3028,6 +3028,7 @@ def toolGetHubInfo() {
     info.hubAdminReadEnabled = settings.enableHubAdminRead ?: false
     info.hubAdminWriteEnabled = settings.enableHubAdminWrite ?: false
     info.builtinAppReadEnabled = settings.enableBuiltinAppRead ?: false
+    info.ruleEngineEnabled = settings.enableRuleEngine != false  // defaults true
     info.developerModeEnabled = settings.enableDeveloperMode ?: false
 
     // PII/location data requires Hub Admin Read
@@ -5376,6 +5377,7 @@ def toolGetHubDetails(args) {
     details.hubAdminReadEnabled = settings.enableHubAdminRead ?: false
     details.hubAdminWriteEnabled = settings.enableHubAdminWrite ?: false
     details.builtinAppReadEnabled = settings.enableBuiltinAppRead ?: false
+    details.ruleEngineEnabled = settings.enableRuleEngine != false  // defaults true
     details.developerModeEnabled = settings.enableDeveloperMode ?: false
 
     mcpLog("info", "hub-admin", "Retrieved extended hub details")

--- a/src/test/groovy/server/HubInfoFieldContractSpec.groovy
+++ b/src/test/groovy/server/HubInfoFieldContractSpec.groovy
@@ -1,0 +1,136 @@
+package server
+
+import spock.lang.Shared
+import support.TestHub
+import support.TestLocation
+import support.ToolSpecBase
+
+/**
+ * Contract spec asserting that {@code ruleEngineEnabled} and
+ * {@code developerModeEnabled} are present in both {@code getHubInfo()} and
+ * {@code getHubDetails()} responses.
+ *
+ * Both fields are read by {@code .github/scripts/mcp_setup_env.sh} to capture
+ * pre-run state before enabling toggles. If either field is dropped or renamed,
+ * the setup script silently misreads pre-state, enabling unexpected settings
+ * permanently on the test hub.
+ *
+ * Mocking strategy:
+ *   - location.hub -> appExecutor.getLocation() returns sharedLocation
+ *   - toolGetHubDetails requires enableHubAdminRead; set in given: per-test
+ */
+class HubInfoFieldContractSpec extends ToolSpecBase {
+
+    @Shared private TestLocation sharedLocation = new TestLocation()
+
+    def setupSpec() {
+        appExecutor.getLocation() >> sharedLocation
+    }
+
+    def cleanup() {
+        sharedLocation.hub = null
+    }
+
+    // -------- toolGetHubInfo --------
+
+    def "getHubInfo includes ruleEngineEnabled=true when enableRuleEngine is true"() {
+        given:
+        settingsMap.enableRuleEngine = true
+        sharedLocation.hub = new TestHub()
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then:
+        result.containsKey('ruleEngineEnabled')
+        result.ruleEngineEnabled == true
+    }
+
+    def "getHubInfo includes developerModeEnabled=true when enableDeveloperMode is true"() {
+        given:
+        settingsMap.enableDeveloperMode = true
+        sharedLocation.hub = new TestHub()
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then:
+        result.containsKey('developerModeEnabled')
+        result.developerModeEnabled == true
+    }
+
+    def "getHubInfo includes both fields as false when toggles are off"() {
+        given:
+        settingsMap.enableRuleEngine = false
+        settingsMap.enableDeveloperMode = false
+        sharedLocation.hub = new TestHub()
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then:
+        result.containsKey('ruleEngineEnabled')
+        result.ruleEngineEnabled == false
+        result.containsKey('developerModeEnabled')
+        result.developerModeEnabled == false
+    }
+
+    // -------- toolGetHubDetails --------
+
+    def "getHubDetails includes ruleEngineEnabled=true when enableRuleEngine is true"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        settingsMap.enableRuleEngine = true
+        sharedLocation.hub = new TestHub()
+
+        when:
+        def result = script.toolGetHubDetails([:])
+
+        then:
+        result.containsKey('ruleEngineEnabled')
+        result.ruleEngineEnabled == true
+    }
+
+    def "getHubDetails includes developerModeEnabled=true when enableDeveloperMode is true"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        settingsMap.enableDeveloperMode = true
+        sharedLocation.hub = new TestHub()
+
+        when:
+        def result = script.toolGetHubDetails([:])
+
+        then:
+        result.containsKey('developerModeEnabled')
+        result.developerModeEnabled == true
+    }
+
+    def "getHubDetails includes both fields as false when toggles are off"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        settingsMap.enableRuleEngine = false
+        settingsMap.enableDeveloperMode = false
+        sharedLocation.hub = new TestHub()
+
+        when:
+        def result = script.toolGetHubDetails([:])
+
+        then:
+        result.containsKey('ruleEngineEnabled')
+        result.ruleEngineEnabled == false
+        result.containsKey('developerModeEnabled')
+        result.developerModeEnabled == false
+    }
+
+    def "getHubDetails throws when Hub Admin Read is disabled"() {
+        given:
+        // enableHubAdminRead not set
+
+        when:
+        script.toolGetHubDetails([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Read')
+    }
+}

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -2493,7 +2493,7 @@ These tests exercise the Developer Mode self-administration surface — the `man
 }
 ```
 
-**Expected**: Tool throws `IllegalArgumentException` (-32602) about safety check requiring `confirm=true`. The variable is preserved. AI relays the gate requirement and offers to retry with `confirm=true`.
+**Expected**: Gateway parameter validation returns an `isError: true` result with message `"Missing required parameter(s): confirm"` and a `parameters` description listing the schema (name, confirm, force). No JSON-RPC error code is set — the validation happens at the gateway layer before tool dispatch. The variable is preserved. AI relays the gate requirement and offers to retry with `confirm=true`.
 
 ---
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -85,7 +85,13 @@ class HubitatMcpClient:
             print(f"    [DEBUG] {msg}")
 
     def _send(self, method: str, params: Optional[dict] = None) -> dict:
-        """Send a JSON-RPC 2.0 request and return the parsed result."""
+        """Send a JSON-RPC 2.0 request and return the parsed result.
+
+        Retries transient HTTP 5xx and network errors (cloud relay flake) with
+        exponential backoff. Never retries on 4xx (real auth/request errors)
+        or on JSON-RPC error responses (intentional tool behavior we're
+        trying to test).
+        """
         self._request_id += 1
         payload: dict[str, Any] = {
             "jsonrpc": "2.0",
@@ -100,14 +106,33 @@ class HubitatMcpClient:
         # Rate-limit: don't overwhelm the hub
         time.sleep(0.2)
 
-        resp = requests.post(
-            self.endpoint,
-            params={"access_token": self.access_token},
-            json=payload,
-            timeout=30,
-        )
-        resp.raise_for_status()
-        data = resp.json()
+        last_exc: Optional[Exception] = None
+        data: Optional[dict] = None
+        for attempt in range(3):
+            try:
+                resp = requests.post(
+                    self.endpoint,
+                    params={"access_token": self.access_token},
+                    json=payload,
+                    timeout=60,
+                )
+                if 500 <= resp.status_code < 600:
+                    # Hub or cloud relay returned a transient error. Heavy
+                    # queries (e.g. get_performance_stats) sometimes 504.
+                    last_exc = requests.HTTPError(f"{resp.status_code} {resp.reason} on {method}")
+                    self._log(f"<< HTTP {resp.status_code} (attempt {attempt + 1}/3) — retrying")
+                    time.sleep(2 ** attempt)  # 1s, 2s, 4s
+                    continue
+                resp.raise_for_status()
+                data = resp.json()
+                break
+            except (requests.ConnectionError, requests.Timeout, requests.exceptions.ChunkedEncodingError) as exc:
+                last_exc = exc
+                self._log(f"<< network error (attempt {attempt + 1}/3): {exc} — retrying")
+                time.sleep(2 ** attempt)
+        else:
+            # Exhausted retries — surface the last transient failure.
+            raise last_exc if last_exc else McpError(f"transport failure on {method}")
 
         self._log(f"<< {json.dumps(data)[:500]}")
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -92,6 +92,9 @@ class HubitatMcpClient:
         exponential backoff. Never retries on 4xx (real auth/request errors)
         or on JSON-RPC error responses (intentional tool behavior we're
         trying to test).
+
+        Retries JSONDecodeError on the same budget — this catches transient
+        Cloudflare HTML error pages on cloud endpoints under load.
         """
         self._request_id += 1
         payload: dict[str, Any] = {
@@ -110,6 +113,7 @@ class HubitatMcpClient:
         last_exc: Optional[Exception] = None
         data: Optional[dict] = None
         for attempt in range(3):
+            resp = None
             try:
                 resp = requests.post(
                     self.endpoint,
@@ -129,12 +133,28 @@ class HubitatMcpClient:
                 resp.raise_for_status()
                 data = resp.json()
                 break
-            except (requests.ConnectionError, requests.Timeout, requests.exceptions.ChunkedEncodingError) as exc:
+            except (requests.ConnectionError, requests.Timeout,
+                    requests.exceptions.ChunkedEncodingError,
+                    json.JSONDecodeError) as exc:
                 last_exc = exc
-                self._log(f"<< network error (attempt {attempt + 1}/3): {exc} — retrying")
+                snippet = ""
+                if isinstance(exc, json.JSONDecodeError) and resp is not None:
+                    try:
+                        snippet = f" body[:200]={resp.text[:200]!r}"
+                    except Exception:
+                        pass
+                self._log(f"<< network/decode error (attempt {attempt + 1}/3): {exc}{snippet} -- retrying")
                 time.sleep((2 ** attempt) + random.uniform(0, 1))
         else:
-            # Exhausted retries — surface the last transient failure.
+            # Exhausted retries — surface the last transient failure with method context.
+            if isinstance(last_exc, json.JSONDecodeError):
+                snippet = ""
+                try:
+                    if resp is not None:
+                        snippet = f" body[:200]={resp.text[:200]!r}"
+                except Exception:
+                    pass
+                raise McpError(f"JSON decode failed on {method}{snippet}") from last_exc
             raise last_exc if last_exc else McpError(f"transport failure on {method}")
 
         self._log(f"<< {json.dumps(data)[:500]}")
@@ -333,8 +353,8 @@ class TestRunner:
         """Delete a rule, swallowing errors."""
         try:
             self.client.call_tool("delete_rule", {"ruleId": rule_id, "confirm": True})
-        except Exception:
-            pass
+        except Exception as exc:
+            print(f"[WARN] _delete_rule_safe({rule_id}) failed: {exc}")
         if rule_id in self.created_rule_ids:
             self.created_rule_ids.remove(rule_id)
 
@@ -354,8 +374,8 @@ class TestRunner:
             self.client.call_tool("manage_hub_variables", {
                 "tool": "delete_variable", "args": {"name": name, "confirm": True},
             })
-        except Exception:
-            pass
+        except Exception as exc:
+            print(f"[WARN] _delete_variable_safe({name}) failed: {exc}")
         if name in self.created_variable_names:
             self.created_variable_names.remove(name)
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -63,7 +63,17 @@ class HubitatMcpClient:
     def __init__(self, hub_url: str, app_id: str, access_token: str, verbose: bool = False):
         self.hub_url = hub_url.rstrip("/")
         self.app_id = app_id
-        self.endpoint = f"{self.hub_url}/apps/api/{app_id}/mcp"
+        # Hubitat URL conventions differ between local hub and Hubitat cloud:
+        #   Local: http://<hub-ip>/apps/api/<id>/mcp?access_token=...
+        #   Cloud: https://cloud.hubitat.com/api/<UUID>/apps/<id>/mcp?access_token=...
+        # In the cloud form, hub_url already includes /api/<UUID>/, so the
+        # path under the app is just /apps/<id>/<endpoint> (no extra /api/).
+        # Detect cloud by the cloud.hubitat.com host marker and adjust.
+        if "cloud.hubitat.com" in self.hub_url:
+            self._app_path_prefix = f"{self.hub_url}/apps/{app_id}"
+        else:
+            self._app_path_prefix = f"{self.hub_url}/apps/api/{app_id}"
+        self.endpoint = f"{self._app_path_prefix}/mcp"
         self.access_token = access_token
         self.verbose = verbose
         self._request_id = 0
@@ -144,7 +154,7 @@ class HubitatMcpClient:
 
     def get_health(self) -> dict:
         """GET the /health REST endpoint (not JSON-RPC)."""
-        url = f"{self.hub_url}/apps/api/{self.app_id}/health"
+        url = f"{self._app_path_prefix}/health"
         resp = requests.get(url, params={"access_token": self.access_token}, timeout=15)
         resp.raise_for_status()
         return resp.json()

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -320,8 +320,11 @@ class TestRunner:
 
     def _delete_variable_safe(self, name: str) -> None:
         try:
+            # confirm=true is required by Hub Admin Write gate; without it the
+            # delete is silently skipped (try/except swallows the refusal),
+            # leaving the variable stranded.
             self.client.call_tool("manage_hub_variables", {
-                "tool": "delete_variable", "args": {"name": name},
+                "tool": "delete_variable", "args": {"name": name, "confirm": True},
             })
         except Exception:
             pass
@@ -991,7 +994,238 @@ class TestRunner:
         assert result is not None, "list_rooms returned None"
 
     # -----------------------------------------------------------------------
-    # GROUP 10: error_verification (1 test)
+    # GROUP 10: developer_mode (10 tests — Section 12 of BAT-v2.md + review-fix coverage)
+    # -----------------------------------------------------------------------
+    # Preconditions (provided by .github/scripts/mcp_setup_env.sh in CI, or
+    # set manually for local runs):
+    #   - enableDeveloperMode: true   (UI-only to enable; lockout protection)
+    #   - enableHubAdminWrite: true   (UI-only to enable)
+    #   - lastBackupTimestamp within 24h
+    #   - enableRuleEngine, enableHubAdminRead, enableBuiltinAppRead: true
+    #
+    # T219 (toggle-OFF refusal) is omitted — would require briefly disabling
+    # Developer Mode via UI, which CI can't do (toggle excluded from
+    # update_mcp_settings allowlist by design). Covered by ToolUpdateMcpSettingsSpec
+    # at the unit level + manual BAT.
+
+    @test("developer_mode")
+    def test_t220_update_mcp_settings_boolean_flip(self) -> None:
+        """T220: update_mcp_settings flips a boolean setting end-to-end."""
+        # Capture initial value so we can restore.
+        info = self.client.call_tool("get_hub_info")
+        # debugLogging isn't surfaced in get_hub_info; just round-trip through
+        # update_mcp_settings — true → false → true and assert success each time.
+        for value in (True, False, True):
+            result = self.client.call_tool("manage_mcp_self", {
+                "tool": "update_mcp_settings",
+                "args": {"settings": {"debugLogging": value}, "confirm": True},
+            })
+            assert result.get("success") is True, f"flip to {value} did not succeed: {result}"
+            assert result.get("updated") == {"debugLogging": value}, f"updated field mismatch for {value}: {result}"
+            assert "Updated 1 setting" in (result.get("message") or ""), f"message missing 'Updated 1 setting': {result}"
+
+    @test("developer_mode")
+    def test_t221_update_mcp_settings_allowlist_rejection(self) -> None:
+        """T221: rejects setting outside the allowlist (enableHubAdminWrite is excluded)."""
+        try:
+            self.client.call_tool("manage_mcp_self", {
+                "tool": "update_mcp_settings",
+                "args": {"settings": {"enableHubAdminWrite": False}, "confirm": True},
+            })
+            assert False, "Expected -32602 rejection for enableHubAdminWrite (footgun)"
+        except McpError as e:
+            msg = str(e)
+            assert "enableHubAdminWrite" in msg, f"error didn't mention the rejected key: {msg}"
+            assert "not allowed" in msg, f"error didn't say 'not allowed': {msg}"
+            # Should list allowed keys for caller to correct
+            assert "Allowed:" in msg or "mcpLogLevel" in msg, f"error didn't list allowed keys: {msg}"
+
+    @test("developer_mode")
+    def test_t222_atomic_batch_one_bad_key_blocks_all(self) -> None:
+        """T222: a single bad key in a multi-key batch rejects the whole batch (no partial writes)."""
+        # Capture pre-state: read debugLogging via update_mcp_settings round-trip
+        # is not feasible from this side, so assert via behavior — flip debugLogging
+        # to a known value first (true), then attempt mixed-batch with a bad key,
+        # then verify debugLogging is STILL true (i.e., the OTHER keys did not flip).
+        self.client.call_tool("manage_mcp_self", {
+            "tool": "update_mcp_settings",
+            "args": {"settings": {"debugLogging": True}, "confirm": True},
+        })
+        # Mixed batch: one valid (debugLogging=false), one invalid (enableHubAdminWrite).
+        try:
+            self.client.call_tool("manage_mcp_self", {
+                "tool": "update_mcp_settings",
+                "args": {
+                    "settings": {"debugLogging": False, "enableHubAdminWrite": False},
+                    "confirm": True,
+                },
+            })
+            assert False, "Expected mixed batch to be rejected atomically"
+        except McpError:
+            pass
+        # debugLogging should STILL be true — flip again with that single key
+        # and assert no-op-like success (atomic validation prevented partial write).
+        # Best assertion we can make from outside: after a mixed-batch reject,
+        # writing the same value again should still succeed.
+        result = self.client.call_tool("manage_mcp_self", {
+            "tool": "update_mcp_settings",
+            "args": {"settings": {"debugLogging": True}, "confirm": True},
+        })
+        assert result.get("success") is True, f"post-rejection write didn't succeed: {result}"
+
+    @test("developer_mode")
+    def test_t223_update_mcp_settings_reconnect_hint(self) -> None:
+        """T223: response message includes a client-reconnect hint."""
+        result = self.client.call_tool("manage_mcp_self", {
+            "tool": "update_mcp_settings",
+            "args": {"settings": {"enableRuleEngine": False}, "confirm": True},
+        })
+        assert result.get("success") is True
+        msg = result.get("message") or ""
+        assert "reconnect" in msg.lower(), f"message missing 'reconnect' hint: {msg}"
+        assert "tool schemas" in msg, f"message missing 'tool schemas' phrase: {msg}"
+        # Restore so the rest of the suite (rule_crud etc.) keeps working.
+        restore = self.client.call_tool("manage_mcp_self", {
+            "tool": "update_mcp_settings",
+            "args": {"settings": {"enableRuleEngine": True}, "confirm": True},
+        })
+        assert restore.get("success") is True
+
+    @test("developer_mode")
+    def test_t224_delete_variable_round_trip(self) -> None:
+        """T224: set → delete → verify gone."""
+        var_name = f"{PREFIX}DELETE_T224"
+        # Setup
+        self.client.call_tool("manage_hub_variables", {
+            "tool": "set_variable",
+            "args": {"name": var_name, "value": "scratch-t224"},
+        })
+        # Track for cleanup in case assertion fails partway
+        self.created_variable_names.append(var_name)
+        # Delete
+        result = self.client.call_tool("manage_hub_variables", {
+            "tool": "delete_variable",
+            "args": {"name": var_name, "confirm": True},
+        })
+        assert result.get("success") is True
+        assert result.get("deleted") is True
+        assert result.get("source") == "rule_engine"
+        assert result.get("previousValue") == "scratch-t224"
+        assert result.get("brokenConsumers") is None  # no rules reference this var
+        # Verify gone
+        try:
+            self.client.call_tool("manage_hub_variables", {
+                "tool": "get_variable",
+                "args": {"name": var_name},
+            })
+            assert False, f"{var_name} should not be retrievable after delete"
+        except McpError as e:
+            assert "not found" in str(e).lower(), f"unexpected error after delete: {e}"
+        # Don't double-cleanup
+        if var_name in self.created_variable_names:
+            self.created_variable_names.remove(var_name)
+
+    @test("developer_mode")
+    def test_t225_delete_variable_not_in_rule_engine_namespace(self) -> None:
+        """T225: refusal with redirect-to-UI hint when name isn't in rule_engine state."""
+        # The refusal fires whether the var exists in the connector namespace or
+        # doesn't exist anywhere at all — error message text is identical.
+        try:
+            self.client.call_tool("manage_hub_variables", {
+                "tool": "delete_variable",
+                "args": {"name": f"{PREFIX}DEFINITELY_NONEXISTENT_T225", "confirm": True},
+            })
+            assert False, "Expected refusal for variable not in rule_engine namespace"
+        except McpError as e:
+            msg = str(e)
+            assert "not found in rule_engine namespace" in msg, f"wrong refusal text: {msg}"
+            assert "Settings" in msg, f"missing UI redirect hint: {msg}"
+            assert "Hub Variables" in msg, f"missing 'Hub Variables' in redirect: {msg}"
+
+    @test("developer_mode")
+    def test_t226_delete_variable_no_confirm(self) -> None:
+        """T226: delete_variable refuses when confirm flag is absent.
+
+        Note: gateway-layer parameter validation returns the refusal as
+        `isError: true` in result content (not as JSON-RPC -32602). Same
+        wire-format pattern other gateway-required-param checks use.
+        """
+        var_name = f"{PREFIX}NO_CONFIRM_T226"
+        self.client.call_tool("manage_hub_variables", {
+            "tool": "set_variable",
+            "args": {"name": var_name, "value": "safe"},
+        })
+        self.created_variable_names.append(var_name)
+        result = self.client.call_tool("manage_hub_variables", {
+            "tool": "delete_variable",
+            "args": {"name": var_name},  # no confirm
+        })
+        assert result.get("isError") is True, f"Expected isError result for missing confirm: {result}"
+        assert "confirm" in str(result.get("error", "")).lower(), f"refusal didn't mention confirm: {result}"
+        # Variable should still exist
+        verify = self.client.call_tool("manage_hub_variables", {
+            "tool": "get_variable",
+            "args": {"name": var_name},
+        })
+        assert verify.get("value") == "safe", f"variable was deleted despite missing confirm: {verify}"
+
+    @test("developer_mode")
+    def test_per_key_mcplogs_validation_atomic(self) -> None:
+        """Atomic rejection — bad mcpLogLevel in a mixed batch with debugLogging blocks both."""
+        # Set known baseline for debugLogging (true) — needs to NOT change despite the bad key.
+        self.client.call_tool("manage_mcp_self", {
+            "tool": "update_mcp_settings",
+            "args": {"settings": {"debugLogging": True}, "confirm": True},
+        })
+        try:
+            self.client.call_tool("manage_mcp_self", {
+                "tool": "update_mcp_settings",
+                "args": {
+                    "settings": {"debugLogging": False, "mcpLogLevel": "blarg"},
+                    "confirm": True,
+                },
+            })
+            assert False, "Expected -32602 rejection for mcpLogLevel='blarg'"
+        except McpError as e:
+            msg = str(e)
+            assert "mcpLogLevel" in msg, f"error didn't mention mcpLogLevel: {msg}"
+            assert "blarg" in msg, f"error didn't surface the rejected value: {msg}"
+
+    @test("developer_mode")
+    def test_type_coercion_string_to_bool(self) -> None:
+        """Type coercion — JSON-RPC clients sending string 'true'/'false' get coerced to native bool."""
+        # JSON in this test runner naturally encodes Python bool as JSON true/false,
+        # so to actually exercise the coercion path we have to send a string literal.
+        result = self.client.call_tool("manage_mcp_self", {
+            "tool": "update_mcp_settings",
+            "args": {"settings": {"debugLogging": "false"}, "confirm": True},
+        })
+        assert result.get("success") is True
+        # Re-read via a write that should be a no-op if coercion landed correctly:
+        # writing native False should also succeed and round-trip cleanly.
+        result2 = self.client.call_tool("manage_mcp_self", {
+            "tool": "update_mcp_settings",
+            "args": {"settings": {"debugLogging": True}, "confirm": True},
+        })
+        assert result2.get("success") is True
+        assert result2.get("updated") == {"debugLogging": True}
+
+    @test("developer_mode")
+    def test_type_coercion_rejects_invalid_bool_string(self) -> None:
+        """Type coercion — strings that aren't 'true'/'false' get rejected, not silently coerced."""
+        try:
+            self.client.call_tool("manage_mcp_self", {
+                "tool": "update_mcp_settings",
+                "args": {"settings": {"debugLogging": "yes"}, "confirm": True},
+            })
+            assert False, "Expected rejection for ambiguous bool-coerced string 'yes'"
+        except McpError as e:
+            msg = str(e)
+            assert "debugLogging" in msg, f"error didn't mention the key: {msg}"
+            assert "boolean" in msg.lower(), f"error didn't say boolean: {msg}"
+
+    # -----------------------------------------------------------------------
+    # GROUP 11: error_verification (1 test)
     # -----------------------------------------------------------------------
 
     @test("error_verification")
@@ -1061,7 +1295,7 @@ class TestRunner:
                 print(f"  Deleting tracked variable {var_name}")
                 self.client.call_tool("manage_hub_variables", {
                     "tool": "delete_variable",
-                    "args": {"name": var_name},
+                    "args": {"name": var_name, "confirm": True},
                 })
             except Exception as exc:
                 print(f"  [WARN] Failed to delete variable {var_name}: {exc}")

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import random
 import sys
 import time
 from datetime import datetime, timezone
@@ -121,7 +122,9 @@ class HubitatMcpClient:
                     # queries (e.g. get_performance_stats) sometimes 504.
                     last_exc = requests.HTTPError(f"{resp.status_code} {resp.reason} on {method}")
                     self._log(f"<< HTTP {resp.status_code} (attempt {attempt + 1}/3) — retrying")
-                    time.sleep(2 ** attempt)  # 1s, 2s, 4s
+                    # Exponential backoff with jitter to avoid thundering-herd if
+                    # multiple consumers ever retry simultaneously.
+                    time.sleep((2 ** attempt) + random.uniform(0, 1))  # ~1-2s, ~2-3s, ~4-5s
                     continue
                 resp.raise_for_status()
                 data = resp.json()
@@ -129,7 +132,7 @@ class HubitatMcpClient:
             except (requests.ConnectionError, requests.Timeout, requests.exceptions.ChunkedEncodingError) as exc:
                 last_exc = exc
                 self._log(f"<< network error (attempt {attempt + 1}/3): {exc} — retrying")
-                time.sleep(2 ** attempt)
+                time.sleep((2 ** attempt) + random.uniform(0, 1))
         else:
             # Exhausted retries — surface the last transient failure.
             raise last_exc if last_exc else McpError(f"transport failure on {method}")


### PR DESCRIPTION
## Background

Per the conversation in #77, this builds tier-3 E2E against a real donated test hub rather than the originally-scoped fake-hub fixture server. The maintainer's three concerns from that thread — cleanup, concurrency, hub overload — are addressed inline below.

## Summary

- New `Hub E2E (test hub)` GitHub Actions workflow that runs `tests/e2e_test.py` against a real Hubitat hub donated for CI use (the `LEVEL99_TEST_HUB_MCP_URL` repo secret). **Advisory-only** — never blocks PR merges, hub flakiness shouldn't gate the codebase.
- Self-configuring: workflow captures the test hub's pre-run toggle state, enables the gates the test suite needs (`enableRuleEngine`, `enableHubAdminRead`, `enableBuiltinAppRead`), runs tests, restores the captured state on exit. Uses `update_mcp_settings` from #145 (Developer Mode).
- 10 new code-level e2e tests under group `developer_mode` covering BAT-v2 Section 12 (T220–T226 from #145) plus review-cycle behaviors (atomic per-key validation, type coercion).
- Retry-on-transient-errors in the JSON-RPC client so single 5xx flakes from the cloud relay don't fail an otherwise-clean run.
- Soft-lease coordination: workflow claims a 30-min Hub Variable lease on the shared test hub before any state-changing op, releases on exit. Prevents two consumers (manual sessions or parallel CI runs) from trampling each other's state.

Closes #77.

## Changes

**Maps to the maintainer's three concerns from #77:**

| #77 concern | This PR's mitigation |
|---|---|
| Cleanup after each CI run | `BAT_E2E_` prefix on every test artifact + dedicated `if: always()` cleanup step (`python tests/e2e_test.py --cleanup-only`) |
| Concurrency (CI↔CI + CI↔manual) | GitHub Actions `concurrency: hub-e2e` group serializes parallel runs (free, native). Soft-lease via `_TEST_HUB_LEASED_BY` Hub Variable for CI↔manual coordination — matches the JSON-shape protocol level99's local agent already honors. 30-min sliding TTL, auto-expiry on crashed runs. |
| Hub overload | Existing 0.2s base sleep between every JSON-RPC call. New retry-on-5xx with 1s/2s/4s backoff. Per-request timeout extended 30s → 60s for slow stats queries. |

**New workflow + scripts:**
- `.github/workflows/hub-e2e.yml` — runs on `pull_request` (paths-filtered to source + test files) and `workflow_dispatch`. Lease release + state restore + artifact cleanup all run in `if: always()` so a crashed test still cleans up. 30-minute job timeout matches the lease TTL.
- `.github/scripts/lease_acquire.sh` / `lease_release.sh` — soft-lease via `_TEST_HUB_LEASED_BY` Hub Variable. Includes post-write race verify so concurrent claimants can't both think they won.
- `.github/scripts/mcp_setup_env.sh` / `mcp_restore_env.sh` — capture pre-run toggle state to `$RUNNER_TEMP/mcp_pre_state.json`, enable the test-required toggles, restore on exit. Setup aborts with a focused error if Developer Mode itself is off (UI-only to enable, by lockout-protection design — `enableDeveloperMode` is excluded from the `update_mcp_settings` allowlist).

**Source change in support of state capture:**
- `hubitat-mcp-server.groovy`: `get_hub_info` and `get_hub_details` now expose `ruleEngineEnabled` alongside the existing `hubAdminReadEnabled` / `hubAdminWriteEnabled` / `builtinAppReadEnabled` / `developerModeEnabled` fields. Without this, the setup script can't tell whether the rule engine was originally on or off.

**`tests/e2e_test.py`:**
- New `developer_mode` group, 10 tests covering BAT-v2 Section 12:
  - T220 boolean flip end-to-end
  - T221 allowlist rejection (`enableHubAdminWrite` is intentionally excluded)
  - T222 atomic batch (one bad key blocks the entire batch — no partial writes)
  - T223 reconnect hint in response message
  - T224 `delete_variable` round-trip with audit log
  - T225 connector-namespace refusal (redirect to UI)
  - T226 missing-confirm refusal (gateway-layer parameter check)
- Plus 3 review-cycle behaviors not in BAT-v2:
  - per-key `mcpLogLevel='blarg'` rejection (atomic validation in mixed batch)
  - type coercion for string-encoded booleans (`"true"` → native `True`)
  - rejection of ambiguous strings (`"yes"` for a bool setting)
- T219 (toggle-OFF refusal) omitted — would require briefly disabling Developer Mode, which CI can't do programmatically (lockout protection by design). Covered by `ToolUpdateMcpSettingsSpec.toggle-off path through handleToolsCall returns clean -32602` at the unit level + manual BAT-v2 T219 for live runs.
- Cloud URL pattern fix in `HubitatMcpClient.__init__`: cloud format is `/apps/<id>/...`, local is `/apps/api/<id>/...`. Detected by host marker.
- Retry-on-transient-errors in `_send()`: 3 attempts with 1s/2s/4s backoff for 5xx + network errors only. Never retries on 4xx (real auth/request errors must surface) or on JSON-RPC error responses (intentional tool errors we want to test). Per-request timeout extended 30s → 60s for slow stats queries.
- Tool count assertion bumped to 34 (was 33) reflecting the `manage_mcp_self` gateway from #145.
- Two pre-existing bugs in the variable-cleanup framework fixed: `_delete_variable_safe` and the main cleanup phase were calling `delete_variable` without `confirm=true`, so the Hub Admin Write gate refused and the try/except silently swallowed it, leaving variables stranded after every test that used the helper.

**`tests/BAT-v2.md`:**
- Section 12 T226 Expected text corrected: gateway parameter validation returns `isError: true` in the result body, not as JSON-RPC -32602. Both this PR's e2e test AND a parallel agent-driven BAT run independently confirmed the actual wire format.

## Testing

**Live runs against the test hub via the cloud-URL secret path, in this branch's HEAD CI run (`workflow_dispatch` ID `25326103265`):**
- 66/66 tests passed in 110.2s end-to-end
- Workflow's 12 steps all green: lease acquire → setup (capture pre-state + enable toggles) → run tests → cleanup → restore → lease release
- All 10 `developer_mode` tests passed
- All 12 `system_tools` tests passed (the prior run's flaky 504 on `get_performance_stats` was caught by the retry logic and recovered cleanly)

**Local validation against the test hub:**
- 10/10 `developer_mode` group tests passed in 8.1s
- Setup/restore scripts validated end-to-end with deliberate baseline-flip-restore cycle (set toggles to false → setup captures false → setup overrides to true → restore brings them back to false)

**Agent-driven BAT-v2 Section 12 run (parallel to the e2e validation):**
- 7/7 scenarios T220–T226 passed (a fresh Sonnet agent ran the test_prompts cold, discovered the right MCP tools, captured responses, verified against Expected). One scenario (T226) flagged the wire-format deviation that's now reflected in the BAT-v2 prose correction in this PR.
- T219 not run live (UI toggle off required); covered by spec.

**Sandbox lint:** clean.

## Checklist

- [x] **Unit tests added for any new MCP tools** (no new tools — workflow tooling only)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally
- [x] Live-hub BAT tests updated (BAT-v2 Section 12 T226 prose corrected)
- [x] Documentation updated (BAT-v2 + e2e_test.py docstrings)

## Release notes

Adds an advisory CI workflow that runs `tests/e2e_test.py` against a real Hubitat hub on every PR (closes #77). Self-configuring via `update_mcp_settings` (from v0.11.0 Developer Mode): captures the test hub's pre-run toggle state, enables required gates for the test run, restores on exit. Coordinates concurrent CI/manual access to the shared test hub via a 30-minute soft lease on a Hub Variable. Adds 10 new `developer_mode` e2e tests covering BAT-v2 Section 12 plus the review-cycle behaviors from PR #145. Includes per-request retry-on-transient-errors so single cloud-relay 5xx flakes don't fail otherwise-clean runs.
