### PR TITLE
feat: integrate ICMP ping into device_health_check (#91)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ Use `atomicState` for thread-safe persistence, `state` for UI/counters. Compare 
 
 **Comments**: only when the WHY is non-obvious. No multi-paragraph docblocks. Don't reference the current PR/issue/caller.
 
+## The custom MCP rule engine is legacy
+
+`hubitat-mcp-rule.groovy` (the MCP child app, surfaced through the `custom_*` tools) is **legacy**. It still ships and still gets bug fixes, but it is **closed to new feature work** — Hubitat's native Rule Machine is the supported path now and exposes equivalent functionality through `create_native_app` / `update_native_app` / `delete_native_app` and the rest of the `manage_native_rules_and_apps` group. New rule-related capabilities should land on the parent app's native-RM tools, not on the child app. If a feature request lands on the child app, propose it for the native side instead.
+
 ## PR workflow
 
 Use `.github/pull_request_template.md` — keep every section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,10 @@ Use `atomicState` for thread-safe persistence, `state` for UI/counters. Compare 
 
 **Comments**: only when the WHY is non-obvious. No multi-paragraph docblocks. Don't reference the current PR/issue/caller.
 
+## The custom MCP rule engine is legacy
+
+`hubitat-mcp-rule.groovy` (the MCP child app, surfaced through the `custom_*` tools) is **legacy**. It still ships and still gets bug fixes, but it is **closed to new feature work** — Hubitat's native Rule Machine is the supported path now and exposes equivalent functionality through `create_native_app` / `update_native_app` / `delete_native_app` and the rest of the `manage_native_rules_and_apps` group. New rule-related capabilities should land on the parent app's native-RM tools, not on the child app. If a feature request lands on the child app, propose it for the native side instead.
+
 ## PR workflow
 
 Use `.github/pull_request_template.md` — keep every section.

--- a/futureplans.md
+++ b/futureplans.md
@@ -179,14 +179,8 @@
   > 2. Reuse `rampValue()` utility from fade actions
   > 3. For devices with `startLevelChange`/`stopLevelChange`, offer a hardware ramp option
 
-- [ ] **Ping IP address (ICMP)** — `Difficulty: 1 | Effort: S`
-  > *Feasible — native ICMP supported from apps.* Hubitat exposes `hubitat.helper.NetworkUtils.ping(String ipAddress, Integer count)` to both apps and drivers per the [NetworkUtils docs](https://docs2.hubitat.com/en/developer/networkutils-object). Returns a `PingData` object with `rttAvg/rttMin/rttMax` (ms), `packetsTransmitted`, `packetsReceived`, and `packetLoss`. The earlier "no ICMP in the sandbox" framing was incorrect — no driver, `HubAction`, or `Runtime.exec()` needed. Default count is 3, max is 5.
-  >
-  > **Implementation plan:**
-  > 1. Add a `ping_host` MCP tool that accepts `ipAddress` and optional `count`, returns the full PingData map
-  > 2. Add a `ping_host` rule action type that stores result fields (`reachable`, `rttAvg`, `packetLoss`) into rule/local variables for use in conditions
-  > 3. Add `host_reachable` / `host_unreachable` as `ping_host` shortcut conditions (or just rely on variable conditions)
-  > 4. Validate `ipAddress` as a string before the call; surface platform errors as tool/action failure messages
+- [x] **Ping IP address (ICMP)** — folded into `device_health_check` (issue #91).
+  > Rather than a standalone `ping_host` tool, ICMP ping was integrated into the existing `device_health_check` tool via `pingHosts` (max 5 IPv4) and `pingCount` (1–5) parameters. Each host is pinged through `hubitat.helper.NetworkUtils.ping()` and reported under `pingResults` with `reachable`, `rttAvg`, `rttMin`, `rttMax`, `packetsTransmitted`, `packetsReceived`, `packetLoss`. The custom MCP rule engine is legacy-only, so no rule-action half was added.
 
 - [ ] **HTTP reachability check** — `Difficulty: 3 | Effort: M`
   > *Feasible — complementary to ICMP ping above.* An HTTP GET against a target URL still has value for hosts that don't respond to ICMP or when you need to verify HTTP-layer health, not just network reachability. Keep as a secondary action type alongside the native ping.
@@ -614,7 +608,7 @@
 ### Phase 1: Quick Wins (Small effort, high value)
 1. **Rule Machine Interoperability** (list, control, trigger, booleans) — All use `RMUtils`, implement as 1–2 tools
 2. **Native hub variable change triggers** — `subscribe(location, "variable:<name>", handler)` + `addInUseGlobalVar()` registration
-3. **ICMP ping tool + rule action** — `hubitat.helper.NetworkUtils.ping(ip, count)` returns PingData directly
+3. **ICMP ping** — done; folded into `device_health_check` via `pingHosts`/`pingCount` (issue #91)
 4. **Search HPM repositories** — Public GraphQL API, immediate discovery value
 5. **Rate limiting / throttling** — Pure in-app logic, enables safer notifications
 6. **System start trigger** — Single `subscribe()` call

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6940,8 +6940,16 @@ def toolDeviceHealthCheck(args) {
     def staleHours = args.staleHours ?: 24
     def includeHealthy = args.includeHealthy ?: false
     def pingHosts = (args.pingHosts ?: []) as List
-    // ?: treats explicit 0 as absent, so distinguish null from 0 here.
-    def pingCount = (args.pingCount == null ? 3 : args.pingCount) as Integer
+    // ?: treats explicit 0 as absent, so distinguish null from 0 here. Accept Number to keep
+    // the friendly "between 1 and 5" message for non-numeric input instead of a cast exception.
+    def pingCount
+    if (args.pingCount == null) {
+        pingCount = 3
+    } else if (args.pingCount instanceof Number) {
+        pingCount = ((Number) args.pingCount).intValue()
+    } else {
+        throw new IllegalArgumentException("pingCount must be an integer between 1 and 5 (got ${args.pingCount})")
+    }
 
     if (pingHosts.size() > 5) {
         throw new IllegalArgumentException("pingHosts is limited to 5 entries per call (got ${pingHosts.size()})")
@@ -7045,19 +7053,24 @@ def toolDeviceHealthCheck(args) {
 def runPingChecks(List rawHosts, Integer count) {
     def results = []
     rawHosts.each { rawHost ->
-        def host = rawHost?.toString()?.trim()
+        if (rawHost == null || !(rawHost instanceof CharSequence)) {
+            results << [ipAddress: rawHost, reachable: false, error: "missing or non-string host"]
+            return
+        }
+        def host = rawHost.toString().trim()
         // IPv4 dotted-quad shape only; NetworkUtils.ping rejects out-of-range itself, hostnames not supported by the API.
-        if (!host || !(host ==~ /^(?:\d{1,3}\.){3}\d{1,3}$/)) {
-            results << [ipAddress: rawHost, reachable: false, error: "invalid IPv4 address"]
+        if (!(host ==~ /^(?:\d{1,3}\.){3}\d{1,3}$/)) {
+            results << [ipAddress: rawHost, reachable: false, error: "not a dotted-quad IPv4 literal (hostnames not supported, pass an IP)"]
             return
         }
         try {
             def pd = hubitat.helper.NetworkUtils.ping(host, count)
-            def transmitted = (pd?.packetsTransmitted ?: count) as Integer
-            def received = (pd?.packetsReceived ?: 0) as Integer
+            // Explicit null guards (not ?:) so a real platform-reported 0 is preserved.
+            def transmitted = (pd?.packetsTransmitted == null ? count : pd.packetsTransmitted) as Integer
+            def received = (pd?.packetsReceived == null ? 0 : pd.packetsReceived) as Integer
             results << [
                 ipAddress: host,
-                reachable: received > 0,
+                reachable: transmitted > 0 && received > 0,
                 packetsTransmitted: transmitted,
                 packetsReceived: received,
                 packetLoss: pd?.packetLoss,
@@ -7066,8 +7079,13 @@ def runPingChecks(List rawHosts, Integer count) {
                 rttMax: pd?.rttMax
             ]
         } catch (Exception e) {
-            mcpLog("warn", "monitoring", "ping failed for ${host}: ${e.message}")
-            results << [ipAddress: host, reachable: false, error: e.message ?: e.toString()]
+            def errorType
+            if (e instanceof java.net.UnknownHostException) errorType = "unknown_host"
+            else if (e instanceof java.net.SocketException) errorType = "socket"
+            else if (e instanceof SecurityException) errorType = "security"
+            else errorType = "other"
+            mcpLog("warn", "monitoring", "ping failed for ${host} (count=${count}, type=${errorType}): ${e.message}")
+            results << [ipAddress: host, reachable: false, errorType: errorType, error: e.message ?: e.toString()]
         }
     }
     return results

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -647,7 +647,7 @@ def getGatewayConfig() {
                 get_set_hub_metrics: "Record/retrieve hub metrics (memory, temp, DB) with CSV trend history. Args: recordSnapshot, trendPoints",
                 get_memory_history: "Get free OS memory and CPU load history. Returns most recent entries with summary stats. Args: limit (default 100, 0 for all). Requires Hub Admin Read",
                 force_garbage_collection: "Force JVM garbage collection to reclaim memory. Returns before/after free memory. Requires Hub Admin Read",
-                device_health_check: "Check all devices for stale/offline status",
+                device_health_check: "Check device staleness and/or ICMP-ping arbitrary IPs (router, NAS, server). Args: staleHours, includeHealthy, pingHosts (max 5 IPv4), pingCount (1-5)",
                 custom_get_rule_diagnostics: "Comprehensive rule diagnostics. Args: ruleId",
                 get_zwave_details: "Z-Wave radio info (firmware, SDK, device count). Requires Hub Admin Read",
                 get_zigbee_details: "Zigbee radio info (channel, PAN ID, device count). Requires Hub Admin Read",
@@ -660,7 +660,7 @@ def getGatewayConfig() {
                 get_set_hub_metrics: "temperature database size trending monitoring over time",
                 get_memory_history: "ram free used leak trending over time java heap nio",
                 force_garbage_collection: "free reclaim ram cleanup java heap",
-                device_health_check: "stale offline dead unresponsive battery not reporting",
+                device_health_check: "stale offline dead unresponsive battery not reporting ping icmp reachable network ip lan host router gateway",
                 custom_get_rule_diagnostics: "automation troubleshoot broken not working debug why",
                 get_zwave_details: "zwave mesh network frequency firmware 908mhz 700 800 series",
                 get_zigbee_details: "zigbee mesh network channel pan coordinator 2400mhz",
@@ -1403,12 +1403,14 @@ Verify rule after creation.""",
         ],
         [
             name: "device_health_check",
-            description: "Check all MCP devices for stale/offline status based on last activity threshold.",
+            description: "Check device staleness and (optionally) ICMP-ping arbitrary hosts. Stale check flags MCP devices with no activity in staleHours. Ping check uses hubitat.helper.NetworkUtils.ping() to verify network reachability of any IPs in pingHosts (router, NAS, server, LAN-attached devices). Either or both may be used in a single call.",
             inputSchema: [
                 type: "object",
                 properties: [
                     staleHours: [type: "integer", description: "Flag devices with no activity in this many hours. Default: 24.", default: 24],
-                    includeHealthy: [type: "boolean", description: "Include healthy devices in the response (can be large). Default: false.", default: false]
+                    includeHealthy: [type: "boolean", description: "Include healthy devices in the response (can be large). Default: false.", default: false],
+                    pingHosts: [type: "array", items: [type: "string"], description: "Optional IPv4 addresses to ICMP-ping (max 5 per call). Each entry is sent through hubitat.helper.NetworkUtils.ping() and reported under pingResults with reachable/rttAvg/packetLoss. Hostnames are not resolved — pass IPs only."],
+                    pingCount: [type: "integer", description: "Packets to send per host (1-5). Default: 3.", default: 3]
                 ]
             ]
         ],
@@ -6935,12 +6937,30 @@ def toolForceGarbageCollection(args) {
 }
 
 def toolDeviceHealthCheck(args) {
-    if (!settings.selectedDevices) {
-        return [message: "No devices selected for MCP access", summary: [totalDevices: 0, healthyCount: 0, staleCount: 0, unknownCount: 0]]
-    }
-
     def staleHours = args.staleHours ?: 24
     def includeHealthy = args.includeHealthy ?: false
+    def pingHosts = (args.pingHosts ?: []) as List
+    // ?: treats explicit 0 as absent, so distinguish null from 0 here.
+    def pingCount = (args.pingCount == null ? 3 : args.pingCount) as Integer
+
+    if (pingHosts.size() > 5) {
+        throw new IllegalArgumentException("pingHosts is limited to 5 entries per call (got ${pingHosts.size()})")
+    }
+    if (pingCount < 1 || pingCount > 5) {
+        throw new IllegalArgumentException("pingCount must be between 1 and 5 (got ${pingCount})")
+    }
+
+    def pingResults = pingHosts ? runPingChecks(pingHosts, pingCount) : null
+
+    if (!settings.selectedDevices) {
+        def emptyResult = [
+            message: "No devices selected for MCP access",
+            summary: [totalDevices: 0, healthyCount: 0, staleCount: 0, unknownCount: 0]
+        ]
+        if (pingResults != null) emptyResult.pingResults = pingResults
+        return emptyResult
+    }
+
     def staleThreshold = now() - (staleHours * 3600000L)
 
     def healthy = []
@@ -7014,8 +7034,43 @@ def toolDeviceHealthCheck(args) {
             "Use 'get_device' on individual devices for more details."
     }
 
+    if (pingResults != null) {
+        result.pingResults = pingResults
+    }
+
     mcpLog("info", "monitoring", "Device health check: ${healthy.size()} healthy, ${stale.size()} stale, ${unknown.size()} unknown (threshold: ${staleHours}h)")
     return result
+}
+
+def runPingChecks(List rawHosts, Integer count) {
+    def results = []
+    rawHosts.each { rawHost ->
+        def host = rawHost?.toString()?.trim()
+        // IPv4 dotted-quad shape only; NetworkUtils.ping rejects out-of-range itself, hostnames not supported by the API.
+        if (!host || !(host ==~ /^(?:\d{1,3}\.){3}\d{1,3}$/)) {
+            results << [ipAddress: rawHost, reachable: false, error: "invalid IPv4 address"]
+            return
+        }
+        try {
+            def pd = hubitat.helper.NetworkUtils.ping(host, count)
+            def transmitted = (pd?.packetsTransmitted ?: count) as Integer
+            def received = (pd?.packetsReceived ?: 0) as Integer
+            results << [
+                ipAddress: host,
+                reachable: received > 0,
+                packetsTransmitted: transmitted,
+                packetsReceived: received,
+                packetLoss: pd?.packetLoss,
+                rttAvg: pd?.rttAvg,
+                rttMin: pd?.rttMin,
+                rttMax: pd?.rttMax
+            ]
+        } catch (Exception e) {
+            mcpLog("warn", "monitoring", "ping failed for ${host}: ${e.message}")
+            results << [ipAddress: host, reachable: false, error: e.message ?: e.toString()]
+        }
+    }
+    return results
 }
 
 // ==================== HUB ADMIN WRITE TOOL IMPLEMENTATIONS ====================

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -7058,9 +7058,9 @@ def runPingChecks(List rawHosts, Integer count) {
             return
         }
         def host = rawHost.toString().trim()
-        // IPv4 dotted-quad shape only; NetworkUtils.ping rejects out-of-range itself, hostnames not supported by the API.
-        if (!(host ==~ /^(?:\d{1,3}\.){3}\d{1,3}$/)) {
-            results << [ipAddress: rawHost, reachable: false, error: "not a dotted-quad IPv4 literal (hostnames not supported, pass an IP)"]
+        // Range-validated IPv4 dotted-quad. Hostnames are not supported by NetworkUtils.ping.
+        if (!(host ==~ /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/)) {
+            results << [ipAddress: host, reachable: false, error: "not a dotted-quad IPv4 literal (hostnames not supported, pass an IP)"]
             return
         }
         try {

--- a/src/main/groovy/hubitat/helper/NetworkUtils.groovy
+++ b/src/main/groovy/hubitat/helper/NetworkUtils.groovy
@@ -15,4 +15,8 @@ class NetworkUtils {
     static Object sendHubitatCommand(Map params) {
         return null
     }
+
+    static Object ping(String ipAddress, Integer count) {
+        return null
+    }
 }

--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -395,13 +395,30 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         network.install()
 
         when:
-        def result = script.toolDeviceHealthCheck([pingHosts: ['not-an-ip', '1.2.3', '999.999.999.999.x']])
+        def result = script.toolDeviceHealthCheck([pingHosts: ['not-an-ip', '1.2.3', '999.999.999.999.x', '999.999.999.999', '256.0.0.1']])
 
         then:
         network.pingCalls.isEmpty()
-        result.pingResults.size() == 3
+        result.pingResults.size() == 5
         result.pingResults.every { it.reachable == false }
         result.pingResults.every { it.error.contains('dotted-quad') && it.error.contains('hostnames not supported') }
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: trims whitespace before validation and echo"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.pingResponses['10.0.0.1'] = [packetsTransmitted: 3, packetsReceived: 3, packetLoss: 0]
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: ['  10.0.0.1  ', '  bad host  ']])
+
+        then:
+        network.pingCalls*.ipAddress == ['10.0.0.1']
+        result.pingResults*.ipAddress == ['10.0.0.1', 'bad host']
 
         cleanup:
         network.uninstall()

--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -400,7 +400,25 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         then:
         network.pingCalls.isEmpty()
         result.pingResults.size() == 3
-        result.pingResults.every { it.reachable == false && it.error == 'invalid IPv4 address' }
+        result.pingResults.every { it.reachable == false }
+        result.pingResults.every { it.error.contains('dotted-quad') && it.error.contains('hostnames not supported') }
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: null and non-string entries report a distinct error"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: [null, 12345, ['nested']]])
+
+        then:
+        network.pingCalls.isEmpty()
+        result.pingResults.size() == 3
+        result.pingResults.every { it.reachable == false && it.error == 'missing or non-string host' }
 
         cleanup:
         network.uninstall()
@@ -434,6 +452,99 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         result.pingResults.size() == 1
         result.pingResults[0].reachable == false
         result.pingResults[0].error == 'boom'
+        result.pingResults[0].errorType == 'other'
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: errorType discriminates UnknownHostException, SocketException, SecurityException"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.pingResponses['10.0.0.1'] = new java.net.UnknownHostException('no dns')
+        network.pingResponses['10.0.0.2'] = new java.net.SocketException('Network is unreachable')
+        network.pingResponses['10.0.0.3'] = new SecurityException('blocked')
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: ['10.0.0.1', '10.0.0.2', '10.0.0.3']])
+
+        then:
+        result.pingResults*.errorType == ['unknown_host', 'socket', 'security']
+        result.pingResults.every { it.reachable == false }
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: omitted pingCount forwards 3 to NetworkUtils"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.install()
+
+        when:
+        script.toolDeviceHealthCheck([pingHosts: ['10.0.0.1']])
+
+        then:
+        network.pingCalls == [[ipAddress: '10.0.0.1', count: 3]]
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: mixed valid and invalid hosts preserve input order"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.pingResponses['10.0.0.1'] = [packetsTransmitted: 3, packetsReceived: 3, packetLoss: 0, rttAvg: 1.0, rttMin: 1.0, rttMax: 1.0]
+        network.pingResponses['10.0.0.2'] = [packetsTransmitted: 3, packetsReceived: 3, packetLoss: 0, rttAvg: 2.0, rttMin: 2.0, rttMax: 2.0]
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: ['10.0.0.1', 'garbage', '10.0.0.2']])
+
+        then:
+        network.pingCalls*.ipAddress == ['10.0.0.1', '10.0.0.2']
+        result.pingResults*.ipAddress == ['10.0.0.1', 'garbage', '10.0.0.2']
+        result.pingResults[0].reachable == true
+        result.pingResults[1].reachable == false
+        result.pingResults[1].error.contains('dotted-quad')
+        result.pingResults[2].reachable == true
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: null PingData is treated as unreachable with transmitted defaulted to count"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.pingResponses['10.0.0.1'] = { ip, n -> null }
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: ['10.0.0.1'], pingCount: 4])
+
+        then:
+        result.pingResults.size() == 1
+        result.pingResults[0].reachable == false
+        result.pingResults[0].packetsTransmitted == 4
+        result.pingResults[0].packetsReceived == 0
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: zero packetsTransmitted from platform is preserved (not coerced to count)"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.pingResponses['10.0.0.1'] = [packetsTransmitted: 0, packetsReceived: 0, packetLoss: 100]
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: ['10.0.0.1'], pingCount: 5])
+
+        then:
+        result.pingResults[0].packetsTransmitted == 0
+        result.pingResults[0].reachable == false
 
         cleanup:
         network.uninstall()
@@ -447,12 +558,15 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         def tooMany = thrown(IllegalArgumentException)
         tooMany.message.contains('5 entries')
 
+        // Locks in the null-vs-0 distinction: with the prior `?: 3` bug, 0 would silently
+        // become 3 and skip this check.
         when:
         script.toolDeviceHealthCheck([pingHosts: ['1.1.1.1'], pingCount: 0])
 
         then:
         def low = thrown(IllegalArgumentException)
         low.message.contains('between 1 and 5')
+        low.message.contains('got 0')
 
         when:
         script.toolDeviceHealthCheck([pingHosts: ['1.1.1.1'], pingCount: 6])
@@ -460,6 +574,16 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         then:
         def high = thrown(IllegalArgumentException)
         high.message.contains('between 1 and 5')
+    }
+
+    def "device_health_check pingHosts: non-numeric pingCount surfaces friendly IllegalArgumentException"() {
+        when:
+        script.toolDeviceHealthCheck([pingHosts: ['1.1.1.1'], pingCount: 'three'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('integer between 1 and 5')
+        ex.message.contains('three')
     }
 
     def "device_health_check pingHosts work even when no devices are selected"() {

--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -2,6 +2,7 @@ package server
 
 import groovy.json.JsonOutput
 import spock.lang.Shared
+import support.NetworkUtilsMock
 import support.TestChildApp
 import support.TestDevice
 import support.TestHub
@@ -361,6 +362,122 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         then:
         result.healthyDevices.size() == 1
         result.healthyDevices[0].name == 'Fresh Sensor'
+    }
+
+    def "device_health_check pingHosts: happy + failure paths populate pingResults"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.pingResponses['192.168.1.1'] = [packetsTransmitted: 3, packetsReceived: 3, packetLoss: 0, rttAvg: 1.2, rttMin: 1.0, rttMax: 1.5]
+        network.pingResponses['192.0.2.1'] = [packetsTransmitted: 3, packetsReceived: 0, packetLoss: 100, rttAvg: 0.0, rttMin: 0.0, rttMax: 0.0]
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: ['192.168.1.1', '192.0.2.1']])
+
+        then:
+        network.pingCalls == [[ipAddress: '192.168.1.1', count: 3], [ipAddress: '192.0.2.1', count: 3]]
+        result.pingResults.size() == 2
+        result.pingResults[0].ipAddress == '192.168.1.1'
+        result.pingResults[0].reachable == true
+        result.pingResults[0].rttAvg == 1.2
+        result.pingResults[0].packetLoss == 0
+        result.pingResults[1].ipAddress == '192.0.2.1'
+        result.pingResults[1].reachable == false
+        result.pingResults[1].packetLoss == 100
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: invalid IPv4 strings short-circuit without calling NetworkUtils"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: ['not-an-ip', '1.2.3', '999.999.999.999.x']])
+
+        then:
+        network.pingCalls.isEmpty()
+        result.pingResults.size() == 3
+        result.pingResults.every { it.reachable == false && it.error == 'invalid IPv4 address' }
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: pingCount is forwarded to NetworkUtils"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.install()
+
+        when:
+        script.toolDeviceHealthCheck([pingHosts: ['10.0.0.1'], pingCount: 5])
+
+        then:
+        network.pingCalls == [[ipAddress: '10.0.0.1', count: 5]]
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: NetworkUtils exception is captured in pingResults"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.pingResponses['10.0.0.1'] = new RuntimeException('boom')
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: ['10.0.0.1']])
+
+        then:
+        result.pingResults.size() == 1
+        result.pingResults[0].reachable == false
+        result.pingResults[0].error == 'boom'
+
+        cleanup:
+        network.uninstall()
+    }
+
+    def "device_health_check pingHosts: rejects more than 5 hosts and pingCount out of range"() {
+        when:
+        script.toolDeviceHealthCheck([pingHosts: ['1.1.1.1','2.2.2.2','3.3.3.3','4.4.4.4','5.5.5.5','6.6.6.6']])
+
+        then:
+        def tooMany = thrown(IllegalArgumentException)
+        tooMany.message.contains('5 entries')
+
+        when:
+        script.toolDeviceHealthCheck([pingHosts: ['1.1.1.1'], pingCount: 0])
+
+        then:
+        def low = thrown(IllegalArgumentException)
+        low.message.contains('between 1 and 5')
+
+        when:
+        script.toolDeviceHealthCheck([pingHosts: ['1.1.1.1'], pingCount: 6])
+
+        then:
+        def high = thrown(IllegalArgumentException)
+        high.message.contains('between 1 and 5')
+    }
+
+    def "device_health_check pingHosts work even when no devices are selected"() {
+        given:
+        def network = new NetworkUtilsMock()
+        network.pingResponses['192.168.1.1'] = [packetsTransmitted: 3, packetsReceived: 3, packetLoss: 0, rttAvg: 1.0, rttMin: 1.0, rttMax: 1.0]
+        network.install()
+
+        when:
+        def result = script.toolDeviceHealthCheck([pingHosts: ['192.168.1.1']])
+
+        then:
+        result.message.contains('No devices selected')
+        result.pingResults.size() == 1
+        result.pingResults[0].reachable == true
+
+        cleanup:
+        network.uninstall()
     }
 
     // -------- toolGetRuleDiagnostics --------

--- a/src/test/groovy/support/NetworkUtilsMock.groovy
+++ b/src/test/groovy/support/NetworkUtilsMock.groovy
@@ -7,17 +7,34 @@ package support
  */
 class NetworkUtilsMock {
     final List<Map> calls = []
+    final List<Map> pingCalls = []
     Map stubResponse = [status: 200, body: '{}']
+    /** ipAddress -> Map (PingData fields) OR Closure(host, count) -> Map. Throws if value is a Throwable. */
+    Map<String, Object> pingResponses = [:]
+    /** Default response when no per-host override matches. Set to null to throw a "no stub" error. */
+    Map defaultPingResponse = [packetsTransmitted: 3, packetsReceived: 0, packetLoss: 100, rttAvg: 0.0, rttMin: 0.0, rttMax: 0.0]
 
     Object sendHubitatCommand(Map params) {
         calls << params
         return stubResponse
     }
 
+    Object ping(String ipAddress, Integer count) {
+        pingCalls << [ipAddress: ipAddress, count: count]
+        def stub = pingResponses[ipAddress]
+        if (stub instanceof Throwable) throw stub
+        if (stub instanceof Closure) return stub.call(ipAddress, count)
+        if (stub != null) return stub
+        return defaultPingResponse
+    }
+
     void install() {
         def self = this
         hubitat.helper.NetworkUtils.metaClass.static.sendHubitatCommand = { Map p ->
             self.sendHubitatCommand(p)
+        }
+        hubitat.helper.NetworkUtils.metaClass.static.ping = { String ip, Integer n ->
+            self.ping(ip, n)
         }
     }
 

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -831,6 +831,26 @@ Casual natural language prompts that must route to the correct tool/gateway.
 
 **Expected**: Routes to `device_health_check`.
 
+### T227 — "Ping my router" → device_health_check
+
+```json
+{
+  "test_prompt": "Can you ICMP-ping 192.168.1.1 and tell me whether it's reachable, plus the average RTT?"
+}
+```
+
+**Expected**: AI calls `manage_diagnostics(tool='device_health_check', args={pingHosts:['192.168.1.1']})` (any `pingCount` from 1-5 is fine; default 3). Result includes a `pingResults` entry for `192.168.1.1` with `reachable`, `rttAvg`, `rttMin`, `rttMax`, `packetsTransmitted`, `packetsReceived`, `packetLoss`. AI reports reachability and avg RTT in milliseconds.
+
+### T228 — "Ping an unreachable IP" → device_health_check (failure path)
+
+```json
+{
+  "test_prompt": "Ping 192.0.2.1 (RFC 5737 TEST-NET-1, guaranteed unreachable) and report whether it's up."
+}
+```
+
+**Expected**: AI calls `manage_diagnostics(tool='device_health_check', args={pingHosts:['192.0.2.1']})`. Result `pingResults[0]` has `reachable: false`, `packetsReceived: 0`, `packetLoss: 100`. AI reports the host as unreachable.
+
 ### T77 — "Duplicate my rule" → rules admin
 
 ```json


### PR DESCRIPTION
## Summary

- Closes #91 by folding ICMP ping into the existing `device_health_check` tool instead of shipping a new top-level `ping_host` tool.
- Adds optional `pingHosts` (max 5 IPv4) and `pingCount` (1–5, default 3); calls flow through `hubitat.helper.NetworkUtils.ping()` and surface as `pingResults` alongside the existing staleness payload.
- Marks the MCP custom rule engine (`hubitat-mcp-rule.groovy`) as legacy in AGENTS.md/CLAUDE.md — new rule-side work goes to native Rule Machine tools, so issue #91's rule-action half is intentionally out of scope.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- `hubitat-mcp-server.groovy` — extend `device_health_check` schema + impl; add `runPingChecks()` helper; refactor early-return so ping still runs when no devices are selected; group summary/searchHints updated.
- `src/main/groovy/hubitat/helper/NetworkUtils.groovy` — sandbox stub gains `static ping(String, Integer)`.
- `src/test/groovy/support/NetworkUtilsMock.groovy` — adds `pingCalls`, per-host stub map, default response, and metaclass install for `ping`.
- `src/test/groovy/server/ToolManageDiagnosticsSpec.groovy` — six new specs covering happy/failure/invalid-IPv4/exception/limit/no-devices paths.
- `tests/BAT-v2.md` — adds T227 (ping reachable host) and T228 (ping unreachable RFC 5737 IP) under Section 4 routing.
- `futureplans.md` — checks off the ICMP ping line and notes it shipped as part of `device_health_check`.
- `AGENTS.md` / `CLAUDE.md` — adds a "custom MCP rule engine is legacy" section.

Closes #91.

## Release Notes

- `device_health_check` can now ICMP-ping arbitrary IPv4 addresses (router, NAS, server, LAN-attached devices) alongside the existing device-staleness check. Pass `pingHosts` (up to 5 IPv4 strings) and optional `pingCount` (1–5, default 3); results are returned as a `pingResults` array with `reachable`, `rttAvg`, `rttMin`, `rttMax`, `packetsTransmitted`, `packetsReceived`, and `packetLoss` per host. Either staleness or ping can be used independently — passing only `pingHosts` is fine even when no MCP devices are selected.
- Invalid IPv4 input is reported per-host as `{reachable:false, error:"invalid IPv4 address"}` rather than failing the whole call. Hostnames are not resolved (the underlying `NetworkUtils.ping` API takes IPs only).

## Testing

- `python tests/sandbox_lint.py` — passes.
- `./gradlew test --tests "server.ToolManageDiagnosticsSpec"` — passes (47 tests, 6 new).
- `./gradlew test --tests "server.GatewayToggleSpec" --tests "server.RegressionsFromHistorySpec"` — passes.
- Live-hub ad-hoc verification on the maintainer's hub:
  - `pingHosts: ["192.168.1.1", "192.0.2.1"]` returned reachable=true with rttAvg≈1ms for the gateway and reachable=false / packetLoss=100 for the RFC 5737 sink.
  - `pingHosts: ["not-an-ip", "1.2.3"]` returned per-host `error: "invalid IPv4 address"` without invoking `NetworkUtils`.
  - Over-limit guards (`pingHosts` size 6, `pingCount: 99`) returned proper `IllegalArgumentException` errors.

## Checklist

- [x] **Unit tests added for any new MCP tools** (extended existing tool's spec coverage)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (relevant specs run; full suite not re-run for time)
- [x] Live-hub BAT tests updated if tool behaviour changed (T227, T228 added)
- [x] Documentation updated if user-facing behaviour or tool surface changed