### PR TITLE
feat: full CRUD + change observation for hub variables (#92, #96)

### DIFF
--- a/futureplans.md
+++ b/futureplans.md
@@ -31,14 +31,8 @@
   > 3. Parent dispatches to matching child rule via key lookup
   > 4. Package request body, headers, and query params into pseudo-event for variable substitution
 
-- [ ] **Hub variable change triggers** — `Difficulty: 2 | Effort: S`
-  > *Feasible — native subscription supported.* Per the [Hub Variable API docs](https://docs2.hubitat.com/en/developer/interfaces/hub-variable-api), hub variable changes fire Location Events named `variable:<name>`. Apps can subscribe directly with `subscribe(location, "variable:<name>", handler)` for all changes of a variable, or `subscribe(location, "variable:<name>.<value>", handler)` to fire only when the variable becomes a specific value (for example, `"variable:myVar.on"` fires only when `myVar` becomes `"on"`). No polling, no Variable Connector workaround required. The earlier "not natively subscribable" framing was incorrect.
-  >
-  > **Implementation plan:**
-  > 1. Add `variable_change` trigger type with `variableName` and optional `value` filter
-  > 2. In `subscribeToTriggers()`, call `subscribe(location, "variable:${varName}", handler)` (or `"variable:${varName}.${value}"` if a value filter is set)
-  > 3. Register interest via `addInUseGlobalVar(varName)` so users cannot accidentally delete a variable a rule depends on; call `removeInUseGlobalVar()` on rule delete/update
-  > 4. Implement the `globalVarRenamed(oldName, newName)` app callback to auto-update trigger definitions when a variable is renamed
+- [x] **Hub variable change triggers** — *Closed differently than originally planned (issue #92).*
+  > Originally scoped as a `variable_change` trigger type for the legacy MCP rule engine. With the legacy engine now frozen and native Rule Machine providing variable triggers natively, the equivalent capability for MCP/AI consumers ships as observation tooling instead: the parent app subscribes to `variable:*` location events on install/update, buffers the last 200 changes in `atomicState.variableHistory`, and exposes them via `get_variable_history`. The `renameVariable(oldName, newName)` callback keeps the buffer consistent across UI renames. See PR closing #92 / #96.
 
 - [ ] **System start trigger** — `Difficulty: 2 | Effort: S`
   > *Feasible.* Hubitat supports `subscribe(location, "systemStart", handler)`. Add a `system_start` trigger type. After hub reboot, the app restores, `initialize()` → `subscribeToTriggers()` runs, and the systemStart event fires the rule. Minor edge case: the event may fire before all apps finish restoring — needs testing on hardware.
@@ -213,14 +207,8 @@
   > 4. Add driver to HPM package manifest
   > 5. Document that hub variables should use Hubitat's built-in connectors instead
 
-- [ ] **Variable change events** — `Difficulty: 2 | Effort: S`
-  > *Feasible.* For MCP rule engine variables: extend `setRuleVariable()` to fire `sendLocationEvent(name: "ruleVariableChanged", value: varName, data: newValue)`. Child rules with a `variable_change` trigger subscribe to this event. For Hubitat hub variables: use the native `subscribe(location, "variable:<name>", handler)` pattern described under "Hub variable change triggers" above — no polling or Variable Connector needed.
-  >
-  > **Implementation plan:**
-  > 1. Add `sendLocationEvent()` call to parent's `setRuleVariable()`
-  > 2. Add `variable_change` trigger type to child app
-  > 3. Child subscribes to `location "ruleVariableChanged"` event
-  > 4. Filter by variable name in the handler
+- [~] **Variable change events** — *Hub-variable half closed under issue #92; MCP-rule-engine half deferred (legacy engine frozen).*
+  > Hub-variable change observation now ships via `get_variable_history` (see "Hub variable change triggers" above). The MCP-rule-engine half — sending a `ruleVariableChanged` location event when `setRuleVariable()` writes — would require new code in the legacy child app, which is no longer being extended. New rule-variable consumers should use native Rule Machine, which has variable triggers built in.
 
 - [ ] **Local variable triggers** — `Difficulty: 2 | Effort: S`
   > *Feasible.* After `set_local_variable` or `variable_math` modifies a local variable, check for matching `local_variable_change` triggers and re-trigger asynchronously via `runIn(0, handler)`. High risk of infinite loops if a rule triggers itself — recommend only firing from external changes (another rule setting this rule's local variable via rule-to-rule control). The loop guard provides a safety net.

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -4036,17 +4036,20 @@ def toolGetVariable(name) {
 
 // Hub variable name validation. Hubitat's UI rejects ' " \ ~ [ : ] < > and
 // blank names. Reproduced here so the create tool fails fast with a clean
-// error before we touch the wizard.
-private static final List<Character> HUB_VAR_FORBIDDEN_CHARS =
-    ["'", '"', '\\', '~', '[', ':', ']', '<', '>'] as List<Character>
-private static final List<String> HUB_VAR_TYPES =
-    ["Number", "Decimal", "String", "Boolean", "DateTime"]
+// error before we touch the wizard. Returned via getters because the
+// Hubitat sandbox rejects `private static final` at script scope.
+private List getHubVarForbiddenChars() {
+    return ["'", '"', '\\', '~', '[', ':', ']', '<', '>']
+}
+private List getHubVarTypes() {
+    return ["Number", "Decimal", "String", "Boolean", "DateTime"]
+}
 
 private void _validateHubVarName(String name) {
     if (!name?.trim()) {
         throw new IllegalArgumentException("Variable name is required")
     }
-    def bad = HUB_VAR_FORBIDDEN_CHARS.findAll { c -> name.contains(c.toString()) }
+    def bad = getHubVarForbiddenChars().findAll { c -> name.contains(c) }
     if (bad) {
         throw new IllegalArgumentException(
             "Variable name '${name}' contains forbidden character(s): ${bad.join(' ')}. " +
@@ -4055,10 +4058,11 @@ private void _validateHubVarName(String name) {
 }
 
 private String _validateHubVarType(String type) {
-    def match = HUB_VAR_TYPES.find { it.equalsIgnoreCase(type) }
+    def types = getHubVarTypes()
+    def match = types.find { it.equalsIgnoreCase(type) }
     if (!match) {
         throw new IllegalArgumentException(
-            "Variable type '${type}' is invalid. Must be one of: ${HUB_VAR_TYPES.join(', ')}")
+            "Variable type '${type}' is invalid. Must be one of: ${types.join(', ')}")
     }
     return match  // canonical casing
 }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -416,13 +416,15 @@ private void _subscribeToAllHubVariables() {
         logDebug("_subscribeToAllHubVariables: getAllGlobalVars threw ${e.class.simpleName}: ${e.message}")
         return
     }
+    if (location == null) return  // unit-test environment safety
     vars?.keySet()?.each { varName ->
         try {
             subscribe(location, "variable:${varName}", "handleHubVariableEvent")
-        } catch (Exception e) {
+        } catch (Throwable e) {
             // Don't let one bad subscribe break the whole loop. The hub
             // sometimes rejects names with characters that getAllGlobalVars
-            // returned but subscribe() refuses; log and continue.
+            // returned but subscribe() refuses; log and continue. Catch
+            // Throwable because hubitat_ci's validator throws AssertionError.
             mcpLog("warn", "hub-vars", "subscribe to variable:${varName} failed: ${e.message}")
         }
     }
@@ -4237,9 +4239,15 @@ def toolCreateVariable(args) {
 
     // Subscribe to the new variable's location event so changes show up in
     // get_variable_history without waiting for the next updated() pass.
-    try { subscribe(location, "variable:${name}", "handleHubVariableEvent") }
-    catch (Exception e) {
-        mcpLog("warn", "hub-vars", "post-create subscribe to variable:${name} failed: ${e.message}")
+    // Null-check + Throwable catch mirrors renameVariable: hubitat_ci's
+    // validator throws AssertionError (not Exception) when location is null
+    // in unit-test environments, and the create itself shouldn't be aborted
+    // by a subscription-registration failure.
+    if (location != null) {
+        try { subscribe(location, "variable:${name}", "handleHubVariableEvent") }
+        catch (Throwable e) {
+            mcpLog("warn", "hub-vars", "post-create subscribe to variable:${name} failed: ${e.message}")
+        }
     }
 
     mcpLog("info", "hub-vars", "Created hub variable '${name}' type=${type} value=${value}")

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -448,9 +448,15 @@ def renameVariable(String oldName, String newName) {
     // Re-subscribe to the new name. The old "variable:OLD" event will
     // never fire again since the variable is gone, but Hubitat's
     // unsubscribe semantics mean it's harmless to leave it in place.
-    try { subscribe(location, "variable:${newName}", "handleHubVariableEvent") }
-    catch (Exception e) {
-        mcpLog("warn", "hub-vars", "post-rename subscribe to variable:${newName} failed: ${e.message}")
+    // Catch Throwable because the hubitat_ci validator throws AssertionError
+    // (not Exception) when location is null in unit-test environments;
+    // history rewrite is the important part and shouldn't be aborted by a
+    // subscription registration failure.
+    if (location != null) {
+        try { subscribe(location, "variable:${newName}", "handleHubVariableEvent") }
+        catch (Throwable e) {
+            mcpLog("warn", "hub-vars", "post-rename subscribe to variable:${newName} failed: ${e.message}")
+        }
     }
 }
 
@@ -4090,7 +4096,11 @@ private String _validateHubVarType(String type) {
  * create_connector -- all of which drive that app's wizard via
  * update_native_app's settings/button POST machinery.
  */
-private Integer _findHubVariablesAppId() {
+// Non-private so test specs can override via script.metaClass — internal calls
+// from this script's other methods would bypass the metaClass dispatch on a
+// private method and hit the real implementation, which makes mocking the
+// hub-side discovery painful in unit tests.
+def _findHubVariablesAppId() {
     def cached = atomicState.hubVarsAppId
     if (cached != null) {
         try { return cached.toString().toInteger() } catch (NumberFormatException e) {

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1355,11 +1355,12 @@ Verify rule after creation.""",
         ],
         [
             name: "create_connector",
-            description: "Create a virtual-device connector for an existing hub variable so apps that only consume devices can read/write it. Connector type is selected by Hubitat from the variable's type. No-op if a connector already exists.",
+            description: "Create a virtual-device connector for an existing hub variable so apps that only consume devices can read/write it. For Number/Decimal vars, Hubitat shows a connector-type chooser (Dimmer/Variable/etc.); pass connectorType to pick, default 'Variable'. For String/Boolean/DateTime vars, the chooser is skipped. No-op if a connector already exists.",
             inputSchema: [
                 type: "object",
                 properties: [
                     name: [type: "string", description: "Existing hub-variable name"],
+                    connectorType: [type: "string", description: "Optional connector type for Number/Decimal vars (e.g. 'Dimmer', 'Variable', 'Volume', 'ColorTemp', 'Humidity', 'Illuminance'). Defaults to 'Variable'. Ignored for vars that don't show a chooser."],
                     confirm: [type: "boolean", description: "REQUIRED: must be true"]
                 ],
                 required: ["name", "confirm"]
@@ -4070,11 +4071,23 @@ private String _validateHubVarType(String type) {
 /**
  * Discover and cache the installed-app id for the system "Hub Variables"
  * app (namespace=hubitat, classLocation=hubVariables, exactly one instance,
- * always installed on every hub). The id varies per hub, so we walk
- * /hub2/appsList once on first need and cache in atomicState.
+ * always installed on every hub). The id varies per hub, so we discover
+ * once on first need and cache in atomicState.
+ *
+ * Discovery is two-stage because /hub2/appsList omits hidden system apps
+ * on at least some firmware versions (verified on 2.5.0.x: Hub Variables
+ * is reachable at /installedapp/configure/json/<id> but not listed in
+ * /hub2/appsList -- same gap that hides it from list_installed_apps):
+ *   1. Walk /hub2/appsList (cheap, single GET) -- catches hubs that DO
+ *      list it.
+ *   2. If miss, fall back to scanning installed-app config endpoints up
+ *      to a bounded ceiling above the highest id we saw in step 1. Each
+ *      404 returns immediately; matches return on appType.name. Result
+ *      caches in atomicState so the scan only happens once per fresh
+ *      install.
  *
  * Used by create_variable, delete_variable's hub-namespace branch, and
- * create_connector — all of which drive that app's wizard via
+ * create_connector -- all of which drive that app's wizard via
  * update_native_app's settings/button POST machinery.
  */
 private Integer _findHubVariablesAppId() {
@@ -4086,32 +4099,71 @@ private Integer _findHubVariablesAppId() {
         }
     }
 
-    def responseText = hubInternalGet("/hub2/appsList")
-    if (!responseText) {
-        throw new IllegalStateException("Cannot discover Hub Variables app: empty response from /hub2/appsList")
-    }
-    def parsed = new groovy.json.JsonSlurper().parseText(responseText)
-    def found = null
-    def recurse
-    recurse = { node ->
-        if (found != null) return
-        def d = node?.data
-        if (d?.type == "Hub Variables" && d?.id != null) {
-            found = d
-            return
+    // Stage 1: /hub2/appsList walk
+    def maxSeenId = 0
+    try {
+        def responseText = hubInternalGet("/hub2/appsList")
+        if (responseText) {
+            def parsed = new groovy.json.JsonSlurper().parseText(responseText)
+            def found = null
+            def recurse
+            recurse = { node ->
+                def d = node?.data
+                if (d?.id != null) {
+                    def idVal = d.id.toString().isInteger() ? d.id.toString().toInteger() : 0
+                    if (idVal > maxSeenId) maxSeenId = idVal
+                }
+                if (found == null && d?.type == "Hub Variables" && d?.id != null) {
+                    found = d
+                }
+                node?.children?.each { c -> recurse(c) }
+            }
+            (parsed?.apps ?: []).each { a -> recurse(a) }
+            if (found?.id != null) {
+                def id = found.id.toString().toInteger()
+                atomicState.hubVarsAppId = id
+                mcpLog("info", "hub-vars", "Discovered Hub Variables app id: ${id} (via /hub2/appsList)")
+                return id
+            }
         }
-        node?.children?.each { c -> recurse(c) }
+    } catch (Exception e) {
+        logDebug("_findHubVariablesAppId: /hub2/appsList walk threw ${e.class.simpleName}: ${e.message}")
     }
-    (parsed?.apps ?: []).each { a -> recurse(a) }
 
-    if (found?.id == null) {
-        throw new IllegalStateException(
-            "Hub Variables system app not found in /hub2/appsList. This should not happen on a normally-functioning hub -- the app is system-installed.")
+    // Stage 2: bounded scan of installed-app config endpoints.
+    // Hubitat sometimes hides the Hub Variables singleton from the
+    // appsList feed even though /installedapp/configure/json/<id> works.
+    // Scan from 1 to maxSeen+500, capped at 3000 to avoid runaway work.
+    // First-time cost is ~5-10s on a typical hub; result is cached so
+    // subsequent calls are free.
+    def upperBound = Math.min(3000, Math.max(maxSeenId + 500, 1500))
+    mcpLog("info", "hub-vars", "Hub Variables not in /hub2/appsList; falling back to id scan 1..${upperBound}")
+    for (int id = 1; id <= upperBound; id++) {
+        def cfgText = null
+        try {
+            cfgText = hubInternalGet("/installedapp/configure/json/${id}")
+        } catch (Exception e) {
+            // 404s are expected for unused ids; only log unusual failures
+            continue
+        }
+        if (!cfgText) continue
+        try {
+            def cfg = new groovy.json.JsonSlurper().parseText(cfgText)
+            def typeName = cfg?.app?.appType?.name
+            if (typeName == "Hub Variables") {
+                atomicState.hubVarsAppId = id
+                mcpLog("info", "hub-vars", "Discovered Hub Variables app id: ${id} (via id scan)")
+                return id
+            }
+        } catch (Exception e) {
+            // Malformed response on this id -- ignore and continue
+        }
     }
-    def id = found.id.toString().toInteger()
-    atomicState.hubVarsAppId = id
-    mcpLog("info", "hub-vars", "Discovered Hub Variables app id: ${id}")
-    return id
+
+    throw new IllegalStateException(
+        "Hub Variables system app not found via /hub2/appsList walk OR id scan up to ${upperBound}. " +
+        "This should not happen on a normally-functioning hub -- the app is system-installed. " +
+        "Try increasing the scan ceiling or check that Hub Variables is enabled (Settings > Hub Variables).")
 }
 
 /**
@@ -4193,17 +4245,21 @@ def toolCreateVariable(args) {
 
 /**
  * create_connector: bind a virtual device to an existing hub variable so
- * apps that only consume devices can read/write it. Single-button
- * wizard: btn <varName> with stateAttribute=createCon on page hubVar.
+ * apps that only consume devices can read/write it. Wizard sequence:
+ *   1. btn <varName> with stateAttribute=createCon on page hubVar
+ *   2. For Number/Decimal vars, page renders a `capab` enum chooser
+ *      (ColorTemp/Dimmer/Humidity/Illuminance/Volume/Variable). Write
+ *      `capab` to commit. For String/Boolean/DateTime vars, single
+ *      click suffices (no chooser).
  *
- * Connector type is determined by the variable's type (Boolean -> Switch,
- * Number/Decimal -> Dimmer-or-Variable, String/DateTime -> Variable). The
- * Hub Variables app handles that mapping internally; we just trigger it.
+ * Optional args.connectorType selects the chooser option when present.
+ * Defaults to "Variable" (the neutral option that exists for every type).
  */
 def toolCreateConnector(args) {
     requireHubAdminWrite(args.confirm)
     def name = args.name?.toString()?.trim()
     if (!name) throw new IllegalArgumentException("Variable name is required")
+    def requestedType = args.connectorType?.toString()?.trim()
 
     def existing
     try { existing = getGlobalVar(name) }
@@ -4225,20 +4281,50 @@ def toolCreateConnector(args) {
     def appId = _findHubVariablesAppId()
     _rmClickAppButton(appId, name, "createCon", "hubVar")
 
+    // Check whether the wizard advanced to a connector-type chooser
+    // (Number/Decimal vars render `capab` enum; others auto-commit).
+    def cfgText = hubInternalGet("/installedapp/configure/json/${appId}")
+    def capabOptions = null
+    def chosenType = null
+    if (cfgText) {
+        def cfg = new groovy.json.JsonSlurper().parseText(cfgText)
+        cfg?.configPage?.sections?.each { section ->
+            section?.inputs?.each { input ->
+                if (input?.name == "capab" && input?.options instanceof List) {
+                    capabOptions = input.options
+                }
+            }
+        }
+    }
+    if (capabOptions) {
+        chosenType = (requestedType && capabOptions.find { it?.toString()?.equalsIgnoreCase(requestedType) })
+            ? capabOptions.find { it?.toString()?.equalsIgnoreCase(requestedType) }
+            : (capabOptions.contains("Variable") ? "Variable" : capabOptions[0])
+        if (requestedType && chosenType?.toString()?.equalsIgnoreCase(requestedType) != true) {
+            mcpLog("warn", "hub-vars", "create_connector: requested connectorType='${requestedType}' not in ${capabOptions}; using '${chosenType}'")
+        }
+        def applied = []
+        def skipped = []
+        _rmWriteSettingOnPage(appId, "hubVar", "capab", chosenType, applied, "enum", skipped)
+    }
+
     def after
     try { after = getGlobalVar(name) } catch (Exception e) { after = null }
     if (after?.deviceId == null) {
         throw new IllegalStateException(
-            "create_connector: wizard completed but '${name}' still has no deviceId. " +
-            "The connector may need a follow-up type selection in Hubitat that we did not handle.")
+            "create_connector: wizard completed but '${name}' still has no deviceId" +
+            (capabOptions ? " (chooser='${chosenType}', options=${capabOptions})" : "") +
+            ". The connector did not bake.")
     }
 
-    mcpLog("info", "hub-vars", "Created connector for '${name}' (deviceId=${after.deviceId}, attribute=${after.attribute})")
+    def capabSuffix = chosenType ? ", capab=${chosenType}" : ""
+    mcpLog("info", "hub-vars", "Created connector for '${name}' (deviceId=${after.deviceId}, attribute=${after.attribute}${capabSuffix})")
     return [
         success: true,
         name: name,
         deviceId: after.deviceId,
         attribute: after.attribute,
+        connectorType: chosenType,
         message: "Connector created for '${name}' (deviceId=${after.deviceId})."
     ]
 }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -319,6 +319,201 @@ def initialize() {
     // Schedule daily version update check at 3am and run immediately
     schedule("0 0 3 ? * *", "checkForUpdate")
     checkForUpdate()
+
+    // Issue #92: subscribe to every hub variable's location event
+    // ("variable:NAME") so the AI can see what changed and when via
+    // get_variable_history. Re-runs on every updated() because Hubitat
+    // calls unsubscribe() implicitly between updated() invocations.
+    _subscribeToAllHubVariables()
+
+    // Issue #96 gap 1: register addInUseGlobalVar for every hub variable
+    // referenced by any child rule. Hubitat then warns users before they
+    // delete/rename a variable that would break a rule. Diff against the
+    // previously-tracked set so we removeInUseGlobalVar for vars no
+    // longer referenced (rule edited away from the var, rule deleted).
+    _refreshHubVarInUseRegistrations()
+}
+
+/**
+ * Issue #96 gap 1: walk every child rule's serialized ruleData, collect
+ * hub-variable names that appear in it (via the same heuristic
+ * delete_variable's safety scan uses), then add/remove the in-use
+ * registration so Hubitat's UI surfaces a warning before a user can
+ * delete/rename a variable a rule depends on.
+ *
+ * Pure parent-side bookkeeping — does not modify any child app code or
+ * data. Tracks the previously-registered set in atomicState.inUseHubVars
+ * so subsequent calls can diff and removeInUseGlobalVar for vars that
+ * stopped being referenced.
+ */
+private void _refreshHubVarInUseRegistrations() {
+    Set<String> currentVars = []
+    Set<String> hubVarNames
+    try {
+        hubVarNames = (getAllGlobalVars()?.keySet() ?: []) as Set<String>
+    } catch (Exception e) {
+        logDebug("_refreshHubVarInUseRegistrations: getAllGlobalVars threw ${e.class.simpleName}: ${e.message}")
+        return
+    }
+    if (!hubVarNames) {
+        // No hub vars at all — clear any stale registrations and bail.
+        def previous = (atomicState.inUseHubVars ?: []) as List<String>
+        previous.each { name ->
+            try { removeInUseGlobalVar(name) } catch (Exception e) { /* idempotent */ }
+        }
+        atomicState.inUseHubVars = []
+        return
+    }
+    try {
+        getChildApps()?.each { child ->
+            def ruleData = null
+            try { ruleData = child.getRuleData() } catch (Exception e) { /* not an MCP rule child */ }
+            if (ruleData) {
+                def serialized = groovy.json.JsonOutput.toJson(ruleData)
+                hubVarNames.each { varName ->
+                    if (serialized?.contains(varName)) {
+                        currentVars << varName
+                    }
+                }
+            }
+        }
+    } catch (Exception e) {
+        logDebug("_refreshHubVarInUseRegistrations: getChildApps() scan failed: ${e.class.simpleName}: ${e.message}")
+        return
+    }
+
+    def previous = ((atomicState.inUseHubVars ?: []) as List<String>) as Set<String>
+    def toAdd = currentVars - previous
+    def toRemove = previous - currentVars
+
+    toAdd.each { name ->
+        try { addInUseGlobalVar(name) }
+        catch (Exception e) { mcpLog("warn", "hub-vars", "addInUseGlobalVar('${name}') failed: ${e.message}") }
+    }
+    toRemove.each { name ->
+        try { removeInUseGlobalVar(name) }
+        catch (Exception e) { mcpLog("warn", "hub-vars", "removeInUseGlobalVar('${name}') failed: ${e.message}") }
+    }
+
+    atomicState.inUseHubVars = (currentVars as List).sort()
+    if (toAdd || toRemove) {
+        mcpLog("info", "hub-vars", "in-use registrations refreshed: added=${toAdd.sort()}, removed=${toRemove.sort()}, total=${currentVars.size()}")
+    }
+}
+
+/**
+ * Issue #92: subscribe to every existing hub variable so location events
+ * land in handleHubVariableEvent and accumulate in atomicState.variableHistory.
+ *
+ * Called from initialize() (so installed/updated re-wire) and from
+ * toolCreateVariable / renameVariable (so newly-created or renamed vars
+ * become observable without requiring an updated() round-trip).
+ */
+private void _subscribeToAllHubVariables() {
+    def vars
+    try { vars = getAllGlobalVars() }
+    catch (Exception e) {
+        logDebug("_subscribeToAllHubVariables: getAllGlobalVars threw ${e.class.simpleName}: ${e.message}")
+        return
+    }
+    vars?.keySet()?.each { varName ->
+        try {
+            subscribe(location, "variable:${varName}", "handleHubVariableEvent")
+        } catch (Exception e) {
+            // Don't let one bad subscribe break the whole loop. The hub
+            // sometimes rejects names with characters that getAllGlobalVars
+            // returned but subscribe() refuses; log and continue.
+            mcpLog("warn", "hub-vars", "subscribe to variable:${varName} failed: ${e.message}")
+        }
+    }
+}
+
+/**
+ * Hubitat fires this app callback when a hub variable is renamed via the
+ * Settings UI. Issue #92: rewrite history entries to the new name and
+ * re-subscribe (the old "variable:OLD" subscription is now stale).
+ */
+def renameVariable(String oldName, String newName) {
+    mcpLog("info", "hub-vars", "renameVariable callback: '${oldName}' -> '${newName}'")
+    def history = atomicState.variableHistory ?: []
+    def rewrote = false
+    history = history.collect { entry ->
+        if (entry?.name == oldName) {
+            rewrote = true
+            return [name: newName] + (entry.findAll { k, v -> k != "name" })
+        }
+        return entry
+    }
+    if (rewrote) atomicState.variableHistory = history
+    // Re-subscribe to the new name. The old "variable:OLD" event will
+    // never fire again since the variable is gone, but Hubitat's
+    // unsubscribe semantics mean it's harmless to leave it in place.
+    try { subscribe(location, "variable:${newName}", "handleHubVariableEvent") }
+    catch (Exception e) {
+        mcpLog("warn", "hub-vars", "post-rename subscribe to variable:${newName} failed: ${e.message}")
+    }
+}
+
+/**
+ * Issue #92: location-event handler for "variable:*" events. Each event
+ * shape (per Hubitat docs): evt.name is the event name with the "variable:"
+ * prefix; evt.value is the new value. We strip the prefix so callers see
+ * the bare variable name and append a {name, value, timestamp} entry to
+ * atomicState.variableHistory (cap 200; oldest dropped).
+ */
+def handleHubVariableEvent(evt) {
+    if (evt == null) return
+    def varName = evt.name?.toString()
+    if (varName?.startsWith("variable:")) {
+        varName = varName.substring("variable:".length())
+    }
+    if (!varName) return
+
+    def entry = [
+        name: varName,
+        value: evt.value,
+        timestamp: now(),
+        descriptionText: evt.descriptionText?.toString()
+    ]
+    def history = atomicState.variableHistory ?: []
+    history << entry
+    // Cap the buffer. 200 entries is enough to survive an MCP-tool
+    // round-trip plus a few minutes of bursty change activity without
+    // blowing up state size on hubs with many vars.
+    def cap = 200
+    if (history.size() > cap) {
+        history = history[(history.size() - cap)..-1]
+    }
+    atomicState.variableHistory = history
+}
+
+/**
+ * get_variable_history: return a window of recent hub-variable changes,
+ * optionally filtered by name and a since-timestamp. Issue #92: lets the
+ * AI catch up on "what variables changed since I last looked" without
+ * polling each one by name.
+ */
+def toolGetVariableHistory(args) {
+    def history = atomicState.variableHistory ?: []
+    def filtered = history
+    if (args?.name) {
+        def n = args.name.toString()
+        filtered = filtered.findAll { it?.name == n }
+    }
+    if (args?.sinceMs != null) {
+        def since = args.sinceMs as Long
+        filtered = filtered.findAll { (it?.timestamp ?: 0L) >= since }
+    }
+    def limit = (args?.limit != null) ? (args.limit as Integer) : 50
+    if (limit < 1) limit = 1
+    // Most-recent first; cap at limit.
+    def recent = filtered.reverse().take(limit)
+    return [
+        entries: recent,
+        total: recent.size(),
+        bufferSize: history.size(),
+        bufferCap: 200
+    ]
 }
 
 // ==================== MCP REQUEST HANDLERS ====================
@@ -522,19 +717,27 @@ def getGatewayConfig() {
             ]
         ],
         manage_hub_variables: [
-            description: "Manage hub connector and rule engine variables.",
-            tools: ["list_variables", "get_variable", "set_variable", "delete_variable"],
+            description: "Manage hub variables (every type: Number, Decimal, String, Boolean, DateTime), their connector devices, and rule-engine variables. Issue #92: full read/write CRUD via the modern Hub Variable API + wizard; observe changes via get_variable_history.",
+            tools: ["list_variables", "get_variable", "set_variable", "create_variable", "delete_variable", "create_connector", "remove_connector", "get_variable_history"],
             summaries: [
-                list_variables: "List all hub connector and rule engine variables",
-                get_variable: "Get a variable value. Args: name",
-                set_variable: "Set a variable value (creates if doesn't exist). Args: name, value",
-                delete_variable: "Permanently delete a rule engine variable (DESTRUCTIVE). Args: name, confirm=true, [force=true if rules reference it]"
+                list_variables: "List all hub variables (with type/connector linkage) and rule-engine variables.",
+                get_variable: "Get a variable's value + metadata (type, deviceId, attribute). Args: name",
+                set_variable: "Set an existing variable's value. Falls back to rule_engine namespace when no hub var matches. Args: name, value",
+                create_variable: "Create a new hub variable. Args: name, type (Number|Decimal|String|Boolean|DateTime), value, confirm=true",
+                delete_variable: "Permanently delete a variable (DESTRUCTIVE — also removes its connector if any). Args: name, confirm=true, [force=true if rules reference it]",
+                create_connector: "Create a virtual-device connector for an existing hub variable. Args: name, confirm=true",
+                remove_connector: "Remove the connector device for a hub variable (variable itself unchanged). Args: name, confirm=true",
+                get_variable_history: "Recent hub-variable changes since the MCP app last started. Args: name (optional filter), sinceMs (optional), limit (optional)"
             ],
             searchHints: [
                 list_variables: "show all global state connector",
                 get_variable: "read fetch lookup global state",
                 set_variable: "write update change store global state",
-                delete_variable: "remove drop destroy purge cleanup orphan stranded BAT_ stale variable"
+                create_variable: "add new hub variable global",
+                delete_variable: "remove drop destroy purge cleanup orphan stranded BAT_ stale variable",
+                create_connector: "expose hub variable as virtual device switch dimmer",
+                remove_connector: "unlink delete connector device variable",
+                get_variable_history: "watch observe changes events recent variable timeline"
             ]
         ],
         manage_rooms: [
@@ -1110,12 +1313,12 @@ Verify rule after creation.""",
         ],
         [
             name: "list_variables",
-            description: "List all hub connector and rule engine variables",
+            description: "List all hub variables (every type, including ones without connectors) and rule-engine variables. Each hub-variable entry includes type (Number/Decimal/String/Boolean/DateTime), value, and connector linkage (deviceId/attribute) when present.",
             inputSchema: [type: "object", properties: [:]]
         ],
         [
             name: "get_variable",
-            description: "Get a variable value",
+            description: "Get a variable's current value plus metadata (type, deviceId, attribute) if it's a hub variable.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -1126,7 +1329,7 @@ Verify rule after creation.""",
         ],
         [
             name: "set_variable",
-            description: "Set a variable value (creates if doesn't exist). Always verify value after.",
+            description: "Set an existing variable's value. For hub variables, value type must match the variable's declared type (creating new hub variables requires create_variable — Hubitat does not allow setGlobalVar to create). Falls back to the rule_engine namespace when no hub variable matches.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -1137,8 +1340,58 @@ Verify rule after creation.""",
             ]
         ],
         [
+            name: "create_variable",
+            description: "Create a new hub variable. Args: name, type (Number|Decimal|String|Boolean|DateTime), value, confirm. Drives Settings → Hub Variables wizard (Hubitat does not expose creation via the public app API). Forbidden chars in name: ' \" \\ ~ [ : ] < >.",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    name: [type: "string", description: "Variable name"],
+                    type: [type: "string", description: "One of: Number, Decimal, String, Boolean, DateTime"],
+                    value: [description: "Initial value (must match the chosen type)"],
+                    confirm: [type: "boolean", description: "REQUIRED: must be true"]
+                ],
+                required: ["name", "type", "value", "confirm"]
+            ]
+        ],
+        [
+            name: "create_connector",
+            description: "Create a virtual-device connector for an existing hub variable so apps that only consume devices can read/write it. Connector type is selected by Hubitat from the variable's type. No-op if a connector already exists.",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    name: [type: "string", description: "Existing hub-variable name"],
+                    confirm: [type: "boolean", description: "REQUIRED: must be true"]
+                ],
+                required: ["name", "confirm"]
+            ]
+        ],
+        [
+            name: "remove_connector",
+            description: "Delete the connector device backing a hub variable. The variable itself is unchanged. No-op if no connector exists.",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    name: [type: "string", description: "Hub-variable name whose connector to remove"],
+                    confirm: [type: "boolean", description: "REQUIRED: must be true"]
+                ],
+                required: ["name", "confirm"]
+            ]
+        ],
+        [
+            name: "get_variable_history",
+            description: "Recent hub-variable changes captured by the MCP app's location-event subscription. Buffer caps at 200 most recent changes (oldest dropped). Cleared on app restart.",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    name: [type: "string", description: "Optional: filter to changes for this variable name only"],
+                    sinceMs: [type: "integer", description: "Optional: only return changes whose timestamp >= this epoch-millis"],
+                    limit: [type: "integer", description: "Optional: max entries to return (default: 50)"]
+                ]
+            ]
+        ],
+        [
             name: "delete_variable",
-            description: "Permanently delete a rule engine variable (DESTRUCTIVE — no undo). Variable must exist. Use the Settings → Hub Variables UI for connector-namespace variable deletion (separate namespace, not yet exposed via MCP).\n\nGated on requireHubAdminWrite + recent backup. Useful for sweeping orphaned BAT_E2E_* artifacts after CI runs, removing stale lease variables, or general cleanup.\n\n**Reference safety:** the tool scans every child rule app for serialized references to this variable name (in triggers/conditions/actions) and refuses by default if any are found — deletion would silently break those rules (null lookups → false conditions, literal `%varname%` left in substitutions). To proceed anyway, pass `force=true` after acknowledging the breakage. The response includes a `brokenConsumers` field listing the affected rules when force=true.",
+            description: "Permanently delete a variable (DESTRUCTIVE — no undo). Auto-detects whether the target is a hub variable (drives Settings → Hub Variables wizard; also deletes the connector device if one exists) or a rule_engine variable (rewrites state). Throws if the name resolves to neither.\n\nGated on requireHubAdminWrite + recent backup. Useful for sweeping orphaned BAT_E2E_* artifacts after CI runs, removing stale lease variables, or general cleanup.\n\n**Reference safety:** the tool scans every child rule app for serialized references to this variable name (in triggers/conditions/actions) and refuses by default if any are found — deletion would silently break those rules (null lookups → false conditions, literal `%varname%` left in substitutions). To proceed anyway, pass `force=true` after acknowledging the breakage. The response includes a `brokenConsumers` field listing the affected rules when force=true.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -2453,7 +2706,11 @@ def executeTool(toolName, args) {
         case "list_variables": return toolListVariables()
         case "get_variable": return toolGetVariable(args.name)
         case "set_variable": return toolSetVariable(args.name, args.value)
+        case "create_variable": return toolCreateVariable(args)
         case "delete_variable": return toolDeleteHubVariable(args)
+        case "create_connector": return toolCreateConnector(args)
+        case "remove_connector": return toolRemoveConnector(args)
+        case "get_variable_history": return toolGetVariableHistory(args)
         case "update_mcp_settings": return toolUpdateMcpSettings(args)
         case "get_hsm_status": return toolGetHsmStatus()
         case "set_hsm": return toolSetHsm(args.mode)
@@ -3717,16 +3974,28 @@ def toolSetMode(modeName) {
 }
 
 def toolListVariables() {
+    // Modern Hub Variable API (issue #92): getAllGlobalVars() sees every hub
+    // variable, not just the connector-exposed subset that the legacy
+    // getAllGlobalConnectorVariables() returned. Each entry is shaped like
+    // [name, type, value, deviceId, attribute] — deviceId/attribute populated
+    // when the variable has a Connector device, null otherwise.
     def hubVariables = []
     try {
-        def allVars = getAllGlobalConnectorVariables()
+        def allVars = getAllGlobalVars()
         if (allVars) {
             hubVariables = allVars.collect { name, var ->
-                [name: name, value: var?.value, type: var?.type, source: "hub"]
+                [
+                    name: name,
+                    value: var?.value,
+                    type: var?.type,
+                    deviceId: var?.deviceId,
+                    attribute: var?.attribute,
+                    source: "hub"
+                ]
             }
         }
     } catch (Exception e) {
-        logDebug("Hub connector variables not available: ${e.message}")
+        logDebug("Hub variable API not available: ${e.message}")
     }
 
     def ruleVariables = state.ruleVariables?.collect { name, value ->
@@ -3742,12 +4011,19 @@ def toolListVariables() {
 
 def toolGetVariable(name) {
     try {
-        def hubVar = getGlobalConnectorVariable(name)
+        def hubVar = getGlobalVar(name)
         if (hubVar != null) {
-            return [name: name, value: hubVar, source: "hub"]
+            return [
+                name: name,
+                value: hubVar.value,
+                type: hubVar.type,
+                deviceId: hubVar.deviceId,
+                attribute: hubVar.attribute,
+                source: "hub"
+            ]
         }
     } catch (Exception e) {
-        logDebug("Hub connector variable '${name}' not found or not accessible: ${e.message}")
+        logDebug("Hub variable '${name}' lookup threw ${e.class.simpleName}: ${e.message}")
     }
 
     def ruleVar = state.ruleVariables?.get(name)
@@ -3758,27 +4034,292 @@ def toolGetVariable(name) {
     throw new IllegalArgumentException("Variable not found: ${name}")
 }
 
-def toolSetVariable(name, value) {
-    try {
-        setGlobalConnectorVariable(name, value)
-        return [success: true, name: name, value: value, source: "hub"]
-    } catch (Exception e) {
-        if (!state.ruleVariables) state.ruleVariables = [:]
-        state.ruleVariables[name] = value
-        return [success: true, name: name, value: value, source: "rule_engine"]
+// Hub variable name validation. Hubitat's UI rejects ' " \ ~ [ : ] < > and
+// blank names. Reproduced here so the create tool fails fast with a clean
+// error before we touch the wizard.
+private static final List<Character> HUB_VAR_FORBIDDEN_CHARS =
+    ["'", '"', '\\', '~', '[', ':', ']', '<', '>'] as List<Character>
+private static final List<String> HUB_VAR_TYPES =
+    ["Number", "Decimal", "String", "Boolean", "DateTime"]
+
+private void _validateHubVarName(String name) {
+    if (!name?.trim()) {
+        throw new IllegalArgumentException("Variable name is required")
     }
+    def bad = HUB_VAR_FORBIDDEN_CHARS.findAll { c -> name.contains(c.toString()) }
+    if (bad) {
+        throw new IllegalArgumentException(
+            "Variable name '${name}' contains forbidden character(s): ${bad.join(' ')}. " +
+            "Hubitat rejects: ' \" \\ ~ [ : ] < >")
+    }
+}
+
+private String _validateHubVarType(String type) {
+    def match = HUB_VAR_TYPES.find { it.equalsIgnoreCase(type) }
+    if (!match) {
+        throw new IllegalArgumentException(
+            "Variable type '${type}' is invalid. Must be one of: ${HUB_VAR_TYPES.join(', ')}")
+    }
+    return match  // canonical casing
+}
+
+/**
+ * Discover and cache the installed-app id for the system "Hub Variables"
+ * app (namespace=hubitat, classLocation=hubVariables, exactly one instance,
+ * always installed on every hub). The id varies per hub, so we walk
+ * /hub2/appsList once on first need and cache in atomicState.
+ *
+ * Used by create_variable, delete_variable's hub-namespace branch, and
+ * create_connector — all of which drive that app's wizard via
+ * update_native_app's settings/button POST machinery.
+ */
+private Integer _findHubVariablesAppId() {
+    def cached = atomicState.hubVarsAppId
+    if (cached != null) {
+        try { return cached.toString().toInteger() } catch (NumberFormatException e) {
+            mcpLog("warn", "hub-vars", "Invalid cached hubVarsAppId '${cached}' -- rediscovering")
+            atomicState.remove("hubVarsAppId")
+        }
+    }
+
+    def responseText = hubInternalGet("/hub2/appsList")
+    if (!responseText) {
+        throw new IllegalStateException("Cannot discover Hub Variables app: empty response from /hub2/appsList")
+    }
+    def parsed = new groovy.json.JsonSlurper().parseText(responseText)
+    def found = null
+    def recurse
+    recurse = { node ->
+        if (found != null) return
+        def d = node?.data
+        if (d?.type == "Hub Variables" && d?.id != null) {
+            found = d
+            return
+        }
+        node?.children?.each { c -> recurse(c) }
+    }
+    (parsed?.apps ?: []).each { a -> recurse(a) }
+
+    if (found?.id == null) {
+        throw new IllegalStateException(
+            "Hub Variables system app not found in /hub2/appsList. This should not happen on a normally-functioning hub -- the app is system-installed.")
+    }
+    def id = found.id.toString().toInteger()
+    atomicState.hubVarsAppId = id
+    mcpLog("info", "hub-vars", "Discovered Hub Variables app id: ${id}")
+    return id
+}
+
+/**
+ * create_variable: drive the Hub Variables system app's wizard to create a
+ * new hub variable. Sequence (probed live 2026-05-06):
+ *   1. btn moreVar (stateAttribute=moreVar) on page hubVar -- opens wizard
+ *   2. set hbVar  = name      -- wizard advances; varType field appears
+ *   3. set varType = type      -- wizard advances; varValue field appears
+ *   4. set varValue = initial  -- wizard auto-commits, var enters the table
+ *
+ * Hubitat does NOT expose creation via the public app API
+ * (setGlobalVar can only modify existing vars, not create), so this tool
+ * fills the gap by automating the same UI flow the user would perform
+ * manually under Settings > Hub Variables.
+ */
+def toolCreateVariable(args) {
+    requireHubAdminWrite(args.confirm)
+    def name = args.name?.toString()?.trim()
+    _validateHubVarName(name)
+    def type = _validateHubVarType(args.type?.toString())
+    def value = args.value
+    if (value == null) {
+        throw new IllegalArgumentException("Initial value is required")
+    }
+    // Refuse to silently overwrite an existing variable — the UI's "Create"
+    // path can't either; the wizard only progresses when the name is novel.
+    try {
+        def existing = getGlobalVar(name)
+        if (existing != null) {
+            throw new IllegalArgumentException(
+                "Hub variable '${name}' already exists (type=${existing.type}, value=${existing.value}). " +
+                "Use set_variable to change the value, or pick a different name.")
+        }
+    } catch (IllegalArgumentException reraise) { throw reraise }
+    catch (Exception e) {
+        logDebug("create_variable: getGlobalVar('${name}') threw ${e.class.simpleName}: ${e.message}")
+    }
+
+    def appId = _findHubVariablesAppId()
+    def applied = []
+    def skipped = []
+
+    _rmClickAppButton(appId, "moreVar", "moreVar", "hubVar")
+    _rmWriteSettingOnPage(appId, "hubVar", "hbVar",    name,  applied, "text",     skipped)
+    _rmWriteSettingOnPage(appId, "hubVar", "varType",  type,  applied, "enum",     skipped)
+    _rmWriteSettingOnPage(appId, "hubVar", "varValue", value, applied, "textarea", skipped)
+
+    // Verify the variable landed. The wizard auto-commits on varValue write,
+    // so the new var should be visible via getGlobalVar immediately. If it
+    // isn't, something went sideways in the wizard walk — fail loud rather
+    // than reporting a false success.
+    def created = null
+    try { created = getGlobalVar(name) } catch (Exception e) {
+        logDebug("create_variable: post-write getGlobalVar('${name}') threw ${e.class.simpleName}: ${e.message}")
+    }
+    if (created == null) {
+        throw new IllegalStateException(
+            "create_variable: wizard completed but '${name}' is not visible via getGlobalVar. " +
+            "Settings applied: ${applied.join(', ')}. Skipped: ${skipped}")
+    }
+
+    // Subscribe to the new variable's location event so changes show up in
+    // get_variable_history without waiting for the next updated() pass.
+    try { subscribe(location, "variable:${name}", "handleHubVariableEvent") }
+    catch (Exception e) {
+        mcpLog("warn", "hub-vars", "post-create subscribe to variable:${name} failed: ${e.message}")
+    }
+
+    mcpLog("info", "hub-vars", "Created hub variable '${name}' type=${type} value=${value}")
+    return [
+        success: true,
+        name: name,
+        type: type,
+        value: created.value,
+        source: "hub",
+        message: "Variable '${name}' (${type}) created with initial value ${created.value}."
+    ]
+}
+
+/**
+ * create_connector: bind a virtual device to an existing hub variable so
+ * apps that only consume devices can read/write it. Single-button
+ * wizard: btn <varName> with stateAttribute=createCon on page hubVar.
+ *
+ * Connector type is determined by the variable's type (Boolean -> Switch,
+ * Number/Decimal -> Dimmer-or-Variable, String/DateTime -> Variable). The
+ * Hub Variables app handles that mapping internally; we just trigger it.
+ */
+def toolCreateConnector(args) {
+    requireHubAdminWrite(args.confirm)
+    def name = args.name?.toString()?.trim()
+    if (!name) throw new IllegalArgumentException("Variable name is required")
+
+    def existing
+    try { existing = getGlobalVar(name) }
+    catch (Exception e) { existing = null }
+    if (existing == null) {
+        throw new IllegalArgumentException("Hub variable '${name}' does not exist. Create it first with create_variable.")
+    }
+    if (existing.deviceId != null) {
+        return [
+            success: true,
+            name: name,
+            deviceId: existing.deviceId,
+            attribute: existing.attribute,
+            alreadyExists: true,
+            message: "Connector for '${name}' already exists (deviceId=${existing.deviceId})."
+        ]
+    }
+
+    def appId = _findHubVariablesAppId()
+    _rmClickAppButton(appId, name, "createCon", "hubVar")
+
+    def after
+    try { after = getGlobalVar(name) } catch (Exception e) { after = null }
+    if (after?.deviceId == null) {
+        throw new IllegalStateException(
+            "create_connector: wizard completed but '${name}' still has no deviceId. " +
+            "The connector may need a follow-up type selection in Hubitat that we did not handle.")
+    }
+
+    mcpLog("info", "hub-vars", "Created connector for '${name}' (deviceId=${after.deviceId}, attribute=${after.attribute})")
+    return [
+        success: true,
+        name: name,
+        deviceId: after.deviceId,
+        attribute: after.attribute,
+        message: "Connector created for '${name}' (deviceId=${after.deviceId})."
+    ]
+}
+
+/**
+ * remove_connector: delete the connector device that backs a hub variable.
+ * Reuses the existing delete_device path (the connector is a regular hub
+ * device once created) -- Hubitat's UI does the same: open the connector
+ * device's page, click Remove Device.
+ *
+ * The hub variable itself is NOT deleted; only the connector linkage.
+ */
+def toolRemoveConnector(args) {
+    requireHubAdminWrite(args.confirm)
+    def name = args.name?.toString()?.trim()
+    if (!name) throw new IllegalArgumentException("Variable name is required")
+
+    def existing
+    try { existing = getGlobalVar(name) }
+    catch (Exception e) { existing = null }
+    if (existing == null) {
+        throw new IllegalArgumentException("Hub variable '${name}' does not exist.")
+    }
+    if (existing.deviceId == null) {
+        return [
+            success: true,
+            name: name,
+            alreadyRemoved: true,
+            message: "Variable '${name}' has no connector to remove."
+        ]
+    }
+
+    def deviceId = existing.deviceId
+    def res = toolDeleteDevice([deviceId: deviceId.toString(), confirm: true])
+
+    mcpLog("info", "hub-vars", "Removed connector for '${name}' (deviceId=${deviceId})")
+    return [
+        success: true,
+        name: name,
+        deviceId: deviceId,
+        deviceDeleted: res?.success == true,
+        message: "Connector for '${name}' (deviceId=${deviceId}) removed. Variable itself is unchanged."
+    ]
+}
+
+def toolSetVariable(name, value) {
+    // setGlobalVar returns true on success, false when the variable doesn't
+    // exist (Hubitat will not auto-create vars from setGlobalVar — creation
+    // requires the Hub Variables UI or our toolCreateVariable tool). Falling
+    // back to rule_engine namespace on false OR exception preserves the
+    // legacy behavior callers depend on.
+    try {
+        if (setGlobalVar(name, value)) {
+            return [success: true, name: name, value: value, source: "hub"]
+        }
+    } catch (Exception e) {
+        logDebug("setGlobalVar('${name}') threw ${e.class.simpleName}: ${e.message}")
+    }
+    if (!state.ruleVariables) state.ruleVariables = [:]
+    state.ruleVariables[name] = value
+    return [success: true, name: name, value: value, source: "rule_engine"]
 }
 
 def toolDeleteHubVariable(args) {
     requireHubAdminWrite(args.confirm)
     def name = args.name
     if (!name) throw new IllegalArgumentException("name is required")
+    def force = args.force == true
 
-    // Currently only rule_engine variables are addressable from this MCP — connector
-    // variables (Settings → Hub Variables) live in a separate namespace not yet
-    // accessible from this app.
-    if (!state.ruleVariables?.containsKey(name)) {
-        throw new IllegalArgumentException("Variable '${name}' not found in rule_engine namespace. (Connector-namespace deletion not yet supported via MCP -- use Settings > Hub Variables UI.)")
+    // Source detection: hub vs rule_engine namespace. Hub vars are deleted
+    // through the Hub Variables system app's wizard; rule_engine vars are a
+    // map in state we can rewrite directly. Same in-use safety scan applies
+    // to both — child rules can reference a hub var by name in their
+    // triggers/conditions/actions JSON.
+    def hubVar = null
+    try { hubVar = getGlobalVar(name) }
+    catch (Exception e) {
+        logDebug("delete_variable: getGlobalVar('${name}') threw ${e.class.simpleName}: ${e.message}")
+    }
+    def isHubVar = (hubVar != null)
+    def isRuleVar = state.ruleVariables?.containsKey(name) ?: false
+
+    if (!isHubVar && !isRuleVar) {
+        throw new IllegalArgumentException(
+            "Variable '${name}' not found in either the hub-variables namespace or the rule_engine namespace.")
     }
 
     // Pre-deletion safety scan: child rule apps that reference this variable will silently
@@ -3786,7 +4327,6 @@ def toolDeleteHubVariable(args) {
     // leaves literal text). Block by default — caller must opt in via force=true after
     // acknowledging the breakage. Match heuristic: variable name appears in the rule's
     // serialized triggers/conditions/actions JSON.
-    def force = args.force == true
     def consumers = []
     try {
         getChildApps()?.each { child ->
@@ -3815,11 +4355,51 @@ def toolDeleteHubVariable(args) {
         )
     }
 
+    if (isHubVar) {
+        // Hub-namespace deletion: drive the Hub Variables system app's
+        // wizard. Two clicks: deleteGV opens the confirm prompt, delConfirm
+        // commits. Hubitat also deletes the connector device when one
+        // exists, surfacing the resulting deviceId in the audit log so the
+        // caller knows what else just disappeared.
+        def previousValue = hubVar.value
+        def previousType  = hubVar.type
+        def hadConnector  = hubVar.deviceId != null
+        def appId = _findHubVariablesAppId()
+        _rmClickAppButton(appId, name, "deleteGV", "hubVar")
+        _rmClickAppButton(appId, "delConfirm", null, "hubVar")
+
+        // Verify the variable is gone. If it isn't, the wizard didn't
+        // commit — surface that loudly so callers don't think the delete
+        // succeeded when it didn't.
+        def stillThere = null
+        try { stillThere = getGlobalVar(name) } catch (Exception e) { stillThere = null }
+        if (stillThere != null) {
+            throw new IllegalStateException(
+                "delete_variable: wizard completed but '${name}' still exists in getGlobalVar.")
+        }
+
+        def prevStr = previousValue?.toString()
+        def auditValue = prevStr == null ? "null" : (prevStr.length() > 80 ? "${prevStr.take(80)} [truncated, original length: ${prevStr.length()}]" : prevStr)
+        def connectorNote = hadConnector ? " (connector deviceId=${hubVar.deviceId} also deleted)" : ""
+        def consumerNote  = consumers ? " (forced; ${consumers.size()} rule(s) now broken: ${consumers.collect { "id=${it.id}" }.join(', ')})" : ""
+        mcpLog("warn", "developer-mode", "delete_variable: removed hub var '${name}' (type=${previousType}, previous value: ${auditValue})${connectorNote}${consumerNote}")
+        return [
+            success: true,
+            name: name,
+            deleted: true,
+            source: "hub",
+            type: previousType,
+            previousValue: previousValue,
+            connectorDeleted: hadConnector,
+            brokenConsumers: consumers ?: null
+        ]
+    }
+
+    // rule_engine fallback (legacy MCP-managed rule variables). Same
+    // top-level reassignment pattern: nested-map mutations on state silently
+    // fail to persist across hub reboot / app restart unless the top-level
+    // key is reassigned. Read-modify-write the whole map.
     def previousValue = state.ruleVariables[name]
-    // Hubitat-sandbox quirk: nested-map mutations on state are not persisted across
-    // hub reboot / app restart unless the top-level key is reassigned. Same pattern
-    // used by toolSetLogLevel for state.debugLogs.config. Read-modify-write the whole
-    // map to force serialization.
     def updated = state.ruleVariables.findAll { k, v -> k != name }
     state.ruleVariables = updated
 
@@ -3958,16 +4538,18 @@ private coerceSettingValue(String key, value, String type) {
     }
 }
 
-// Helper method for child apps to get variable values
+// Helper method for child apps to get variable values. Issue #92: switched
+// to the modern getGlobalVar API so this sees every hub variable, not just
+// connector-exposed ones.
 def getVariableValue(name) {
     try {
-        def hubVar = getGlobalConnectorVariable(name)
-        if (hubVar != null) return hubVar
+        def hubVar = getGlobalVar(name)
+        if (hubVar != null) return hubVar.value
     } catch (Exception e) {
-        // Hub connector variable not found — fall through to rule_engine namespace.
-        // Logged at DEBUG so investigators can tell whether the connector lookup
+        // Hub variable lookup failed — fall through to rule_engine namespace.
+        // Logged at DEBUG so investigators can tell whether the lookup
         // genuinely missed (no such variable) or errored for some other reason.
-        logDebug("getVariableValue: connector lookup for '${name}' threw ${e.class.simpleName}: ${e.message}")
+        logDebug("getVariableValue: hub lookup for '${name}' threw ${e.class.simpleName}: ${e.message}")
     }
     return state.ruleVariables?.get(name)
 }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -4279,46 +4279,41 @@ def toolCreateConnector(args) {
     }
 
     def appId = _findHubVariablesAppId()
+    // Pre-click priming: see toolDeleteHubVariable. Hub Variables system-app
+    // wizard clicks silently no-op without a preceding /app/ajax/code fetch.
+    try { backupItemSource("app", appId.toString()) }
+    catch (Exception backupExc) { logDebug("create_connector: pre-click backupItemSource for ${appId} threw ${backupExc.class.simpleName}: ${backupExc.message}") }
     _rmClickAppButton(appId, name, "createCon", "hubVar")
 
-    // Check whether the wizard advanced to a connector-type chooser
-    // (Number/Decimal vars render `capab` enum; others auto-commit).
-    def cfgText = hubInternalGet("/installedapp/configure/json/${appId}")
-    def capabOptions = null
-    def chosenType = null
-    if (cfgText) {
-        def cfg = new groovy.json.JsonSlurper().parseText(cfgText)
-        cfg?.configPage?.sections?.each { section ->
-            section?.inputs?.each { input ->
-                if (input?.name == "capab" && input?.options instanceof List) {
-                    capabOptions = input.options
-                }
-            }
-        }
-    }
-    if (capabOptions) {
-        chosenType = (requestedType && capabOptions.find { it?.toString()?.equalsIgnoreCase(requestedType) })
-            ? capabOptions.find { it?.toString()?.equalsIgnoreCase(requestedType) }
-            : (capabOptions.contains("Variable") ? "Variable" : capabOptions[0])
-        if (requestedType && chosenType?.toString()?.equalsIgnoreCase(requestedType) != true) {
-            mcpLog("warn", "hub-vars", "create_connector: requested connectorType='${requestedType}' not in ${capabOptions}; using '${chosenType}'")
-        }
-        def applied = []
-        def skipped = []
-        _rmWriteSettingOnPage(appId, "hubVar", "capab", chosenType, applied, "enum", skipped)
+    // For Number/Decimal vars Hubitat opens a chooser sub-wizard requiring
+    // a 'capab' enum pick (Dimmer / Variable / etc.); for String/Boolean/
+    // DateTime the click commits the connector immediately. We commit the
+    // chooser unconditionally via toolUpdateNativeApp's settings path —
+    // that path bakes the enum reliably where a raw _rmWriteSettingOnPage
+    // silently drops it on this firmware. The write is a no-op when no
+    // chooser is open. Internal helper call only; the tool surface remains
+    // create_connector.
+    def chosenType = requestedType?.trim() ?: "Variable"
+    try {
+        toolUpdateNativeApp([
+            appId: appId,
+            settings: [capab: chosenType],
+            pageName: "hubVar",
+            confirm: true
+        ])
+    } catch (Exception writeExc) {
+        logDebug("create_connector: capab write threw ${writeExc.class.simpleName}: ${writeExc.message} (may be benign for non-chooser var types)")
     }
 
     def after
     try { after = getGlobalVar(name) } catch (Exception e) { after = null }
     if (after?.deviceId == null) {
         throw new IllegalStateException(
-            "create_connector: wizard completed but '${name}' still has no deviceId" +
-            (capabOptions ? " (chooser='${chosenType}', options=${capabOptions})" : "") +
-            ". The connector did not bake.")
+            "create_connector: wizard completed but '${name}' still has no deviceId. " +
+            "Tried capab='${chosenType}' (only relevant for Number/Decimal). The connector did not bake.")
     }
 
-    def capabSuffix = chosenType ? ", capab=${chosenType}" : ""
-    mcpLog("info", "hub-vars", "Created connector for '${name}' (deviceId=${after.deviceId}, attribute=${after.attribute}${capabSuffix})")
+    mcpLog("info", "hub-vars", "Created connector for '${name}' (deviceId=${after.deviceId}, attribute=${after.attribute}, capab=${chosenType})")
     return [
         success: true,
         name: name,
@@ -4389,10 +4384,29 @@ def toolSetVariable(name, value) {
 }
 
 def toolDeleteHubVariable(args) {
-    requireHubAdminWrite(args.confirm)
-    def name = args.name
-    if (!name) throw new IllegalArgumentException("name is required")
-    def force = args.force == true
+    // Inlined requireHubAdminWrite body — calling the helper from this site
+    // produced an unexplained MissingMethodException ("String.call('true')")
+    // that the same helper call from create_variable / create_connector /
+    // remove_connector did NOT produce on the same hub session. Inlining
+    // sidesteps the issue and makes the gate transparent for diagnosis.
+    if (!settings.enableHubAdminWrite) {
+        throw new IllegalArgumentException("Hub Admin Write access is disabled. Enable 'Enable Hub Admin Write Tools' in MCP Rule Server app settings to use this tool.")
+    }
+    def confirmVal = args["confirm"]
+    if (!(confirmVal == true || confirmVal == "true")) {
+        throw new IllegalArgumentException("SAFETY CHECK FAILED: confirm=true required. Got: ${confirmVal} (${confirmVal?.class?.simpleName})")
+    }
+    def lastBackupTs = state.lastBackupTimestamp
+    if (!lastBackupTs || (lastBackupTs instanceof Number && (now() - (lastBackupTs as Long)) > 86400000)) {
+        def lastDisplay = lastBackupTs ? lastBackupTs.toString() : 'Never'
+        throw new IllegalArgumentException("BACKUP REQUIRED: No hub backup found within the last 24 hours. You MUST call create_hub_backup FIRST. Last backup: ${lastDisplay}")
+    }
+
+    // Local rename: avoid `name` to prevent any chance of shadowing the
+    // SmartApp's `name` property in the binding.
+    def varName = args["name"]?.toString()?.trim()
+    if (!varName) throw new IllegalArgumentException("name is required")
+    def force = args["force"] == true
 
     // Source detection: hub vs rule_engine namespace. Hub vars are deleted
     // through the Hub Variables system app's wizard; rule_engine vars are a
@@ -4400,16 +4414,16 @@ def toolDeleteHubVariable(args) {
     // to both — child rules can reference a hub var by name in their
     // triggers/conditions/actions JSON.
     def hubVar = null
-    try { hubVar = getGlobalVar(name) }
+    try { hubVar = getGlobalVar(varName) }
     catch (Exception e) {
-        logDebug("delete_variable: getGlobalVar('${name}') threw ${e.class.simpleName}: ${e.message}")
+        logDebug("delete_variable: getGlobalVar('${varName}') threw ${e.class.simpleName}: ${e.message}")
     }
     def isHubVar = (hubVar != null)
-    def isRuleVar = state.ruleVariables?.containsKey(name) ?: false
+    def isRuleVar = state.ruleVariables?.containsKey(varName) ?: false
 
     if (!isHubVar && !isRuleVar) {
         throw new IllegalArgumentException(
-            "Variable '${name}' not found in either the hub-variables namespace or the rule_engine namespace.")
+            "Variable '${varName}' not found in either the hub-variables namespace or the rule_engine namespace.")
     }
 
     // Pre-deletion safety scan: child rule apps that reference this variable will silently
@@ -4424,7 +4438,7 @@ def toolDeleteHubVariable(args) {
             try { ruleData = child.getRuleData() } catch (Exception e) { /* not an MCP rule child */ }
             if (ruleData) {
                 def serialized = groovy.json.JsonOutput.toJson(ruleData)
-                if (serialized?.contains(name)) {
+                if (serialized?.contains(varName)) {
                     consumers << [id: child.id, label: child.label]
                 }
             }
@@ -4437,10 +4451,10 @@ def toolDeleteHubVariable(args) {
     }
     if (consumers && !force) {
         throw new IllegalArgumentException(
-            "Variable '${name}' is referenced by ${consumers.size()} rule(s): " +
+            "Variable '${varName}' is referenced by ${consumers.size()} rule(s): " +
             "${consumers.collect { "${it.label} (id=${it.id})" }.join(', ')}. " +
             "Deleting will silently break those rules (null lookups, false conditions, " +
-            "literal %${name}% in substitutions). Pass force=true to proceed anyway, " +
+            "literal %${varName}% in substitutions). Pass force=true to proceed anyway, " +
             "or update/remove the consuming rules first."
         )
     }
@@ -4455,27 +4469,39 @@ def toolDeleteHubVariable(args) {
         def previousType  = hubVar.type
         def hadConnector  = hubVar.deviceId != null
         def appId = _findHubVariablesAppId()
-        _rmClickAppButton(appId, name, "deleteGV", "hubVar")
+        // Pre-click: backupItemSource fetches /app/ajax/code which has the
+        // observed side effect of priming the system-app's wizard state for
+        // subsequent button clicks. update_native_app does this before every
+        // click and the same wizard sequence works through that path; raw
+        // _rmClickAppButton without the fetch silently no-ops (state.editVar
+        // never lands). Verified live 2026-05-06 by isolating the difference
+        // between update_native_app's working path and our raw call path.
+        try { backupItemSource("app", appId.toString()) }
+        catch (Exception backupExc) { logDebug("delete_variable: pre-click backupItemSource for ${appId} threw ${backupExc.class.simpleName}: ${backupExc.message}") }
+        _rmClickAppButton(appId, varName, "deleteGV", "hubVar")
+        try { backupItemSource("app", appId.toString()) }
+        catch (Exception backupExc) { logDebug("delete_variable: pre-confirm backupItemSource for ${appId} threw ${backupExc.class.simpleName}: ${backupExc.message}") }
         _rmClickAppButton(appId, "delConfirm", null, "hubVar")
 
         // Verify the variable is gone. If it isn't, the wizard didn't
         // commit — surface that loudly so callers don't think the delete
         // succeeded when it didn't.
+        try { pauseExecution(500) } catch (Exception ignored) { }
         def stillThere = null
-        try { stillThere = getGlobalVar(name) } catch (Exception e) { stillThere = null }
+        try { stillThere = getGlobalVar(varName) } catch (Exception e) { stillThere = null }
         if (stillThere != null) {
             throw new IllegalStateException(
-                "delete_variable: wizard completed but '${name}' still exists in getGlobalVar.")
+                "delete_variable: wizard completed but '${varName}' still exists in getGlobalVar.")
         }
 
         def prevStr = previousValue?.toString()
         def auditValue = prevStr == null ? "null" : (prevStr.length() > 80 ? "${prevStr.take(80)} [truncated, original length: ${prevStr.length()}]" : prevStr)
         def connectorNote = hadConnector ? " (connector deviceId=${hubVar.deviceId} also deleted)" : ""
         def consumerNote  = consumers ? " (forced; ${consumers.size()} rule(s) now broken: ${consumers.collect { "id=${it.id}" }.join(', ')})" : ""
-        mcpLog("warn", "developer-mode", "delete_variable: removed hub var '${name}' (type=${previousType}, previous value: ${auditValue})${connectorNote}${consumerNote}")
+        mcpLog("warn", "developer-mode", "delete_variable: removed hub var '${varName}' (type=${previousType}, previous value: ${auditValue})${connectorNote}${consumerNote}")
         return [
             success: true,
-            name: name,
+            name: varName,
             deleted: true,
             source: "hub",
             type: previousType,
@@ -4489,15 +4515,15 @@ def toolDeleteHubVariable(args) {
     // top-level reassignment pattern: nested-map mutations on state silently
     // fail to persist across hub reboot / app restart unless the top-level
     // key is reassigned. Read-modify-write the whole map.
-    def previousValue = state.ruleVariables[name]
-    def updated = state.ruleVariables.findAll { k, v -> k != name }
+    def previousValue = state.ruleVariables[varName]
+    def updated = state.ruleVariables.findAll { k, v -> k != varName }
     state.ruleVariables = updated
 
     def prevStr = previousValue?.toString()
     def auditValue = prevStr == null ? "null" : (prevStr.length() > 80 ? "${prevStr.take(80)} [truncated, original length: ${prevStr.length()}]" : prevStr)
     def consumerNote = consumers ? " (forced; ${consumers.size()} rule(s) now broken: ${consumers.collect { "id=${it.id}" }.join(', ')})" : ""
-    mcpLog("warn", "developer-mode", "delete_variable: removed '${name}' (previous value: ${auditValue})${consumerNote}")
-    return [success: true, name: name, deleted: true, source: "rule_engine", previousValue: previousValue, brokenConsumers: consumers ?: null]
+    mcpLog("warn", "developer-mode", "delete_variable: removed '${varName}' (previous value: ${auditValue})${consumerNote}")
+    return [success: true, name: varName, deleted: true, source: "rule_engine", previousValue: previousValue, brokenConsumers: consumers ?: null]
 }
 
 def toolUpdateMcpSettings(args) {

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -347,7 +347,7 @@ def initialize() {
  * stopped being referenced.
  */
 private void _refreshHubVarInUseRegistrations() {
-    Set<String> currentVars = []
+    Set<String> currentVars = [] as Set
     Set<String> hubVarNames
     try {
         hubVarNames = (getAllGlobalVars()?.keySet() ?: []) as Set<String>
@@ -442,7 +442,9 @@ def renameVariable(String oldName, String newName) {
     history = history.collect { entry ->
         if (entry?.name == oldName) {
             rewrote = true
-            return [name: newName] + (entry.findAll { k, v -> k != "name" })
+            // Groovy Map +: rightmost map's keys override; produces a new
+            // map with `name` updated and other fields preserved.
+            return entry + [name: newName]
         }
         return entry
     }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -10584,7 +10584,10 @@ private Integer _rmCreateChildApp(Integer parentAppId, String namespace = "hubit
  * Pass pageName for sub-page wizard buttons (hasAll on selectTriggers,
  * actionDone on selectActions, etc.) so the form-context fields fire.
  */
-private Map _rmClickAppButton(Integer appId, String buttonName, String stateAttribute = null, String pageName = null) {
+// Non-private so test specs can override via script.metaClass — internal
+// Groovy-script dispatch to private methods bypasses the per-instance
+// metaClass override.
+def _rmClickAppButton(Integer appId, String buttonName, String stateAttribute = null, String pageName = null) {
     def body = [
         id: appId.toString(),
         name: buttonName,
@@ -14438,7 +14441,9 @@ private Integer _rmBuildCondition(Integer appId, Integer idx, Map condSpec, List
  * The `applied` accumulator collects every key that actually landed on
  * the page so the caller can include it in the response.
  */
-private void _rmWriteSettingOnPage(Integer appId, String pageName, String key, Object value, List applied, String typeHintOverride = null, List skipped = null) {
+// Non-private so test specs can override via script.metaClass — see
+// _rmClickAppButton for the same rationale.
+def _rmWriteSettingOnPage(Integer appId, String pageName, String key, Object value, List applied, String typeHintOverride = null, List skipped = null) {
     def config = _rmFetchConfigJson(appId, pageName)
     def schema = _rmCollectInputSchema(config?.configPage)
     if (!schema?.containsKey(key)) {

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -352,7 +352,13 @@ private void _refreshHubVarInUseRegistrations() {
     try {
         hubVarNames = (getAllGlobalVars()?.keySet() ?: []) as Set<String>
     } catch (Exception e) {
-        logDebug("_refreshHubVarInUseRegistrations: getAllGlobalVars threw ${e.class.simpleName}: ${e.message}")
+        // Surface as ERROR — when this fails the in-use safety net is stale,
+        // and delete_variable's pre-deletion warning won't fire. Users need
+        // to know the safety registrations weren't refreshed.
+        mcpLog("error", "hub-vars",
+            "_refreshHubVarInUseRegistrations: getAllGlobalVars failed (${e.class.simpleName}: ${e.message}) -- " +
+            "in-use safety registrations are STALE. delete_variable's hub-side warning may not fire until " +
+            "this resolves and updated() runs again.")
         return
     }
     if (!hubVarNames) {
@@ -371,7 +377,12 @@ private void _refreshHubVarInUseRegistrations() {
             if (ruleData) {
                 def serialized = groovy.json.JsonOutput.toJson(ruleData)
                 hubVarNames.each { varName ->
-                    if (serialized?.contains(varName)) {
+                    // Check for the JSON-quoted form so `temp` doesn't match
+                    // `temperature` / `attempt`. Names live as JSON values
+                    // (and sometimes keys) in the serialized blob, so the
+                    // `"<name>"` form is a reliable word-boundary proxy.
+                    def needle = "\"${varName}\""
+                    if (serialized?.contains(needle)) {
                         currentVars << varName
                     }
                 }
@@ -387,12 +398,15 @@ private void _refreshHubVarInUseRegistrations() {
     def toRemove = previous - currentVars
 
     toAdd.each { name ->
+        // ERROR level: failure here means Hubitat won't warn the user before
+        // they delete a variable a rule depends on. Warn-level would be
+        // dropped at the default mcpLogLevel="error" config.
         try { addInUseGlobalVar(name) }
-        catch (Exception e) { mcpLog("warn", "hub-vars", "addInUseGlobalVar('${name}') failed: ${e.message}") }
+        catch (Exception e) { mcpLog("error", "hub-vars", "addInUseGlobalVar('${name}') failed: ${e.message} -- in-use safety warning will not surface for this var") }
     }
     toRemove.each { name ->
         try { removeInUseGlobalVar(name) }
-        catch (Exception e) { mcpLog("warn", "hub-vars", "removeInUseGlobalVar('${name}') failed: ${e.message}") }
+        catch (Exception e) { mcpLog("error", "hub-vars", "removeInUseGlobalVar('${name}') failed: ${e.message} -- stale in-use registration will linger") }
     }
 
     atomicState.inUseHubVars = (currentVars as List).sort()
@@ -425,7 +439,10 @@ private void _subscribeToAllHubVariables() {
             // sometimes rejects names with characters that getAllGlobalVars
             // returned but subscribe() refuses; log and continue. Catch
             // Throwable because hubitat_ci's validator throws AssertionError.
-            mcpLog("warn", "hub-vars", "subscribe to variable:${varName} failed: ${e.message}")
+            // ERROR level: a persistent failure here means get_variable_history
+            // silently misses changes for this variable; warn-level would be
+            // dropped at default mcpLogLevel="error".
+            mcpLog("error", "hub-vars", "subscribe to variable:${varName} failed: ${e.message} -- get_variable_history will not capture changes for this var")
         }
     }
 }
@@ -459,7 +476,7 @@ def renameVariable(String oldName, String newName) {
     if (location != null) {
         try { subscribe(location, "variable:${newName}", "handleHubVariableEvent") }
         catch (Throwable e) {
-            mcpLog("warn", "hub-vars", "post-rename subscribe to variable:${newName} failed: ${e.message}")
+            mcpLog("error", "hub-vars", "post-rename subscribe to variable:${newName} failed: ${e.message} -- history capture for renamed var will lag until next initialize()")
         }
     }
 }
@@ -4085,7 +4102,7 @@ private String _validateHubVarType(String type) {
  * once on first need and cache in atomicState.
  *
  * Discovery is two-stage because /hub2/appsList omits hidden system apps
- * on at least some firmware versions (verified on 2.5.0.x: Hub Variables
+ * on at least some firmware versions (verified on 2.5.0.126: Hub Variables
  * is reachable at /installedapp/configure/json/<id> but not listed in
  * /hub2/appsList -- same gap that hides it from list_installed_apps):
  *   1. Walk /hub2/appsList (cheap, single GET) -- catches hubs that DO
@@ -4100,6 +4117,21 @@ private String _validateHubVarType(String type) {
  * create_connector -- all of which drive that app's wizard via
  * update_native_app's settings/button POST machinery.
  */
+// Wizard-priming for the Hub Variables system app. Verified on firmware
+// 2.5.0.126: clicks via _rmClickAppButton silently no-op unless the app's
+// wizard state is "warmed" first. The configure-json + statusJson GET pair
+// reliably primes it; a single bare GET does not.
+//
+// Non-private so test specs can override via script.metaClass.
+def _primeHubVarsWizard(Integer appId, String context) {
+    try {
+        hubInternalGet("/installedapp/configure/json/${appId}")
+        hubInternalGet("/installedapp/statusJson/${appId}")
+    } catch (Exception e) {
+        logDebug("${context}: _primeHubVarsWizard for ${appId} threw ${e.class.simpleName}: ${e.message}")
+    }
+}
+
 // Non-private so test specs can override via script.metaClass — internal calls
 // from this script's other methods would bypass the metaClass dispatch on a
 // private method and hit the real implementation, which makes mocking the
@@ -4157,7 +4189,6 @@ def _findHubVariablesAppId() {
         try {
             cfgText = hubInternalGet("/installedapp/configure/json/${id}")
         } catch (Exception e) {
-            // 404s are expected for unused ids; only log unusual failures
             continue
         }
         if (!cfgText) continue
@@ -4182,7 +4213,7 @@ def _findHubVariablesAppId() {
 
 /**
  * create_variable: drive the Hub Variables system app's wizard to create a
- * new hub variable. Sequence (probed live 2026-05-06):
+ * new hub variable. Sequence (probed on firmware 2.5.0.126):
  *   1. btn moreVar (stateAttribute=moreVar) on page hubVar -- opens wizard
  *   2. set hbVar  = name      -- wizard advances; varType field appears
  *   3. set varType = type      -- wizard advances; varValue field appears
@@ -4220,18 +4251,50 @@ def toolCreateVariable(args) {
     def applied = []
     def skipped = []
 
+    _primeHubVarsWizard(appId, "create_variable pre-moreVar")
     _rmClickAppButton(appId, "moreVar", "moreVar", "hubVar")
-    _rmWriteSettingOnPage(appId, "hubVar", "hbVar",    name,  applied, "text",     skipped)
-    _rmWriteSettingOnPage(appId, "hubVar", "varType",  type,  applied, "enum",     skipped)
-    _rmWriteSettingOnPage(appId, "hubVar", "varValue", value, applied, "textarea", skipped)
+    _rmWriteSettingOnPage(appId, "hubVar", "hbVar",   name, applied, "text", skipped)
+    _rmWriteSettingOnPage(appId, "hubVar", "varType", type, applied, "enum", skipped)
+    if (type == "DateTime") {
+        // DateTime renders varDate + varTime instead of varValue. Accept ISO
+        // "yyyy-MM-ddTHH:mm[:ss]", "yyyy-MM-dd HH:mm[:ss]", or a Map
+        // {date:"yyyy-MM-dd", time:"HH:mm"}.
+        def dateStr, timeStr
+        if (value instanceof Map) {
+            dateStr = value.date?.toString()
+            timeStr = value.time?.toString()
+        } else {
+            def s = value.toString().trim()
+            def parts = s.contains("T") ? s.split("T", 2) : (s.contains(" ") ? s.split(" ", 2) : [s, null])
+            dateStr = parts[0]
+            timeStr = parts.size() > 1 ? parts[1]?.take(5) : null  // "HH:mm" only
+        }
+        if (!dateStr || !timeStr) {
+            throw new IllegalArgumentException(
+                "DateTime variable '${name}' requires both date and time. " +
+                "Pass an ISO string like '2026-05-06T12:00:00' or a {date,time} map. Got: ${value}")
+        }
+        _rmWriteSettingOnPage(appId, "hubVar", "varDate", dateStr, applied, "date", skipped)
+        _rmWriteSettingOnPage(appId, "hubVar", "varTime", timeStr, applied, "time", skipped)
+        // DateTime requires an explicit Done click to commit (the other
+        // types auto-commit when varValue is written). Prime first — same
+        // wizard quirk as delete/create_connector clicks.
+        _primeHubVarsWizard(appId, "create_variable DateTime pre-Done")
+        _rmClickAppButton(appId, "dateTimeDone", null, "hubVar")
+    } else {
+        _rmWriteSettingOnPage(appId, "hubVar", "varValue", value, applied, "textarea", skipped)
+    }
 
-    // Verify the variable landed. The wizard auto-commits on varValue write,
-    // so the new var should be visible via getGlobalVar immediately. If it
-    // isn't, something went sideways in the wizard walk — fail loud rather
-    // than reporting a false success.
+    // Verify the variable landed. The wizard auto-commits on varValue write
+    // (or dateTimeDone for DateTime); the var becomes visible to getGlobalVar
+    // shortly after. Retry with backoff up to ~3s before giving up.
     def created = null
-    try { created = getGlobalVar(name) } catch (Exception e) {
-        logDebug("create_variable: post-write getGlobalVar('${name}') threw ${e.class.simpleName}: ${e.message}")
+    for (int attempt = 0; attempt < 4; attempt++) {
+        try { pauseExecution(500) } catch (Exception e) { logDebug("pauseExecution interrupted: ${e.class.simpleName}: ${e.message}") }
+        try { created = getGlobalVar(name) } catch (Exception e) {
+            logDebug("create_variable: post-write getGlobalVar('${name}') threw ${e.class.simpleName}: ${e.message}")
+        }
+        if (created != null) break
     }
     if (created == null) {
         throw new IllegalStateException(
@@ -4248,7 +4311,7 @@ def toolCreateVariable(args) {
     if (location != null) {
         try { subscribe(location, "variable:${name}", "handleHubVariableEvent") }
         catch (Throwable e) {
-            mcpLog("warn", "hub-vars", "post-create subscribe to variable:${name} failed: ${e.message}")
+            mcpLog("error", "hub-vars", "post-create subscribe to variable:${name} failed: ${e.message} -- get_variable_history won't capture this var's changes until next initialize()")
         }
     }
 
@@ -4299,34 +4362,27 @@ def toolCreateConnector(args) {
     }
 
     def appId = _findHubVariablesAppId()
-    // Pre-click priming: see toolDeleteHubVariable. Hub Variables system-app
-    // wizard clicks silently no-op without a preceding /app/ajax/code fetch.
-    try { backupItemSource("app", appId.toString()) }
-    catch (Exception backupExc) { logDebug("create_connector: pre-click backupItemSource for ${appId} threw ${backupExc.class.simpleName}: ${backupExc.message}") }
+    _primeHubVarsWizard(appId, "create_connector pre-click")
     _rmClickAppButton(appId, name, "createCon", "hubVar")
 
     // For Number/Decimal vars Hubitat opens a chooser sub-wizard requiring
     // a 'capab' enum pick (Dimmer / Variable / etc.); for String/Boolean/
-    // DateTime the click commits the connector immediately. We commit the
-    // chooser unconditionally via toolUpdateNativeApp's settings path —
-    // that path bakes the enum reliably where a raw _rmWriteSettingOnPage
-    // silently drops it on this firmware. The write is a no-op when no
-    // chooser is open. Internal helper call only; the tool surface remains
-    // create_connector.
+    // DateTime the click commits the connector immediately and the capab
+    // input isn't in the schema, so the write is a schema-skip no-op.
+    // Prime the wizard fresh (the chooser sub-page is its own wizard step
+    // and benefits from the same priming as the parent click).
     def chosenType = requestedType?.trim() ?: "Variable"
-    try {
-        toolUpdateNativeApp([
-            appId: appId,
-            settings: [capab: chosenType],
-            pageName: "hubVar",
-            confirm: true
-        ])
-    } catch (Exception writeExc) {
-        logDebug("create_connector: capab write threw ${writeExc.class.simpleName}: ${writeExc.message} (may be benign for non-chooser var types)")
-    }
+    def applied = []
+    def skipped = []
+    _primeHubVarsWizard(appId, "create_connector pre-capab")
+    _rmWriteSettingOnPage(appId, "hubVar", "capab", chosenType, applied, "enum", skipped)
 
     def after
-    try { after = getGlobalVar(name) } catch (Exception e) { after = null }
+    for (int v = 0; v < 4; v++) {
+        try { pauseExecution(500) } catch (Exception e) { logDebug("pauseExecution interrupted: ${e.class.simpleName}: ${e.message}") }
+        try { after = getGlobalVar(name) } catch (Exception e) { after = null }
+        if (after?.deviceId != null) break
+    }
     if (after?.deviceId == null) {
         throw new IllegalStateException(
             "create_connector: wizard completed but '${name}' still has no deviceId. " +
@@ -4353,8 +4409,8 @@ def toolCreateConnector(args) {
  * The hub variable itself is NOT deleted; only the connector linkage.
  */
 def toolRemoveConnector(args) {
-    requireHubAdminWrite(args.confirm)
-    def name = args.name?.toString()?.trim()
+    requireHubAdminWrite(args?.confirm as Boolean)
+    def name = args?.name?.toString()?.trim()
     if (!name) throw new IllegalArgumentException("Variable name is required")
 
     def existing
@@ -4374,13 +4430,31 @@ def toolRemoveConnector(args) {
 
     def deviceId = existing.deviceId
     def res = toolDeleteDevice([deviceId: deviceId.toString(), confirm: true])
+    if (res?.success != true) {
+        throw new IllegalStateException(
+            "remove_connector: toolDeleteDevice failed for deviceId=${deviceId}: ${res?.error ?: 'unknown error'}")
+    }
+
+    // Verify the variable's deviceId linkage is cleared. Without this, a
+    // delete_device that returned success but didn't actually remove (or the
+    // hub didn't propagate the unlinking) would silently report success here.
+    def after = null
+    for (int v = 0; v < 4; v++) {
+        try { pauseExecution(500) } catch (Exception e) { logDebug("pauseExecution interrupted: ${e.class.simpleName}: ${e.message}") }
+        try { after = getGlobalVar(name) } catch (Exception e) { after = null }
+        if (after?.deviceId == null) break
+    }
+    if (after?.deviceId != null) {
+        throw new IllegalStateException(
+            "remove_connector: device ${deviceId} delete returned success but variable '${name}' still has deviceId=${after.deviceId}")
+    }
 
     mcpLog("info", "hub-vars", "Removed connector for '${name}' (deviceId=${deviceId})")
     return [
         success: true,
         name: name,
         deviceId: deviceId,
-        deviceDeleted: res?.success == true,
+        deviceDeleted: true,
         message: "Connector for '${name}' (deviceId=${deviceId}) removed. Variable itself is unchanged."
     ]
 }
@@ -4404,29 +4478,10 @@ def toolSetVariable(name, value) {
 }
 
 def toolDeleteHubVariable(args) {
-    // Inlined requireHubAdminWrite body — calling the helper from this site
-    // produced an unexplained MissingMethodException ("String.call('true')")
-    // that the same helper call from create_variable / create_connector /
-    // remove_connector did NOT produce on the same hub session. Inlining
-    // sidesteps the issue and makes the gate transparent for diagnosis.
-    if (!settings.enableHubAdminWrite) {
-        throw new IllegalArgumentException("Hub Admin Write access is disabled. Enable 'Enable Hub Admin Write Tools' in MCP Rule Server app settings to use this tool.")
-    }
-    def confirmVal = args["confirm"]
-    if (!(confirmVal == true || confirmVal == "true")) {
-        throw new IllegalArgumentException("SAFETY CHECK FAILED: confirm=true required. Got: ${confirmVal} (${confirmVal?.class?.simpleName})")
-    }
-    def lastBackupTs = state.lastBackupTimestamp
-    if (!lastBackupTs || (lastBackupTs instanceof Number && (now() - (lastBackupTs as Long)) > 86400000)) {
-        def lastDisplay = lastBackupTs ? lastBackupTs.toString() : 'Never'
-        throw new IllegalArgumentException("BACKUP REQUIRED: No hub backup found within the last 24 hours. You MUST call create_hub_backup FIRST. Last backup: ${lastDisplay}")
-    }
-
-    // Local rename: avoid `name` to prevent any chance of shadowing the
-    // SmartApp's `name` property in the binding.
-    def varName = args["name"]?.toString()?.trim()
+    requireHubAdminWrite(args?.confirm as Boolean)
+    def varName = args?.name?.toString()?.trim()
     if (!varName) throw new IllegalArgumentException("name is required")
-    def force = args["force"] == true
+    def force = args?.force == true
 
     // Source detection: hub vs rule_engine namespace. Hub vars are deleted
     // through the Hub Variables system app's wizard; rule_engine vars are a
@@ -4453,12 +4508,15 @@ def toolDeleteHubVariable(args) {
     // serialized triggers/conditions/actions JSON.
     def consumers = []
     try {
+        // Word-boundary match: look for "<varName>" (JSON-quoted) so a var
+        // named `temp` doesn't match rules referencing `temperature` etc.
+        def needle = "\"${varName}\""
         getChildApps()?.each { child ->
             def ruleData = null
             try { ruleData = child.getRuleData() } catch (Exception e) { /* not an MCP rule child */ }
             if (ruleData) {
                 def serialized = groovy.json.JsonOutput.toJson(ruleData)
-                if (serialized?.contains(varName)) {
+                if (serialized?.contains(needle)) {
                     consumers << [id: child.id, label: child.label]
                 }
             }
@@ -4489,29 +4547,27 @@ def toolDeleteHubVariable(args) {
         def previousType  = hubVar.type
         def hadConnector  = hubVar.deviceId != null
         def appId = _findHubVariablesAppId()
-        // Pre-click: backupItemSource fetches /app/ajax/code which has the
-        // observed side effect of priming the system-app's wizard state for
-        // subsequent button clicks. update_native_app does this before every
-        // click and the same wizard sequence works through that path; raw
-        // _rmClickAppButton without the fetch silently no-ops (state.editVar
-        // never lands). Verified live 2026-05-06 by isolating the difference
-        // between update_native_app's working path and our raw call path.
-        try { backupItemSource("app", appId.toString()) }
-        catch (Exception backupExc) { logDebug("delete_variable: pre-click backupItemSource for ${appId} threw ${backupExc.class.simpleName}: ${backupExc.message}") }
-        _rmClickAppButton(appId, varName, "deleteGV", "hubVar")
-        try { backupItemSource("app", appId.toString()) }
-        catch (Exception backupExc) { logDebug("delete_variable: pre-confirm backupItemSource for ${appId} threw ${backupExc.class.simpleName}: ${backupExc.message}") }
-        _rmClickAppButton(appId, "delConfirm", null, "hubVar")
-
-        // Verify the variable is gone. If it isn't, the wizard didn't
-        // commit — surface that loudly so callers don't think the delete
-        // succeeded when it didn't.
-        try { pauseExecution(500) } catch (Exception ignored) { }
+        // The wizard's first click sequence after a fresh create/edit can be
+        // dropped silently by the hub (state-machine race that priming
+        // alone doesn't reliably defeat). Retry the full click
+        // sequence once if the verification fails — empirically the second
+        // attempt always commits.
         def stillThere = null
-        try { stillThere = getGlobalVar(varName) } catch (Exception e) { stillThere = null }
+        for (int attempt = 0; attempt < 2; attempt++) {
+            _primeHubVarsWizard(appId, "delete_variable pre-click attempt-${attempt + 1}")
+            _rmClickAppButton(appId, varName, "deleteGV", "hubVar")
+            _rmClickAppButton(appId, "delConfirm", null, "hubVar")
+            // Brief pause + verification. If the var is gone, we're done.
+            for (int v = 0; v < 4; v++) {
+                try { pauseExecution(500) } catch (Exception e) { logDebug("pauseExecution interrupted: ${e.class.simpleName}: ${e.message}") }
+                try { stillThere = getGlobalVar(varName) } catch (Exception e) { stillThere = null }
+                if (stillThere == null) break
+            }
+            if (stillThere == null) break
+        }
         if (stillThere != null) {
             throw new IllegalStateException(
-                "delete_variable: wizard completed but '${varName}' still exists in getGlobalVar.")
+                "delete_variable: wizard completed but '${varName}' still exists in getGlobalVar after 2 click-sequence attempts.")
         }
 
         def prevStr = previousValue?.toString()

--- a/src/test/groovy/server/ToolHubVariablesSpec.groovy
+++ b/src/test/groovy/server/ToolHubVariablesSpec.groovy
@@ -601,6 +601,10 @@ class ToolHubVariablesSpec extends ToolSpecBase {
             if (applied != null) applied << key
         }
         script.metaClass._findHubVariablesAppId = { -> 1424 }
+        // backupItemSource is called as a wizard-priming side effect on this firmware (see
+        // toolDeleteHubVariable / toolCreateConnector comments in hubitat-mcp-server.groovy).
+        // Stub to no-op so it doesn't try to fetch /app/ajax/code in tests.
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
 
         when:
         def result = script.toolCreateVariable([name: 'newVar', type: 'String', value: 'hi', confirm: true])
@@ -636,6 +640,7 @@ class ToolHubVariablesSpec extends ToolSpecBase {
             if (applied != null) applied << key
         }
         script.metaClass._findHubVariablesAppId = { -> 1424 }
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
 
         when:
         script.toolCreateVariable([name: 'ghostVar', type: 'String', value: 'x', confirm: true])
@@ -664,6 +669,8 @@ class ToolHubVariablesSpec extends ToolSpecBase {
             return [status: 200]
         }
         script.metaClass._findHubVariablesAppId = { -> 1424 }
+        // backupItemSource is called between clicks as wizard priming on this firmware.
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
 
         when:
         def result = script.toolDeleteHubVariable([name: 'condemned', confirm: true])
@@ -692,6 +699,7 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         and: 'wizard primitives recorded but no real effect'
         script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName -> [status: 200] }
         script.metaClass._findHubVariablesAppId = { -> 1424 }
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
 
         when:
         script.toolDeleteHubVariable([name: 'stuck', confirm: true])
@@ -702,7 +710,7 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         ex.message.contains('stuck')
     }
 
-    def "create_connector wizard sequence: one button click on the variable name with createCon"() {
+    def "create_connector wizard sequence: createCon click + capab commit via toolUpdateNativeApp"() {
         given:
         enableHubAdminWrite()
 
@@ -722,13 +730,28 @@ class ToolHubVariablesSpec extends ToolSpecBase {
             return [status: 200]
         }
         script.metaClass._findHubVariablesAppId = { -> 1424 }
+        // backupItemSource priming + toolUpdateNativeApp chooser-commit are both
+        // wizard side effects of the firmware quirk for Number/Decimal vars.
+        // Stub to no-op so the test exercises only the orchestration logic.
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
+        def chooserWrites = []
+        script.metaClass.toolUpdateNativeApp = { Map argsMap ->
+            chooserWrites << argsMap
+            return [success: true, settingsApplied: argsMap?.settings?.keySet()?.toList()]
+        }
 
         when:
         def result = script.toolCreateConnector([name: 'foo', confirm: true])
 
-        then: 'exactly one click — variable-name button with createCon stateAttribute on the hubVar page'
+        then: 'one createCon click on the row'
         buttonClicks.size() == 1
         buttonClicks[0] == [appId: 1424, btn: 'foo', stateAttr: 'createCon', pageName: 'hubVar']
+
+        and: 'chooser commit attempted via toolUpdateNativeApp (no-op for Boolean vars but called unconditionally)'
+        chooserWrites.size() == 1
+        chooserWrites[0].appId == 1424
+        chooserWrites[0].pageName == 'hubVar'
+        chooserWrites[0].settings == [capab: 'Variable']  // default when no connectorType arg
 
         and: 'response surfaces the new connector deviceId'
         result.success == true

--- a/src/test/groovy/server/ToolHubVariablesSpec.groovy
+++ b/src/test/groovy/server/ToolHubVariablesSpec.groovy
@@ -710,7 +710,7 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         ex.message.contains('stuck')
     }
 
-    def "create_connector wizard sequence: createCon click + capab commit via toolUpdateNativeApp"() {
+    def "create_connector wizard sequence: createCon click + capab commit via _rmWriteSettingOnPage"() {
         given:
         enableHubAdminWrite()
 
@@ -730,14 +730,10 @@ class ToolHubVariablesSpec extends ToolSpecBase {
             return [status: 200]
         }
         script.metaClass._findHubVariablesAppId = { -> 1424 }
-        // backupItemSource priming + toolUpdateNativeApp chooser-commit are both
-        // wizard side effects of the firmware quirk for Number/Decimal vars.
-        // Stub to no-op so the test exercises only the orchestration logic.
-        script.metaClass.backupItemSource = { String type, String id -> [:] }
-        def chooserWrites = []
-        script.metaClass.toolUpdateNativeApp = { Map argsMap ->
-            chooserWrites << argsMap
-            return [success: true, settingsApplied: argsMap?.settings?.keySet()?.toList()]
+        script.metaClass._primeHubVarsWizard = { Integer appId, String context -> /* no-op */ }
+        def settingWrites = []
+        script.metaClass._rmWriteSettingOnPage = { Integer appId, String pageName, String settingName, val, List applied, String fieldType, List skipped ->
+            settingWrites << [appId: appId, pageName: pageName, name: settingName, value: val, fieldType: fieldType]
         }
 
         when:
@@ -747,11 +743,13 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         buttonClicks.size() == 1
         buttonClicks[0] == [appId: 1424, btn: 'foo', stateAttr: 'createCon', pageName: 'hubVar']
 
-        and: 'chooser commit attempted via toolUpdateNativeApp (no-op for Boolean vars but called unconditionally)'
-        chooserWrites.size() == 1
-        chooserWrites[0].appId == 1424
-        chooserWrites[0].pageName == 'hubVar'
-        chooserWrites[0].settings == [capab: 'Variable']  // default when no connectorType arg
+        and: 'chooser capab commit via _rmWriteSettingOnPage (no-op for Boolean vars but called unconditionally)'
+        settingWrites.size() == 1
+        settingWrites[0].appId == 1424
+        settingWrites[0].pageName == 'hubVar'
+        settingWrites[0].name == 'capab'
+        settingWrites[0].value == 'Variable'  // default when no connectorType arg
+        settingWrites[0].fieldType == 'enum'
 
         and: 'response surfaces the new connector deviceId'
         result.success == true

--- a/src/test/groovy/server/ToolHubVariablesSpec.groovy
+++ b/src/test/groovy/server/ToolHubVariablesSpec.groovy
@@ -10,10 +10,17 @@ import support.ToolSpecBase
  * - toolSetVariable      -> set_variable
  * - toolDeleteHubVariable -> delete_variable
  *
- * Hub-variable APIs (getAllGlobalConnectorVariables / getGlobalConnectorVariable /
- * setGlobalConnectorVariable) are purely dynamic — not on AppExecutor — so
- * they're stubbed per-test via script.metaClass in given: blocks. See
- * docs/testing.md "Which interception point to use" for the general pattern.
+ * Migrated to the modern Hub Variable API (issue #92): getAllGlobalVars /
+ * getGlobalVar / setGlobalVar see ALL hub variables, not just the
+ * connector-exposed subset that getAllGlobalConnectorVariables saw. The
+ * modern API also returns richer metadata: each entry is shaped like
+ * [name, type, value, deviceId, attribute] so callers can tell whether a
+ * connector exists (deviceId/attribute populated) and what type the var
+ * is (Number/Decimal/String/Boolean/DateTime).
+ *
+ * These APIs are dynamic — not on AppExecutor — so they're stubbed
+ * per-test via script.metaClass in given: blocks. See docs/testing.md
+ * "Which interception point to use" for the general pattern.
  *
  * delete_variable is gated by requireHubAdminWrite (3-layer: setting flag,
  * args.confirm, 24h backup window). Helper enableHubAdminWrite() seeds those.
@@ -28,11 +35,11 @@ class ToolHubVariablesSpec extends ToolSpecBase {
     // -------- toolListVariables --------
 
     def "list_variables returns both hub and rule-engine variables with correct total"() {
-        given: 'hub exposes two connector variables'
-        script.metaClass.getAllGlobalConnectorVariables = { ->
+        given: 'hub exposes two variables — one connector-backed, one not'
+        script.metaClass.getAllGlobalVars = { ->
             [
-                'temp_setpoint': [value: 72, type: 'number'],
-                'vacation_mode': [value: false, type: 'boolean']
+                'temp_setpoint': [name: 'temp_setpoint', type: 'Number',  value: 72,    deviceId: 305, attribute: 'variable'],
+                'vacation_mode': [name: 'vacation_mode', type: 'Boolean', value: false, deviceId: null, attribute: null]
             ]
         }
 
@@ -42,30 +49,36 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         when:
         def result = script.toolListVariables()
 
-        then:
+        then: 'hub variables come back with the modern shape including connector linkage'
         result.hubVariables.size() == 2
-        result.hubVariables.find { it.name == 'temp_setpoint' }.value == 72
-        result.hubVariables.find { it.name == 'temp_setpoint' }.type == 'number'
-        result.hubVariables.find { it.name == 'temp_setpoint' }.source == 'hub'
+        def temp = result.hubVariables.find { it.name == 'temp_setpoint' }
+        temp.value == 72
+        temp.type == 'Number'
+        temp.source == 'hub'
+        temp.deviceId == 305
+        temp.attribute == 'variable'
+        def vac = result.hubVariables.find { it.name == 'vacation_mode' }
+        vac.deviceId == null
+        vac.attribute == null
+
+        and: 'rule-engine variables come back unchanged'
         result.ruleVariables.size() == 1
         result.ruleVariables[0].name == 'last_motion'
         result.ruleVariables[0].source == 'rule_engine'
         result.total == 3
     }
 
-    def "list_variables falls back to rule variables when hub connector API throws"() {
-        given: 'the hub connector API is unavailable'
-        script.metaClass.getAllGlobalConnectorVariables = { ->
-            throw new RuntimeException('Hub connector not available')
+    def "list_variables falls back to rule variables when the hub API throws"() {
+        given:
+        script.metaClass.getAllGlobalVars = { ->
+            throw new RuntimeException('Hub variable API not available')
         }
-
-        and: 'a rule-engine variable exists'
         stateMap.ruleVariables = [counter: 5]
 
         when:
         def result = script.toolListVariables()
 
-        then: 'hub list is empty but the call does not throw'
+        then:
         result.hubVariables == []
         result.ruleVariables.size() == 1
         result.total == 1
@@ -73,7 +86,7 @@ class ToolHubVariablesSpec extends ToolSpecBase {
 
     def "list_variables returns empty collections when no variables are defined"() {
         given:
-        script.metaClass.getAllGlobalConnectorVariables = { -> [:] }
+        script.metaClass.getAllGlobalVars = { -> [:] }
 
         when:
         def result = script.toolListVariables()
@@ -86,10 +99,11 @@ class ToolHubVariablesSpec extends ToolSpecBase {
 
     // -------- toolGetVariable --------
 
-    def "get_variable returns hub connector value with source 'hub' when found"() {
+    def "get_variable returns the modern shape with type and connector linkage"() {
         given:
-        script.metaClass.getGlobalConnectorVariable = { String name ->
-            name == 'outdoor_temp' ? 68 : null
+        script.metaClass.getGlobalVar = { String name ->
+            if (name != 'outdoor_temp') return null
+            [name: 'outdoor_temp', type: 'Decimal', value: 68.4, deviceId: 312, attribute: 'variable']
         }
 
         when:
@@ -97,17 +111,36 @@ class ToolHubVariablesSpec extends ToolSpecBase {
 
         then:
         result.name == 'outdoor_temp'
-        result.value == 68
+        result.value == 68.4
+        result.type == 'Decimal'
+        result.deviceId == 312
+        result.attribute == 'variable'
         result.source == 'hub'
     }
 
-    def "get_variable falls back to rule-engine value when hub connector throws"() {
-        given: 'hub connector API unavailable'
-        script.metaClass.getGlobalConnectorVariable = { String name ->
-            throw new RuntimeException('Not supported')
+    def "get_variable returns hub var without connector linkage when no connector exists"() {
+        given: 'a Boolean var without a connector — deviceId/attribute null'
+        script.metaClass.getGlobalVar = { String name ->
+            [name: 'vacation_mode', type: 'Boolean', value: true, deviceId: null, attribute: null]
         }
 
-        and: 'rule engine has the variable'
+        when:
+        def result = script.toolGetVariable('vacation_mode')
+
+        then:
+        result.name == 'vacation_mode'
+        result.value == true
+        result.type == 'Boolean'
+        result.deviceId == null
+        result.attribute == null
+        result.source == 'hub'
+    }
+
+    def "get_variable falls back to rule-engine value when hub API throws"() {
+        given:
+        script.metaClass.getGlobalVar = { String name ->
+            throw new RuntimeException('Not supported')
+        }
         stateMap.ruleVariables = [porch_light_pref: 'bright']
 
         when:
@@ -121,7 +154,7 @@ class ToolHubVariablesSpec extends ToolSpecBase {
 
     def "get_variable throws when variable exists in neither source"() {
         given:
-        script.metaClass.getGlobalConnectorVariable = { String name -> null }
+        script.metaClass.getGlobalVar = { String name -> null }
         stateMap.ruleVariables = [:]
 
         when:
@@ -135,10 +168,10 @@ class ToolHubVariablesSpec extends ToolSpecBase {
 
     // -------- toolSetVariable --------
 
-    def "set_variable writes via hub connector and reports source 'hub' on success"() {
+    def "set_variable writes via setGlobalVar and reports source 'hub' on success"() {
         given:
         def captured = [:]
-        script.metaClass.setGlobalConnectorVariable = { String name, Object value ->
+        script.metaClass.setGlobalVar = { String name, Object value ->
             captured[name] = value
             return true
         }
@@ -154,11 +187,9 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         result.source == 'hub'
     }
 
-    def "set_variable falls back to rule engine when hub connector throws"() {
-        given:
-        script.metaClass.setGlobalConnectorVariable = { String name, Object value ->
-            throw new RuntimeException('Connector variable not defined on hub')
-        }
+    def "set_variable falls back to rule engine when setGlobalVar returns false (var not found)"() {
+        given: 'setGlobalVar returns false when the hub var does not exist'
+        script.metaClass.setGlobalVar = { String name, Object value -> false }
 
         when:
         def result = script.toolSetVariable('new_rule_var', 42)
@@ -172,11 +203,28 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         result.value == 42
     }
 
-    def "set_variable passes string values through to hub connector unchanged"() {
+    def "set_variable falls back to rule engine when setGlobalVar throws"() {
+        given:
+        script.metaClass.setGlobalVar = { String name, Object value ->
+            throw new RuntimeException('Hub variable API unavailable')
+        }
+
+        when:
+        def result = script.toolSetVariable('weather_state', 'sunny')
+
+        then:
+        stateMap.ruleVariables == [weather_state: 'sunny']
+        result.success == true
+        result.value == 'sunny'
+        result.source == 'rule_engine'
+    }
+
+    def "set_variable passes string values through to setGlobalVar unchanged"() {
         given:
         def captured = [:]
-        script.metaClass.setGlobalConnectorVariable = { String name, Object value ->
+        script.metaClass.setGlobalVar = { String name, Object value ->
             captured[name] = value
+            return true
         }
 
         when:
@@ -186,22 +234,6 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         captured == [weather_state: 'sunny']
         result.value == 'sunny'
         result.source == 'hub'
-    }
-
-    def "set_variable accepts null values via rule-engine fallback"() {
-        given: 'hub connector rejects null (some connector types require non-null)'
-        script.metaClass.setGlobalConnectorVariable = { String name, Object value ->
-            throw new IllegalArgumentException('Connector variable must not be null')
-        }
-
-        when:
-        def result = script.toolSetVariable('last_motion', null)
-
-        then:
-        stateMap.ruleVariables == [last_motion: null]
-        result.success == true
-        result.value == null
-        result.source == 'rule_engine'
     }
 
     // -------- toolDeleteHubVariable --------
@@ -277,9 +309,10 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         ex.message.contains('name is required')
     }
 
-    def "delete_variable throws with helpful hint when variable is not in rule_engine namespace"() {
-        given: 'rule_engine namespace is empty'
+    def "delete_variable throws when variable exists in neither hub nor rule_engine namespace"() {
+        given:
         enableHubAdminWrite()
+        script.metaClass.getGlobalVar = { String n -> null }
         stateMap.ruleVariables = [:]
 
         when:
@@ -288,14 +321,14 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         then:
         def ex = thrown(IllegalArgumentException)
         ex.message.contains("'nonexistent'")
+        ex.message.contains('hub-variables namespace')
         ex.message.contains('rule_engine namespace')
-        // Error should redirect users to UI for connector-namespace deletion
-        ex.message.contains('Hub Variables UI')
     }
 
-    def "delete_variable throws when ruleVariables map is null (variable also not present)"() {
+    def "delete_variable throws when ruleVariables map is null and var is not a hub var"() {
         given:
         enableHubAdminWrite()
+        script.metaClass.getGlobalVar = { String n -> null }
         // stateMap.ruleVariables not seeded at all — null check path
 
         when:
@@ -304,7 +337,6 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         then:
         def ex = thrown(IllegalArgumentException)
         ex.message.contains("'never_set'")
-        ex.message.contains('rule_engine namespace')
     }
 
     def "delete_variable reassigns the top-level state.ruleVariables map (Hubitat persistence quirk)"() {
@@ -406,5 +438,528 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         result.success == true
         result.deleted == true
         result.brokenConsumers == null
+    }
+
+    // -------- toolCreateVariable validation (issue #92) --------
+
+    def "create_variable rejects forbidden characters in name"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolCreateVariable([name: 'has[brackets]', type: 'String', value: 'x', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('forbidden character')
+    }
+
+    def "create_variable rejects unknown type"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolCreateVariable([name: 'goodName', type: 'NotAType', value: 'x', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('NotAType')
+        ex.message.contains('Number, Decimal, String, Boolean, DateTime')
+    }
+
+    def "create_variable rejects null/missing initial value"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolCreateVariable([name: 'goodName', type: 'String', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Initial value is required')
+    }
+
+    def "create_variable refuses to overwrite an existing hub variable"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.getGlobalVar = { String n ->
+            n == 'taken' ? [name: 'taken', type: 'String', value: 'already here', deviceId: null, attribute: null] : null
+        }
+
+        when:
+        script.toolCreateVariable([name: 'taken', type: 'String', value: 'new', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("already exists")
+        ex.message.contains('set_variable')
+    }
+
+    def "create_variable requires confirm"() {
+        when:
+        script.toolCreateVariable([name: 'goodName', type: 'String', value: 'x'])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    // -------- toolCreateConnector / toolRemoveConnector validation --------
+
+    def "create_connector throws when the variable does not exist"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.getGlobalVar = { String n -> null }
+
+        when:
+        script.toolCreateConnector([name: 'missing', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('does not exist')
+    }
+
+    def "create_connector is a no-op when a connector already exists"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.getGlobalVar = { String n ->
+            [name: 'has_conn', type: 'Boolean', value: true, deviceId: 305, attribute: 'switch']
+        }
+
+        when:
+        def result = script.toolCreateConnector([name: 'has_conn', confirm: true])
+
+        then:
+        result.success == true
+        result.alreadyExists == true
+        result.deviceId == 305
+    }
+
+    def "remove_connector throws when the variable does not exist"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.getGlobalVar = { String n -> null }
+
+        when:
+        script.toolRemoveConnector([name: 'missing', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('does not exist')
+    }
+
+    def "remove_connector is a no-op when no connector exists"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.getGlobalVar = { String n ->
+            [name: 'no_conn', type: 'String', value: 'x', deviceId: null, attribute: null]
+        }
+
+        when:
+        def result = script.toolRemoveConnector([name: 'no_conn', confirm: true])
+
+        then:
+        result.success == true
+        result.alreadyRemoved == true
+    }
+
+    // -------- Wizard-sequencing coverage (issue #92) --------
+    //
+    // The create/delete/connector tools drive the system Hub Variables app's UI
+    // by chaining `_rmClickAppButton` and `_rmWriteSettingOnPage` calls. Both
+    // are app-defined private methods (class 1 on the dispatch cheat sheet —
+    // not declared on AppExecutor / BaseExecutor / HubitatAppScript), so per-
+    // instance `script.metaClass` overrides win the dispatch and we can record
+    // the call args without hitting the network. `_findHubVariablesAppId` is
+    // also stubbed so we don't need to fake the /hub2/appsList tree.
+    //
+    // `getGlobalVar` is dynamic (also class 1) and we use a counter so the
+    // *first* call in each tool (the pre-flight existence check) sees one
+    // state of the world, and the *post-wizard verification* call sees the
+    // post-write state — this is what the production code expects when the
+    // wizard auto-commits on the final setting write / button click.
+
+    def "create_variable wizard sequence: one button click then three settings in order"() {
+        given:
+        enableHubAdminWrite()
+
+        and: 'getGlobalVar: null pre-flight, populated after wizard commits'
+        def callCount = 0
+        script.metaClass.getGlobalVar = { String n ->
+            callCount++
+            return callCount == 1 ? null : [name: 'newVar', type: 'String', value: 'hi', deviceId: null, attribute: null]
+        }
+
+        and: 'wizard primitives recorded instead of hitting the hub'
+        def buttonClicks = []
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName ->
+            buttonClicks << [appId: appId, btn: btnName, stateAttr: stateAttr, pageName: pageName]
+            return [status: 200]
+        }
+        def settingWrites = []
+        script.metaClass._rmWriteSettingOnPage = { Integer appId, String pageName, String key, Object value, List applied, String typeHint = null, List skipped = null ->
+            settingWrites << [appId: appId, pageName: pageName, key: key, value: value, typeHint: typeHint]
+            if (applied != null) applied << key
+        }
+        script.metaClass._findHubVariablesAppId = { -> 1424 }
+
+        when:
+        def result = script.toolCreateVariable([name: 'newVar', type: 'String', value: 'hi', confirm: true])
+
+        then: 'exactly one button click — opens the create form on the hubVar page'
+        buttonClicks.size() == 1
+        buttonClicks[0] == [appId: 1424, btn: 'moreVar', stateAttr: 'moreVar', pageName: 'hubVar']
+
+        and: 'three setting writes in order: name, type, value'
+        settingWrites.size() == 3
+        settingWrites[0] == [appId: 1424, pageName: 'hubVar', key: 'hbVar',    value: 'newVar', typeHint: 'text']
+        settingWrites[1] == [appId: 1424, pageName: 'hubVar', key: 'varType',  value: 'String', typeHint: 'enum']
+        settingWrites[2] == [appId: 1424, pageName: 'hubVar', key: 'varValue', value: 'hi',     typeHint: 'textarea']
+
+        and: 'tool reports success with hub source'
+        result.success == true
+        result.source == 'hub'
+        result.name == 'newVar'
+        result.type == 'String'
+        result.value == 'hi'
+    }
+
+    def "create_variable post-wizard verification fails when getGlobalVar still returns null"() {
+        given:
+        enableHubAdminWrite()
+
+        and: 'getGlobalVar returns null both pre-flight AND after the wizard supposedly committed'
+        script.metaClass.getGlobalVar = { String n -> null }
+
+        and: 'wizard primitives recorded but no real effect'
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName -> [status: 200] }
+        script.metaClass._rmWriteSettingOnPage = { Integer appId, String pageName, String key, Object value, List applied, String typeHint = null, List skipped = null ->
+            if (applied != null) applied << key
+        }
+        script.metaClass._findHubVariablesAppId = { -> 1424 }
+
+        when:
+        script.toolCreateVariable([name: 'ghostVar', type: 'String', value: 'x', confirm: true])
+
+        then: 'IllegalStateException — wizard ran but the var is not visible'
+        def ex = thrown(IllegalStateException)
+        ex.message.contains('wizard completed but')
+        ex.message.contains('ghostVar')
+    }
+
+    def "delete_variable hub-namespace wizard sequence: deleteGV then delConfirm"() {
+        given:
+        enableHubAdminWrite()
+
+        and: 'getGlobalVar: returns hub var pre-flight, null after delete commits'
+        def callCount = 0
+        script.metaClass.getGlobalVar = { String n ->
+            callCount++
+            return callCount == 1 ? [name: 'condemned', type: 'String', value: 'bye', deviceId: null, attribute: null] : null
+        }
+
+        and: 'wizard primitives recorded'
+        def buttonClicks = []
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName ->
+            buttonClicks << [appId: appId, btn: btnName, stateAttr: stateAttr, pageName: pageName]
+            return [status: 200]
+        }
+        script.metaClass._findHubVariablesAppId = { -> 1424 }
+
+        when:
+        def result = script.toolDeleteHubVariable([name: 'condemned', confirm: true])
+
+        then: 'two clicks: open the delete prompt, then commit it'
+        buttonClicks.size() == 2
+        buttonClicks[0] == [appId: 1424, btn: 'condemned',  stateAttr: 'deleteGV',   pageName: 'hubVar']
+        buttonClicks[1] == [appId: 1424, btn: 'delConfirm', stateAttr: null,         pageName: 'hubVar']
+
+        and: 'response reports hub-namespace deletion'
+        result.success == true
+        result.source == 'hub'
+        result.deleted == true
+        result.name == 'condemned'
+    }
+
+    def "delete_variable hub-namespace post-wizard verification fails when var still exists"() {
+        given:
+        enableHubAdminWrite()
+
+        and: 'getGlobalVar always returns the var — delete wizard ran but did not commit'
+        script.metaClass.getGlobalVar = { String n ->
+            [name: 'stuck', type: 'String', value: 'still here', deviceId: null, attribute: null]
+        }
+
+        and: 'wizard primitives recorded but no real effect'
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName -> [status: 200] }
+        script.metaClass._findHubVariablesAppId = { -> 1424 }
+
+        when:
+        script.toolDeleteHubVariable([name: 'stuck', confirm: true])
+
+        then: 'IllegalStateException — wizard claimed success but the var is still there'
+        def ex = thrown(IllegalStateException)
+        ex.message.contains('wizard completed but')
+        ex.message.contains('stuck')
+    }
+
+    def "create_connector wizard sequence: one button click on the variable name with createCon"() {
+        given:
+        enableHubAdminWrite()
+
+        and: 'getGlobalVar: deviceId=null pre-flight, deviceId=305 after wizard commits'
+        def callCount = 0
+        script.metaClass.getGlobalVar = { String n ->
+            callCount++
+            return callCount == 1 ?
+                [name: 'foo', type: 'Boolean', value: true, deviceId: null, attribute: null] :
+                [name: 'foo', type: 'Boolean', value: true, deviceId: 305,  attribute: 'switch']
+        }
+
+        and: 'wizard primitives recorded'
+        def buttonClicks = []
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName ->
+            buttonClicks << [appId: appId, btn: btnName, stateAttr: stateAttr, pageName: pageName]
+            return [status: 200]
+        }
+        script.metaClass._findHubVariablesAppId = { -> 1424 }
+
+        when:
+        def result = script.toolCreateConnector([name: 'foo', confirm: true])
+
+        then: 'exactly one click — variable-name button with createCon stateAttribute on the hubVar page'
+        buttonClicks.size() == 1
+        buttonClicks[0] == [appId: 1424, btn: 'foo', stateAttr: 'createCon', pageName: 'hubVar']
+
+        and: 'response surfaces the new connector deviceId'
+        result.success == true
+        result.deviceId == 305
+        result.attribute == 'switch'
+        result.name == 'foo'
+    }
+
+    // -------- handleHubVariableEvent + toolGetVariableHistory --------
+
+    def "handleHubVariableEvent strips the 'variable:' prefix and appends to atomicState.variableHistory"() {
+        given:
+        atomicStateMap.variableHistory = []
+        def evt = [name: 'variable:porch_light_pref', value: 'bright', descriptionText: 'changed by user']
+
+        when:
+        script.handleHubVariableEvent(evt)
+
+        then:
+        atomicStateMap.variableHistory.size() == 1
+        atomicStateMap.variableHistory[0].name == 'porch_light_pref'
+        atomicStateMap.variableHistory[0].value == 'bright'
+        atomicStateMap.variableHistory[0].timestamp == 1234567890000L  // HarnessSpec's fixed now()
+        atomicStateMap.variableHistory[0].descriptionText == 'changed by user'
+    }
+
+    def "handleHubVariableEvent caps the buffer at 200 entries — oldest dropped"() {
+        given: 'history pre-loaded with 200 entries'
+        atomicStateMap.variableHistory = (1..200).collect { i -> [name: 'var', value: i, timestamp: i] }
+        def evt = [name: 'variable:var', value: 999]
+
+        when:
+        script.handleHubVariableEvent(evt)
+
+        then: 'still 200 entries; the oldest (value=1) is gone, newest is at the tail'
+        atomicStateMap.variableHistory.size() == 200
+        atomicStateMap.variableHistory[0].value == 2
+        atomicStateMap.variableHistory[-1].value == 999
+    }
+
+    def "handleHubVariableEvent ignores null events and missing names"() {
+        given:
+        atomicStateMap.variableHistory = []
+
+        when:
+        script.handleHubVariableEvent(null)
+        script.handleHubVariableEvent([name: null, value: 'x'])
+
+        then:
+        atomicStateMap.variableHistory == []
+    }
+
+    def "get_variable_history returns most-recent-first capped at limit"() {
+        given:
+        atomicStateMap.variableHistory = (1..10).collect { i -> [name: 'v', value: i, timestamp: i] }
+
+        when:
+        def result = script.toolGetVariableHistory([limit: 3])
+
+        then: 'newest three, reverse-chronological'
+        result.entries.size() == 3
+        result.entries[0].value == 10
+        result.entries[1].value == 9
+        result.entries[2].value == 8
+        result.bufferSize == 10
+        result.bufferCap == 200
+    }
+
+    def "get_variable_history filters by name when provided"() {
+        given:
+        atomicStateMap.variableHistory = [
+            [name: 'foo', value: 1, timestamp: 1],
+            [name: 'bar', value: 2, timestamp: 2],
+            [name: 'foo', value: 3, timestamp: 3]
+        ]
+
+        when:
+        def result = script.toolGetVariableHistory([name: 'foo'])
+
+        then:
+        result.entries.size() == 2
+        result.entries.every { it.name == 'foo' }
+        result.entries[0].value == 3  // newest first
+    }
+
+    def "get_variable_history filters by sinceMs when provided"() {
+        given:
+        atomicStateMap.variableHistory = [
+            [name: 'v', value: 1, timestamp: 100],
+            [name: 'v', value: 2, timestamp: 200],
+            [name: 'v', value: 3, timestamp: 300]
+        ]
+
+        when:
+        def result = script.toolGetVariableHistory([sinceMs: 200])
+
+        then: 'only entries with timestamp >= 200'
+        result.entries.size() == 2
+        result.entries[0].timestamp == 300
+        result.entries[1].timestamp == 200
+    }
+
+    def "get_variable_history returns empty entries when buffer is empty"() {
+        given:
+        atomicStateMap.variableHistory = []
+
+        when:
+        def result = script.toolGetVariableHistory([:])
+
+        then:
+        result.entries == []
+        result.bufferSize == 0
+    }
+
+    // -------- renameVariable callback --------
+
+    def "renameVariable rewrites matching history entries to the new name"() {
+        given:
+        atomicStateMap.variableHistory = [
+            [name: 'old', value: 'a', timestamp: 1],
+            [name: 'unrelated', value: 'x', timestamp: 2],
+            [name: 'old', value: 'b', timestamp: 3]
+        ]
+        // subscribe is on AppExecutor — already stubbed in HarnessSpec
+
+        when:
+        script.renameVariable('old', 'new')
+
+        then: 'old -> new for matching entries; others untouched'
+        atomicStateMap.variableHistory[0].name == 'new'
+        atomicStateMap.variableHistory[1].name == 'unrelated'
+        atomicStateMap.variableHistory[2].name == 'new'
+        // Values preserved
+        atomicStateMap.variableHistory[0].value == 'a'
+        atomicStateMap.variableHistory[2].value == 'b'
+    }
+
+    def "renameVariable is a no-op on history when no entries match"() {
+        given:
+        atomicStateMap.variableHistory = [[name: 'untouched', value: 'x', timestamp: 1]]
+
+        when:
+        script.renameVariable('absent', 'replacement')
+
+        then: 'history unchanged'
+        atomicStateMap.variableHistory[0].name == 'untouched'
+    }
+
+    // -------- _refreshHubVarInUseRegistrations (issue #96 gap 1) --------
+
+    def "in-use refresh registers vars referenced by child rules"() {
+        given: 'two hub vars on the hub'
+        script.metaClass.getAllGlobalVars = { ->
+            [shared_var: [name: 'shared_var', type: 'String', value: 'x'],
+             unused_var: [name: 'unused_var', type: 'String', value: 'y']]
+        }
+        and: 'a child rule that references shared_var'
+        def consumer = new support.TestChildApp(id: 11L, label: 'Uses shared_var')
+        consumer.ruleData = [
+            triggers: [],
+            conditions: [[type: 'variable', name: 'shared_var']],
+            actions: []
+        ]
+        childAppsList << consumer
+
+        and: 'recorders for the in-use API calls'
+        def added = []
+        def removed = []
+        script.metaClass.addInUseGlobalVar    = { String n -> added    << n; true }
+        script.metaClass.removeInUseGlobalVar = { String n -> removed  << n; true }
+
+        when:
+        script._refreshHubVarInUseRegistrations()
+
+        then: 'only the referenced var was registered; the unreferenced one was not'
+        added == ['shared_var']
+        removed == []
+        atomicStateMap.inUseHubVars == ['shared_var']
+    }
+
+    def "in-use refresh removes registrations for vars no longer referenced"() {
+        given: 'previous run registered two vars'
+        atomicStateMap.inUseHubVars = ['old_a', 'old_b']
+        script.metaClass.getAllGlobalVars = { ->
+            [old_a: [name: 'old_a'], old_b: [name: 'old_b'], still_used: [name: 'still_used']]
+        }
+        and: 'a child rule that now only references still_used'
+        def consumer = new support.TestChildApp(id: 22L, label: 'Migrated')
+        consumer.ruleData = [conditions: [[type: 'variable', name: 'still_used']]]
+        childAppsList << consumer
+
+        def added = []
+        def removed = []
+        script.metaClass.addInUseGlobalVar    = { String n -> added   << n; true }
+        script.metaClass.removeInUseGlobalVar = { String n -> removed << n; true }
+
+        when:
+        script._refreshHubVarInUseRegistrations()
+
+        then: 'still_used is newly registered; old_a + old_b are unregistered'
+        added == ['still_used']
+        removed.toSet() == ['old_a', 'old_b'] as Set
+        atomicStateMap.inUseHubVars == ['still_used']
+    }
+
+    def "in-use refresh clears all registrations when there are no hub vars at all"() {
+        given:
+        atomicStateMap.inUseHubVars = ['stale']
+        script.metaClass.getAllGlobalVars = { -> [:] }
+
+        def removed = []
+        script.metaClass.removeInUseGlobalVar = { String n -> removed << n; true }
+
+        when:
+        script._refreshHubVarInUseRegistrations()
+
+        then:
+        removed == ['stale']
+        atomicStateMap.inUseHubVars == []
+    }
+
+    def "in-use refresh tolerates getAllGlobalVars throwing — does not mutate state"() {
+        given:
+        atomicStateMap.inUseHubVars = ['existing']
+        script.metaClass.getAllGlobalVars = { -> throw new RuntimeException('hub api down') }
+
+        when:
+        script._refreshHubVarInUseRegistrations()
+
+        then: 'state unchanged — better to keep stale registration than wipe it on a transient error'
+        atomicStateMap.inUseHubVars == ['existing']
+        noExceptionThrown()
     }
 }


### PR DESCRIPTION
## Summary

- Closes #92 (hub-variable change observation), partially closes #96 (modern-API listing + rename callback + in-use registration).
- Migrates four existing tools off the legacy connector-only API to the modern Hub Variable API + adds four new tools (`create_variable`, `create_connector`, `remove_connector`, `get_variable_history`).
- All eight tools registered under the existing `manage_hub_variables` category gateway.
- No changes to the legacy MCP rule engine — issue #96's child-app pieces (auto-rewriting rule references on rename) remain deferred per the "child app is frozen" direction.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix`
- [ ] `chore`
- [ ] `refactor`
- [ ] `docs`
- [ ] `test`
- [ ] `ci`

## Changes

**Modern Hub Variable API migration** (`hubitat-mcp-server.groovy`):
- `toolListVariables` / `toolGetVariable` / `toolSetVariable` / `getVariableValue` switched from `getAllGlobalConnectorVariables` / `getGlobalConnectorVariable` / `setGlobalConnectorVariable` to `getAllGlobalVars` / `getGlobalVar` / `setGlobalVar`.
- Result shape now includes `type`, `deviceId`, `attribute` per variable so callers can tell whether a connector exists and what numeric/string/boolean type a var is.
- Hub vars without connectors are now visible (the legacy API only saw connector-exposed ones).

**Wizard-driven CRUD** (`hubitat-mcp-server.groovy`):
- `_findHubVariablesAppId()` discovers + caches the system "Hub Variables" app id from `/hub2/appsList`; falls back to a bounded id-scan when the app is hidden from the apps-list feed (observed on firmware 2.5.0.126).
- `_primeHubVarsWizard()` issues a `configure-json` + `statusJson` GET pair to "warm" the system app's wizard state before each click — without this, clicks silently no-op on a fresh wizard. Used by every wizard-driving tool below.
- `toolCreateVariable(name, type, value, confirm)` walks `moreVar` → `hbVar` → `varType` → `varValue` (or `varDate` + `varTime` + `dateTimeDone` for DateTime), then verifies via `getGlobalVar` with retry-with-backoff.
- `toolDeleteHubVariable` extended: when the target is a hub variable, drives `deleteGV` → `delConfirm` (also removes the connector if one exists). Retries the click sequence once if verification finds the var still present (defeats a firmware state-machine race after fresh creates). Existing rule_engine + reference-safety / `force=true` semantics preserved; the consumer scan now uses a JSON-quoted word-boundary needle so a var named `temp` doesn't false-positive against rules referencing `temperature` / `attempt`.
- `toolCreateConnector(name, confirm)` clicks the row's `createCon` button, then commits the `capab` chooser sub-page (Variable / Dimmer / etc., relevant only for Number/Decimal vars — schema-skip no-op for Boolean/String/DateTime). Verifies the new `deviceId` lands via `getGlobalVar` with retry-with-backoff. Idempotent when a connector already exists.
- `toolRemoveConnector(name, confirm)` deletes the connector device via the existing `delete_device` flow using `getGlobalVar(name).deviceId`, propagates a failure from `delete_device` (throws) instead of silently reporting `deviceDeleted: false`, and verifies the variable's `deviceId` linkage is cleared post-delete. The variable itself is unchanged.

**Issue #92 — change observation**:
- `initialize()` calls `_subscribeToAllHubVariables()` which subscribes to `variable:NAME` for every hub variable.
- `handleHubVariableEvent(evt)` strips the `variable:` prefix and appends `{name, value, timestamp, descriptionText}` to `atomicState.variableHistory` (cap 200; oldest dropped).
- `renameVariable(oldName, newName)` callback rewrites buffered history entries so post-rename queries still find the right events; re-subscribes to the new name.
- `toolGetVariableHistory(args)` returns recent changes filterable by `name` / `sinceMs` / `limit` (default 50, most-recent first).

**Issue #96 gap 1 — in-use registration**:
- `_refreshHubVarInUseRegistrations()` walks every child rule's serialized `ruleData`, collects hub-variable names referenced (word-boundary match: `"<name>"` JSON-quoted), and calls `addInUseGlobalVar` / `removeInUseGlobalVar` to track the delta in `atomicState.inUseHubVars`. Hubitat's Settings UI then warns users before deleting/renaming a variable a rule depends on.
- Pure parent-side bookkeeping — no legacy-engine code touched.
- Failures during refresh / subscribe / addInUse / removeInUse surface at ERROR log level so users notice when in-use safety is stale.

**Tool surfacing**:
- All eight tools registered in the `manage_hub_variables` gateway. With `useGateways=true` they consolidate behind the single `manage_hub_variables` proxy tool; with `useGateways=false` they surface individually.
- The four mutating tools (`create_variable`, `delete_variable`, `create_connector`, `remove_connector`) require `requireHubAdminWrite` (Enable Hub Admin Write Tools setting + `confirm=true` + 24h hub backup). Read-only tools and `set_variable` follow the existing convention (no admin gate).

**Why no `rename_variable` tool**: probed Hubitat's Settings → Hub Variables page live; the row exposes only edit-value, delete, and create-connector actions. No rename surface exists in Hubitat itself, so an MCP tool would have to bypass the documented UI flow. The `renameVariable(old, new)` parent-app callback in this PR is for *receiving* rename events from the UI, not for triggering them.

**futureplans.md**: marked the "Hub variable change triggers" + "Variable change events" bullets done/partial with cross-references to #92's closure.

## Release Notes

- Add `create_variable` tool: create a new hub variable with `name`, `type` (Number / Decimal / String / Boolean / DateTime), and initial `value`.
- Add `create_connector` tool: create a virtual-device connector for an existing hub variable (the same "Create" link in Settings → Hub Variables, automated).
- Add `remove_connector` tool: delete the connector device backing a hub variable; the variable itself is unchanged.
- Add `get_variable_history` tool: see what hub variables have changed recently. Buffers the last 200 changes; filterable by name, since-timestamp, and limit.
- `delete_variable` now also handles **hub variables** (previously only rule-engine variables); also deletes the connector device when one exists.
- `list_variables` and `get_variable` now see **every** hub variable (previously only connector-exposed ones) and return type / connector linkage in their response.
- `set_variable` writes to any hub variable (previously only connector-exposed ones).
- Hubitat now warns you before deleting or renaming a hub variable that an MCP rule depends on (issue #96 gap 1).

## Testing

- 49 specs in `ToolHubVariablesSpec.groovy` covering: modern-API migration shape, wizard-sequencing for create / delete (hub branch) / create_connector (with capab chooser commit), DateTime branch, post-write verification + retry, handler/history (prefix stripping, 200-cap, null tolerance), `renameVariable` callback (history rewrite + re-subscribe), `_refreshHubVarInUseRegistrations` (register-only-referenced, diff-removes-stale, word-boundary scan, error tolerance).
- CI green: 982 unit tests pass; lint, guard, and e2e checks all pass.
- Live-hub BAT performed against the maintainer's hub on firmware 2.5.0.126: end-to-end create / set / get / get_variable_history / create_connector / remove_connector / delete_variable for Number / String / Boolean types, plus word-boundary consumer-scan validation (`temp` deletes cleanly without false-positive matches against rules referencing `temperature` etc.).

## Checklist

- [x] **Unit tests added for any new MCP tools**
- [x] Sandbox lint passes: `python tests/sandbox_lint.py` (CI)
- [x] `./gradlew test` passes (CI; local runs deferred per maintainer pref)
- [x] Live-hub BAT performed
- [x] Documentation updated if user-facing behaviour or tool surface changed (gateway summaries + tools-list descriptions + futureplans.md)
