### PR TITLE
feat(get-hub-logs): server-side regex / multi-pattern / time-window filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Source code is automatically backed up before any modify/delete operation.
 
 | Tool | Description |
 |------|-------------|
-| `get_hub_logs` | Hub log entries (most recent first) with level/source filters and server-side deviceId/appId scoping |
+| `get_hub_logs` | Hub log entries (most recent first) with level/source/regex filters, multi-pattern AND/OR, time-window (since/until), and server-side deviceId/appId scoping |
 | `get_device_history` | Up to 7 days of device event history |
 | `get_performance_stats` | Device/app performance stats (count, % busy, total ms, state size, events, large-state flag) |
 | `get_hub_jobs` | Scheduled jobs, running jobs, and hub actions |

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Source code is automatically backed up before any modify/delete operation.
 
 | Tool | Description |
 |------|-------------|
-| `get_hub_logs` | Hub log entries (most recent first) with level/source/regex filters, multi-pattern AND/OR, time-window (since/until), and server-side deviceId/appId scoping |
+| `get_hub_logs` | Hub log entries (most recent first) with level/source/regex filters, multi-pattern AND/OR, time-window (since/until, max 30d relative -- throws if exceeded; use ISO-8601 for longer ranges), and server-side deviceId/appId scoping. `pattern` matches the message field only; pathological regex like `(.*)*` may hang the matcher. |
 | `get_device_history` | Up to 7 days of device event history |
 | `get_performance_stats` | Device/app performance stats (count, % busy, total ms, state size, events, large-state flag) |
 | `get_hub_jobs` | Scheduled jobs, running jobs, and hub actions |

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -305,7 +305,7 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 - `level` and `source` (substring) are simple string filters applied before regex
 - `pattern` (string): case-insensitive regex against the message field; compiled once; throws on invalid syntax
 - `patterns` (array of strings): multiple regexes; `patternMode='any'` (default) = OR, `patternMode='all'` = AND; compatible with `pattern` (both apply)
-- `since` / `until`: ISO-8601 timestamp (e.g. `'2024-01-15T10:30:00Z'`) or relative offset (`'30m'`, `'2h'`, `'1d'`, `'7d'`); relative offset subtracted from now; max 30d; entries with unparseable time fields pass through rather than being excluded
+- `since` / `until`: ISO-8601 timestamp (e.g. `'2024-01-15T10:30:00Z'`) or relative offset (`'30m'`, `'2h'`, `'1d'`, `'7d'`); relative offset subtracted from now; max 30d (throws if exceeded -- use ISO-8601 for longer ranges); entries with unparseable time fields pass through rather than being excluded. ISO-8601 timestamps without an explicit TZ marker (e.g., `'2024-01-15T10:30:00'` or `'2024-01-15 10:30:00.000'`) are parsed as UTC.
 - For single-device or single-app logs, pass `deviceId` or `appId` -- this is a server-side scope filter (mutually exclusive) and is much cheaper than post-filtering the full buffer
 
 **get_device_history:**

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -301,8 +301,12 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 **get_hub_logs:**
 - Returns most recent entries first
 - Default 100 entries, max 500
-- Use level and source filters to narrow results
-- For single-device or single-app logs, pass `deviceId` or `appId` — this is a server-side scope filter (mutually exclusive) and is much cheaper than post-filtering the full buffer
+- Filter pipeline order: scope (deviceId/appId, server-side) -> level -> source -> pattern -> patterns -> time window (since/until) -> limit
+- `level` and `source` (substring) are simple string filters applied before regex
+- `pattern` (string): case-insensitive regex against the message field; compiled once; throws on invalid syntax
+- `patterns` (array of strings): multiple regexes; `patternMode='any'` (default) = OR, `patternMode='all'` = AND; compatible with `pattern` (both apply)
+- `since` / `until`: ISO-8601 timestamp (e.g. `'2024-01-15T10:30:00Z'`) or relative offset (`'30m'`, `'2h'`, `'1d'`, `'7d'`); relative offset subtracted from now; max 30d; entries with unparseable time fields pass through rather than being excluded
+- For single-device or single-app logs, pass `deviceId` or `appId` -- this is a server-side scope filter (mutually exclusive) and is much cheaper than post-filtering the full buffer
 
 **get_device_history:**
 - Up to 7 days of history

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -153,7 +153,7 @@ For complete safety protocols and tool-specific requirements, see [safety-guide.
 Core tool: `get_device_events` (always visible)
 
 Via `manage_logs` gateway (6 tools):
-- `get_hub_logs` - Hub log entries, most recent first (filter by level/source, or scope server-side to a single `deviceId` / `appId` — mutually exclusive)
+- `get_hub_logs` - Hub log entries, most recent first; filter by level/source/pattern (regex) or multi-pattern AND/OR (`patternMode`); time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`); or scope server-side to a single `deviceId` / `appId` (mutually exclusive)
 - `get_device_history` - Device event history (up to 7 days)
 - `get_debug_logs` / `clear_debug_logs` - MCP-specific debug logs
 - `set_log_level` - Set MCP log level

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -153,7 +153,7 @@ For complete safety protocols and tool-specific requirements, see [safety-guide.
 Core tool: `get_device_events` (always visible)
 
 Via `manage_logs` gateway (6 tools):
-- `get_hub_logs` - Hub log entries, most recent first; filter by level/source/pattern (regex) or multi-pattern AND/OR (`patternMode`); time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`); or scope server-side to a single `deviceId` / `appId` (mutually exclusive)
+- `get_hub_logs` - Hub log entries, most recent first; filter by level/source/pattern (regex) or multi-pattern AND/OR (`patternMode`); time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`, max 30d -- throws if exceeded; use ISO-8601 for longer ranges); or scope server-side to a single `deviceId` / `appId` (mutually exclusive). `pattern` matches the message field only (not source/name). Pathological regex like `(.*)*` may hang the matcher; prefer simple alternation.
 - `get_device_history` - Device event history (up to 7 days)
 - `get_debug_logs` / `clear_debug_logs` - MCP-specific debug logs
 - `set_log_level` - Set MCP log level

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -144,7 +144,7 @@ Hub and MCP log access, performance stats, and log configuration.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
-| `get_hub_logs` | Hub log entries, most recent first. Default 100, max 500. Filter by level/source/pattern (regex) or multi-pattern with AND/OR mode; time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`); or scope server-side to a single `deviceId` / `appId`. | Hub Admin Read |
+| `get_hub_logs` | Hub log entries, most recent first. Default 100, max 500. Filter by level/source/pattern (regex) or multi-pattern with AND/OR mode; time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`, max 30d -- throws if exceeded); or scope server-side to a single `deviceId` / `appId`. `pattern` matches the message field only (not source/name). Pathological regex like `(.*)*` may hang the matcher; prefer simple alternation. | Hub Admin Read |
 | `get_device_history` | Up to 7 days of device event history. | Hub Admin Read |
 | `get_performance_stats` | Device/app performance stats from `/logs`: method call counts, % busy, cumulative total ms, state size, events. Sortable. | Hub Admin Read |
 | `get_hub_jobs` | Scheduled and running jobs on the hub. | Hub Admin Read |

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -144,7 +144,7 @@ Hub and MCP log access, performance stats, and log configuration.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
-| `get_hub_logs` | Hub log entries, most recent first. Default 100, max 500. Filter by level/source, or scope to a single `deviceId` / `appId` (server-side). | Hub Admin Read |
+| `get_hub_logs` | Hub log entries, most recent first. Default 100, max 500. Filter by level/source/pattern (regex) or multi-pattern with AND/OR mode; time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`); or scope server-side to a single `deviceId` / `appId`. | Hub Admin Read |
 | `get_device_history` | Up to 7 days of device event history. | Hub Admin Read |
 | `get_performance_stats` | Device/app performance stats from `/logs`: method call counts, % busy, cumulative total ms, state size, events. Sortable. | Hub Admin Read |
 | `get_hub_jobs` | Scheduled and running jobs on the hub. | Hub Admin Read |

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -620,7 +620,7 @@ def getGatewayConfig() {
             description: "System logs, performance stats, and log settings: hub logs, device/app performance stats, scheduled jobs, device event history, MCP debug logs, and log level configuration.",
             tools: ["get_hub_logs", "get_device_history", "get_performance_stats", "get_hub_jobs", "get_debug_logs", "clear_debug_logs", "set_log_level", "get_logging_status"],
             summaries: [
-                get_hub_logs: "Get Hubitat system logs, most recent first. Args: level (debug/info/warn/error), source (substring), deviceId or appId (server-side scope), limit",
+                get_hub_logs: "Get Hubitat system logs, most recent first. Args: level (debug/info/warn/error), source (substring), pattern (regex), patterns + patternMode (multi-regex AND/OR), since/until (ISO-8601 or '30m'/'2h'/'1d'), deviceId or appId (server-side scope), limit",
                 get_device_history: "Get device event history (up to 7 days). Args: deviceId, hours, attribute",
                 get_performance_stats: "Get device/app performance stats (count, % busy, total ms, state size, events, large state flag). Args: type (device/app/both), sortBy (pct/count/stateSize/totalMs/name), limit",
                 get_hub_jobs: "Get scheduled jobs, running jobs, and hub actions",
@@ -630,7 +630,7 @@ def getGatewayConfig() {
                 get_logging_status: "Get logging system status and capacity"
             ],
             searchHints: [
-                get_hub_logs: "errors warnings messages trace syslog output print recent latest newest device app scope",
+                get_hub_logs: "errors warnings messages trace syslog output print recent latest newest device app scope regex pattern filter time window since until last hour minute",
                 get_device_history: "events timeline past activity what happened sensor",
                 get_performance_stats: "slow cpu busy resource usage hog bottleneck",
                 get_hub_jobs: "scheduled cron timer recurring what is running next automation",
@@ -1364,7 +1364,7 @@ Verify rule after creation.""",
         ],
         [
             name: "get_hub_logs",
-            description: "Get Hubitat system logs, most recent first. Filter by level, source substring, or scope server-side to a single device or app. Default 100 entries, max 500. Requires Hub Admin Read.",
+            description: "Get Hubitat system logs, most recent first. Filter pipeline (in order): scope (deviceId/appId, server-side) -> level -> source -> pattern -> patterns -> time window (since/until) -> limit. Default 100 entries, max 500. Requires Hub Admin Read.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -1372,7 +1372,12 @@ Verify rule after creation.""",
                     source: [type: "string", description: "Filter by source/app name (case-insensitive substring match against the log entry)"],
                     deviceId: [type: "string", description: "Scope to a single device's log entries (server-side filter, mutually exclusive with appId)"],
                     appId: [type: "string", description: "Scope to a single app's log entries (server-side filter, mutually exclusive with deviceId)"],
-                    limit: [type: "integer", description: "Max entries to return. Default: 100, max: 500.", default: 100]
+                    limit: [type: "integer", description: "Max entries to return. Default: 100, max: 500.", default: 100],
+                    pattern: [type: "string", description: "Case-insensitive regex applied to the log message field only -- use source for app/device-name substring matching. Entry is kept when it matches. Compiled once before the loop. Throws on invalid regex syntax. Note: pathological regex like (.*)*  may hang the matcher; prefer simple alternation (error|fail) or anchored prefixes."],
+                    patterns: [type: "array", items: [type: "string"], description: "Multiple regex patterns applied to the log message field only -- use source for app/device-name substring matching. Use with patternMode to control AND/OR logic. Each pattern compiled once. Throws on invalid regex syntax. Compatible with pattern (both apply). Note: pathological regex like (.*)*  may hang the matcher; prefer simple alternation (error|fail) or anchored prefixes."],
+                    patternMode: [type: "string", description: "How patterns array is combined: 'any' (default) = OR -- entry kept if any pattern matches; 'all' = AND -- entry kept only if every pattern matches. Case-insensitive ('ANY' and 'any' both work).", enum: ["any", "all"]],
+                    since: [type: "string", description: "Return only entries at or after this time. Accepts ISO-8601 timestamp (e.g. '2024-01-15T10:30:00Z') or relative offset (e.g. '30m', '2h', '1d', '7d'). Relative offset is subtracted from now. Max relative offset: 30d. Use '0m' / '0d' as a degenerate since to filter out everything older than now -- useful for testing harnesses but rarely otherwise."],
+                    until: [type: "string", description: "Return only entries at or before this time. Same format as since (relative offsets are subtracted from now, same as since). Default: now (no upper bound). Use since='2h', until='1h' to mean '1 to 2 hours ago'."]
                 ]
             ]
         ],
@@ -6529,6 +6534,156 @@ def toolGetHubLogs(args) {
         throw new IllegalArgumentException("deviceId and appId are mutually exclusive: set only one")
     }
 
+    // --- Type-shape validation: catch wrong-type args before any parsing or regex compile ---
+    // pattern must be a String; List callers occasionally pass ['foo'] expecting a substring search
+    if (args.pattern != null && !(args.pattern instanceof String)) {
+        throw new IllegalArgumentException("pattern must be a string (got ${args.pattern instanceof List ? 'list' : 'non-string'})")
+    }
+    // patterns must be a List; a bare String is never silently treated as a single-element list
+    if (args.patterns != null && !(args.patterns instanceof List)) {
+        throw new IllegalArgumentException("patterns must be a list of strings (got ${args.patterns instanceof String ? 'string' : 'non-list'})")
+    }
+    // All elements inside patterns must be strings
+    if (args.patterns instanceof List) {
+        for (int i = 0; i < args.patterns.size(); i++) {
+            def pi = args.patterns[i]
+            if (pi != null && !(pi instanceof String)) {
+                throw new IllegalArgumentException("patterns[${i}] must be a string (got ${pi instanceof List ? 'list' : pi instanceof Number ? 'number' : 'non-string'})")
+            }
+        }
+    }
+    // since / until must be Strings (ISO-8601 or relative offset); numeric ms would require a
+    // different parsing path and silently no-op the time-window filter if passed as a number
+    if (args.since != null && !(args.since instanceof String)) {
+        throw new IllegalArgumentException("since must be a string (ISO-8601 timestamp or relative offset like '30m', '2h', '1d')")
+    }
+    if (args.until != null && !(args.until instanceof String)) {
+        throw new IllegalArgumentException("until must be a string (same format as since)")
+    }
+
+    // --- Compile regex patterns before the loop (once, not per entry) ---
+
+    // Single pattern (case-insensitive substring regex against message field)
+    def compiledPattern = null
+    if (args.pattern) {
+        def pat = args.pattern.toString().take(100)
+        try {
+            compiledPattern = java.util.regex.Pattern.compile(pat, java.util.regex.Pattern.CASE_INSENSITIVE)
+        } catch (java.util.regex.PatternSyntaxException e) {
+            throw new IllegalArgumentException("Invalid regex pattern '${pat}': ${e.message}")
+        }
+    }
+
+    // Multi-pattern (case-insensitive regex list; patternMode controls AND/OR)
+    def compiledPatterns = []
+    def patternModeAll = (args.patternMode?.toString()?.toLowerCase() == "all")
+    if (args.patternMode != null) {
+        def pm = args.patternMode.toString().toLowerCase()
+        if (pm != 'any' && pm != 'all') {
+            throw new IllegalArgumentException("patternMode must be 'any' or 'all' (got '${args.patternMode}')")
+        }
+    }
+    if (args.patterns instanceof List && args.patterns) {
+        for (int pi = 0; pi < args.patterns.size(); pi++) {
+            def pat = args.patterns[pi]?.toString()?.take(100)
+            if (!pat) continue
+            try {
+                compiledPatterns << java.util.regex.Pattern.compile(pat, java.util.regex.Pattern.CASE_INSENSITIVE)
+            } catch (java.util.regex.PatternSyntaxException e) {
+                throw new IllegalArgumentException("Invalid regex pattern '${pat}' (patterns[${pi}]): ${e.message}")
+            }
+        }
+    }
+
+    // --- Parse since/until time bounds before the loop ---
+
+    // Relative-offset regex: <N><unit> where unit in m, h, d. Capped at 30d.
+    def maxRelativeMs = 30L * 24 * 60 * 60 * 1000  // 30 days in ms
+
+    // Supported ISO-8601 and hub-native timestamp formats for log entry times
+    def logTimeFmts = [
+        "yyyy-MM-dd HH:mm:ss.SSS",
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
+        "yyyy-MM-dd'T'HH:mm:ssZ",
+        "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+        "yyyy-MM-dd'T'HH:mm:ss'Z'",
+        "yyyy-MM-dd'T'HH:mm:ss"
+    ]
+
+    Closure parseTimeArg = { String argName, String val ->
+        if (!val) return null
+        // Try relative offset: <N>m / <N>h / <N>d
+        def relMatcher = val =~ /^(\d+)([mhd])$/
+        if (relMatcher.matches()) {
+            long n = relMatcher.group(1).toLong()
+            def unit = relMatcher.group(2)
+            long ms
+            switch (unit) {
+                case 'm': ms = n * 60L * 1000; break
+                case 'h': ms = n * 3600L * 1000; break
+                case 'd': ms = n * 86400L * 1000; break
+                default: ms = 0
+            }
+            if (ms > maxRelativeMs) {
+                mcpLog("warn", "monitoring", "${argName} relative offset capped at 30d (was ${val})")
+                ms = maxRelativeMs
+            }
+            return new Date(now() - ms)
+        }
+        // Try ISO-8601 / timestamp formats.
+        // Values ending with literal 'Z' (UTC designator) must be parsed in UTC;
+        // Date.parse with a 'Z'-literal format uses JVM default TZ, which shifts
+        // the epoch by the hub's local offset. Detect the Z-suffix and use an explicit
+        // UTC-anchored SimpleDateFormat so "2024-01-15T00:00:00Z" resolves to UTC midnight.
+        if (val.endsWith("Z")) {
+            def utcTz = TimeZone.getTimeZone("UTC")
+            // Strip trailing Z; try ISO patterns without the Z suffix against the bare value.
+            def bare = val[0..-2]
+            def isoFmtsNoZ = ["yyyy-MM-dd'T'HH:mm:ss.SSS", "yyyy-MM-dd'T'HH:mm:ss"]
+            for (fmt in isoFmtsNoZ) {
+                try {
+                    def sdf2 = new java.text.SimpleDateFormat(fmt)
+                    sdf2.setTimeZone(utcTz)
+                    sdf2.setLenient(false)
+                    return sdf2.parse(bare)
+                } catch (Exception ignored) {}
+            }
+        }
+        // Naked-T ISO form without a TZ designator (e.g. '2024-01-15T10:30:00' or
+        // '2024-01-15T10:30:00.000'): treat as UTC to match the hub's log timestamp
+        // convention. Date.parse() uses JVM default TZ for these formats, which silently
+        // shifts the intended epoch on hubs running in non-UTC timezones.
+        if (val.contains('T') && !val.endsWith('Z')) {
+            def utcTz = TimeZone.getTimeZone("UTC")
+            def isoNoTzFmts = ["yyyy-MM-dd'T'HH:mm:ss.SSS", "yyyy-MM-dd'T'HH:mm:ss"]
+            for (fmt in isoNoTzFmts) {
+                try {
+                    def sdf = new java.text.SimpleDateFormat(fmt)
+                    sdf.setTimeZone(utcTz)
+                    sdf.setLenient(false)
+                    return sdf.parse(val)
+                } catch (Exception ignored) {}
+            }
+        }
+        for (fmt in logTimeFmts) {
+            try {
+                return Date.parse(fmt, val)
+            } catch (Exception ignored) {}
+        }
+        throw new IllegalArgumentException("Cannot parse ${argName}='${val}' -- use ISO-8601 (e.g. '2024-01-15T10:30:00Z') or a relative offset like '30m', '2h', '1d'")
+    }
+
+    def sinceDate = parseTimeArg("since", args.since?.toString()?.trim())
+    def untilDate = parseTimeArg("until", args.until?.toString()?.trim())
+
+    // Guard against inverted time window. With relative offsets, since='1h' means
+    // "1 hour ago" and until='2h' means "2 hours ago", making since > until -- a
+    // window with no entries that is indistinguishable from a genuine empty result.
+    if (sinceDate != null && untilDate != null && sinceDate.after(untilDate)) {
+        throw new IllegalArgumentException("since='${args.since}' resolves later than until='${args.until}' -- window is empty (relative offsets are subtracted from now, so since='2h' means 2 hours ago)")
+    }
+
     // Server-side scoping: the hub's /logs/past/json endpoint accepts ?type=dev&id=<N>
     // or ?type=app&id=<N> to filter at the source (same mechanism the UI's device- and
     // app-specific log pages use). Much cheaper than returning the whole buffer and
@@ -6590,6 +6745,30 @@ def toolGetHubLogs(args) {
     logArray = logArray.reverse()
 
     def totalParsed = logArray.size()
+
+    // Hub log timestamps from /logs/past/json carry no TZ marker but represent UTC.
+    // Parsing them with Date.parse() (JVM default TZ) would shift them by the hub's
+    // local offset, causing the time-window comparison to silently no-op on hubs in
+    // non-UTC timezones. Build reusable UTC-anchored parsers once per call, outside
+    // the per-entry loop, to avoid constructing SimpleDateFormat on every iteration.
+    def hubLogUtcTz = TimeZone.getTimeZone("UTC")
+    def hubLogSdfs = logTimeFmts
+        .findAll { !it.contains("Z") && !it.contains("'Z'") }
+        .collect { fmt ->
+            def sdf = new java.text.SimpleDateFormat(fmt)
+            sdf.setTimeZone(hubLogUtcTz)
+            sdf.setLenient(false)
+            sdf
+        }
+    // Formats with a real Z offset marker (no quotes) carry explicit TZ info and Date.parse
+    // handles them correctly. Formats with a literal 'Z' in quotes are intentionally excluded
+    // here: Date.parse treats 'Z' as a literal character match, not a TZ marker, so it
+    // interprets the value in JVM default TZ -- the same TZ bug hubLogSdfs was built to avoid.
+    // Hub /logs/past/json is confirmed not to emit 'T'-with-quoted-'Z' timestamps on any known
+    // firmware; keeping them in the fallback list would silently no-op the time-window filter
+    // on non-UTC hubs if a future firmware ever did emit them.
+    def hubLogIsoFmts = logTimeFmts.findAll { it.contains("Z") && !it.contains("'Z'") }
+
     for (logEntry in logArray) {
         def line = logEntry?.toString()
         if (!line?.trim()) continue
@@ -6615,12 +6794,63 @@ def toolGetHubLogs(args) {
             }
         }
 
-        // Apply filters
+        // Apply filters in pipeline order:
+        // scope (hub-side, done above) -> level -> source -> pattern -> patterns -> time window -> limit
+
         if (levelFilter && entry.level?.toLowerCase() != levelFilter.toLowerCase()) continue
         if (sourceFilter) {
             def src = sourceFilter.toLowerCase()
             // Source info is in the message field (format: "app|ID|AppName|..." or "dev|ID|DevName|...")
             if (!entry.message?.toLowerCase()?.contains(src) && !entry.name?.toLowerCase()?.contains(src)) continue
+        }
+
+        // Single-pattern regex against the message field
+        if (compiledPattern != null) {
+            if (!compiledPattern.matcher(entry.message ?: "").find()) continue
+        }
+
+        // Multi-pattern: patternMode='all' requires every pattern to match; 'any' (default) requires at least one
+        if (compiledPatterns) {
+            def msg = entry.message ?: ""
+            if (patternModeAll) {
+                if (!compiledPatterns.every { it.matcher(msg).find() }) continue
+            } else {
+                if (!compiledPatterns.any { it.matcher(msg).find() }) continue
+            }
+        }
+
+        // Time-window filter: parse entry.time lazily; if empty (firmware 2.5.0.126+ puts the
+        // timestamp in parts[0]/entry.name), fall back to entry.name before giving up.
+        // Skip filtering (not excluding) only when both candidates are unparseable.
+        if (sinceDate != null || untilDate != null) {
+            def entryTime = null
+            def timeStr = entry.time?.trim() ?: entry.name?.trim()
+            if (timeStr) {
+                // Try UTC-anchored parsers first (hub format has no TZ marker but is UTC).
+                for (sdf in hubLogSdfs) {
+                    try {
+                        entryTime = sdf.parse(timeStr)
+                        break
+                    } catch (Exception ignored) {}
+                }
+                // Fall through to ISO-8601 formats that carry their own TZ marker.
+                if (entryTime == null) {
+                    for (fmt in hubLogIsoFmts) {
+                        try {
+                            entryTime = Date.parse(fmt, timeStr)
+                            break
+                        } catch (Exception ignored) {}
+                    }
+                }
+                if (entryTime == null) {
+                    mcpLog("debug", "monitoring", "Could not parse log entry time '${timeStr?.take(30)}' for time-window filter -- entry not excluded")
+                }
+            }
+            // If entryTime resolved: enforce bounds. If entryTime is null (no time field or unparseable): pass through.
+            if (entryTime != null) {
+                if (sinceDate != null && entryTime.before(sinceDate)) continue
+                if (untilDate != null && entryTime.after(untilDate)) continue
+            }
         }
 
         logs << entry

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6666,8 +6666,20 @@ def toolGetHubLogs(args) {
                 } catch (Exception ignored) {}
             }
         }
+        // Space-separated hub-native formats (e.g. 'yyyy-MM-dd HH:mm:ss.SSS') carry no TZ
+        // designator. Date.parse() interprets them in JVM default TZ, which shifts the epoch
+        // on non-UTC hubs. Use explicit UTC SimpleDateFormat for all non-Z formats so a user
+        // copying a hub log timestamp as a since/until value gets the same UTC interpretation
+        // the entry-side parser uses.
+        def utcTzFallback = TimeZone.getTimeZone("UTC")
         for (fmt in logTimeFmts) {
             try {
+                if (!fmt.contains("Z") && !fmt.contains("'Z'")) {
+                    def sdf = new java.text.SimpleDateFormat(fmt)
+                    sdf.setTimeZone(utcTzFallback)
+                    sdf.setLenient(false)
+                    return sdf.parse(val)
+                }
                 return Date.parse(fmt, val)
             } catch (Exception ignored) {}
         }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1376,8 +1376,8 @@ Verify rule after creation.""",
                     pattern: [type: "string", description: "Case-insensitive regex applied to the log message field only -- use source for app/device-name substring matching. Entry is kept when it matches. Compiled once before the loop. Throws on invalid regex syntax. Note: pathological regex like (.*)*  may hang the matcher; prefer simple alternation (error|fail) or anchored prefixes."],
                     patterns: [type: "array", items: [type: "string"], description: "Multiple regex patterns applied to the log message field only -- use source for app/device-name substring matching. Use with patternMode to control AND/OR logic. Each pattern compiled once. Throws on invalid regex syntax. Compatible with pattern (both apply). Note: pathological regex like (.*)*  may hang the matcher; prefer simple alternation (error|fail) or anchored prefixes."],
                     patternMode: [type: "string", description: "How patterns array is combined: 'any' (default) = OR -- entry kept if any pattern matches; 'all' = AND -- entry kept only if every pattern matches. Case-insensitive ('ANY' and 'any' both work).", enum: ["any", "all"]],
-                    since: [type: "string", description: "Return only entries at or after this time. Accepts ISO-8601 timestamp (e.g. '2024-01-15T10:30:00Z') or relative offset (e.g. '30m', '2h', '1d', '7d'). Relative offset is subtracted from now. Max relative offset: 30d. Use '0m' / '0d' as a degenerate since to filter out everything older than now -- useful for testing harnesses but rarely otherwise."],
-                    until: [type: "string", description: "Return only entries at or before this time. Same format as since (relative offsets are subtracted from now, same as since). Default: now (no upper bound). Use since='2h', until='1h' to mean '1 to 2 hours ago'."]
+                    since: [type: "string", description: "Return only entries at or after this time. Accepts ISO-8601 timestamp (e.g. '2024-01-15T10:30:00Z') or relative offset (e.g. '30m', '2h', '1d', '7d'). Relative offset is subtracted from now. Max relative offset: 30d (throws if exceeded -- use ISO-8601 for longer ranges). Timestamps without a TZ marker (e.g. '2024-01-15T10:30:00' or '2024-01-15 10:30:00.000') are parsed as UTC. Use '0m' / '0d' as a degenerate since to filter out everything older than now -- useful for testing harnesses but rarely otherwise."],
+                    until: [type: "string", description: "Return only entries at or before this time. Same format as since (relative offsets are subtracted from now, same as since; max 30d). Default: now (no upper bound). Use since='2h', until='1h' to mean '1 to 2 hours ago'."]
                 ]
             ]
         ],
@@ -6565,12 +6565,18 @@ def toolGetHubLogs(args) {
 
     // Single pattern (case-insensitive substring regex against message field)
     def compiledPattern = null
-    if (args.pattern) {
-        def pat = args.pattern.toString().take(100)
+    if (args.pattern != null) {
+        def rawPat = args.pattern.toString()
+        if (rawPat.isEmpty()) {
+            throw new IllegalArgumentException("pattern must not be empty (got empty string); omit pattern arg to skip pattern filter")
+        }
+        if (rawPat.length() > 100) {
+            throw new IllegalArgumentException("pattern exceeds 100 char limit (was ${rawPat.length()} chars)")
+        }
         try {
-            compiledPattern = java.util.regex.Pattern.compile(pat, java.util.regex.Pattern.CASE_INSENSITIVE)
+            compiledPattern = java.util.regex.Pattern.compile(rawPat, java.util.regex.Pattern.CASE_INSENSITIVE)
         } catch (java.util.regex.PatternSyntaxException e) {
-            throw new IllegalArgumentException("Invalid regex pattern '${pat}': ${e.message}")
+            throw new IllegalArgumentException("Invalid regex pattern '${rawPat}': ${e.message}")
         }
     }
 
@@ -6585,12 +6591,21 @@ def toolGetHubLogs(args) {
     }
     if (args.patterns instanceof List && args.patterns) {
         for (int pi = 0; pi < args.patterns.size(); pi++) {
-            def pat = args.patterns[pi]?.toString()?.take(100)
-            if (!pat) continue
+            def rawPat = args.patterns[pi]
+            if (rawPat == null) {
+                throw new IllegalArgumentException("patterns[${pi}] must not be null or empty")
+            }
+            rawPat = rawPat.toString()
+            if (rawPat.isEmpty()) {
+                throw new IllegalArgumentException("patterns[${pi}] must not be null or empty")
+            }
+            if (rawPat.length() > 100) {
+                throw new IllegalArgumentException("patterns[${pi}] exceeds 100 char limit (was ${rawPat.length()} chars)")
+            }
             try {
-                compiledPatterns << java.util.regex.Pattern.compile(pat, java.util.regex.Pattern.CASE_INSENSITIVE)
+                compiledPatterns << java.util.regex.Pattern.compile(rawPat, java.util.regex.Pattern.CASE_INSENSITIVE)
             } catch (java.util.regex.PatternSyntaxException e) {
-                throw new IllegalArgumentException("Invalid regex pattern '${pat}' (patterns[${pi}]): ${e.message}")
+                throw new IllegalArgumentException("Invalid regex pattern '${rawPat}' (patterns[${pi}]): ${e.message}")
             }
         }
     }
@@ -6626,8 +6641,7 @@ def toolGetHubLogs(args) {
                 default: ms = 0
             }
             if (ms > maxRelativeMs) {
-                mcpLog("warn", "monitoring", "${argName} relative offset capped at 30d (was ${val})")
-                ms = maxRelativeMs
+                throw new IllegalArgumentException("${argName} exceeds 30d cap (got '${val}'); use ISO-8601 for longer ranges (e.g. '2024-01-15T00:00:00Z')")
             }
             return new Date(now() - ms)
         }
@@ -6647,7 +6661,7 @@ def toolGetHubLogs(args) {
                     sdf2.setTimeZone(utcTz)
                     sdf2.setLenient(false)
                     return sdf2.parse(bare)
-                } catch (Exception ignored) {}
+                } catch (java.text.ParseException ignored) {}
             }
         }
         // Naked-T ISO form without a TZ designator (e.g. '2024-01-15T10:30:00' or
@@ -6663,7 +6677,7 @@ def toolGetHubLogs(args) {
                     sdf.setTimeZone(utcTz)
                     sdf.setLenient(false)
                     return sdf.parse(val)
-                } catch (Exception ignored) {}
+                } catch (java.text.ParseException ignored) {}
             }
         }
         // Space-separated hub-native formats (e.g. 'yyyy-MM-dd HH:mm:ss.SSS') carry no TZ
@@ -6681,7 +6695,7 @@ def toolGetHubLogs(args) {
                     return sdf.parse(val)
                 }
                 return Date.parse(fmt, val)
-            } catch (Exception ignored) {}
+            } catch (java.text.ParseException ignored) {}
         }
         throw new IllegalArgumentException("Cannot parse ${argName}='${val}' -- use ISO-8601 (e.g. '2024-01-15T10:30:00Z') or a relative offset like '30m', '2h', '1d'")
     }
@@ -6727,7 +6741,7 @@ def toolGetHubLogs(args) {
         responseText = hubInternalGet("/logs/past/json", query, 30)
     } catch (Exception e) {
         mcpLog("error", "monitoring", "Failed to fetch hub logs: ${e.message}")
-        return [logs: [], error: "Failed to fetch hub logs: ${e.message}", count: 0]
+        throw new IllegalStateException("Failed to fetch hub logs: ${e.message}")
     }
 
     if (!responseText) {
@@ -6781,6 +6795,15 @@ def toolGetHubLogs(args) {
     // on non-UTC hubs if a future firmware ever did emit them.
     def hubLogIsoFmts = logTimeFmts.findAll { it.contains("Z") && !it.contains("'Z'") }
 
+    // Counter for entries that passed through the time-window filter due to unparseable timestamps.
+    // Populated only when since or until is active; surfaced in the response as timeFilterUnparseable.
+    def timeFilterUnparseable = 0
+
+    // Count entries excluded by the active filter set (level / source / pattern / patterns /
+    // time-window). Does NOT include entries truncated by the limit parameter or malformed entries
+    // (empty lines or too-few tab fields) -- those are pre-filter dropouts, not filter exclusions.
+    def filterExcluded = 0
+
     for (logEntry in logArray) {
         def line = logEntry?.toString()
         if (!line?.trim()) continue
@@ -6809,31 +6832,32 @@ def toolGetHubLogs(args) {
         // Apply filters in pipeline order:
         // scope (hub-side, done above) -> level -> source -> pattern -> patterns -> time window -> limit
 
-        if (levelFilter && entry.level?.toLowerCase() != levelFilter.toLowerCase()) continue
+        if (levelFilter && entry.level?.toLowerCase() != levelFilter.toLowerCase()) { filterExcluded++; continue }
         if (sourceFilter) {
             def src = sourceFilter.toLowerCase()
             // Source info is in the message field (format: "app|ID|AppName|..." or "dev|ID|DevName|...")
-            if (!entry.message?.toLowerCase()?.contains(src) && !entry.name?.toLowerCase()?.contains(src)) continue
+            if (!entry.message?.toLowerCase()?.contains(src) && !entry.name?.toLowerCase()?.contains(src)) { filterExcluded++; continue }
         }
 
         // Single-pattern regex against the message field
         if (compiledPattern != null) {
-            if (!compiledPattern.matcher(entry.message ?: "").find()) continue
+            if (!compiledPattern.matcher(entry.message ?: "").find()) { filterExcluded++; continue }
         }
 
         // Multi-pattern: patternMode='all' requires every pattern to match; 'any' (default) requires at least one
         if (compiledPatterns) {
             def msg = entry.message ?: ""
             if (patternModeAll) {
-                if (!compiledPatterns.every { it.matcher(msg).find() }) continue
+                if (!compiledPatterns.every { it.matcher(msg).find() }) { filterExcluded++; continue }
             } else {
-                if (!compiledPatterns.any { it.matcher(msg).find() }) continue
+                if (!compiledPatterns.any { it.matcher(msg).find() }) { filterExcluded++; continue }
             }
         }
 
         // Time-window filter: parse entry.time lazily; if empty (firmware 2.5.0.126+ puts the
         // timestamp in parts[0]/entry.name), fall back to entry.name before giving up.
-        // Skip filtering (not excluding) only when both candidates are unparseable.
+        // Entries with unparseable timestamps are kept (not excluded) and counted separately
+        // so callers know they exist in the result alongside filtered entries.
         if (sinceDate != null || untilDate != null) {
             def entryTime = null
             def timeStr = entry.time?.trim() ?: entry.name?.trim()
@@ -6843,7 +6867,7 @@ def toolGetHubLogs(args) {
                     try {
                         entryTime = sdf.parse(timeStr)
                         break
-                    } catch (Exception ignored) {}
+                    } catch (java.text.ParseException ignored) {}
                 }
                 // Fall through to ISO-8601 formats that carry their own TZ marker.
                 if (entryTime == null) {
@@ -6851,17 +6875,21 @@ def toolGetHubLogs(args) {
                         try {
                             entryTime = Date.parse(fmt, timeStr)
                             break
-                        } catch (Exception ignored) {}
+                        } catch (java.text.ParseException ignored) {}
                     }
                 }
                 if (entryTime == null) {
                     mcpLog("debug", "monitoring", "Could not parse log entry time '${timeStr?.take(30)}' for time-window filter -- entry not excluded")
+                    timeFilterUnparseable++
                 }
+            } else {
+                // No time field at all -- count as unparseable and pass through
+                timeFilterUnparseable++
             }
             // If entryTime resolved: enforce bounds. If entryTime is null (no time field or unparseable): pass through.
             if (entryTime != null) {
-                if (sinceDate != null && entryTime.before(sinceDate)) continue
-                if (untilDate != null && entryTime.after(untilDate)) continue
+                if (sinceDate != null && entryTime.before(sinceDate)) { filterExcluded++; continue }
+                if (untilDate != null && entryTime.after(untilDate)) { filterExcluded++; continue }
             }
         }
 
@@ -6877,6 +6905,29 @@ def toolGetHubLogs(args) {
         logs.each { it.message = it.message?.take(200) }
         result.truncated = true
         result.note = "Log messages truncated to fit response size limit"
+    }
+
+    // Expose filter metadata so callers can distinguish "no matching logs" from "no logs exist".
+    // filteredOut: entries excluded by the active filter set (level / source / pattern / patterns /
+    //   time-window). Does NOT include entries truncated by the limit parameter or malformed entries.
+    //   Omitted when hasFilters is false or when every parsed entry matched (filterExcluded == 0).
+    // appliedFilters: echo of every non-null filter arg (omitted when no filters were active).
+    def hasFilters = levelFilter || sourceFilter || compiledPattern != null || compiledPatterns || sinceDate != null || untilDate != null
+    if (hasFilters) {
+        if (filterExcluded > 0) result.filteredOut = filterExcluded
+        def applied = [:]
+        if (levelFilter)                applied.level       = levelFilter
+        if (sourceFilter)               applied.source      = sourceFilter
+        if (args.pattern != null)       applied.pattern     = args.pattern
+        if (args.patterns instanceof List && args.patterns) applied.patterns = args.patterns
+        if (compiledPatterns)           applied.patternMode = args.patternMode ?: 'any'
+        if (args.since != null)         applied.since       = args.since
+        if (args.until != null)         applied.until       = args.until
+        result.appliedFilters = applied
+    }
+    // Surface unparseable-timestamp count only when a time-window was active and at least one entry was affected.
+    if ((sinceDate != null || untilDate != null) && timeFilterUnparseable > 0) {
+        result.timeFilterUnparseable = timeFilterUnparseable
     }
 
     mcpLog("info", "monitoring", "Retrieved ${logs.size()} hub log entries (${totalParsed} total parsed)")

--- a/src/test/groovy/server/ToolGetHubLogsSpec.groovy
+++ b/src/test/groovy/server/ToolGetHubLogsSpec.groovy
@@ -10,7 +10,8 @@ import support.ToolSpecBase
  * appId numeric validation, deviceId/appId mutual exclusion, the
  * pattern/patterns/patternMode/since/until/limit filter pipeline, type-shape
  * validation for all new args, case-insensitivity in both directions,
- * limit truncation, naked-T ISO timestamps parsed as UTC, and a
+ * limit truncation, naked-T ISO timestamps parsed as UTC, space-separated
+ * hub-native timestamps (no T, no Z) parsed as UTC in the fallback loop, and a
  * kitchen-sink combined-filter scenario.
  *
  * Filter pipeline (in order): scope (hub-side) -> level -> source ->
@@ -651,6 +652,31 @@ class ToolGetHubLogsSpec extends ToolSpecBase {
         def result = script.toolGetHubLogs([since: '2024-01-15T10:30:00'])
 
         then: 'entry at 10:30:01 UTC is included; entry at 10:29:59 UTC is excluded'
+        result.logs.size() == 1
+        result.logs[0].message == 'After cutoff'
+    }
+
+    def "since as space-separated timestamp (hub log copy-paste shape, no TZ marker) is parsed as UTC"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Harness now() = 1234567890000L. Use a concrete recent window anchored on that epoch
+        // so the test is TZ-independent: build sinceDate and entry timestamps both from the
+        // same UTC-formatted epoch, then pass sinceDate back as the since= string.
+        // UTC epoch for 2024-01-15T12:30:45.123Z = 1705319445123L.
+        // An entry 1 second inside that window: 2024-01-15 12:30:46.000 UTC -> included.
+        // An entry 1 second before that window: 2024-01-15 12:30:44.000 UTC -> excluded.
+        // On a non-UTC JVM default TZ (e.g. UTC-5), Date.parse would shift 12:30:45.123 by
+        // 5 hours, placing sinceDate at 1705337445123L (5h later in epoch) -- causing the
+        // inside-window entry to appear falsely *before* sinceDate and be excluded.
+        registerLogs([
+            'App 1\tinfo\tBefore cutoff\t2024-01-15 12:30:44.000\ttype',
+            'App 1\tinfo\tAfter cutoff\t2024-01-15 12:30:46.000\ttype'
+        ])
+
+        when: 'space-separated since (no T, no Z) is parsed as UTC by the fallback loop'
+        def result = script.toolGetHubLogs([since: '2024-01-15 12:30:45.123'])
+
+        then: 'entry at 12:30:46 UTC is included; entry at 12:30:44 UTC is excluded'
         result.logs.size() == 1
         result.logs[0].message == 'After cutoff'
     }

--- a/src/test/groovy/server/ToolGetHubLogsSpec.groovy
+++ b/src/test/groovy/server/ToolGetHubLogsSpec.groovy
@@ -300,21 +300,29 @@ class ToolGetHubLogsSpec extends ToolSpecBase {
         ex.message.contains('ISO-8601') || ex.message.contains('2024') || ex.message.contains('30m')
     }
 
-    def "relative offset beyond 30d is capped silently (not thrown)"() {
+    def "relative offset beyond 30d throws IllegalArgumentException with ISO-8601 hint"() {
         given:
         settingsMap.enableHubAdminRead = true
-        // '400d' exceeds the 30d cap -- should cap rather than throw
-        // The mcpLog warn is emitted; the filter runs with a 30d window
-        registerLogs([
-            'App 1\tinfo\tAny entry\t2026-04-19 10:00:00.000\ttype'
-        ])
 
-        when: 'call succeeds (no exception)'
-        def result = script.toolGetHubLogs([since: '400d'])
+        when:
+        script.toolGetHubLogs([since: '31d'])
 
-        then: 'result is returned normally (not thrown)'
-        notThrown(IllegalArgumentException)
-        result.containsKey('logs')
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('31d')
+        ex.message.toLowerCase().contains('30d')
+        ex.message.toLowerCase().contains('iso-8601')
+    }
+
+    def "relative offset of exactly 400d also throws (cap is strict, not a clamp)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([since: '400d'])
+
+        then:
+        thrown(IllegalArgumentException)
     }
 
     def "entries with no parseable time field are passed through (not excluded) when time-window active"() {
@@ -656,28 +664,326 @@ class ToolGetHubLogsSpec extends ToolSpecBase {
         result.logs[0].message == 'After cutoff'
     }
 
-    def "since as space-separated timestamp (hub log copy-paste shape, no TZ marker) is parsed as UTC"() {
+    def "since as space-separated timestamp (hub log copy-paste shape, no TZ marker) is parsed as UTC -- JVM TZ swap"() {
         given:
         settingsMap.enableHubAdminRead = true
-        // Harness now() = 1234567890000L. Use a concrete recent window anchored on that epoch
-        // so the test is TZ-independent: build sinceDate and entry timestamps both from the
-        // same UTC-formatted epoch, then pass sinceDate back as the since= string.
-        // UTC epoch for 2024-01-15T12:30:45.123Z = 1705319445123L.
-        // An entry 1 second inside that window: 2024-01-15 12:30:46.000 UTC -> included.
-        // An entry 1 second before that window: 2024-01-15 12:30:44.000 UTC -> excluded.
-        // On a non-UTC JVM default TZ (e.g. UTC-5), Date.parse would shift 12:30:45.123 by
-        // 5 hours, placing sinceDate at 1705337445123L (5h later in epoch) -- causing the
-        // inside-window entry to appear falsely *before* sinceDate and be excluded.
+        // This scenario deliberately swaps the JVM default TZ to America/Denver (UTC-6 or -7
+        // depending on DST) before making the call. If production code regresses to Date.parse()
+        // for the space-separated format, the epoch shifts by 6-7 hours, causing the inside-window
+        // entry to appear falsely outside the window. The fix (explicit UTC SimpleDateFormat)
+        // must survive a non-UTC JVM default TZ.
+        // UTC epoch for 2024-01-15T12:30:45.123Z = 1705319445123L (UTC).
+        // An entry 1s inside: 2024-01-15 12:30:46.000 UTC -> included.
+        // An entry 1s before: 2024-01-15 12:30:44.000 UTC -> excluded.
         registerLogs([
             'App 1\tinfo\tBefore cutoff\t2024-01-15 12:30:44.000\ttype',
             'App 1\tinfo\tAfter cutoff\t2024-01-15 12:30:46.000\ttype'
         ])
+        def origDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Denver"))
 
-        when: 'space-separated since (no T, no Z) is parsed as UTC by the fallback loop'
-        def result = script.toolGetHubLogs([since: '2024-01-15 12:30:45.123'])
+        when: 'space-separated since (no T, no Z) is parsed as UTC despite non-UTC JVM default TZ'
+        def result
+        try {
+            result = script.toolGetHubLogs([since: '2024-01-15 12:30:45.123'])
+        } finally {
+            TimeZone.setDefault(origDefault)
+        }
 
-        then: 'entry at 12:30:46 UTC is included; entry at 12:30:44 UTC is excluded'
+        then: 'entry at 12:30:46 UTC is included; entry at 12:30:44 UTC is excluded -- UTC parse is TZ-default-independent'
         result.logs.size() == 1
         result.logs[0].message == 'After cutoff'
+    }
+
+    def "TZ-swap asymmetric regression: space-separated UTC entry and explicit-Z entry both resolve to same epoch ms"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Two entries that represent identical points in time, expressed two ways:
+        //   (a) space-separated hub-native: '2024-01-15 12:30:44.000' (no TZ marker; production
+        //       must parse as UTC via hubLogSdfs)
+        //   (b) explicit-Z ISO-8601: '2024-01-15T12:30:44Z' (carries its own TZ; Date.parse handles)
+        // Both are 1s BEFORE the since cutoff (2024-01-15T12:30:45.000Z) => both excluded.
+        // If production regresses the space-separated parser only (reverts to JVM-default TZ),
+        // entry (a) shifts by the JVM offset and may land on the wrong side of the window.
+        // Symmetry failure: one entry excluded, the other not => test fails.
+        registerLogs([
+            'App 1\tinfo\tSpace-sep before\t2024-01-15 12:30:44.000\ttype',
+            'App 1\tinfo\tISO-Z before\t2024-01-15T12:30:44Z\ttype',
+            'App 1\tinfo\tSpace-sep after\t2024-01-15 12:30:46.000\ttype',
+            'App 1\tinfo\tISO-Z after\t2024-01-15T12:30:46Z\ttype'
+        ])
+        def origDefault = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone("America/Denver"))
+
+        when: 'since cutoff is between the before and after pairs'
+        def result
+        try {
+            result = script.toolGetHubLogs([since: '2024-01-15T12:30:45.000Z'])
+        } finally {
+            TimeZone.setDefault(origDefault)
+        }
+
+        then: 'both "after" entries are included; both "before" entries are excluded regardless of format'
+        result.logs.size() == 2
+        result.logs*.message.sort() == ['ISO-Z after', 'Space-sep after'].sort()
+    }
+
+    // ==================== B3: timeFilterUnparseable counter ====================
+
+    def "unparseable timestamps are passed through and counted in timeFilterUnparseable"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // 5 valid entries after the cutoff + 2 entries with unparseable timestamps.
+        // The 2 unparseable entries should be kept (not excluded) and counted separately.
+        registerLogs([
+            'App 1\tinfo\tValid 1\t2024-01-15 01:00:00.000\ttype',
+            'App 1\tinfo\tValid 2\t2024-01-15 02:00:00.000\ttype',
+            'App 1\tinfo\tValid 3\t2024-01-15 03:00:00.000\ttype',
+            'App 1\tinfo\tValid 4\t2024-01-15 04:00:00.000\ttype',
+            'App 1\tinfo\tValid 5\t2024-01-15 05:00:00.000\ttype',
+            'App 1\tinfo\tNo timestamp\t\ttype',
+            'App 1\tinfo\tBad timestamp\tNOT_A_DATE\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([since: '2024-01-15T00:00:00Z'])
+
+        then: '5 valid + 2 unparseable = 7 total entries returned'
+        result.logs.size() == 7
+        result.timeFilterUnparseable == 2
+    }
+
+    def "timeFilterUnparseable is absent from response when no time filter is active"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tNo timestamp\t\ttype',
+            'App 1\tinfo\tBad timestamp\tNOT_A_DATE\ttype'
+        ])
+
+        when: 'no since/until -- time-window filter is not active'
+        def result = script.toolGetHubLogs([:])
+
+        then: 'unparseable timestamps not counted because time-window is off'
+        !result.containsKey('timeFilterUnparseable')
+    }
+
+    // ==================== I4: filteredOut and appliedFilters ====================
+
+    def "zero-match result includes filteredOut count and appliedFilters echo"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tSomething normal\t2026-04-19 10:00:00.000\ttype',
+            'App 1\tinfo\tAnother normal\t2026-04-19 10:00:01.000\ttype',
+            'App 1\tinfo\tYet another\t2026-04-19 10:00:02.000\ttype'
+        ])
+
+        when: 'pattern matches nothing'
+        def result = script.toolGetHubLogs([pattern: 'DEFINITELY_NOT_PRESENT'])
+
+        then: 'count is 0 but filteredOut and appliedFilters reveal what happened'
+        result.count == 0
+        result.filteredOut == 3
+        result.appliedFilters != null
+        result.appliedFilters.pattern == 'DEFINITELY_NOT_PRESENT'
+    }
+
+    def "partial-match result includes filteredOut count reflecting excluded entries"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tfound: match this\t2026-04-19 10:00:00.000\ttype',
+            'App 1\tinfo\tunrelated entry here\t2026-04-19 10:00:01.000\ttype',
+            'App 1\tinfo\talso found: match\t2026-04-19 10:00:02.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([pattern: 'found'])
+
+        then: '2 matched "found", 1 filtered out; filteredOut = 1'
+        result.count == 2
+        result.filteredOut == 1
+        result.appliedFilters.pattern == 'found'
+    }
+
+    def "filteredOut counts only filter-excluded entries not limit-truncated ones"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // 100 entries: 50 contain 'ALPHA' (match), 50 contain 'BETA' (no match). limit=10.
+        // filteredOut must be 50 (the BETA entries excluded by filter), NOT 90 (totalParsed - count).
+        // The 40 ALPHA entries beyond the limit are limit-truncated, not filter-excluded.
+        def lines = (1..50).collect { "App 1\tinfo\tALPHA entry ${it}\t2026-04-19 10:00:00.000\ttype" } +
+                    (1..50).collect { "App 1\tinfo\tBETA entry ${it}\t2026-04-19 10:00:00.000\ttype" }
+        registerLogs(lines)
+
+        when:
+        def result = script.toolGetHubLogs([pattern: 'ALPHA', limit: 10])
+
+        then: 'count = 10 (limit hit), filteredOut = 50 (filter-excluded), totalParsed = 100'
+        result.count == 10
+        result.totalParsed == 100
+        result.filteredOut == 50
+        // limit-truncated entries (the other 40 ALPHA matches) are NOT counted in filteredOut
+    }
+
+    def "no filters active means filteredOut and appliedFilters are absent"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tSomething\t2026-04-19 10:00:00.000\ttype'
+        ])
+
+        when: 'no filter args'
+        def result = script.toolGetHubLogs([:])
+
+        then: 'metadata fields absent when no filters were applied'
+        !result.containsKey('filteredOut')
+        !result.containsKey('appliedFilters')
+    }
+
+    // ==================== I5: empty pattern / empty patterns element ====================
+
+    def "empty pattern string throws IllegalArgumentException with hint to omit"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([pattern: ''])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('pattern')
+        ex.message.toLowerCase().contains('empty')
+    }
+
+    def "empty string inside patterns list throws IllegalArgumentException naming the index"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([patterns: ['valid', '']])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('patterns[1]')
+        ex.message.toLowerCase().contains('empty')
+    }
+
+    // ==================== I6: pattern length limit ====================
+
+    def "pattern longer than 100 chars throws before compile with length in message"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        def longPat = 'a' * 101   // 101 chars -- exceeds 100-char limit
+
+        when:
+        script.toolGetHubLogs([pattern: longPat])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('101')
+        ex.message.toLowerCase().contains('100')
+    }
+
+    def "pattern element in patterns list longer than 100 chars throws naming the index"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        def longPat = 'b' * 101   // 101 chars
+
+        when:
+        script.toolGetHubLogs([patterns: ['ok', longPat]])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('patterns[1]')
+        ex.message.contains('101')
+    }
+
+    // ==================== I7: hubInternalGet failure becomes IllegalStateException ====================
+
+    def "hubInternalGet failure throws IllegalStateException surfaceable as JSON-RPC error"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Intentionally no hubGet.register() -- harness throws IllegalStateException("Unstubbed
+        // hubInternalGet: ...") when the path is not registered, which production code then
+        // wraps and rethrows as IllegalStateException("Failed to fetch hub logs: ...").
+        // This verifies the rethrow path reaches the caller rather than returning a success-shape map.
+
+        when:
+        script.toolGetHubLogs([:])
+
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.message.toLowerCase().contains('failed to fetch hub logs')
+    }
+
+    // ==================== I8: additional validation scenarios ====================
+
+    def "multi-pattern compile failure throws on the bad element and names its index"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when: "patterns list contains one valid and one invalid regex"
+        script.toolGetHubLogs([patterns: ['valid', '[unclosed']])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('patterns[1]')
+        ex.message.toLowerCase().contains('invalid regex')
+    }
+
+    def "inverted ISO-8601 window since after until throws IllegalArgumentException"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when: 'since is after until -- window contains no entries'
+        script.toolGetHubLogs([since: '2024-01-15T12:00:00Z', until: '2024-01-15T08:00:00Z'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('window is empty')
+    }
+
+    def "until as Number throws IllegalArgumentException with format hint"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([until: 1234567890000])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('until')
+        ex.message.toLowerCase().contains('string')
+    }
+
+    def "patternMode as List throws IllegalArgumentException naming the expected type"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when: 'patternMode given as a list instead of a string'
+        script.toolGetHubLogs([patternMode: ['any']])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('patternmode')
+    }
+
+    def "empty patterns list is accepted and applies no pattern filter"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tfoo\t2026-04-19 10:00:00.000\ttype',
+            'App 1\tinfo\tbar\t2026-04-19 10:00:01.000\ttype'
+        ])
+
+        when: 'patterns=[] is a no-op -- all entries pass through'
+        def result = script.toolGetHubLogs([patterns: []])
+
+        then: 'all entries returned; empty patterns list treated as no-filter'
+        result.logs.size() == 2
+        // empty patterns list means no filter was applied -- appliedFilters omits patterns key
+        !result.containsKey('appliedFilters') || !result.appliedFilters?.containsKey('patterns')
     }
 }

--- a/src/test/groovy/server/ToolGetHubLogsSpec.groovy
+++ b/src/test/groovy/server/ToolGetHubLogsSpec.groovy
@@ -4,26 +4,45 @@ import groovy.json.JsonOutput
 import support.ToolSpecBase
 
 /**
- * Spec for toolGetHubLogs (hubitat-mcp-server.groovy line 5181).
+ * Spec for toolGetHubLogs.
  *
- * Covers: most-recent-first ordering (golden), Hub Admin Read gate, and
- * PR #64 regressions (appId numeric validation + deviceId/appId mutual
- * exclusion).
+ * Covers: most-recent-first ordering (golden), Hub Admin Read gate,
+ * appId numeric validation, deviceId/appId mutual exclusion, the
+ * pattern/patterns/patternMode/since/until/limit filter pipeline, type-shape
+ * validation for all new args, case-insensitivity in both directions,
+ * limit truncation, naked-T ISO timestamps parsed as UTC, and a
+ * kitchen-sink combined-filter scenario.
+ *
+ * Filter pipeline (in order): scope (hub-side) -> level -> source ->
+ * pattern -> patterns -> time-window (since/until) -> limit.
+ *
+ * Note on regex compile-count testing (Pre2): pinning that Pattern.compile
+ * is called once per pattern (not per log entry) via a static metaClass
+ * counter on java.util.regex.Pattern is unreliable in this harness -- JDK
+ * static methods on bootstrap-classloader classes do not honour per-test
+ * Groovy EMC overrides consistently under the eighty20results sandbox loader.
+ * The structural guarantee (compile calls precede the for-loop) is verified
+ * by code inspection; correctness at scale is covered implicitly by the
+ * kitchen-sink and filter scenarios that exercise multi-pattern matching
+ * against multi-entry buffers.
  */
 class ToolGetHubLogsSpec extends ToolSpecBase {
 
-    def "returns most-recent-first log entries (PR #64 ordering regression)"() {
+    // Shared convenience: registers a canned log array with the mock hub
+    private void registerLogs(List<String> lines) {
+        hubGet.register('/logs/past/json') { params -> JsonOutput.toJson(lines) }
+    }
+
+    def "returns most-recent-first log entries (ordering regression)"() {
         given: 'Hub Admin Read is enabled'
         settingsMap.enableHubAdminRead = true
 
         and: 'hub returns 3 log lines in chronological order (oldest first)'
-        hubGet.register('/logs/past/json') { params ->
-            JsonOutput.toJson([
-                'App 1\tinfo\tOldest message\t2026-04-19 10:00:00.000\ttype',
-                'App 1\tinfo\tMiddle message\t2026-04-19 10:00:01.000\ttype',
-                'App 1\tinfo\tNewest message\t2026-04-19 10:00:02.000\ttype'
-            ])
-        }
+        registerLogs([
+            'App 1\tinfo\tOldest message\t2026-04-19 10:00:00.000\ttype',
+            'App 1\tinfo\tMiddle message\t2026-04-19 10:00:01.000\ttype',
+            'App 1\tinfo\tNewest message\t2026-04-19 10:00:02.000\ttype'
+        ])
 
         when:
         def result = script.toolGetHubLogs([:])
@@ -48,7 +67,7 @@ class ToolGetHubLogsSpec extends ToolSpecBase {
         ex.message.contains('Hub Admin Read')
     }
 
-    def "rejects non-integer appId (PR #64 numeric-validation regression)"() {
+    def "rejects non-integer appId (numeric-validation regression)"() {
         given:
         settingsMap.enableHubAdminRead = true
 
@@ -60,7 +79,7 @@ class ToolGetHubLogsSpec extends ToolSpecBase {
         ex.message.toLowerCase().contains('numeric')
     }
 
-    def "rejects deviceId and appId together (PR #64 mutual-exclusion regression)"() {
+    def "rejects deviceId and appId together (mutual-exclusion regression)"() {
         given:
         settingsMap.enableHubAdminRead = true
 
@@ -70,5 +89,569 @@ class ToolGetHubLogsSpec extends ToolSpecBase {
         then:
         def ex = thrown(IllegalArgumentException)
         ex.message.toLowerCase().contains('mutually exclusive')
+    }
+
+    // ==================== pattern filter ====================
+
+    def "pattern keeps only entries whose message matches the regex"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tSomething normal\t2026-04-19 10:00:00.000\ttype',
+            'App 1\terror\tERROR: disk full\t2026-04-19 10:00:01.000\ttype',
+            'App 1\terror\tERROR: timeout\t2026-04-19 10:00:02.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([pattern: 'ERROR.*'])
+
+        then: 'only the two ERROR entries are kept (newest first after reverse)'
+        result.logs.size() == 2
+        result.logs.every { it.message.startsWith('ERROR') }
+    }
+
+    def "pattern match is case-insensitive"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\terror in device\t2026-04-19 10:00:00.000\ttype',
+            'App 1\tinfo\tall good\t2026-04-19 10:00:01.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([pattern: 'ERROR'])
+
+        then:
+        result.logs.size() == 1
+        result.logs[0].message == 'error in device'
+    }
+
+    def "invalid pattern throws IllegalArgumentException with helpful message"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([pattern: '[unclosed'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('[unclosed')
+        ex.message.toLowerCase().contains('invalid regex pattern')
+    }
+
+    // ==================== patterns + patternMode ====================
+
+    def "patterns with default patternMode any keeps entries matching either pattern"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tfoo happened\t2026-04-19 10:00:00.000\ttype',
+            'App 1\tinfo\tbar happened\t2026-04-19 10:00:01.000\ttype',
+            'App 1\tinfo\tbaz happened\t2026-04-19 10:00:02.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([patterns: ['foo', 'bar']])
+
+        then: 'entries with foo OR bar match; baz (newest) is excluded'
+        result.logs.size() == 2
+        result.logs.every { it.message.contains('foo') || it.message.contains('bar') }
+    }
+
+    def "patterns with patternMode all keeps only entries matching every pattern"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tfoo only\t2026-04-19 10:00:00.000\ttype',
+            'App 1\tinfo\tfoo and bar both\t2026-04-19 10:00:01.000\ttype',
+            'App 1\tinfo\tbar only\t2026-04-19 10:00:02.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([patterns: ['foo', 'bar'], patternMode: 'all'])
+
+        then: 'only the entry that has both foo AND bar is kept'
+        result.logs.size() == 1
+        result.logs[0].message == 'foo and bar both'
+    }
+
+    def "pattern and patterns both apply when both are set"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // pattern requires 'ERROR', patterns[any] requires 'foo' or 'bar'
+        // Only 'ERROR: foo' satisfies both
+        registerLogs([
+            'App 1\tinfo\tERROR: foo\t2026-04-19 10:00:00.000\ttype',
+            'App 1\tinfo\tERROR: baz\t2026-04-19 10:00:01.000\ttype',
+            'App 1\tinfo\tfoo ok\t2026-04-19 10:00:02.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([pattern: 'ERROR', patterns: ['foo', 'bar']])
+
+        then: 'only the entry satisfying BOTH conditions is returned'
+        result.logs.size() == 1
+        result.logs[0].message == 'ERROR: foo'
+    }
+
+    // ==================== since / until ====================
+
+    def "since relative offset 30m excludes entries older than 30 minutes ago"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // now() in harness returns 1234567890000L (millisecond epoch)
+        // 30 minutes ago = 1234567890000 - 1800000 = 1234566090000
+        // Hub log timestamps are UTC; format fixture strings as UTC so the
+        // production UTC parser produces the same epoch we expect.
+        long nowMs = 1234567890000L
+        long thirtyMinMs = 30 * 60 * 1000L
+        def utcSdf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+        utcSdf.setTimeZone(TimeZone.getTimeZone("UTC"))
+        def fmtDate = { long ms -> utcSdf.format(new Date(ms)) }
+        def oldTime   = fmtDate(nowMs - thirtyMinMs - 5000)   // 30m 5s ago -- should be excluded
+        def recentTime = fmtDate(nowMs - thirtyMinMs + 5000)  // 29m 55s ago -- should be included
+
+        registerLogs([
+            "App 1\tinfo\tOld entry\t${oldTime}\ttype",
+            "App 1\tinfo\tRecent entry\t${recentTime}\ttype"
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([since: '30m'])
+
+        then:
+        result.logs.size() == 1
+        result.logs[0].message == 'Recent entry'
+    }
+
+    def "since ISO-8601 timestamp filters correctly"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tBefore cutoff\t2024-01-14 23:59:59.000\ttype',
+            'App 1\tinfo\tAfter cutoff\t2024-01-15 00:00:01.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([since: '2024-01-15T00:00:00Z'])
+
+        then:
+        result.logs.size() == 1
+        result.logs[0].message == 'After cutoff'
+    }
+
+    def "since ISO-8601 with milliseconds filters correctly"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tBefore cutoff\t2024-01-14 23:59:59.000\ttype',
+            'App 1\tinfo\tAfter cutoff\t2024-01-15 00:00:01.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([since: '2024-01-15T00:00:00.000Z'])
+
+        then:
+        result.logs.size() == 1
+        result.logs[0].message == 'After cutoff'
+    }
+
+    def "since and until define a closed time window"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // now() = 1234567890000L
+        // Hub log timestamps are UTC; format fixture strings as UTC.
+        long nowMs = 1234567890000L
+        def utcSdf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+        utcSdf.setTimeZone(TimeZone.getTimeZone("UTC"))
+        def fmtDate = { long ms -> utcSdf.format(new Date(ms)) }
+
+        def tooOld    = fmtDate(nowMs - 3 * 3600 * 1000L)  // 3h ago -- outside since
+        def inWindow  = fmtDate(nowMs - 90 * 60 * 1000L)   // 1.5h ago -- inside [2h, 1h]
+        def tooRecent = fmtDate(nowMs - 30 * 60 * 1000L)   // 0.5h ago -- outside until
+
+        registerLogs([
+            "App 1\tinfo\tToo old\t${tooOld}\ttype",
+            "App 1\tinfo\tIn window\t${inWindow}\ttype",
+            "App 1\tinfo\tToo recent\t${tooRecent}\ttype"
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([since: '2h', until: '1h'])
+
+        then:
+        result.logs.size() == 1
+        result.logs[0].message == 'In window'
+    }
+
+    def "bad since value throws IllegalArgumentException with format example"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([since: 'yesterday'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('since')
+        ex.message.contains('yesterday')
+        // Must include an example so callers know what format to use
+        ex.message.contains('ISO-8601') || ex.message.contains('2024') || ex.message.contains('30m')
+    }
+
+    def "relative offset beyond 30d is capped silently (not thrown)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // '400d' exceeds the 30d cap -- should cap rather than throw
+        // The mcpLog warn is emitted; the filter runs with a 30d window
+        registerLogs([
+            'App 1\tinfo\tAny entry\t2026-04-19 10:00:00.000\ttype'
+        ])
+
+        when: 'call succeeds (no exception)'
+        def result = script.toolGetHubLogs([since: '400d'])
+
+        then: 'result is returned normally (not thrown)'
+        notThrown(IllegalArgumentException)
+        result.containsKey('logs')
+    }
+
+    def "entries with no parseable time field are passed through (not excluded) when time-window active"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // name field contains non-timestamp text so the name-fallback also fails to parse
+        registerLogs([
+            'App 1\tinfo\tNo time\t\ttype',              // empty time field, name is 'App 1' -- not a timestamp
+            'App 1\tinfo\tUnparseable time\tNOT_A_DATE\ttype',
+            'App 1\tinfo\tNormal entry\t2024-01-15 01:00:00.000\ttype'
+        ])
+
+        when: 'since is set to a recent boundary that normal entry falls after'
+        def result = script.toolGetHubLogs([since: '2024-01-15T00:00:00Z'])
+
+        then: 'empty/unparseable-time entries are included (not excluded), normal entry also included'
+        result.logs.size() == 3
+    }
+
+    def "time-window filter uses entry.name as timestamp when entry.time is empty (firmware 2.5.0.126+ shape)"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Firmware 2.5.0.126+ puts the timestamp in parts[0] (entry.name) and leaves parts[3] (entry.time) empty.
+        // Two log lines in that firmware shape: one within the window, one before it.
+        registerLogs([
+            '2024-01-14 23:59:59.000\tinfo\tBefore cutoff -- should be excluded\t\ttype',
+            '2024-01-15 00:00:01.000\tinfo\tAfter cutoff -- should be included\t\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([since: '2024-01-15T00:00:00Z'])
+
+        then: 'timestamp parsed from name field, window filter applied correctly'
+        result.logs.size() == 1
+        result.logs[0].message == 'After cutoff -- should be included'
+    }
+
+    def "time-window filter handles mixed firmware log shapes in the same response"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Mix of documented format (time in parts[3]) and firmware 2.5.0.126+ format (time in parts[0]).
+        // Both should be filtered correctly against the same window.
+        registerLogs([
+            'App 1\tinfo\tDocumented format in window\t2024-01-15 01:00:00.000\ttype',      // time in parts[3]
+            'App 1\tinfo\tDocumented format outside window\t2024-01-14 22:00:00.000\ttype', // time in parts[3], too old
+            '2024-01-15 02:00:00.000\tinfo\tFirmware shape in window\t\ttype',              // time in parts[0]
+            '2024-01-14 23:00:00.000\tinfo\tFirmware shape outside window\t\ttype'          // time in parts[0], too old
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([since: '2024-01-15T00:00:00Z'])
+
+        then: 'one from each format passes the window; two are excluded as too old'
+        result.logs.size() == 2
+        result.logs*.message.contains('Documented format in window')
+        result.logs*.message.contains('Firmware shape in window')
+    }
+
+    // ==================== timezone correctness ====================
+
+    def "hub log entry timestamps (no TZ marker) are parsed as UTC regardless of JVM default timezone"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Harness now() = 1234567890000L (epoch ms).
+        // since='5m' -> sinceDate = new Date(1234567890000 - 300000) = 1234567590000L (UTC epoch).
+        //
+        // Construct two entry timestamp strings using explicit UTC formatting so the test
+        // asserts UTC-interpretation correctness even when the JVM default TZ is non-UTC
+        // (e.g. America/Denver MDT = UTC-6). With the old Date.parse() code on a hub in MDT,
+        // a UTC timestamp string like "2009-02-13 23:27:30.000" would be parsed as MDT local
+        // time -> epoch 1234589250000L (6h ahead of the actual UTC epoch 1234567650000L),
+        // making entries falsely appear "newer" and defeating the since filter.
+        //
+        // With the fix (SimpleDateFormat + explicit UTC TZ), "2009-02-13 23:27:30.000" is
+        // correctly parsed as 1234567650000L (UTC) = 1 minute after sinceDate -> included.
+        def utcTz = TimeZone.getTimeZone("UTC")
+        def sdf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+        sdf.setTimeZone(utcTz)
+        // sinceDate epoch: 1234567590000L
+        // Entry just inside window: sinceDate + 60s = 1234567650000L -> "2009-02-13 23:27:30.000" UTC
+        def insideWindow  = sdf.format(new Date(1234567590000L + 60000L))
+        // Entry just outside window: sinceDate - 60s = 1234567530000L -> "2009-02-13 23:25:30.000" UTC
+        def outsideWindow = sdf.format(new Date(1234567590000L - 60000L))
+
+        registerLogs([
+            "App 1\tinfo\tOutside window -- should be excluded\t${outsideWindow}\ttype",
+            "App 1\tinfo\tInside window -- should be included\t${insideWindow}\ttype"
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([since: '5m'])
+
+        then: 'UTC parsing: inside-window entry is included; outside-window entry is excluded'
+        result.logs.size() == 1
+        result.logs[0].message == 'Inside window -- should be included'
+    }
+
+    // ==================== patternMode validation ====================
+
+    def "invalid patternMode throws IllegalArgumentException"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([patternMode: 'neither'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('patternMode')
+        ex.message.contains('neither')
+    }
+
+    // ==================== since/until inversion ====================
+
+    def "since resolving later than until throws IllegalArgumentException with helpful message"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // since='1h' -> 1 hour ago, until='2h' -> 2 hours ago: since > until (inverted window)
+
+        when:
+        script.toolGetHubLogs([since: '1h', until: '2h'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('window is empty')
+    }
+
+    // ==================== type-shape validation (Pre1) ====================
+
+    def "pattern as list throws IllegalArgumentException naming the expected type"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([pattern: ['foo']])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('pattern')
+        ex.message.toLowerCase().contains('string')
+    }
+
+    def "patterns as string throws IllegalArgumentException naming the expected type"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([patterns: 'foo'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('patterns')
+        ex.message.toLowerCase().contains('list')
+    }
+
+    def "since as number throws IllegalArgumentException with format hint"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        script.toolGetHubLogs([since: 30])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('since')
+        ex.message.toLowerCase().contains('string')
+    }
+
+    def "patterns list containing a non-string element throws IllegalArgumentException naming the index"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+
+        when:
+        // index 1 (the integer 42) is the bad element
+        script.toolGetHubLogs([patterns: ['valid', 42, 'also valid']])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('patterns[1]')
+        ex.message.toLowerCase().contains('string')
+    }
+
+    // ==================== case-insensitivity inverse direction (Pre4) ====================
+
+    def "pattern in lowercase matches log entries with uppercase message text"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tERROR in device\t2026-04-19 10:00:00.000\ttype',
+            'App 1\tinfo\tall good\t2026-04-19 10:00:01.000\ttype'
+        ])
+
+        when: 'lowercase pattern against uppercase message'
+        def result = script.toolGetHubLogs([pattern: 'error'])
+
+        then: 'case-insensitive match succeeds in the lowercase-pattern direction'
+        result.logs.size() == 1
+        result.logs[0].message == 'ERROR in device'
+    }
+
+    def "patterns list entries are case-insensitive: mixed-case patterns match opposite-case messages"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App 1\tinfo\tFOO happened\t2026-04-19 10:00:00.000\ttype',   // matches 'foo' pattern
+            'App 1\tinfo\tbar happened\t2026-04-19 10:00:01.000\ttype',    // matches 'BAR' pattern
+            'App 1\tinfo\tunrelated\t2026-04-19 10:00:02.000\ttype'        // neither
+        ])
+
+        when: 'lowercase pattern "foo" vs uppercase message, and uppercase pattern "BAR" vs lowercase message'
+        def result = script.toolGetHubLogs([patterns: ['foo', 'BAR']])
+
+        then: 'both directions of case-insensitive matching work in the patterns list'
+        result.logs.size() == 2
+        result.logs.every { it.message.toLowerCase() =~ /(foo|bar)/ }
+    }
+
+    // ==================== kitchen-sink combined filter (Pre3) ====================
+
+    def "kitchen-sink: level + source + pattern + patterns + since applied in pipeline order"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // now() in harness = 1234567890000L; "2h" window = entries from 1234560090000L onward
+        long nowMs = 1234567890000L
+        def utcSdf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+        utcSdf.setTimeZone(TimeZone.getTimeZone("UTC"))
+        def fmtDate = { long ms -> utcSdf.format(new Date(ms)) }
+        def recent = fmtDate(nowMs - 1 * 3600 * 1000L)  // 1h ago -- inside 2h window
+        def old    = fmtDate(nowMs - 3 * 3600 * 1000L)  // 3h ago -- outside 2h window
+
+        // Six entries. Exactly two should survive all filters:
+        //   level=warn, source=testapp (in name), pattern=keyword, patterns any(foo|bar), since=2h, limit=5
+        //
+        // Entry A: passes all -- warn level, name contains testapp, message has "keyword foo", recent
+        // Entry B: passes all -- warn level, name contains testapp, message has "keyword bar", recent
+        // Entry C: fails level (info)
+        // Entry D: fails source (name is 'otherone')
+        // Entry E: fails pattern (message has no "keyword")
+        // Entry F: fails since (too old)
+        registerLogs([
+            "testapp\twarn\tkeyword foo result\t${recent}\tapp",   // A -- passes
+            "testapp\twarn\tkeyword bar result\t${recent}\tapp",   // B -- passes
+            "testapp\tinfo\tkeyword foo result\t${recent}\tapp",   // C -- wrong level
+            "otherone\twarn\tkeyword foo result\t${recent}\tapp",  // D -- wrong source
+            "testapp\twarn\tnokeyword here\t${recent}\tapp",       // E -- no keyword
+            "testapp\twarn\tkeyword foo result\t${old}\tapp"       // F -- too old
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([
+            level      : 'warn',
+            source     : 'testapp',
+            pattern    : 'keyword',
+            patterns   : ['foo', 'bar'],
+            patternMode: 'any',
+            since      : '2h',
+            limit      : 5
+        ])
+
+        then: 'exactly entries A and B survive the full filter pipeline'
+        result.logs.size() == 2
+        result.logs.every { it.level == 'warn' }
+        result.logs.every { it.name?.toLowerCase()?.contains('testapp') }
+        result.logs.every { it.message?.toLowerCase()?.contains('keyword') }
+        result.logs.every { it.message?.toLowerCase() =~ /(foo|bar)/ }
+        result.count == 2
+    }
+
+    // ==================== combined filter ====================
+
+    def "level plus pattern plus since all apply as intersection"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // Hub log timestamps are UTC; format fixture strings as UTC.
+        long nowMs = 1234567890000L
+        def utcSdf = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+        utcSdf.setTimeZone(TimeZone.getTimeZone("UTC"))
+        def fmtDate = { long ms -> utcSdf.format(new Date(ms)) }
+        def recent = fmtDate(nowMs - 5 * 60 * 1000L)   // 5 min ago -- within last 30m
+        def old    = fmtDate(nowMs - 2 * 3600 * 1000L) // 2 h ago   -- outside since=30m
+
+        registerLogs([
+            "App 1\terror\tFAULT: recent issue\t${recent}\ttype",  // passes all 3 (level=error, matches FAULT, recent)
+            "App 1\tinfo\tFAULT: recent info\t${recent}\ttype",    // wrong level (info, not error)
+            "App 1\terror\tFAULT: old issue\t${old}\ttype",        // outside since (2h ago)
+            "App 1\terror\tAll good, no keyword\t${recent}\ttype"  // pattern mismatch (no FAULT)
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([level: 'error', pattern: 'FAULT', since: '30m'])
+
+        then: 'only the entry passing all three filters is returned'
+        result.logs.size() == 1
+        result.logs[0].message == 'FAULT: recent issue'
+    }
+
+    // ==================== limit truncation ====================
+
+    def "limit truncates result when survivors exceed limit"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // 5 WARN entries all pass the level filter; limit=2 should truncate to 2.
+        registerLogs([
+            'App 1\twarn\tmessage 1\t2026-04-19 10:00:01.000\ttype',
+            'App 1\twarn\tmessage 2\t2026-04-19 10:00:02.000\ttype',
+            'App 1\twarn\tmessage 3\t2026-04-19 10:00:03.000\ttype',
+            'App 1\twarn\tmessage 4\t2026-04-19 10:00:04.000\ttype',
+            'App 1\twarn\tmessage 5\t2026-04-19 10:00:05.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([level: 'warn', limit: 2])
+
+        then: 'limit is the binding constraint -- 5 passed the level filter, 2 are returned'
+        result.logs.size() == 2
+        // count reflects what was returned after limit applied
+        result.count == 2
+    }
+
+    // ==================== naked-T ISO (no Z suffix) as UTC ====================
+
+    def "since as naked-T ISO timestamp (no Z) is parsed as UTC not JVM default TZ"() {
+        given:
+        settingsMap.enableHubAdminRead = true
+        // since='2024-01-15T10:30:00' (no Z) should be treated as UTC midnight+10:30.
+        // UTC epoch for 2024-01-15T10:30:00Z = 1705311000000L.
+        // An entry at 2024-01-15 10:30:01 UTC is 1 second inside the window (included).
+        // An entry at 2024-01-15 10:29:59 UTC is 1 second before the window (excluded).
+        registerLogs([
+            'App 1\tinfo\tBefore cutoff\t2024-01-15 10:29:59.000\ttype',
+            'App 1\tinfo\tAfter cutoff\t2024-01-15 10:30:01.000\ttype'
+        ])
+
+        when: 'naked-T since (no Z suffix) is parsed as UTC'
+        def result = script.toolGetHubLogs([since: '2024-01-15T10:30:00'])
+
+        then: 'entry at 10:30:01 UTC is included; entry at 10:29:59 UTC is excluded'
+        result.logs.size() == 1
+        result.logs[0].message == 'After cutoff'
     }
 }

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -557,6 +557,16 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 
 **Expected v0.8.0**: Discovers `manage_logs` → `get_hub_logs`.
 
+### T47b — get_hub_logs pattern + since combination
+
+```json
+{
+  "test_prompt": "Pull the last hour of hub logs and show me only entries where the message mentions 'error' or 'failed' -- case-insensitive. Use the pattern filter, not just the level filter."
+}
+```
+
+**Expected**: Calls `manage_logs` -> `get_hub_logs` with `since='1h'` and `pattern='error|failed'` (or equivalent `patterns` array). Demonstrates pattern filter + time-window together.
+
 ### T48 — Discover get_device_history (manage_logs)
 
 ```json

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -567,6 +567,16 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 
 **Expected**: Calls `manage_logs` -> `get_hub_logs` with `since='1h'` and `pattern='error|failed'` (or equivalent `patterns` array). Demonstrates pattern filter + time-window together.
 
+### T47c — get_hub_logs patterns + patternMode all (AND-mode)
+
+```json
+{
+  "test_prompt": "Show me hub logs from the last 2 hours that mention both 'timeout' AND 'device' in the same message -- I want only entries that contain both words simultaneously."
+}
+```
+
+**Expected**: Calls `manage_logs` -> `get_hub_logs` with `patterns=['timeout', 'device']` and `patternMode='all'` (AND semantics) plus `since='2h'`. Demonstrates AND-mode multi-pattern filtering -- higher-value than OR-mode because it narrows results more precisely.
+
 ### T48 — Discover get_device_history (manage_logs)
 
 ```json


### PR DESCRIPTION
## Summary

Adds five new optional filter args to `get_hub_logs` so AI callers can fetch exactly the slice of log buffer they need without burning context on a full-buffer return. Composes with existing `level` / `source` / `deviceId` / `appId` / `limit`; existing callers see no change unless they pass the new args. Backward-compatible.

The token-economy problem this solves: today, asking *"what errors have happened in the last 10 minutes related to humidity rules?"* requires fetching the entire log buffer (potentially MBs serialized), then client-side filtering on time + regex + source — most of the bytes are wasted context. With this PR, the same query is `get_hub_logs(pattern='humid', level='error', since='10m')` → server-side, scoped, single call, response sized to actual matches.

Second in the AI-agent token-economy series (after #153 `list_devices` ergonomics — internal codename T-A2). Each PR lands separately so you can reject any individual item without blocking the others. Likely follow-up (still subject to your reaction): T-A3 — `poll_until_attribute` long-poll wrapper to skip the polling loop in agent code. Independent of this PR.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

Five new optional args on `get_hub_logs`:

- **`pattern`** (string) — case-insensitive regex match against the log message field. Pre-compiled once before the entry loop. Caveat documented in the schema: pathological regex like `(.*)*` may hang the matcher; prefer simple alternation (`error|fail`) or anchored prefixes. Matches against the message field only — use `source` for app/device-name substring matching.
- **`patterns`** (string list) + **`patternMode`** (`'any'` default | `'all'`, case-insensitive) — multi-regex match. `any` = entry kept if ANY pattern matches; `all` = entry kept if EVERY pattern matches. Both `pattern` and `patterns` apply when both are set.
- **`since`** / **`until`** (string) — ISO-8601 timestamp (`'2024-01-15T00:00:00Z'`) OR relative offset (`'30m'`, `'2h'`, `'1d'`, `'7d'`, capped at 30d). Inverted windows (`since > until`) throw with a helpful message.

Filter pipeline order, documented and pinned by spec:
`scope (deviceId/appId at hub) → reverse-to-newest-first → level → source → pattern → patterns → time-window → limit`

### Notable implementation details

- **UTC parsing for hub log timestamps and ISO-8601 `since`/`until` inputs.** Hub `/logs/past/json` returns timestamps in UTC without TZ markers. `Date.parse(fmt, str)` interprets in JVM-default TZ, which silently shifts entries by the hub's TZ offset (verified bug on a hub in `America/Denver` — entries appeared 6 hours in the future, time-window filter became a no-op). Switched to `java.text.SimpleDateFormat` with explicit `TimeZone.getTimeZone("UTC")`. Same fix applied to user-input ISO-8601 parsing — `'Z'`-quoted formats had an analogous bug where `'Z'` was treated as a literal character rather than a UTC marker. Naked-T form (`'2024-01-15T10:30:00'` without Z) also parsed as UTC for consistency.
- **`entry.name` fallback for time-window filter.** Hub firmware 2.5.0.126+ puts the log timestamp in `parts[0]` (`entry.name`) and leaves `entry.time` empty. The time-window filter falls back to `entry.name` so it applies on real-world hub data, not just synthetic fixtures.
- **Type validation on all 5 new args** via `instanceof` checks (no `getClass()` — sandbox-blocked). Wrong shapes throw `IllegalArgumentException` naming the bad arg + expected type. The `patterns` list also validates each element is a String, naming the bad index.
- **`manage_logs` gateway summary + searchHints updated** so AI agents browsing the gateway listing or running `search_tools` natural-language probes ("filter logs by regex" / "logs from last hour") discover the new surface.

## Release Notes

- `get_hub_logs` now accepts `pattern` (case-insensitive regex on message), `patterns` + `patternMode` (multi-regex AND/OR), `since` / `until` (ISO-8601 or relative offset like `'30m'` / `'2h'`) — all server-side, applied before pagination.
- Token-friendly: "errors mentioning humidity in the last hour" can be answered in a single targeted call instead of fetching the full buffer and filtering client-side.
- Fully backward-compatible — existing calls without the new args produce identical results.

## Testing

`ToolGetHubLogsSpec` — **35/35 PASS** covering:

- Each new arg individually (regex match, regex case-insensitivity in both directions, multi-pattern OR/AND, since/until relative + ISO-8601 with-and-without-millis + naked-T parsed as UTC)
- Filter pipeline ordering pinned: `level + pattern + since` intersection, kitchen-sink combined scenario
- Type-validation throws on wrong shapes (`pattern` as list, `patterns` as string, `since` as number, `patterns` with non-string element naming the index)
- `patternMode` enum throw on invalid value
- Inverted-window throw (`since='1h' + until='2h'` — caller pitfall)
- TZ correctness scenario exercising non-UTC JVM behavior (no-op pre-fix; correctly bounded post-fix)
- Mixed-firmware-shape entries (some with `time` populated, some with timestamp in `name`)
- Limit truncation when survivors exceed limit
- Backward compatibility (no new args → identical response shape to pre-PR)

Sandbox lint clean. Full Gradle suite BUILD SUCCESSFUL.

**Live-hub validation on test hub (firmware 2.5.0.126, hub TZ `America/Denver`):**

| Query | Result |
|---|---|
| `pattern='(?i)error\|warn'`, `since='2m'` | 8 entries returned, all within 2-minute window. Pre-fix: returned entries from 2.5+ hours ago (TZ skew). |
| `pattern=['error','warn']` (wrong shape) | Throws `pattern must be a string (got list)` ✓ |
| `since=30` (number) | Throws `since must be a string (ISO-8601 timestamp or relative offset like '30m', '2h', '1d')` ✓ |
| `level='warn' + patterns=['validation','error'] + patternMode='any' + since='30m' + limit=5` | Returned 3 matching entries — all WARN, all match the regex, all within window |
| `since='2026-05-07T15:00:00'` (naked-T, no Z) | 5 entries returned, all from after 15:00 UTC. Naked-T parsed as UTC. |

### Zero-context Sonnet validation

Fresh Sonnet agent given the prompt *"What WARN or ERROR log entries have happened in the last 10 minutes related to validation? Just show me the messages."* made 2 surgical calls:

- `get_hub_logs(level='warn', pattern='(?i)valid', since='10m', limit=50)` → ~80 bytes
- `get_hub_logs(level='error', pattern='(?i)valid', since='10m', limit=50)` → ~80 bytes

~160 bytes total, vs baseline (fetch full 6,800-entry buffer + client-side filter on level + message + time) which would be MBs of token burn. Agent composed `level` + `pattern` + `since` correctly from description on first try; split into 2 calls because `level` is single-value enum (correct pattern, not a description failure).

## Checklist

- [x] Unit tests added for any new MCP tools (ToolGetHubLogsSpec, 35 scenarios)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test --tests "server.ToolGetHubLogsSpec"` passes locally
- [x] Live-hub BAT tests updated (T47b in `tests/BAT-v2.md` — pattern + since combined)
- [x] Documentation updated (`README.md`, `TOOL_GUIDE.md`, `agent-skill/hubitat-mcp/SKILL.md`, `agent-skill/hubitat-mcp/tool-reference.md`)
