### PR TITLE
feat: add clone/export/import_native_app via Hubitat appCloner

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -18364,7 +18364,7 @@ private String _appClonerExtractJsonFromSettings(Integer clonerAppId) {
     def settings = (cfg?.settings instanceof Map) ? cfg.settings : [:]
     for (entry in settings) {
         def v = entry?.value
-        if (v instanceof String && v.length() > 100 && v.contains("appReplacements") && v.startsWith("{")) {
+        if (v instanceof String && v.startsWith("{") && v.contains("appReplacements")) {
             return v
         }
     }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6223,6 +6223,48 @@ def hubInternalPost(String path, Map body = null, boolean isRetry = false) {
  * Make an authenticated POST request to the hub's internal API with form-encoded body.
  * Used for app/driver management endpoints that require application/x-www-form-urlencoded.
  */
+/**
+ * POST a pre-encoded form-urlencoded body to the hub's internal API. Use
+ * this instead of `hubInternalPostForm` when the body contains values
+ * HTTPBuilder's auto-encoder mangles (notably backslash + quote sequences
+ * inside JSON values). Caller is responsible for URL-encoding keys/values
+ * themselves; this method passes the body string straight through.
+ */
+def hubInternalPostFormRaw(String path, String encodedBody, int timeout = 420, boolean isRetry = false) {
+    def cookie = getHubSecurityCookie()
+    def params = [
+        uri: "http://127.0.0.1:8080",
+        path: path,
+        requestContentType: "application/x-www-form-urlencoded",
+        textParser: true,
+        headers: ["Connection": "keep-alive"],
+        body: encodedBody,
+        timeout: timeout,
+        ignoreSSLIssues: true
+    ]
+    if (cookie) params.headers["Cookie"] = cookie
+    def result = null
+    try {
+        httpPost(params) { resp ->
+            def responseData = resp.data
+            try { responseData = responseData.text }
+            catch (Exception readErr) { responseData = responseData?.toString() }
+            result = [
+                status: resp.status,
+                location: resp.headers?."Location"?.toString(),
+                data: responseData
+            ]
+        }
+    } catch (Exception e) {
+        if (shouldRetryWithFreshCookie(e, isRetry)) {
+            mcpLog("debug", "hub-admin", "Retrying with fresh cookie after auth failure on POST-form-raw ${path}")
+            return hubInternalPostFormRaw(path, encodedBody, timeout, true)
+        }
+        throw e
+    }
+    return result
+}
+
 def hubInternalPostForm(String path, Map body, int timeout = 420, boolean isRetry = false) {
     def cookie = getHubSecurityCookie()
     def params = [
@@ -18138,6 +18180,19 @@ private Map _appClonerInit(Integer sourceAppId) {
         // Cloner appears to need a beat to commit state.cloneSource after
         // the source-context render before subsequent clicks are honored.
         pauseExecution(1000)
+        // Mimic browser flow: fetch the configPage JSON before any settings
+        // POSTs. Without this, file-text widgets (`settings[ruleUpload]`)
+        // silently drop their values — the cloner accepts the POST (200,
+        // ruleUpload key registered) but stores null. The browser's main
+        // page render fires this XHR after navigation; settings writes
+        // sent before it land in a half-initialized cloner that can't
+        // receive uploads. Required for import_native_app; harmless for
+        // clone/export.
+        try {
+            hubInternalGet("/installedapp/configure/json/${clonerId}/main", [:])
+        } catch (Exception primeErr) {
+            mcpLog("warn", "rm-native", "appCloner: configPage JSON prime failed for cloner ${clonerId}: ${primeErr.message}")
+        }
     } catch (Exception followErr) {
         // Source-context render is best-effort. If it fails, the click POSTs
         // still try; some firmwares may seed source context differently.
@@ -18203,7 +18258,20 @@ private Map _appClonerSubmitForm(Integer clonerAppId, String currentPage, String
             break
     }
     if (extras) body.putAll(extras)
-    def resp = hubInternalPostForm("/installedapp/update/json", body)
+    // URL-encode manually — HTTPBuilder's Map auto-encoder mangles backslash
+    // sequences inside form-urlencoded bodies, so JSON content with embedded
+    // `\"` (e.g. canonical exports' multi-select enum encoding) loses its
+    // escaping on the wire and the cloner silently rejects the upload.
+    StringBuilder sb = new StringBuilder()
+    boolean first = true
+    body.each { k, v ->
+        if (!first) sb.append('&')
+        first = false
+        sb.append(URLEncoder.encode(k.toString(), "UTF-8"))
+        sb.append('=')
+        sb.append(v == null ? "" : URLEncoder.encode(v.toString(), "UTF-8"))
+    }
+    def resp = hubInternalPostFormRaw("/installedapp/update/json", sb.toString())
     return resp ?: [:]
 }
 
@@ -18217,14 +18285,47 @@ private Map _appClonerSubmitForm(Integer clonerAppId, String currentPage, String
  * it's the source rule's id; for import it's the original source id from
  * the JSON's `appReplacements` map.
  */
+private Integer _appClonerFindActionHrefIdx(Integer clonerAppId, String pageName, String targetActionName) {
+    // Hubitat assigns action_href elements a session-scoped numeric id at
+    // render time — the same logical button gets a different number on the
+    // post-clone confirmation page (low — usually 0) than on the post-upload
+    // restore-or-import page (high — observed 55 live), and the cloner's
+    // server-side dispatcher matches on the EXACT `<action>|<idx>` pair.
+    // Fetch the page JSON and regex out the current id; without this the
+    // navigate POST hits a no-op and the importNow click later fires on
+    // the wrong page (silent failure — settings persist but no rule).
+    def pn = pageName ?: "main"
+    String body = null
+    try {
+        def resp = hubInternalGet("/installedapp/configure/json/${clonerAppId}/${pn}", [:])
+        body = (resp instanceof Map) ? (resp.data?.toString()) : (resp?.toString())
+    } catch (Exception e) {
+        mcpLog("warn", "rm-native", "appCloner: fetch state for href discovery failed: ${e.message}")
+        return null
+    }
+    if (!body) return null
+    def m = (body =~ /_action_href_name\|${java.util.regex.Pattern.quote(targetActionName)}\|(\d+)/)
+    return m.find() ? (m[0][1] as Integer) : null
+}
+
 private void _appClonerCommitImportRule(Integer clonerAppId, Integer sourceAppId, String newName, String referrer, String configUrl) {
     // Step 3: navigate /main → /main/importRule via _action_href_name. The
-    // cloner is in "confirmation" state at this point — its form has
-    // cancelUpload as the only schema-input; the "Clone..." button is an
-    // href submission that submits with name=_action_href_name|importRule|N.
+    // cloner is in either confirmation (post-clone) or restore-or-import
+    // (post-upload) state — both expose an importRule action_href but at
+    // different session-scoped indices.
+    // The cloner re-renders asynchronously after a state-transition POST;
+    // poll the page state a few times to give the action_href button time
+    // to appear before falling back to 0 (which would only succeed for
+    // the clone path's confirmation page).
+    Integer hrefIdx = null
+    for (int attempt = 0; attempt < 4 && hrefIdx == null; attempt++) {
+        if (attempt > 0) pauseExecution(500)
+        hrefIdx = _appClonerFindActionHrefIdx(clonerAppId, "main", "importRule")
+    }
+    if (hrefIdx == null) hrefIdx = 0
     _appClonerSubmitForm(clonerAppId, "main", "confirmation", referrer, configUrl, [
-        ("_action_href_name|importRule|0".toString()): "",
-        ("params_for_action_href_name|importRule|0".toString()): ""
+        ("_action_href_name|importRule|${hrefIdx}".toString()): "",
+        ("params_for_action_href_name|importRule|${hrefIdx}".toString()): ""
     ])
     pauseExecution(500)
 
@@ -18407,27 +18508,27 @@ def toolExportNativeApp(args) {
     String referrer = initRes.referrer
     String configUrl = initRes.configUrl
 
-    // Step 2: click exportRuleButton + form refresh — twice (state-machine
-    // race; first click drops, second commits).
+    // Step 2: click exportRuleButton, then capture the form-refresh response.
+    // Unlike clone (which writes persistent state and needs a double-click
+    // to commit the state transition), export's serialized JSON is rendered
+    // INTO the form-refresh POST response itself as
+    // configPage.sections[].input[].filecontent — session-keyed and not
+    // persisted to the cloner's settings. So we must capture the response
+    // body of the same POST that fires the click rather than fetching the
+    // cloner's state in a subsequent request (different session = bare view,
+    // no JSON). One click is sufficient here.
     def btnBody = [
         id: clonerAppId.toString(),
         name: "exportRuleButton",
         ("settings[exportRuleButton]".toString()): "clicked",
         ("exportRuleButton.type".toString()): "button"
     ]
-    for (int attempt = 0; attempt < 2; attempt++) {
-        hubInternalPostForm("/installedapp/btn", btnBody)
-        pauseExecution(500)
-        _appClonerSubmitForm(clonerAppId, "main", "source", referrer, configUrl, null)
-        pauseExecution(500)
-    }
-
-    // Step 3: read the cloner's settings to extract the JSON. The export
-    // content lives in a setting whose name varies by firmware — search for
-    // any setting whose value is a JSON object containing "appReplacements".
-    String jsonContent = _appClonerExtractJsonFromSettings(clonerAppId)
+    hubInternalPostForm("/installedapp/btn", btnBody)
+    pauseExecution(500)
+    def refreshResp = _appClonerSubmitForm(clonerAppId, "main", "source", referrer, configUrl, null)
+    String jsonContent = _appClonerExtractJsonFromResponse(refreshResp?.data)
     if (!jsonContent) {
-        throw new IllegalStateException("appCloner export fired but no JSON content could be extracted from cloner ${clonerAppId} — wire format may have changed")
+        throw new IllegalStateException("appCloner export fired but no JSON content could be extracted from cloner ${clonerAppId} — wire format may have changed (looked for configPage.sections[].input[].filecontent)")
     }
 
     def result = [
@@ -18453,10 +18554,54 @@ def toolExportNativeApp(args) {
 }
 
 /**
- * Internal: pull the exported JSON out of the cloner's settings. The setting
- * key isn't stable across firmwares (seen as `ruleDownload` and similar) —
- * scan all settings and pick the first whose value parses as JSON containing
- * "appReplacements".
+ * Internal: pull the exported JSON out of the form-refresh POST response
+ * body. The cloner renders the export content into configPage.sections[]
+ * .input[].filecontent (and .body[].filecontent) on the post-click render —
+ * but only within the same request/session as the click. A subsequent fetch
+ * sees the bare 3-button view because Hubitat's post-click rendering is
+ * session-keyed and our groovy helpers don't share a cookie jar.
+ *
+ * So we extract from the response body of the form-refresh POST itself.
+ */
+private String _appClonerExtractJsonFromResponse(String responseBody) {
+    if (!responseBody || !(responseBody instanceof String)) return null
+    def parsed
+    try { parsed = new groovy.json.JsonSlurper().parseText(responseBody) }
+    catch (Exception e) {
+        mcpLog("debug", "rm-native", "appCloner: response JSON parse failed: ${e.message}")
+        return null
+    }
+    def sections = (parsed instanceof Map) ? parsed?.configPage?.sections : null
+    if (!(sections instanceof List)) return null
+    for (section in sections) {
+        // The filecontent lives on input[] entries (download-type inputs)
+        // and is mirrored in body[] entries. Either works.
+        for (key in ["input", "inputs", "body"]) {
+            def items = section?."${key}"
+            if (!(items instanceof List)) continue
+            for (item in items) {
+                def fc = (item instanceof Map) ? item.filecontent : null
+                if (fc instanceof String && fc.contains("appReplacements") && fc.startsWith("{")) {
+                    // Hubitat appCloner over-escapes multi-select enum values
+                    // by one extra level when generating the download payload —
+                    // its `filecontent` has `\\"` (2 backslashes + quote) where
+                    // canonical JSON requires `\"` (1 backslash + quote). The
+                    // result is malformed JSON that won't round-trip back into
+                    // import. The pattern `\\"` is unreachable in valid JSON
+                    // (a literal `\` + `"` would encode as `\\\"`), so we can
+                    // safely collapse it.
+                    return fc.replace('\\\\"', '\\"')
+                }
+            }
+        }
+    }
+    return null
+}
+
+/**
+ * Legacy: pull the exported JSON from the cloner's persisted settings. Kept
+ * as a fallback for firmwares that may persist the content there. The
+ * primary extraction path is now from the form-refresh response body.
  */
 private String _appClonerExtractJsonFromSettings(Integer clonerAppId) {
     def cfg
@@ -18554,19 +18699,28 @@ def toolImportNativeApp(args) {
 
     def initRes = _appClonerInit(parentHintAppId)
     Integer clonerAppId = initRes.clonerAppId
-    String referrer = initRes.referrer
+    // For import the cloner's state machine validates session against the
+    // local config URL (the page the user uploaded from). The OAuth source-
+    // context URL the init returns is correct for clone (that's where the
+    // cloneRuleButton lives) but trips a session check on the import path.
+    // Verified live: same wire shape with OAuth referrer → no rule created;
+    // with local-URL referrer → rule created. Use configUrl for both.
+    String referrer = initRes.configUrl
     String configUrl = initRes.configUrl
 
-    // Step 2: stage the JSON via settings[ruleUpload]= — twice (same
-    // state-machine race; the upload-and-process needs a second cycle to
-    // commit before the importRule sub-page becomes available).
-    def uploadExtras = [
+    // Step 2: stage the JSON via settings[ruleUpload]= — single POST. The
+    // UI fires this exactly once (file picker change → FileReader → one
+    // jsonSubmit). A second pass is harmful here: the cloner has already
+    // transitioned to restore-or-import state and the source-state form
+    // body no longer matches.
+    _appClonerSubmitForm(clonerAppId, "main", "source", referrer, configUrl, [
         ("settings[ruleUpload]".toString()): jsonContent
-    ]
-    for (int attempt = 0; attempt < 2; attempt++) {
-        _appClonerSubmitForm(clonerAppId, "main", "source", referrer, configUrl, uploadExtras)
-        pauseExecution(500)
-    }
+    ])
+    // Cloner needs time to JSON-parse the upload + transition to the
+    // restore-or-import page before our discovery sees the new sections.
+    // Larger JSON inputs (full canonical exports) need more — 500ms is
+    // enough for trivial JSON but races on a 3KB rule body.
+    pauseExecution(2000)
 
     // Steps 3-5: navigate importRule, optional rename, click importNow.
     _appClonerCommitImportRule(clonerAppId, originalSourceId, newName, referrer, configUrl)

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -18086,7 +18086,7 @@ def toolCheckRuleHealth(args) {
  *   /apps/api/<clonerId>/app/<sourceId>?access_token=...   (current)
  *   /installedapp/configure/<clonerId>                      (older)
  */
-private Integer _appClonerInit(Integer sourceAppId) {
+private Map _appClonerInit(Integer sourceAppId) {
     def resp
     try {
         resp = hubInternalGetRaw("/installedapp/sysAppApi/appCloner/app/${sourceAppId}")
@@ -18102,7 +18102,48 @@ private Integer _appClonerInit(Integer sourceAppId) {
     if (clonerId == null) {
         throw new IllegalStateException("Unexpected appCloner Location: ${loc}")
     }
-    return clonerId
+    // Capture the full OAuth source-context URL — the cloner state machine
+    // requires this as the `referrer` field on subsequent form POSTs to
+    // verify they originate from the source-authorized session. Without
+    // it, every state transition is silently rejected even though POSTs
+    // return 200. Hubitat's UI reads this from window.location after
+    // following the 302; we capture it directly from the redirect target.
+    String sourceContextUrl = loc.startsWith("http") ? loc : "http://192.168.1.133${loc}"
+    // CRITICAL: follow the redirect target. The cloner's `app(sourceId)`
+    // mapping renders the source-context page and sets internal state
+    // (state.cloneSource, etc.). Without this GET, the cloner accepts our
+    // form POSTs but its state machine never knows what rule to clone, so
+    // cloneRuleButton/importNow clicks register but no new rule appears.
+    // The Location is OAuth-token-protected (/apps/api/<clonerId>/app/<sourceId>
+    // ?access_token=...) — split path + query so HTTPBuilder doesn't URL-encode
+    // the `?` and break the access_token lookup.
+    try {
+        def relPath = loc.replaceFirst(/^https?:\/\/[^\/]+/, '')
+        def parts = relPath.split(/\?/, 2)
+        def justPath = parts[0]
+        def query = [:]
+        if (parts.length > 1) {
+            parts[1].split('&').each { kv ->
+                def eq = kv.indexOf('=')
+                if (eq > 0) {
+                    def k = kv.substring(0, eq)
+                    def v = kv.substring(eq + 1)
+                    // values aren't url-encoded in the redirect Location — pass through
+                    query[k] = v
+                }
+            }
+        }
+        hubInternalGet(justPath, query)
+        mcpLog("debug", "rm-native", "appCloner: source-context render of ${justPath} succeeded for cloner ${clonerId}")
+        // Cloner appears to need a beat to commit state.cloneSource after
+        // the source-context render before subsequent clicks are honored.
+        pauseExecution(1000)
+    } catch (Exception followErr) {
+        // Source-context render is best-effort. If it fails, the click POSTs
+        // still try; some firmwares may seed source context differently.
+        mcpLog("warn", "rm-native", "appCloner: source-context render of ${loc} failed for cloner ${clonerId}: ${followErr.message}")
+    }
+    return [clonerAppId: clonerId, referrer: sourceContextUrl, configUrl: "http://192.168.1.133/installedapp/configure/${clonerId}/main".toString()]
 }
 
 /**
@@ -18111,14 +18152,56 @@ private Integer _appClonerInit(Integer sourceAppId) {
  * Mirrors the form refresh the UI fires automatically after every click —
  * required to advance the cloner's server-side state machine.
  */
-private Map _appClonerSubmitForm(Integer clonerAppId, String currentPage, Map extras = null, String pageBreadcrumbs = null) {
+private Map _appClonerSubmitForm(Integer clonerAppId, String currentPage, String formState, String referrer, String configUrl, Map extras = null) {
+    // Build a form-refresh body that mirrors the Hubitat UI's POST shape
+    // for the cloner's current rendering state. Each formState corresponds
+    // to a distinct view the cloner can render at /main:
+    //   "source"        — initial source-context view (3 buttons)
+    //   "confirmation"  — after cloneRuleButton: "Clone..." + Cancel
+    //   "importRule"    — after navigation: name editor + importNow button
+    // Each POST must emit the input triplets matching the rendered view —
+    // sending the WRONG view's fields stalls the state machine silently.
+    def pageBreadcrumbs = currentPage == "main" ? "[]" : '["main"]'
     def body = [
         formAction: "update",
         id: clonerAppId.toString(),
+        version: "1",
+        appTypeId: "",
+        appTypeName: "",
         currentPage: currentPage,
-        pageBreadcrumbs: pageBreadcrumbs ?: (currentPage == "main" ? "[]" : '["main"]'),
-        version: "1"
+        pageBreadcrumbs: pageBreadcrumbs,
+        // The cloner state machine validates that subsequent form POSTs
+        // come from the source-authorized session. The UI's referrer is the
+        // OAuth-tokened source-context URL (.../apps/api/<cloner>/app/
+        // <source>?access_token=...); without it the cloner silently rejects
+        // state transitions. Captured during _appClonerInit.
+        referrer: referrer ?: "",
+        url: configUrl ?: "",
+        _cancellable: "false"
     ]
+    switch (formState) {
+        case "source":
+            body["exportRuleButton.type"] = "button"
+            body["exportRuleButton.multiple"] = "false"
+            body["settings[exportRuleButton]"] = ""
+            body["ruleUpload.type"] = "file-text"
+            body["ruleUpload.multiple"] = "false"
+            body["settings[ruleUpload]"] = ""
+            body["cloneRuleButton.type"] = "button"
+            body["cloneRuleButton.multiple"] = "false"
+            body["settings[cloneRuleButton]"] = ""
+            break
+        case "confirmation":
+            body["cancelUpload.type"] = "button"
+            body["cancelUpload.multiple"] = "false"
+            body["settings[cancelUpload]"] = ""
+            break
+        case "importRule":
+            // importRule fields are dynamic per source — caller passes them via extras
+            break
+        default:
+            break
+    }
     if (extras) body.putAll(extras)
     def resp = hubInternalPostForm("/installedapp/update/json", body)
     return resp ?: [:]
@@ -18134,49 +18217,59 @@ private Map _appClonerSubmitForm(Integer clonerAppId, String currentPage, Map ex
  * it's the source rule's id; for import it's the original source id from
  * the JSON's `appReplacements` map.
  */
-private void _appClonerCommitImportRule(Integer clonerAppId, Integer sourceAppId, String newName) {
-    // Step 3: navigate /main -> /main/importRule via _action_href_name. The
-    // <idx> in the field name is the embedded-action index in the page's
-    // action list; the hub accepts any value as long as the page name matches.
-    _appClonerSubmitForm(clonerAppId, "main", [
+private void _appClonerCommitImportRule(Integer clonerAppId, Integer sourceAppId, String newName, String referrer, String configUrl) {
+    // Step 3: navigate /main → /main/importRule via _action_href_name. The
+    // cloner is in "confirmation" state at this point — its form has
+    // cancelUpload as the only schema-input; the "Clone..." button is an
+    // href submission that submits with name=_action_href_name|importRule|N.
+    _appClonerSubmitForm(clonerAppId, "main", "confirmation", referrer, configUrl, [
         ("_action_href_name|importRule|0".toString()): "",
         ("params_for_action_href_name|importRule|0".toString()): ""
     ])
+    pauseExecution(500)
 
     // Step 4 (optional): override the cloner's default new-app label. The
     // setting name is dynamic per source: settings[newName<sourceId>].
+    def newNameField = "settings[newName${sourceAppId}]".toString()
+    def newNameTypeKey = "newName${sourceAppId}.type".toString()
+    def newNameMultKey = "newName${sourceAppId}.multiple".toString()
     if (newName) {
-        def field = "settings[newName${sourceAppId}]".toString()
-        def typeKey = "newName${sourceAppId}.type".toString()
-        def multipleKey = "newName${sourceAppId}.multiple".toString()
-        _appClonerSubmitForm(clonerAppId, "importRule", [
-            (field): newName,
-            (typeKey): "text",
-            (multipleKey): "false"
+        _appClonerSubmitForm(clonerAppId, "importRule", "importRule", referrer, configUrl, [
+            (newNameField): newName,
+            (newNameTypeKey): "text",
+            (newNameMultKey): "false"
         ])
     }
 
     // Step 5: click importNow — fires the actual create. The button is
     // named `importNow` regardless of which path (clone vs import) brought
-    // us here — both surfaces converge on this final commit.
+    // us here. Same double-click pattern: first click drops, second commits.
     def btnBody = [
         id: clonerAppId.toString(),
         name: "importNow",
         ("settings[importNow]".toString()): "clicked",
         ("importNow.type".toString()): "button"
     ]
-    def resp = hubInternalPostForm("/installedapp/btn", btnBody)
-    if (resp?.status != null && resp.status >= 400) {
-        throw new IllegalStateException("appCloner importNow click failed: status=${resp.status}")
-    }
-
-    // Step 5 follow-up: form refresh on importRule that the UI fires after
-    // the click. The actual create on the hub side completes here.
-    _appClonerSubmitForm(clonerAppId, "importRule", [
+    def finalExtras = [
+        (newNameField): (newName ?: ""),
+        (newNameTypeKey): "text",
+        (newNameMultKey): "false",
         ("importNow.type".toString()): "button",
         ("importNow.multiple".toString()): "false",
         ("settings[importNow]".toString()): ""
-    ])
+    ]
+    for (int attempt = 0; attempt < 2; attempt++) {
+        def resp = hubInternalPostForm("/installedapp/btn", btnBody)
+        if (resp?.status != null && resp.status >= 400) {
+            throw new IllegalStateException("appCloner importNow click failed: status=${resp.status}")
+        }
+        pauseExecution(500)
+        // Form refresh on importRule that the UI fires after the click.
+        // Body includes newName and importNow fields. The actual create
+        // commits on the hub side during the second pass's form refresh.
+        _appClonerSubmitForm(clonerAppId, "importRule", "importRule", referrer, configUrl, finalExtras)
+        pauseExecution(500)
+    }
 }
 
 /**
@@ -18247,24 +18340,32 @@ def toolCloneNativeApp(args) {
         }
     }
 
-    Integer clonerAppId = _appClonerInit(sourceAppId)
+    def initRes = _appClonerInit(sourceAppId)
+    Integer clonerAppId = initRes.clonerAppId
+    String referrer = initRes.referrer
+    String configUrl = initRes.configUrl
 
-    // Step 2: click cloneRuleButton + form refresh.
+    // Step 2: click cloneRuleButton + form refresh — TWICE. Hubitat's
+    // appCloner state machine drops the first click event silently
+    // (verified live via Chrome XHR sniffing — same race the
+    // delete_variable wizard works around with a retry-once loop).
+    // The second click+refresh commits the state transition to the
+    // confirmation page.
     def btnBody = [
         id: clonerAppId.toString(),
         name: "cloneRuleButton",
         ("settings[cloneRuleButton]".toString()): "clicked",
         ("cloneRuleButton.type".toString()): "button"
     ]
-    hubInternalPostForm("/installedapp/btn", btnBody)
-    _appClonerSubmitForm(clonerAppId, "main", [
-        ("cloneRuleButton.type".toString()): "button",
-        ("cloneRuleButton.multiple".toString()): "false",
-        ("settings[cloneRuleButton]".toString()): ""
-    ])
+    for (int attempt = 0; attempt < 2; attempt++) {
+        hubInternalPostForm("/installedapp/btn", btnBody)
+        pauseExecution(500)
+        _appClonerSubmitForm(clonerAppId, "main", "source", referrer, configUrl, null)
+        pauseExecution(500)
+    }
 
     // Steps 3-5: navigate importRule, optional rename, click importNow.
-    _appClonerCommitImportRule(clonerAppId, sourceAppId, newName)
+    _appClonerCommitImportRule(clonerAppId, sourceAppId, newName, referrer, configUrl)
 
     Integer newAppId = _appClonerDiscoverNewChild(parentAppId, preIds, sourceLabel, newName)
 
@@ -18301,21 +18402,25 @@ def toolExportNativeApp(args) {
     }
     def sourceLabel = sourceCfg.app.label?.toString() ?: "app-${sourceAppId}"
 
-    Integer clonerAppId = _appClonerInit(sourceAppId)
+    def initRes = _appClonerInit(sourceAppId)
+    Integer clonerAppId = initRes.clonerAppId
+    String referrer = initRes.referrer
+    String configUrl = initRes.configUrl
 
-    // Step 2: click exportRuleButton + form refresh.
+    // Step 2: click exportRuleButton + form refresh — twice (state-machine
+    // race; first click drops, second commits).
     def btnBody = [
         id: clonerAppId.toString(),
         name: "exportRuleButton",
         ("settings[exportRuleButton]".toString()): "clicked",
         ("exportRuleButton.type".toString()): "button"
     ]
-    hubInternalPostForm("/installedapp/btn", btnBody)
-    _appClonerSubmitForm(clonerAppId, "main", [
-        ("exportRuleButton.type".toString()): "button",
-        ("exportRuleButton.multiple".toString()): "false",
-        ("settings[exportRuleButton]".toString()): ""
-    ])
+    for (int attempt = 0; attempt < 2; attempt++) {
+        hubInternalPostForm("/installedapp/btn", btnBody)
+        pauseExecution(500)
+        _appClonerSubmitForm(clonerAppId, "main", "source", referrer, configUrl, null)
+        pauseExecution(500)
+    }
 
     // Step 3: read the cloner's settings to extract the JSON. The export
     // content lives in a setting whose name varies by firmware — search for
@@ -18447,18 +18552,24 @@ def toolImportNativeApp(args) {
         } catch (Exception ignored) { /* heuristic */ }
     }
 
-    Integer clonerAppId = _appClonerInit(parentHintAppId)
+    def initRes = _appClonerInit(parentHintAppId)
+    Integer clonerAppId = initRes.clonerAppId
+    String referrer = initRes.referrer
+    String configUrl = initRes.configUrl
 
-    // Step 2: stage the JSON via settings[ruleUpload]=. Hubitat accepts
-    // urlencoded form fields with the full JSON content inline.
-    _appClonerSubmitForm(clonerAppId, "main", [
-        ("settings[ruleUpload]".toString()): jsonContent,
-        ("ruleUpload.type".toString()): "file-text",
-        ("ruleUpload.multiple".toString()): "false"
-    ])
+    // Step 2: stage the JSON via settings[ruleUpload]= — twice (same
+    // state-machine race; the upload-and-process needs a second cycle to
+    // commit before the importRule sub-page becomes available).
+    def uploadExtras = [
+        ("settings[ruleUpload]".toString()): jsonContent
+    ]
+    for (int attempt = 0; attempt < 2; attempt++) {
+        _appClonerSubmitForm(clonerAppId, "main", "source", referrer, configUrl, uploadExtras)
+        pauseExecution(500)
+    }
 
     // Steps 3-5: navigate importRule, optional rename, click importNow.
-    _appClonerCommitImportRule(clonerAppId, originalSourceId, newName)
+    _appClonerCommitImportRule(clonerAppId, originalSourceId, newName, referrer, configUrl)
 
     Integer newAppId = _appClonerDiscoverNewChild(parentAppId, preIds, originalLabel, newName)
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -2702,7 +2702,11 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
                     newName: [type: "string", description: "Label for the imported app. If omitted, the cloner default ('<original-label> import') is kept."],
                     confirm: [type: "boolean", description: "Must be true."]
                 ],
-                required: ["parentHintAppId", "confirm"]
+                required: ["parentHintAppId", "confirm"],
+                oneOf: [
+                    [required: ["jsonContent"]],
+                    [required: ["fromFile"]]
+                ]
             ]
         ],
         [
@@ -18544,7 +18548,9 @@ def toolExportNativeApp(args) {
         try {
             uploadHubFile(saveAs, jsonContent.getBytes("UTF-8"))
             result.savedAs = saveAs
-            result.savedUrl = "http://<HUB_IP>/local/${saveAs}"
+            String hubIp = null
+            try { hubIp = location?.hub?.localIP?.toString() } catch (Exception ignored) { /* fall back below */ }
+            result.savedUrl = "http://${hubIp ?: '<HUB_IP>'}/local/${saveAs}"
         } catch (Exception fileErr) {
             result.saveError = fileErr.message
             mcpLog("warn", "rm-native", "export_native_app: saveAs '${saveAs}' upload failed: ${fileErr.message}")
@@ -18625,7 +18631,7 @@ private String _appClonerExtractJsonFromSettings(Integer clonerAppId) {
             def m = (html =~ /id="ruledownload-value"[^>]*value="([^"]+)"/)
             if (m.find()) {
                 def encoded = m[0][1]
-                return encoded.replace("&quot;", "\"").replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+                return encoded.replace("&quot;", "\"").replace("&apos;", "'").replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
             }
         }
     } catch (Exception htmlErr) {

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -2703,7 +2703,9 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
                     confirm: [type: "boolean", description: "Must be true."]
                 ],
                 required: ["parentHintAppId", "confirm"],
-                oneOf: [
+                // anyOf (not oneOf) — the impl accepts either field and prefers
+                // jsonContent if both are present; oneOf would reject that.
+                anyOf: [
                     [required: ["jsonContent"]],
                     [required: ["fromFile"]]
                 ]
@@ -18143,18 +18145,21 @@ private Map _appClonerInit(Integer sourceAppId) {
     if (!loc) {
         throw new IllegalStateException("appCloner entry returned no Location header for source ${sourceAppId} (status=${resp?.status})")
     }
+    // regex covers two redirect shapes seen across firmwares (apps/api/* current, installedapp/configure/* older)
     def m = (loc =~ /\/(?:apps\/api|installedapp\/configure)\/(\d+)/)
     Integer clonerId = m.find() ? (m[0][1] as Integer) : null
     if (clonerId == null) {
         throw new IllegalStateException("Unexpected appCloner Location: ${loc}")
     }
-    // Capture the full OAuth source-context URL — the cloner state machine
-    // requires this as the `referrer` field on subsequent form POSTs to
-    // verify they originate from the source-authorized session. Without
-    // it, every state transition is silently rejected even though POSTs
-    // return 200. Hubitat's UI reads this from window.location after
-    // following the 302; we capture it directly from the redirect target.
-    String sourceContextUrl = loc.startsWith("http") ? loc : "http://192.168.1.133${loc}"
+    // Cloner state machine validates `referrer`/`url` against the session that
+    // opened the cloner. Use the running hub's IP — hardcoding fails for any
+    // other deployment. Falls back to 127.0.0.1 (the loopback the parent app
+    // already uses for hubInternal* calls) if location.hub.localIP is null.
+    String hubIp = null
+    try { hubIp = location?.hub?.localIP?.toString() } catch (Exception ignored) { /* fall through */ }
+    if (!hubIp) hubIp = "127.0.0.1"
+    String sourceContextUrl = loc.startsWith("http") ? loc : "http://${hubIp}${loc}"
+    String configUrl = "http://${hubIp}/installedapp/configure/${clonerId}/main".toString()
     // CRITICAL: follow the redirect target. The cloner's `app(sourceId)`
     // mapping renders the source-context page and sets internal state
     // (state.cloneSource, etc.). Without this GET, the cloner accepts our
@@ -18163,46 +18168,35 @@ private Map _appClonerInit(Integer sourceAppId) {
     // The Location is OAuth-token-protected (/apps/api/<clonerId>/app/<sourceId>
     // ?access_token=...) — split path + query so HTTPBuilder doesn't URL-encode
     // the `?` and break the access_token lookup.
-    try {
-        def relPath = loc.replaceFirst(/^https?:\/\/[^\/]+/, '')
-        def parts = relPath.split(/\?/, 2)
-        def justPath = parts[0]
-        def query = [:]
-        if (parts.length > 1) {
-            parts[1].split('&').each { kv ->
-                def eq = kv.indexOf('=')
-                if (eq > 0) {
-                    def k = kv.substring(0, eq)
-                    def v = kv.substring(eq + 1)
-                    // values aren't url-encoded in the redirect Location — pass through
-                    query[k] = v
-                }
-            }
+    def relPath = loc.replaceFirst(/^https?:\/\/[^\/]+/, '')
+    def parts = relPath.split(/\?/, 2)
+    def justPath = parts[0]
+    def query = [:]
+    if (parts.length > 1) {
+        parts[1].split('&').each { kv ->
+            def eq = kv.indexOf('=')
+            if (eq > 0) query[kv.substring(0, eq)] = kv.substring(eq + 1)
         }
-        hubInternalGet(justPath, query)
-        mcpLog("debug", "rm-native", "appCloner: source-context render of ${justPath} succeeded for cloner ${clonerId}")
-        // Cloner appears to need a beat to commit state.cloneSource after
-        // the source-context render before subsequent clicks are honored.
-        pauseExecution(1000)
-        // Mimic browser flow: fetch the configPage JSON before any settings
-        // POSTs. Without this, file-text widgets (`settings[ruleUpload]`)
-        // silently drop their values — the cloner accepts the POST (200,
-        // ruleUpload key registered) but stores null. The browser's main
-        // page render fires this XHR after navigation; settings writes
-        // sent before it land in a half-initialized cloner that can't
-        // receive uploads. Required for import_native_app; harmless for
-        // clone/export.
-        try {
-            hubInternalGet("/installedapp/configure/json/${clonerId}/main", [:])
-        } catch (Exception primeErr) {
-            mcpLog("warn", "rm-native", "appCloner: configPage JSON prime failed for cloner ${clonerId}: ${primeErr.message}")
-        }
-    } catch (Exception followErr) {
-        // Source-context render is best-effort. If it fails, the click POSTs
-        // still try; some firmwares may seed source context differently.
-        mcpLog("warn", "rm-native", "appCloner: source-context render of ${loc} failed for cloner ${clonerId}: ${followErr.message}")
     }
-    return [clonerAppId: clonerId, referrer: sourceContextUrl, configUrl: "http://192.168.1.133/installedapp/configure/${clonerId}/main".toString()]
+    try {
+        hubInternalGet(justPath, query)
+    } catch (Exception followErr) {
+        // Source-context render is load-bearing — clone/import will silently
+        // produce no new rule without it. Surface the failure instead of
+        // letting the wizard fire and reporting "no new child appeared".
+        throw new IllegalStateException("appCloner source-context render failed for source ${sourceAppId} (cloner ${clonerId}): ${followErr.message}. Without this step the cloner state machine never seeds state.cloneSource and subsequent clicks silently produce no rule.")
+    }
+    pauseExecution(1000)
+    // Mimic browser flow: fetch the configPage JSON before any settings POSTs.
+    // Without this, file-text widgets (`settings[ruleUpload]`) silently drop
+    // their values — the cloner accepts the POST (200, ruleUpload key
+    // registered) but stores null. Required for import_native_app.
+    try {
+        hubInternalGet("/installedapp/configure/json/${clonerId}/main", [:])
+    } catch (Exception primeErr) {
+        throw new IllegalStateException("appCloner configPage prime failed for cloner ${clonerId}: ${primeErr.message}. Without this step settings[ruleUpload] writes are silently dropped on the import path.")
+    }
+    return [clonerAppId: clonerId, referrer: sourceContextUrl, configUrl: configUrl]
 }
 
 /**
@@ -18276,7 +18270,13 @@ private Map _appClonerSubmitForm(Integer clonerAppId, String currentPage, String
         sb.append(v == null ? "" : URLEncoder.encode(v.toString(), "UTF-8"))
     }
     def resp = hubInternalPostFormRaw("/installedapp/update/json", sb.toString())
-    return resp ?: [:]
+    if (resp == null) {
+        // Closure never ran -> network call produced no response. Don't coerce
+        // to [:] (export's "no JSON content" error would point at the wrong
+        // root cause). Bubble so callers see the real failure.
+        throw new IllegalStateException("appCloner POST /installedapp/update/json returned no response (cloner ${clonerAppId}, currentPage=${currentPage}, formState=${formState}). Network call failed before delivering a status.")
+    }
+    return resp
 }
 
 /**
@@ -18319,14 +18319,16 @@ private void _appClonerCommitImportRule(Integer clonerAppId, Integer sourceAppId
     // different session-scoped indices.
     // The cloner re-renders asynchronously after a state-transition POST;
     // poll the page state a few times to give the action_href button time
-    // to appear before falling back to 0 (which would only succeed for
-    // the clone path's confirmation page).
+    // to appear. Fail loudly if it never shows — the import path silently
+    // no-ops when this idx is wrong (the very symptom we're fighting).
     Integer hrefIdx = null
     for (int attempt = 0; attempt < 4 && hrefIdx == null; attempt++) {
         if (attempt > 0) pauseExecution(500)
         hrefIdx = _appClonerFindActionHrefIdx(clonerAppId, "main", "importRule")
     }
-    if (hrefIdx == null) hrefIdx = 0
+    if (hrefIdx == null) {
+        throw new IllegalStateException("appCloner importRule action_href not found on cloner ${clonerAppId} main page after 4 polls (~2s). The cloner did not transition to the expected confirmation/restore-or-import state — clicking importNow now would silently no-op.")
+    }
     _appClonerSubmitForm(clonerAppId, "main", "confirmation", referrer, configUrl, [
         ("_action_href_name|importRule|${hrefIdx}".toString()): "",
         ("params_for_action_href_name|importRule|${hrefIdx}".toString()): ""
@@ -18486,13 +18488,10 @@ def toolCloneNativeApp(args) {
 }
 
 /**
- * export_native_app — wraps the appCloner's Export path.
- *
- * After clicking exportRuleButton the cloner renders a download button whose
- * onclick reads the JSON from a hidden input. The JSON also lands in the
- * cloner's settings as `ruleDownload` (or similar) and is exposed via
- * /installedapp/configure/json/<clonerId> with includeSettings. We read it
- * from there directly — no HTML scraping required.
+ * export_native_app — wraps the appCloner's Export path. JSON is captured
+ * from the form-refresh response body of the click POST itself; see
+ * `_appClonerExtractJsonFromResponse` for why settings/HTML scraping doesn't
+ * work (the filecontent is session-keyed, only present in the same request).
  */
 def toolExportNativeApp(args) {
     requireBuiltinApp()
@@ -18501,7 +18500,12 @@ def toolExportNativeApp(args) {
     def saveAs = args?.saveAs?.toString()?.trim()
 
     def sourceCfg
-    try { sourceCfg = _rmFetchConfigJson(sourceAppId) } catch (Exception ignored) { sourceCfg = null }
+    try {
+        sourceCfg = _rmFetchConfigJson(sourceAppId)
+    } catch (Exception sourceErr) {
+        mcpLog("warn", "rm-native", "export_native_app: source ${sourceAppId} config fetch failed: ${sourceErr.message}")
+        sourceCfg = null
+    }
     if (!sourceCfg?.app) {
         throw new IllegalArgumentException("Source app ${sourceAppId} not found or unreadable")
     }
@@ -18549,8 +18553,14 @@ def toolExportNativeApp(args) {
             uploadHubFile(saveAs, jsonContent.getBytes("UTF-8"))
             result.savedAs = saveAs
             String hubIp = null
-            try { hubIp = location?.hub?.localIP?.toString() } catch (Exception ignored) { /* fall back below */ }
-            result.savedUrl = "http://${hubIp ?: '<HUB_IP>'}/local/${saveAs}"
+            try { hubIp = location?.hub?.localIP?.toString() } catch (Exception ignored) { /* fall through */ }
+            if (hubIp) {
+                result.savedUrl = "http://${hubIp}/local/${saveAs}"
+            } else {
+                // Don't emit a literally-broken http://<HUB_IP>/... URL — flag
+                // the lookup failure instead.
+                mcpLog("warn", "rm-native", "export_native_app: location.hub.localIP unavailable; savedUrl omitted from result")
+            }
         } catch (Exception fileErr) {
             result.saveError = fileErr.message
             mcpLog("warn", "rm-native", "export_native_app: saveAs '${saveAs}' upload failed: ${fileErr.message}")
@@ -18605,42 +18615,6 @@ private String _appClonerExtractJsonFromResponse(String responseBody) {
 }
 
 /**
- * Legacy: pull the exported JSON from the cloner's persisted settings. Kept
- * as a fallback for firmwares that may persist the content there. The
- * primary extraction path is now from the form-refresh response body.
- */
-private String _appClonerExtractJsonFromSettings(Integer clonerAppId) {
-    def cfg
-    try {
-        cfg = _rmFetchConfigJson(clonerAppId)
-    } catch (Exception e) {
-        mcpLog("warn", "rm-native", "appCloner: extract config fetch failed for ${clonerAppId}: ${e.message}")
-        return null
-    }
-    def settings = (cfg?.settings instanceof Map) ? cfg.settings : [:]
-    for (entry in settings) {
-        def v = entry?.value
-        if (v instanceof String && v.startsWith("{") && v.contains("appReplacements")) {
-            return v
-        }
-    }
-    // Fallback: parse the rendered HTML page for <input id="ruledownload-value" value="...">
-    try {
-        def html = hubInternalGet("/installedapp/configure/${clonerAppId}")
-        if (html instanceof String) {
-            def m = (html =~ /id="ruledownload-value"[^>]*value="([^"]+)"/)
-            if (m.find()) {
-                def encoded = m[0][1]
-                return encoded.replace("&quot;", "\"").replace("&apos;", "'").replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
-            }
-        }
-    } catch (Exception htmlErr) {
-        mcpLog("debug", "rm-native", "appCloner: HTML scrape fallback failed for ${clonerAppId}: ${htmlErr.message}")
-    }
-    return null
-}
-
-/**
  * import_native_app — wraps the appCloner's Import path.
  *
  * Stages the JSON via settings[ruleUpload]= (urlencoded, NOT multipart),
@@ -18687,20 +18661,32 @@ def toolImportNativeApp(args) {
 
     // Snapshot pre-import children of the target parent.
     def parentHintCfg
-    try { parentHintCfg = _rmFetchConfigJson(parentHintAppId) } catch (Exception ignored) { parentHintCfg = null }
+    try {
+        parentHintCfg = _rmFetchConfigJson(parentHintAppId)
+    } catch (Exception hintErr) {
+        mcpLog("warn", "rm-native", "import_native_app: parentHintAppId ${parentHintAppId} fetch failed: ${hintErr.message}")
+        parentHintCfg = null
+    }
     if (!parentHintCfg?.app) {
         throw new IllegalArgumentException("parentHintAppId ${parentHintAppId} not found or unreadable")
     }
     Integer parentAppId = null
     try {
         parentAppId = (parentHintCfg.app.parentAppId != null) ? (parentHintCfg.app.parentAppId.toString() as Integer) : null
-    } catch (NumberFormatException ignored) { /* fall through */ }
+    } catch (NumberFormatException nfe) {
+        mcpLog("warn", "rm-native", "import_native_app: parentHintAppId ${parentHintAppId} parentAppId not numeric: ${parentHintCfg.app.parentAppId}; new-child discovery will be skipped")
+    }
+    if (parentAppId == null) {
+        // Without a parent we can't diff children to identify the new rule.
+        // Refuse rather than firing the wizard and reporting a false failure.
+        throw new IllegalArgumentException("parentHintAppId ${parentHintAppId} has no numeric parentAppId — pass a hint that's a child of the target parent app (e.g. an existing RM rule for an RM import).")
+    }
     def preIds = [] as Set
-    if (parentAppId != null) {
-        try {
-            def pc = _rmFetchConfigJson(parentAppId)
-            preIds = ((pc?.childApps ?: []) as List).collect { it?.id?.toString() }.findAll { it } as Set
-        } catch (Exception ignored) { /* heuristic */ }
+    try {
+        def pc = _rmFetchConfigJson(parentAppId)
+        preIds = ((pc?.childApps ?: []) as List).collect { it?.id?.toString() }.findAll { it } as Set
+    } catch (Exception preErr) {
+        mcpLog("warn", "rm-native", "import_native_app: pre-import parent ${parentAppId} fetch failed: ${preErr.message}; new-child discovery may misidentify a pre-existing app")
     }
 
     def initRes = _appClonerInit(parentHintAppId)
@@ -18722,10 +18708,8 @@ def toolImportNativeApp(args) {
     _appClonerSubmitForm(clonerAppId, "main", "source", referrer, configUrl, [
         ("settings[ruleUpload]".toString()): jsonContent
     ])
-    // Cloner needs time to JSON-parse the upload + transition to the
-    // restore-or-import page before our discovery sees the new sections.
-    // Larger JSON inputs (full canonical exports) need more — 500ms is
-    // enough for trivial JSON but races on a 3KB rule body.
+    // Cloner needs ~2s to JSON-parse large uploads + transition to
+    // restore-or-import; <1s races on multi-KB exports.
     pauseExecution(2000)
 
     // Steps 3-5: navigate importRule, optional rename, click importNow.

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -934,7 +934,7 @@ def getGatewayConfig() {
         ],
         manage_native_rules_and_apps: [
             description: "WHEN TO USE: this is the right path for any user who says 'create a rule machine rule,' 'make a Hubitat rule,' or wants the rule visible in Hubitat's Rule Machine app list / web UI. Use this for default rule-creation requests. The custom_* MCP rule engine (separate surface) is only appropriate when the user EXPLICITLY wants a sandbox MCP-managed rule that does not appear in Hubitat's UI -- uncommon outside power-user / testing scenarios. QUICK FLOW for a default rule create: (1) create_native_app(appType='rule_machine', name='...', confirm=true) returns appId. (2) update_native_app(appId=N, addTrigger={capability:'Certain Time (and optional date)', time:'A specific time', atTime:'17:00'}, confirm=true). (3) update_native_app(appId=N, addAction={capability:'log', message:'...'}, confirm=true). Three calls. Each call returns settingsApplied so you can confirm the rule baked. Native rules + apps (RM rules, Room Lighting, Button Controllers, Basic Rules, Notifier, Groups+Scenes, Visual Rules -- any classic SmartApp). Two surfaces: (1) RMUtils-based runtime control for RM rules (list/run/pause/resume/setBoolean -- RM-specific because RMUtils is RM-only); (2) admin-layer CRUD that works uniformly across ALL classic SmartApps via /installedapp/* (create/update/delete by appId). Writes snapshot before every change; restore via the unified list_item_backups + restore_item_backup tools in manage_apps_drivers. Completely separate from the MCP custom rule engine (custom_* tools). Requires Built-in App Tools enabled; CRUD additionally requires Hub Admin Write. Verification protocol: write operations on RM 5.1 are asynchronous; if a response indicates a hard failure (success: false) or a partial state needing repair (partial: true, or non-empty settingsSkipped), the hub may have applied the change post-response despite the reported status -- verify via get_app_config(appId=N) and inspect persisted settings before retrying.",
-            tools: ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "check_rule_health"],
+            tools: ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "clone_native_app", "export_native_app", "import_native_app", "check_rule_health"],
             summaries: [
                 list_rm_rules: "List all Rule Machine rules (RM 4.x + 5.x) with IDs and labels (uses RMUtils — RM only)",
                 run_rm_rule: "Trigger an RM rule lifecycle verb. Args: ruleId, action (rule/actions/stop/start, default rule). rule/actions use RMUtils; stop/start toggle the stopRule button (start also resets private boolean).",
@@ -944,6 +944,9 @@ def getGatewayConfig() {
                 create_native_app: "Create a new empty native automation app (RM rule by default; expand via _appTypeRegistry for Room Lighting / Button Controllers / etc.). Args: appType (default rule_machine), name, confirm. Returns appId — use update_native_app next to populate.",
                 update_native_app: "Modify any classic native app: write settings (multiple=true contract automatic), click a page-transition button, or use a high-level structured shortcut (addTrigger / addAction / addRequiredExpression / addTriggers / addActions / replaceActions / removeAction / clearActions / moveAction / removeTrigger / modifyTrigger / walkStep). Auto-backs-up first. Args: appId, settings|button|<shortcut>, pageName (opt), stateAttribute (opt), confirm",
                 delete_native_app: "Delete any classic native app (soft by default, force=true for hard). Auto-backs-up first. Args: appId, force (opt), confirm",
+                clone_native_app: "Clone an existing rule/app via Hubitat's first-party appCloner. Cheaper than rebuilding from scratch via the wizard. Args: sourceAppId, newName (opt), confirm. Returns newAppId.",
+                export_native_app: "Export a rule/app to its canonical JSON shape via Hubitat's first-party appCloner. Args: sourceAppId, saveAs (opt File Manager filename). Returns the JSON content (and writes to File Manager if saveAs given).",
+                import_native_app: "Create a new rule/app from a previously-exported JSON via Hubitat's first-party appCloner. Args: jsonContent | fromFile, parentHintAppId (existing rule under the target parent — used to seed the cloner), newName (opt), confirm. Returns newAppId.",
                 check_rule_health: "Inspect a rule for broken state (label *BROKEN*, **Broken Trigger** markers, configPage errors, multiple-flag corruption). Args: appId. Returns {ok, issues, ...}. Auto-attached to update_native_app responses too."
             ],
             searchHints: [
@@ -955,6 +958,9 @@ def getGatewayConfig() {
                 create_native_app: "create new native rule machine room lighting button controller basic rule notifier scene group automation app",
                 update_native_app: "modify edit change native rule machine room lighting button controller basic rule notifier app trigger action condition setting",
                 delete_native_app: "remove delete destroy native rule machine room lighting button controller basic rule notifier app",
+                clone_native_app: "copy duplicate clone existing rule app appCloner template surgical edit",
+                export_native_app: "export serialize download rule app json appCloner backup transfer canonical shape",
+                import_native_app: "import restore upload create rule app from json appCloner backup transfer round trip",
                 check_rule_health: "broken validate inspect rule health diagnostic broken trigger broken action multiple flag corruption"
             ]
         ],
@@ -1074,12 +1080,12 @@ def getToolDefinitions() {
     def hideGatewaySubTools = [:].withDefault { [] as Set }
 
     if (!builtinAppOn) {
-        def biTools = ["list_installed_apps", "get_device_in_use_by", "list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "check_rule_health"]
+        def biTools = ["list_installed_apps", "get_device_in_use_by", "list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "clone_native_app", "export_native_app", "import_native_app", "check_rule_health"]
         biTools.each { hideByName << it }
         // Sub-tool removal from gateways (when in gateway mode):
-        //   manage_native_rules_and_apps: ALL 9 sub-tools require enableBuiltinApp → empty gateway → drops entirely
+        //   manage_native_rules_and_apps: ALL 12 sub-tools require enableBuiltinApp → empty gateway → drops entirely
         //   manage_installed_apps: 2/4 sub-tools require enableBuiltinApp; the other 2 (get_app_config, list_app_pages) only need Hub Admin Read
-        hideGatewaySubTools["manage_native_rules_and_apps"] = ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "check_rule_health"] as Set
+        hideGatewaySubTools["manage_native_rules_and_apps"] = ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "clone_native_app", "export_native_app", "import_native_app", "check_rule_health"] as Set
         hideGatewaySubTools["manage_installed_apps"] = ["list_installed_apps", "get_device_in_use_by"] as Set
     }
     if (customEngineMode == "off") {
@@ -2660,6 +2666,46 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
             ]
         ],
         [
+            name: "clone_native_app",
+            description: """Clone any classic native automation app (RM rule, Room Lighting, Button Controller, Basic Rule, Notifier, etc.) using Hubitat's first-party appCloner system app. Lower-overhead alternative to rebuilding via the wizard — clone an existing rule that has the shape you want, then surgically edit fields via update_native_app. Preserves the full rule shape (state.actNdx, conditions, expressions, IF/THEN/ELSE positional arrays). Drives the appCloner's 4-step wizard (cloneRuleButton → confirmation → importRule sub-page → importNow); the actual clone fires in tens of seconds for typical rules. Returns newAppId on success. Requires Built-in App Tools enabled + Hub Admin Write + confirm=true.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    sourceAppId: [type: "integer", description: "Installed-app ID of the rule/app to clone."],
+                    newName: [type: "string", description: "Label for the new cloned app. If omitted, the cloner default ('<source-label> clone') is kept."],
+                    confirm: [type: "boolean", description: "Must be true."]
+                ],
+                required: ["sourceAppId", "confirm"]
+            ]
+        ],
+        [
+            name: "export_native_app",
+            description: """Export any classic native automation app to its canonical JSON shape via Hubitat's first-party appCloner. The exported JSON is the same format Hubitat's UI 'Export' button produces — a self-contained document with appReplacements + deviceReplacements + the full rule state — that round-trips cleanly through import_native_app. Use for: (1) backup before risky edits, (2) edit-as-text workflows that materialize the rule, mutate the JSON, and re-import as a new rule, (3) hub-to-hub transfer. Pass saveAs to also write the JSON to the hub's File Manager (e.g. for HPM-style distribution). Requires Built-in App Tools enabled.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    sourceAppId: [type: "integer", description: "Installed-app ID of the rule/app to export."],
+                    saveAs: [type: "string", description: "Optional File Manager filename (.json or .txt). When provided, the export is also written to /local/<saveAs>."]
+                ],
+                required: ["sourceAppId"]
+            ]
+        ],
+        [
+            name: "import_native_app",
+            description: """Create a new rule/app from a previously-exported JSON via Hubitat's first-party appCloner. Pair with export_native_app for round-trip edits or backup/restore workflows. Pass jsonContent (the exported JSON string) OR fromFile (a File Manager filename written by export_native_app). The cloner needs an existing rule under the target parent to seed itself — pass parentHintAppId (any existing rule id under the same parent app you want the imported rule to land under, e.g. another RM rule for an RM import). Requires Built-in App Tools enabled + Hub Admin Write + confirm=true.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    jsonContent: [type: "string", description: "The exported JSON content. Either jsonContent or fromFile is required."],
+                    fromFile: [type: "string", description: "File Manager filename to read the JSON from. Either jsonContent or fromFile is required."],
+                    parentHintAppId: [type: "integer", description: "Any existing rule's id under the target parent app. Used purely to seed the cloner instance — has no semantic effect on the imported rule beyond placing it under the same parent."],
+                    newName: [type: "string", description: "Label for the imported app. If omitted, the cloner default ('<original-label> import') is kept."],
+                    confirm: [type: "boolean", description: "Must be true."]
+                ],
+                required: ["parentHintAppId", "confirm"]
+            ]
+        ],
+        [
             name: "check_rule_health",
             description: """Inspect a rule's current state and return a structured health report — the LLM uses this to detect broken rules without having to investigate via curl. Surfaces:
 
@@ -2882,6 +2928,9 @@ def executeTool(toolName, args) {
         case "create_native_app": return toolCreateNativeApp(args)
         case "update_native_app": return toolUpdateNativeApp(args)
         case "delete_native_app": return toolDeleteNativeApp(args)
+        case "clone_native_app": return toolCloneNativeApp(args)
+        case "export_native_app": return toolExportNativeApp(args)
+        case "import_native_app": return toolImportNativeApp(args)
         case "check_rule_health": return toolCheckRuleHealth(args)
 
         // Tool Guide
@@ -18014,6 +18063,418 @@ def toolCheckRuleHealth(args) {
     return _rmCheckRuleHealth(appId)
 }
 
+// ==================== APP CLONER (clone / export / import) ====================
+//
+// Wraps Hubitat's first-party appCloner system app for clone, export, and
+// import of any classic SmartApp. The cloner UI is a 4-step wizard:
+//
+//   /main                    -> three buttons: Export / Import / Clone
+//   click cloneRuleButton    -> /main with a "Clone..." confirmation page
+//   _action_href_name=importRule -> /importRule sub-page with name editor + final button
+//   click importNow on /importRule -> commits the actual clone
+//
+// Each click is followed by a /installedapp/update/json form refresh that
+// carries the full form state — without it the cloner's state machine
+// stalls. Confirmed via Chrome XHR sniffing on firmware 2.5.0.x.
+
+/**
+ * Initialize a fresh appCloner instance for a given source rule. Hits
+ * /installedapp/sysAppApi/appCloner/app/<sourceId> which returns 302 with
+ * Location pointing at the new cloner instance. Returns the cloner's appId.
+ *
+ * Two Location shapes seen across firmwares:
+ *   /apps/api/<clonerId>/app/<sourceId>?access_token=...   (current)
+ *   /installedapp/configure/<clonerId>                      (older)
+ */
+private Integer _appClonerInit(Integer sourceAppId) {
+    def resp
+    try {
+        resp = hubInternalGetRaw("/installedapp/sysAppApi/appCloner/app/${sourceAppId}")
+    } catch (Exception e) {
+        throw new IllegalStateException("appCloner entry failed for source ${sourceAppId}: ${e.message}. The source app may not exist or appCloner may be unavailable.")
+    }
+    def loc = resp?.location
+    if (!loc) {
+        throw new IllegalStateException("appCloner entry returned no Location header for source ${sourceAppId} (status=${resp?.status})")
+    }
+    def m = (loc =~ /\/(?:apps\/api|installedapp\/configure)\/(\d+)/)
+    Integer clonerId = m.find() ? (m[0][1] as Integer) : null
+    if (clonerId == null) {
+        throw new IllegalStateException("Unexpected appCloner Location: ${loc}")
+    }
+    return clonerId
+}
+
+/**
+ * Submit a form-refresh POST to the cloner's /installedapp/update/json with
+ * `formAction=update, currentPage=<page>` plus optional extra form fields.
+ * Mirrors the form refresh the UI fires automatically after every click —
+ * required to advance the cloner's server-side state machine.
+ */
+private Map _appClonerSubmitForm(Integer clonerAppId, String currentPage, Map extras = null, String pageBreadcrumbs = null) {
+    def body = [
+        formAction: "update",
+        id: clonerAppId.toString(),
+        currentPage: currentPage,
+        pageBreadcrumbs: pageBreadcrumbs ?: (currentPage == "main" ? "[]" : '["main"]'),
+        version: "1"
+    ]
+    if (extras) body.putAll(extras)
+    def resp = hubInternalPostForm("/installedapp/update/json", body)
+    return resp ?: [:]
+}
+
+/**
+ * Drive the appCloner's importRule sub-page commit (steps 3-5: navigate to
+ * importRule, optionally write newName, click importNow). Shared by clone +
+ * import — they converge here once the initial state-setting click has
+ * happened (cloneRuleButton for clone, ruleUpload write for import).
+ *
+ * sourceAppId is the id used in the dynamic `newName<id>` field. For clone
+ * it's the source rule's id; for import it's the original source id from
+ * the JSON's `appReplacements` map.
+ */
+private void _appClonerCommitImportRule(Integer clonerAppId, Integer sourceAppId, String newName) {
+    // Step 3: navigate /main -> /main/importRule via _action_href_name. The
+    // <idx> in the field name is the embedded-action index in the page's
+    // action list; the hub accepts any value as long as the page name matches.
+    _appClonerSubmitForm(clonerAppId, "main", [
+        ("_action_href_name|importRule|0".toString()): "",
+        ("params_for_action_href_name|importRule|0".toString()): ""
+    ])
+
+    // Step 4 (optional): override the cloner's default new-app label. The
+    // setting name is dynamic per source: settings[newName<sourceId>].
+    if (newName) {
+        def field = "settings[newName${sourceAppId}]".toString()
+        def typeKey = "newName${sourceAppId}.type".toString()
+        def multipleKey = "newName${sourceAppId}.multiple".toString()
+        _appClonerSubmitForm(clonerAppId, "importRule", [
+            (field): newName,
+            (typeKey): "text",
+            (multipleKey): "false"
+        ])
+    }
+
+    // Step 5: click importNow — fires the actual create. The button is
+    // named `importNow` regardless of which path (clone vs import) brought
+    // us here — both surfaces converge on this final commit.
+    def btnBody = [
+        id: clonerAppId.toString(),
+        name: "importNow",
+        ("settings[importNow]".toString()): "clicked",
+        ("importNow.type".toString()): "button"
+    ]
+    def resp = hubInternalPostForm("/installedapp/btn", btnBody)
+    if (resp?.status != null && resp.status >= 400) {
+        throw new IllegalStateException("appCloner importNow click failed: status=${resp.status}")
+    }
+
+    // Step 5 follow-up: form refresh on importRule that the UI fires after
+    // the click. The actual create on the hub side completes here.
+    _appClonerSubmitForm(clonerAppId, "importRule", [
+        ("importNow.type".toString()): "button",
+        ("importNow.multiple".toString()): "false",
+        ("settings[importNow]".toString()): ""
+    ])
+}
+
+/**
+ * Discover the new app id created by the cloner. Diffs the parent app's
+ * children before vs after the commit. Tiebreaks on the cloner's "<label> clone"
+ * / "<label> import" naming convention if multiple new children appeared.
+ */
+private Integer _appClonerDiscoverNewChild(Integer parentAppId, Set<String> preCloneIds, String sourceLabel, String hint) {
+    if (parentAppId == null) return null
+    def afterCfg
+    try {
+        afterCfg = _rmFetchConfigJson(parentAppId)
+    } catch (Exception e) {
+        mcpLog("warn", "rm-native", "appCloner: parent ${parentAppId} fetch after commit failed: ${e.message}")
+        return null
+    }
+    def afterIds = ((afterCfg?.childApps ?: []) as List).collect { it?.id?.toString() }.findAll { it }
+    def added = afterIds.findAll { !preCloneIds.contains(it) }
+    if (added.isEmpty()) return null
+    if (added.size() == 1) return added[0] as Integer
+    // Multiple new children: prefer hint match, then "<label> clone/import" prefix, else max id.
+    def candidates = (afterCfg.childApps as List).findAll { added.contains(it?.id?.toString()) }
+    def hintMatch = hint ? candidates.find { (it.label?.toString() ?: "") == hint } : null
+    if (hintMatch) return hintMatch.id as Integer
+    def labelMatch = sourceLabel ? candidates.find {
+        def lbl = it.label?.toString() ?: ""
+        lbl.startsWith("${sourceLabel} clone") || lbl.startsWith("${sourceLabel} import") || lbl.startsWith("Clone of ${sourceLabel}")
+    } : null
+    if (labelMatch) return labelMatch.id as Integer
+    return (candidates.collect { it.id as Integer }.max()) as Integer
+}
+
+/**
+ * clone_native_app — wraps the appCloner's Clone path.
+ */
+def toolCloneNativeApp(args) {
+    requireBuiltinApp()
+    requireHubAdminWrite(args?.confirm as Boolean)
+    if (args?.sourceAppId == null) throw new IllegalArgumentException("sourceAppId is required")
+    def sourceAppId = normalizeRuleId(args.sourceAppId)
+    def newName = args?.newName?.toString()?.trim()
+
+    def sourceCfg
+    try {
+        sourceCfg = _rmFetchConfigJson(sourceAppId)
+    } catch (Exception sourceErr) {
+        mcpLog("warn", "rm-native", "clone_native_app: source ${sourceAppId} config fetch failed: ${sourceErr.message}")
+        sourceCfg = null
+    }
+    if (!sourceCfg?.app) {
+        throw new IllegalArgumentException("Source app ${sourceAppId} not found or unreadable")
+    }
+    def sourceLabel = sourceCfg.app.label?.toString()
+    Integer parentAppId = null
+    try {
+        parentAppId = (sourceCfg.app.parentAppId != null) ? (sourceCfg.app.parentAppId.toString() as Integer) : null
+    } catch (NumberFormatException ignored) {
+        mcpLog("warn", "rm-native", "clone_native_app: source ${sourceAppId} parentAppId not numeric: ${sourceCfg.app.parentAppId}")
+    }
+
+    def preIds = [] as Set
+    if (parentAppId != null) {
+        try {
+            def pc = _rmFetchConfigJson(parentAppId)
+            preIds = ((pc?.childApps ?: []) as List).collect { it?.id?.toString() }.findAll { it } as Set
+        } catch (Exception preErr) {
+            mcpLog("warn", "rm-native", "clone_native_app: pre-clone parent ${parentAppId} fetch failed: ${preErr.message}; new-child discovery may misidentify a pre-existing app")
+        }
+    }
+
+    Integer clonerAppId = _appClonerInit(sourceAppId)
+
+    // Step 2: click cloneRuleButton + form refresh.
+    def btnBody = [
+        id: clonerAppId.toString(),
+        name: "cloneRuleButton",
+        ("settings[cloneRuleButton]".toString()): "clicked",
+        ("cloneRuleButton.type".toString()): "button"
+    ]
+    hubInternalPostForm("/installedapp/btn", btnBody)
+    _appClonerSubmitForm(clonerAppId, "main", [
+        ("cloneRuleButton.type".toString()): "button",
+        ("cloneRuleButton.multiple".toString()): "false",
+        ("settings[cloneRuleButton]".toString()): ""
+    ])
+
+    // Steps 3-5: navigate importRule, optional rename, click importNow.
+    _appClonerCommitImportRule(clonerAppId, sourceAppId, newName)
+
+    Integer newAppId = _appClonerDiscoverNewChild(parentAppId, preIds, sourceLabel, newName)
+
+    return [
+        success: newAppId != null,
+        sourceAppId: sourceAppId,
+        clonerAppId: clonerAppId,
+        newAppId: newAppId,
+        note: newAppId
+            ? "Cloned source ${sourceAppId} -> new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
+            : "Clone fired but no new child appeared under parent ${parentAppId}. Re-check via list_installed_apps shortly."
+    ]
+}
+
+/**
+ * export_native_app — wraps the appCloner's Export path.
+ *
+ * After clicking exportRuleButton the cloner renders a download button whose
+ * onclick reads the JSON from a hidden input. The JSON also lands in the
+ * cloner's settings as `ruleDownload` (or similar) and is exposed via
+ * /installedapp/configure/json/<clonerId> with includeSettings. We read it
+ * from there directly — no HTML scraping required.
+ */
+def toolExportNativeApp(args) {
+    requireBuiltinApp()
+    if (args?.sourceAppId == null) throw new IllegalArgumentException("sourceAppId is required")
+    def sourceAppId = normalizeRuleId(args.sourceAppId)
+    def saveAs = args?.saveAs?.toString()?.trim()
+
+    def sourceCfg
+    try { sourceCfg = _rmFetchConfigJson(sourceAppId) } catch (Exception ignored) { sourceCfg = null }
+    if (!sourceCfg?.app) {
+        throw new IllegalArgumentException("Source app ${sourceAppId} not found or unreadable")
+    }
+    def sourceLabel = sourceCfg.app.label?.toString() ?: "app-${sourceAppId}"
+
+    Integer clonerAppId = _appClonerInit(sourceAppId)
+
+    // Step 2: click exportRuleButton + form refresh.
+    def btnBody = [
+        id: clonerAppId.toString(),
+        name: "exportRuleButton",
+        ("settings[exportRuleButton]".toString()): "clicked",
+        ("exportRuleButton.type".toString()): "button"
+    ]
+    hubInternalPostForm("/installedapp/btn", btnBody)
+    _appClonerSubmitForm(clonerAppId, "main", [
+        ("exportRuleButton.type".toString()): "button",
+        ("exportRuleButton.multiple".toString()): "false",
+        ("settings[exportRuleButton]".toString()): ""
+    ])
+
+    // Step 3: read the cloner's settings to extract the JSON. The export
+    // content lives in a setting whose name varies by firmware — search for
+    // any setting whose value is a JSON object containing "appReplacements".
+    String jsonContent = _appClonerExtractJsonFromSettings(clonerAppId)
+    if (!jsonContent) {
+        throw new IllegalStateException("appCloner export fired but no JSON content could be extracted from cloner ${clonerAppId} — wire format may have changed")
+    }
+
+    def result = [
+        success: true,
+        sourceAppId: sourceAppId,
+        sourceLabel: sourceLabel,
+        clonerAppId: clonerAppId,
+        contentLength: jsonContent.length(),
+        jsonContent: jsonContent,
+        note: "Exported source ${sourceAppId} via appCloner. Pass jsonContent to import_native_app to re-create the rule."
+    ]
+    if (saveAs) {
+        try {
+            uploadHubFile(saveAs, jsonContent.getBytes("UTF-8"))
+            result.savedAs = saveAs
+            result.savedUrl = "http://<HUB_IP>/local/${saveAs}"
+        } catch (Exception fileErr) {
+            result.saveError = fileErr.message
+            mcpLog("warn", "rm-native", "export_native_app: saveAs '${saveAs}' upload failed: ${fileErr.message}")
+        }
+    }
+    return result
+}
+
+/**
+ * Internal: pull the exported JSON out of the cloner's settings. The setting
+ * key isn't stable across firmwares (seen as `ruleDownload` and similar) —
+ * scan all settings and pick the first whose value parses as JSON containing
+ * "appReplacements".
+ */
+private String _appClonerExtractJsonFromSettings(Integer clonerAppId) {
+    def cfg
+    try {
+        cfg = _rmFetchConfigJson(clonerAppId)
+    } catch (Exception e) {
+        mcpLog("warn", "rm-native", "appCloner: extract config fetch failed for ${clonerAppId}: ${e.message}")
+        return null
+    }
+    def settings = (cfg?.settings instanceof Map) ? cfg.settings : [:]
+    for (entry in settings) {
+        def v = entry?.value
+        if (v instanceof String && v.length() > 100 && v.contains("appReplacements") && v.startsWith("{")) {
+            return v
+        }
+    }
+    // Fallback: parse the rendered HTML page for <input id="ruledownload-value" value="...">
+    try {
+        def html = hubInternalGet("/installedapp/configure/${clonerAppId}")
+        if (html instanceof String) {
+            def m = (html =~ /id="ruledownload-value"[^>]*value="([^"]+)"/)
+            if (m.find()) {
+                def encoded = m[0][1]
+                return encoded.replace("&quot;", "\"").replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+            }
+        }
+    } catch (Exception htmlErr) {
+        mcpLog("debug", "rm-native", "appCloner: HTML scrape fallback failed for ${clonerAppId}: ${htmlErr.message}")
+    }
+    return null
+}
+
+/**
+ * import_native_app — wraps the appCloner's Import path.
+ *
+ * Stages the JSON via settings[ruleUpload]= (urlencoded, NOT multipart),
+ * then drives the same importRule -> importNow commit as clone.
+ */
+def toolImportNativeApp(args) {
+    requireBuiltinApp()
+    requireHubAdminWrite(args?.confirm as Boolean)
+    if (args?.parentHintAppId == null) {
+        throw new IllegalArgumentException("parentHintAppId is required (any existing rule's id under the target parent — used to seed the cloner)")
+    }
+    def parentHintAppId = normalizeRuleId(args.parentHintAppId)
+    def newName = args?.newName?.toString()?.trim()
+
+    String jsonContent = args?.jsonContent?.toString()
+    if (!jsonContent && args?.fromFile) {
+        try {
+            def bytes = downloadHubFile(args.fromFile.toString())
+            jsonContent = new String(bytes, "UTF-8")
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot read fromFile '${args.fromFile}': ${e.message}")
+        }
+    }
+    if (!jsonContent) {
+        throw new IllegalArgumentException("jsonContent or fromFile is required")
+    }
+
+    // Parse to verify shape + extract original source id (for the dynamic
+    // newName<id> field on the importRule sub-page).
+    def parsed
+    try { parsed = new groovy.json.JsonSlurper().parseText(jsonContent) }
+    catch (Exception e) { throw new IllegalArgumentException("jsonContent is not valid JSON: ${e.message}") }
+    def appReplacements = (parsed instanceof Map) ? parsed.appReplacements : null
+    if (!(appReplacements instanceof Map) || appReplacements.isEmpty()) {
+        throw new IllegalArgumentException("jsonContent does not contain an appReplacements map — not an appCloner export")
+    }
+    Integer originalSourceId = null
+    try {
+        originalSourceId = ((appReplacements.keySet() as List)[0]).toString() as Integer
+    } catch (Exception e) {
+        throw new IllegalArgumentException("Could not extract original source id from appReplacements: ${e.message}")
+    }
+    def originalLabel = appReplacements[originalSourceId.toString()]?.appLabel?.toString()
+
+    // Snapshot pre-import children of the target parent.
+    def parentHintCfg
+    try { parentHintCfg = _rmFetchConfigJson(parentHintAppId) } catch (Exception ignored) { parentHintCfg = null }
+    if (!parentHintCfg?.app) {
+        throw new IllegalArgumentException("parentHintAppId ${parentHintAppId} not found or unreadable")
+    }
+    Integer parentAppId = null
+    try {
+        parentAppId = (parentHintCfg.app.parentAppId != null) ? (parentHintCfg.app.parentAppId.toString() as Integer) : null
+    } catch (NumberFormatException ignored) { /* fall through */ }
+    def preIds = [] as Set
+    if (parentAppId != null) {
+        try {
+            def pc = _rmFetchConfigJson(parentAppId)
+            preIds = ((pc?.childApps ?: []) as List).collect { it?.id?.toString() }.findAll { it } as Set
+        } catch (Exception ignored) { /* heuristic */ }
+    }
+
+    Integer clonerAppId = _appClonerInit(parentHintAppId)
+
+    // Step 2: stage the JSON via settings[ruleUpload]=. Hubitat accepts
+    // urlencoded form fields with the full JSON content inline.
+    _appClonerSubmitForm(clonerAppId, "main", [
+        ("settings[ruleUpload]".toString()): jsonContent,
+        ("ruleUpload.type".toString()): "file-text",
+        ("ruleUpload.multiple".toString()): "false"
+    ])
+
+    // Steps 3-5: navigate importRule, optional rename, click importNow.
+    _appClonerCommitImportRule(clonerAppId, originalSourceId, newName)
+
+    Integer newAppId = _appClonerDiscoverNewChild(parentAppId, preIds, originalLabel, newName)
+
+    return [
+        success: newAppId != null,
+        clonerAppId: clonerAppId,
+        newAppId: newAppId,
+        originalSourceId: originalSourceId,
+        originalLabel: originalLabel,
+        contentLength: jsonContent.length(),
+        note: newAppId
+            ? "Imported '${originalLabel ?: 'app'}' as new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
+            : "Import fired but no new child appeared under parent ${parentAppId}. Re-check via list_installed_apps shortly."
+    ]
+}
+
 /**
  * Internal: replay an RM rule snapshot. Called by the unified
  * restore_item_backup tool when entry.type == "rm-rule". Two paths:
@@ -18679,7 +19140,7 @@ Tools in the manage_installed_apps and manage_native_rules_and_apps gateways hav
   - Returns curated page directory for known app types (HPM, RM 5.x, Room Lighting, Mode Manager) plus an introspected primary page for unknown app types
   - Cuts the page-name guessing cycle for multi-page apps. Especially useful for HPM which exposes multiple sub-pages (prefPkgUninstall / prefPkgModify / prefPkgInstall / prefPkgMatchUp) for different operations.
 
-**manage_native_rules_and_apps (9 tools) — read, trigger, AND full CRUD on native RM rules:**
+**manage_native_rules_and_apps (12 tools) — read, trigger, AND full CRUD on native RM rules:**
 
 RMUtils-based control surface (Built-in App Tools gate only):
 - **list_rm_rules** — enumerate Rule Machine rules (RM 4.x + 5.x combined, deduplicated by id)
@@ -18694,6 +19155,9 @@ Native CRUD (hub admin-layer, additionally requires Hub Admin Write):
 - **create_native_app** — create a new empty classic SmartApp (RM 5.1 by default; appType enum covers rule_machine / button_controller / groups_scenes / notifier / visual_rule). Args: appType (default rule_machine), name, confirm. Returns appId. Call update_native_app afterward to populate; or pass triggers=[...] / actions=[...] arrays to populate in one call.
 - **update_native_app** — modify any classic SmartApp. Two raw modes (settings (Map) OR button (String)) plus 14 structured shortcuts (addTrigger, addTriggers, addAction, addActions, addRequiredExpression, addLocalVariable, removeAction, clearActions, replaceActions, moveAction, removeTrigger, modifyTrigger, patches, walkStep). Args: appId + one of those shortcut keys, plus optional pageName, stateAttribute, confirm. Auto-backs-up before writing; emits the multiple=true 3-field capability contract automatically. removeTrigger={index:N} deletes a trigger; modifyTrigger={index:N, mods:{state:'...'}} changes the state field of an existing trigger (capability/deviceIds changes require removeTrigger + addTrigger).
 - **delete_native_app** — soft delete (default; refuses if children exist) or force=true. Args: appId, force, confirm. Auto-backs-up before deleting.
+- **clone_native_app** — clone any classic SmartApp via Hubitat's first-party appCloner. Args: sourceAppId, newName (opt), confirm. Returns newAppId. Drives the appCloner's 4-step wizard (cloneRuleButton -> confirmation -> importRule sub-page -> importNow); typical clones complete in tens of seconds.
+- **export_native_app** — export any classic SmartApp to its canonical JSON shape via Hubitat's first-party appCloner. Args: sourceAppId, saveAs (opt File Manager filename). Returns jsonContent. Self-contained document with appReplacements + deviceReplacements + full rule state; round-trips through import_native_app.
+- **import_native_app** — re-create a rule/app from a previously-exported JSON via Hubitat's first-party appCloner. Args: jsonContent | fromFile, parentHintAppId, newName (opt), confirm. Returns newAppId. The cloner needs an existing rule under the target parent to seed itself (parentHintAppId).
 - **check_rule_health** — read-only health check on any installed app. Args: appId. Returns ok / configPageError / brokenMarkers / multipleFlagPoison / issues.
 
 For READING an RM rule's current state, use **get_app_config** in the manage_installed_apps gateway — it works on any installed app including RM rules and returns the same configPage shape that update_native_app expects to see.

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -82,10 +82,12 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
     // Minimal RM rule config JSON. Schema inputs drive _rmBuildSettingsBody's
     // 3-field group logic, so tests shape the sections/inputs as needed.
-    private String ruleConfigJson(int ruleId, String label = "BAT-RM-test", List inputs = []) {
+    private String ruleConfigJson(int ruleId, String label = "BAT-RM-test", List inputs = [], Integer parentAppId = null) {
+        def app = [id: ruleId, name: "Rule-5.1", label: label, trueLabel: label, installed: true,
+                   appType: [name: "Rule-5.1", namespace: "hubitat"]]
+        if (parentAppId != null) app.parentAppId = parentAppId
         JsonOutput.toJson([
-            app: [id: ruleId, name: "Rule-5.1", label: label, trueLabel: label, installed: true,
-                  appType: [name: "Rule-5.1", namespace: "hubitat"]],
+            app: app,
             configPage: [name: "mainPage", title: "Edit Rule", install: true, error: null, sections: [
                 [title: "", input: inputs]
             ]],

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -112,6 +112,18 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         return out
     }
 
+    // Build a cloner-page-state response that exposes a `_action_href_name|<action>|<idx>`
+    // marker so _appClonerFindActionHrefIdx can pick it up. Idx 0 matches the
+    // post-clone confirmation page; idx 55+ matches the post-upload restore-or-import
+    // page seen live.
+    private String clonerPageStateWithIdx(String action, int idx) {
+        return JsonOutput.toJson([configPage: [name: "main", sections: [
+            [input: [], body: [[
+                description: "<button name='_action_href_name|${action}|${idx}'>Go</button>"
+            ]]]
+        ]]])
+    }
+
     private String statusJson(int ruleId, List appSettings = [], int subs = 1) {
         JsonOutput.toJson([
             installedApp: [id: ruleId],
@@ -2200,10 +2212,12 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         given:
         enableHubAdminWrite()
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Source Rule", [], 21) }
-        // _appClonerInit primes the cloner state before any POST; needs to
-        // resolve. _appClonerFindActionHrefIdx parses this for the navigate
-        // index and falls back to 0 when missing.
-        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
+        // OAuth follow-up render. _appClonerInit now throws if this 404s — the
+        // cloner state machine relies on it to seed state.cloneSource.
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context page</html>' }
+        // configPage prime fetch + idx discovery target. Post-clone confirmation
+        // page exposes importRule action_href at idx 0 (clone-path live behavior).
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> clonerPageStateWithIdx("importRule", 0) }
         int parentCalls = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             parentCalls++
@@ -2234,19 +2248,16 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.clonerAppId == 4242
         result.newAppId == 250
 
-        and: "cloneRuleButton click POSTed to /installedapp/btn with the 4-field contract"
-        def cloneClick = posts.find { it.path == "/installedapp/btn" && it.body?.name == "cloneRuleButton" }
-        cloneClick != null
-        cloneClick.body["settings[cloneRuleButton]"] == "clicked"
-        cloneClick.body["cloneRuleButton.type"] == "button"
-        cloneClick.body.id == "4242"
+        and: "cloneRuleButton clicked TWICE on /installedapp/btn (state-machine race — first is silently dropped)"
+        def cloneClicks = posts.findAll { it.path == "/installedapp/btn" && it.body?.name == "cloneRuleButton" }
+        cloneClicks.size() == 2
+        cloneClicks.every { it.body["settings[cloneRuleButton]"] == "clicked" && it.body["cloneRuleButton.type"] == "button" && it.body.id == "4242" }
 
-        and: "importNow click POSTed (the actual commit)"
-        def importNowClick = posts.find { it.path == "/installedapp/btn" && it.body?.name == "importNow" }
-        importNowClick != null
-        importNowClick.body.id == "4242"
+        and: "importNow clicked TWICE on /installedapp/btn (same race; second commits)"
+        def importNowClicks = posts.findAll { it.path == "/installedapp/btn" && it.body?.name == "importNow" }
+        importNowClicks.size() == 2
 
-        and: "page-navigation POST sent to advance to the importRule sub-page"
+        and: "page-navigation POST uses the discovered href idx (0 for clone confirmation page)"
         def navPost = posts.find { it.path == "/installedapp/update/json" && it.body?.containsKey("_action_href_name|importRule|0") }
         navPost != null
     }
@@ -2255,7 +2266,8 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         given:
         enableHubAdminWrite()
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
-        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context</html>' }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> clonerPageStateWithIdx("importRule", 0) }
         int parentCalls = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             parentCalls++
@@ -2293,7 +2305,8 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         enableHubAdminWrite()
         def fakeJson = '{"deviceReplacements":{},"appReplacements":{"100":{"appLabel":"Source Rule"}}}'
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Source Rule", [], 21) }
-        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context</html>' }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> clonerPageStateWithIdx("importRule", 0) }
         script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
             [status: 302, location: "/apps/api/4242/app/100", data: ""]
         }
@@ -2328,7 +2341,8 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         enableHubAdminWrite()
         def fakeJson = '{"deviceReplacements":{},"appReplacements":{"100":{"appLabel":"X"}}}'
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "X", [], 21) }
-        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context</html>' }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> clonerPageStateWithIdx("importRule", 0) }
         script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
             [status: 302, location: "/apps/api/4242/app/100", data: ""]
         }
@@ -2396,7 +2410,10 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         def importJson = '{"deviceReplacements":{},"appReplacements":{"42":{"appLabel":"Source Rule","appTypeName":"Rule-5.1"}}}'
         // parentHint = an existing rule under parent 21
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "ExistingRule", [], 21) }
-        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context</html>' }
+        // Post-upload restore-or-import page; idx=55 matches the live-observed
+        // session-scoped index on import (vs idx=0 on the clone confirmation page).
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> clonerPageStateWithIdx("importRule", 55) }
         int parentCalls = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             parentCalls++
@@ -2426,10 +2443,18 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.originalSourceId == 42
         result.originalLabel == "Source Rule"
 
-        and: "JSON staged via settings[ruleUpload] (urlencoded, NOT multipart)"
-        def stage = posts.find { it.path == "/installedapp/update/json" && it.body?.containsKey("settings[ruleUpload]") }
-        stage != null
-        stage.body["settings[ruleUpload]"] == importJson
+        and: "JSON staged via settings[ruleUpload] (urlencoded, NOT multipart) — exactly ONCE (a second pass is harmful per inline comment)"
+        def stages = posts.findAll { it.path == "/installedapp/update/json" && it.body?.containsKey("settings[ruleUpload]") && it.body["settings[ruleUpload]"] == importJson }
+        stages.size() == 1
+
+        and: "navigate POST uses the discovered idx=55 (post-upload page) — NOT the clone-path fallback of 0"
+        def navPost = posts.find { it.path == "/installedapp/update/json" && it.body?.containsKey("_action_href_name|importRule|55") }
+        navPost != null
+        !posts.any { it.path == "/installedapp/update/json" && it.body?.containsKey("_action_href_name|importRule|0") }
+
+        and: "import path uses the LOCAL config URL as referrer, not the OAuth source-context URL — verified live: OAuth referrer trips the cloner's session check"
+        stages[0].body.referrer != null
+        !stages[0].body.referrer.contains("apps/api")
 
         and: "importNow click fired the actual commit"
         posts.any { it.path == "/installedapp/btn" && it.body?.name == "importNow" }
@@ -2439,6 +2464,148 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         importRulePosts.any { it.body?.containsKey("settings[newName42]") }
         importRulePosts.every { it.body?["settings[newName42]"] == "" }
         !importRulePosts.any { it.body?.containsKey("settings[newName100]") }
+    }
+
+    def "import_native_app preserves backslash-escapes in settings[ruleUpload] (HTTPBuilder Map encoder mangles them)"() {
+        given:
+        enableHubAdminWrite()
+        // Canonical exports embed multi-select enum values as JSON-encoded
+        // strings: `"value":"[\"Events\",...]"`. HTTPBuilder's Map auto-encoder
+        // strips the leading `\\` from `\\"` sequences in form-urlencoded
+        // bodies — must go through hubInternalPostFormRaw with manual
+        // URL-encoding (the helper introduced in this PR).
+        def importJson = '{"appReplacements":{"42":{"appLabel":"X"}},"appData":{"42":{"appSettings":[{"name":"logging","type":"enum","multiple":true,"value":"[\\"Events\\",\\"Triggers\\"]"}]}}}'
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "ExistingRule", [], 21) }
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context</html>' }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> clonerPageStateWithIdx("importRule", 55) }
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentConfigJson(21, [[id: 100, label: "ExistingRule"], [id: 700, label: "X import"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        // /installedapp/update/json (the form refresh that carries settings[ruleUpload])
+        // MUST go through hubInternalPostFormRaw — the Map encoder strips
+        // backslashes. /btn POSTs (button clicks) carry no JSON and are fine
+        // through the Map path; let those pass.
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/update/json") {
+                throw new IllegalStateException("cloner /update/json POSTs must use hubInternalPostFormRaw — the Map encoder mangles backslashes")
+            }
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        def rawBodies = []
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            rawBodies << encodedBody
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        script.toolImportNativeApp([jsonContent: importJson, parentHintAppId: 100, confirm: true])
+
+        then: "the staged ruleUpload value, after URL-decoding, is byte-equal to the input JSON — backslash-escapes preserved"
+        def stagingBody = rawBodies.find { it.contains("settings%5BruleUpload%5D=") }
+        stagingBody != null
+        decodeForm(stagingBody)["settings[ruleUpload]"] == importJson
+    }
+
+    def "export_native_app collapses appCloner's over-escaped multi-select values"() {
+        given:
+        enableHubAdminWrite()
+        // Hubitat appCloner emits `\\"` (2 backslashes + quote) where canonical
+        // JSON requires `\"` — the result is malformed and won't round-trip
+        // back into import. _appClonerExtractJsonFromResponse collapses the
+        // `\\"` triplets back to canonical form. Without the fix, the import
+        // returned by export would JSON-parse-fail on read.
+        def overEscapedFilecontent = '{"appReplacements":{"100":{"appLabel":"X"}},"appData":{"100":{"appSettings":[{"name":"logging","value":"[\\\\"Events\\\\"]"}]}}}'
+        def expectedCanonical       = '{"appReplacements":{"100":{"appLabel":"X"}},"appData":{"100":{"appSettings":[{"name":"logging","value":"[\\"Events\\"]"}]}}}'
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "X", [], 21) }
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context</html>' }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> clonerPageStateWithIdx("importRule", 0) }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        // The post-exportRuleButton form refresh is what carries the over-escaped
+        // filecontent — that's the response we need to fix in-flight.
+        def refreshResp = JsonOutput.toJson([
+            configPage: [name: "main", sections: [
+                [input: [[name: "ruleDownload", type: "download-text", filecontent: overEscapedFilecontent]]]
+            ]]
+        ])
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            [status: 200, location: null, data: refreshResp]
+        }
+
+        when:
+        def result = script.toolExportNativeApp([sourceAppId: 100])
+
+        then: "returned jsonContent is canonical (single-escape) and JSON-parses round-trip"
+        result.success == true
+        result.jsonContent == expectedCanonical
+        // Round-trip parse: must produce a real Map without throwing.
+        def parsed = new groovy.json.JsonSlurper().parseText(result.jsonContent)
+        parsed instanceof Map
+        parsed.appData["100"].appSettings[0].value == '["Events"]'
+    }
+
+    def "import_native_app refuses parentHintAppId that has no parent (no diff target -> would silently false-fail)"() {
+        given:
+        enableHubAdminWrite()
+        // Top-level app (parentAppId == null) — we can't diff children to spot
+        // the new rule, so we'd return success:false even on a successful
+        // import. Refuse up front instead.
+        hubGet.register('/installedapp/configure/json/200') { params ->
+            JsonOutput.toJson([
+                app: [id: 200, name: "Notifier", label: "Notifier",
+                      installed: true,
+                      appType: [name: "Notifier", namespace: "hubitat"]],
+                configPage: [name: "main", sections: []],
+                settings: [:],
+                childApps: []
+            ])
+        }
+
+        when:
+        script.toolImportNativeApp([
+            jsonContent: '{"appReplacements":{"42":{"appLabel":"X"}}}',
+            parentHintAppId: 200,
+            confirm: true
+        ])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("no numeric parentAppId") || ex.message.toLowerCase().contains("parent")
+    }
+
+    def "_appClonerCommitImportRule throws when action_href idx never appears (no silent fallback to 0)"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context</html>' }
+        // Empty sections — the regex never finds `_action_href_name|importRule|N`.
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentConfigJson(21, [[id: 100, label: "Src"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        script.toolCloneNativeApp([sourceAppId: 100, confirm: true])
+
+        then:
+        def ex = thrown(IllegalStateException)
+        ex.message.contains("action_href not found")
     }
 
     // ---------- post-write verification heuristic itself ----------

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -96,6 +96,22 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         ])
     }
 
+    // Decode a URL-encoded form body (key=value&key=value...) back into a Map
+    // for assertion-friendly access. The cloner POSTs go through
+    // hubInternalPostFormRaw with a pre-encoded body string; tests want to
+    // assert on logical fields, not the percent-escape level.
+    private Map decodeForm(String encoded) {
+        if (!encoded) return [:]
+        Map out = [:]
+        encoded.split('&').each { kv ->
+            int eq = kv.indexOf('=')
+            String k = eq < 0 ? kv : kv.substring(0, eq)
+            String v = eq < 0 ? "" : kv.substring(eq + 1)
+            out[URLDecoder.decode(k, "UTF-8")] = URLDecoder.decode(v, "UTF-8")
+        }
+        return out
+    }
+
     private String statusJson(int ruleId, List appSettings = [], int subs = 1) {
         JsonOutput.toJson([
             installedApp: [id: ruleId],
@@ -2184,6 +2200,10 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         given:
         enableHubAdminWrite()
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Source Rule", [], 21) }
+        // _appClonerInit primes the cloner state before any POST; needs to
+        // resolve. _appClonerFindActionHrefIdx parses this for the navigate
+        // index and falls back to 0 when missing.
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
         int parentCalls = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             parentCalls++
@@ -2198,6 +2218,10 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         def posts = []
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
             posts << [path: path, body: body]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            posts << [path: path, body: decodeForm(encodedBody)]
             [status: 200, location: null, data: '{"status":"success"}']
         }
 
@@ -2231,6 +2255,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         given:
         enableHubAdminWrite()
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
         int parentCalls = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             parentCalls++
@@ -2246,6 +2271,10 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             posts << [path: path, body: body]
             [status: 200, location: null, data: '{"status":"success"}']
         }
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            posts << [path: path, body: decodeForm(encodedBody)]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
 
         when:
         def result = script.toolCloneNativeApp([sourceAppId: 100, newName: "My Renamed", confirm: true])
@@ -2259,29 +2288,28 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         renamePost.body["settings[newName100]"] == "My Renamed"
     }
 
-    def "export_native_app pulls JSON from the cloner's settings"() {
+    def "export_native_app pulls JSON from the cloner's form-refresh response"() {
         given:
         enableHubAdminWrite()
         def fakeJson = '{"deviceReplacements":{},"appReplacements":{"100":{"appLabel":"Source Rule"}}}'
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Source Rule", [], 21) }
-        // Cloner's /configure/json includes the export content as a settings value
-        // after the exportRuleButton click — return shape mirrors what
-        // _rmFetchConfigJson sees with the settings field populated.
-        hubGet.register('/installedapp/configure/json/4242') { params ->
-            JsonOutput.toJson([
-                app: [id: 4242, label: "Export/Import/Clone", name: "Export/Import/Clone",
-                      installed: true, parentAppId: null,
-                      appType: [name: "Export/Import/Clone", namespace: "hubitat"]],
-                configPage: [name: "main", install: true, error: null, sections: []],
-                settings: [ruleDownload: fakeJson, exportRuleButton: ""],
-                childApps: []
-            ])
-        }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
         script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
             [status: 302, location: "/apps/api/4242/app/100", data: ""]
         }
+        // The post-exportRuleButton form refresh response carries the canonical
+        // JSON in configPage.sections[].input[].filecontent — the cloner renders
+        // it there session-keyed and only on the click-fired POST.
+        def refreshResp = JsonOutput.toJson([
+            configPage: [name: "main", sections: [
+                [input: [[name: "ruleDownload", type: "download-text", filecontent: fakeJson]]]
+            ]]
+        ])
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
             [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            [status: 200, location: null, data: refreshResp]
         }
 
         when:
@@ -2300,20 +2328,20 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         enableHubAdminWrite()
         def fakeJson = '{"deviceReplacements":{},"appReplacements":{"100":{"appLabel":"X"}}}'
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "X", [], 21) }
-        hubGet.register('/installedapp/configure/json/4242') { params ->
-            JsonOutput.toJson([
-                app: [id: 4242, label: "Export/Import/Clone", installed: true,
-                      appType: [name: "Export/Import/Clone", namespace: "hubitat"]],
-                configPage: [name: "main", install: true, error: null, sections: []],
-                settings: [ruleDownload: fakeJson],
-                childApps: []
-            ])
-        }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
         script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
             [status: 302, location: "/apps/api/4242/app/100", data: ""]
         }
+        def refreshResp = JsonOutput.toJson([
+            configPage: [name: "main", sections: [
+                [input: [[name: "ruleDownload", type: "download-text", filecontent: fakeJson]]]
+            ]]
+        ])
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
             [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            [status: 200, location: null, data: refreshResp]
         }
         def uploaded = []
         script.metaClass.uploadHubFile = { String fn, byte[] bytes -> uploaded << [name: fn, len: bytes.length] }
@@ -2368,6 +2396,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         def importJson = '{"deviceReplacements":{},"appReplacements":{"42":{"appLabel":"Source Rule","appTypeName":"Rule-5.1"}}}'
         // parentHint = an existing rule under parent 21
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "ExistingRule", [], 21) }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> '{"configPage":{"sections":[]}}' }
         int parentCalls = 0
         hubGet.register('/installedapp/configure/json/21') { params ->
             parentCalls++
@@ -2381,6 +2410,10 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         def posts = []
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
             posts << [path: path, body: body]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            posts << [path: path, body: decodeForm(encodedBody)]
             [status: 200, location: null, data: '{"status":"success"}']
         }
 

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -2122,6 +2122,289 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.issues.any { it.toString().toLowerCase().contains("broken") }
     }
 
+    // ---------- clone / export / import_native_app (appCloner trio) ----------
+    // These three tools share the appCloner system app's wire format. Wire
+    // format captured live via Chrome XHR sniffing on firmware 2.5.0.x:
+    //
+    //   GET /installedapp/sysAppApi/appCloner/app/<sourceId> -> 302
+    //     Location: /apps/api/<clonerId>/app/<sourceId>?access_token=...
+    //   POST /installedapp/btn  (cloneRuleButton or exportRuleButton)
+    //   POST /installedapp/update/json  (form refresh after each click)
+    //   POST /installedapp/update/json  (with _action_href_name|importRule|<idx>=)
+    //   POST /installedapp/btn  (importNow — actual commit, clone+import only)
+    //
+    // Helpers shared by these tests construct minimal source/parent configs
+    // and stub the cloner's GET-302 + POST responses.
+
+    private String parentConfigJson(int parentId, List<Map> children) {
+        JsonOutput.toJson([
+            app: [id: parentId, label: "Rule Machine"],
+            configPage: [name: "mainPage", title: "RM", install: true, error: null, sections: []],
+            settings: [:],
+            childApps: children
+        ])
+    }
+
+    def "clone_native_app requires confirm=true"() {
+        given: enableHubAdminWrite()
+
+        when: script.toolCloneNativeApp([sourceAppId: 100])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("SAFETY CHECK FAILED")
+    }
+
+    def "clone_native_app throws when sourceAppId is missing"() {
+        given: enableHubAdminWrite()
+
+        when: script.toolCloneNativeApp([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains("sourceappid")
+    }
+
+    def "clone_native_app throws when source app config fetch returns empty"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/999') { params -> "" }
+
+        when: script.toolCloneNativeApp([sourceAppId: 999, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("999")
+        ex.message.toLowerCase().contains("not found")
+    }
+
+    def "clone_native_app drives the full appCloner wizard and returns the new appId"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Source Rule", [], 21) }
+        int parentCalls = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentCalls++
+            // Pre-clone snapshot: just the source. Post-commit: source + new clone.
+            parentCalls <= 1
+                ? parentConfigJson(21, [[id: 100, label: "Source Rule"]])
+                : parentConfigJson(21, [[id: 100, label: "Source Rule"], [id: 250, label: "Source Rule clone"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true])
+
+        then: "tool returns the discovered new appId"
+        result.success == true
+        result.sourceAppId == 100
+        result.clonerAppId == 4242
+        result.newAppId == 250
+
+        and: "cloneRuleButton click POSTed to /installedapp/btn with the 4-field contract"
+        def cloneClick = posts.find { it.path == "/installedapp/btn" && it.body?.name == "cloneRuleButton" }
+        cloneClick != null
+        cloneClick.body["settings[cloneRuleButton]"] == "clicked"
+        cloneClick.body["cloneRuleButton.type"] == "button"
+        cloneClick.body.id == "4242"
+
+        and: "importNow click POSTed (the actual commit)"
+        def importNowClick = posts.find { it.path == "/installedapp/btn" && it.body?.name == "importNow" }
+        importNowClick != null
+        importNowClick.body.id == "4242"
+
+        and: "page-navigation POST sent to advance to the importRule sub-page"
+        def navPost = posts.find { it.path == "/installedapp/update/json" && it.body?.containsKey("_action_href_name|importRule|0") }
+        navPost != null
+    }
+
+    def "clone_native_app rename writes settings[newName<sourceId>] before importNow"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Src", [], 21) }
+        int parentCalls = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentCalls++
+            parentCalls <= 1
+                ? parentConfigJson(21, [[id: 100, label: "Src"]])
+                : parentConfigJson(21, [[id: 100, label: "Src"], [id: 500, label: "My Renamed"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, newName: "My Renamed", confirm: true])
+
+        then: "rename POSTed with the dynamic settings[newName<sourceId>] field"
+        result.success == true
+        result.newAppId == 500
+        result.note?.contains("renamed to 'My Renamed'")
+        def renamePost = posts.find { it.path == "/installedapp/update/json" && it.body?.containsKey("settings[newName100]") }
+        renamePost != null
+        renamePost.body["settings[newName100]"] == "My Renamed"
+    }
+
+    def "export_native_app pulls JSON from the cloner's settings"() {
+        given:
+        enableHubAdminWrite()
+        def fakeJson = '{"deviceReplacements":{},"appReplacements":{"100":{"appLabel":"Source Rule"}}}'
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Source Rule", [], 21) }
+        // Cloner's /configure/json includes the export content as a settings value
+        // after the exportRuleButton click — return shape mirrors what
+        // _rmFetchConfigJson sees with the settings field populated.
+        hubGet.register('/installedapp/configure/json/4242') { params ->
+            JsonOutput.toJson([
+                app: [id: 4242, label: "Export/Import/Clone", name: "Export/Import/Clone",
+                      installed: true, parentAppId: null,
+                      appType: [name: "Export/Import/Clone", namespace: "hubitat"]],
+                configPage: [name: "main", install: true, error: null, sections: []],
+                settings: [ruleDownload: fakeJson, exportRuleButton: ""],
+                childApps: []
+            ])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolExportNativeApp([sourceAppId: 100])
+
+        then:
+        result.success == true
+        result.sourceAppId == 100
+        result.clonerAppId == 4242
+        result.jsonContent == fakeJson
+        result.contentLength == fakeJson.length()
+    }
+
+    def "export_native_app saveAs uploads to File Manager"() {
+        given:
+        enableHubAdminWrite()
+        def fakeJson = '{"deviceReplacements":{},"appReplacements":{"100":{"appLabel":"X"}}}'
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "X", [], 21) }
+        hubGet.register('/installedapp/configure/json/4242') { params ->
+            JsonOutput.toJson([
+                app: [id: 4242, label: "Export/Import/Clone", installed: true,
+                      appType: [name: "Export/Import/Clone", namespace: "hubitat"]],
+                configPage: [name: "main", install: true, error: null, sections: []],
+                settings: [ruleDownload: fakeJson],
+                childApps: []
+            ])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        def uploaded = []
+        script.metaClass.uploadHubFile = { String fn, byte[] bytes -> uploaded << [name: fn, len: bytes.length] }
+
+        when:
+        def result = script.toolExportNativeApp([sourceAppId: 100, saveAs: "x-export.json"])
+
+        then:
+        result.success == true
+        result.savedAs == "x-export.json"
+        uploaded.size() == 1
+        uploaded[0].name == "x-export.json"
+        uploaded[0].len == fakeJson.getBytes("UTF-8").length
+    }
+
+    def "import_native_app requires parentHintAppId + confirm"() {
+        given: enableHubAdminWrite()
+
+        when:
+        script.toolImportNativeApp([jsonContent: '{"appReplacements":{"100":{}}}'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("SAFETY CHECK FAILED") || ex.message.toLowerCase().contains("parenthint")
+    }
+
+    def "import_native_app rejects non-JSON content"() {
+        given: enableHubAdminWrite()
+
+        when:
+        script.toolImportNativeApp([jsonContent: 'not-json', parentHintAppId: 100, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains("not valid json") || ex.message.toLowerCase().contains("appreplacements")
+    }
+
+    def "import_native_app rejects JSON without appReplacements"() {
+        given: enableHubAdminWrite()
+
+        when:
+        script.toolImportNativeApp([jsonContent: '{"foo":"bar"}', parentHintAppId: 100, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains("appreplacements")
+    }
+
+    def "import_native_app drives the cloner with settings[ruleUpload]= and finds the new appId"() {
+        given:
+        enableHubAdminWrite()
+        def importJson = '{"deviceReplacements":{},"appReplacements":{"42":{"appLabel":"Source Rule","appTypeName":"Rule-5.1"}}}'
+        // parentHint = an existing rule under parent 21
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "ExistingRule", [], 21) }
+        int parentCalls = 0
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentCalls++
+            parentCalls <= 1
+                ? parentConfigJson(21, [[id: 100, label: "ExistingRule"]])
+                : parentConfigJson(21, [[id: 100, label: "ExistingRule"], [id: 700, label: "Source Rule import"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolImportNativeApp([jsonContent: importJson, parentHintAppId: 100, confirm: true])
+
+        then: "import succeeds with newAppId discovered"
+        result.success == true
+        result.newAppId == 700
+        result.originalSourceId == 42
+        result.originalLabel == "Source Rule"
+
+        and: "JSON staged via settings[ruleUpload] (urlencoded, NOT multipart)"
+        def stage = posts.find { it.path == "/installedapp/update/json" && it.body?.containsKey("settings[ruleUpload]") }
+        stage != null
+        stage.body["settings[ruleUpload]"] == importJson
+
+        and: "importNow click fired the actual commit"
+        posts.any { it.path == "/installedapp/btn" && it.body?.name == "importNow" }
+
+        and: "rename used the ORIGINAL source id (42), not parentHintAppId (100)"
+        def renamePostCheck = posts.findAll { it.path == "/installedapp/update/json" }
+        // No newName passed, so settings[newName42] should NOT appear
+        !renamePostCheck.any { it.body?.containsKey("settings[newName42]") }
+    }
+
     // ---------- post-write verification heuristic itself ----------
     // The silent-rejection / verification-fetch-failed paths are load-bearing
     // for the entire write-bookkeeping subsystem. Without these tests, a

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -2401,10 +2401,11 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         and: "importNow click fired the actual commit"
         posts.any { it.path == "/installedapp/btn" && it.body?.name == "importNow" }
 
-        and: "rename used the ORIGINAL source id (42), not parentHintAppId (100)"
-        def renamePostCheck = posts.findAll { it.path == "/installedapp/update/json" }
-        // No newName passed, so settings[newName42] should NOT appear
-        !renamePostCheck.any { it.body?.containsKey("settings[newName42]") }
+        and: "the importRule form refresh uses the ORIGINAL source id (42) as the newName field's <sourceId>, not parentHintAppId (100). With no newName argument the field is still emitted (matches UI behaviour) but its value is empty."
+        def importRulePosts = posts.findAll { it.path == "/installedapp/update/json" && it.body?.currentPage == "importRule" }
+        importRulePosts.any { it.body?.containsKey("settings[newName42]") }
+        importRulePosts.every { it.body?["settings[newName42]"] == "" }
+        !importRulePosts.any { it.body?.containsKey("settings[newName100]") }
     }
 
     // ---------- post-write verification heuristic itself ----------

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1174,21 +1174,19 @@ class TestRunner:
             self.created_variable_names.remove(var_name)
 
     @test("developer_mode")
-    def test_t225_delete_variable_not_in_rule_engine_namespace(self) -> None:
-        """T225: refusal with redirect-to-UI hint when name isn't in rule_engine state."""
-        # The refusal fires whether the var exists in the connector namespace or
-        # doesn't exist anywhere at all — error message text is identical.
+    def test_t225_delete_variable_not_in_either_namespace(self) -> None:
+        """T225: refusal when the variable doesn't exist in either namespace."""
+        # delete_variable now addresses both hub-variables and rule_engine
+        # namespaces (PR #151), so the refusal mentions both.
         try:
             self.client.call_tool("manage_hub_variables", {
                 "tool": "delete_variable",
                 "args": {"name": f"{PREFIX}DEFINITELY_NONEXISTENT_T225", "confirm": True},
             })
-            assert False, "Expected refusal for variable not in rule_engine namespace"
+            assert False, "Expected refusal for variable missing from both namespaces"
         except McpError as e:
             msg = str(e)
-            assert "not found in rule_engine namespace" in msg, f"wrong refusal text: {msg}"
-            assert "Settings" in msg, f"missing UI redirect hint: {msg}"
-            assert "Hub Variables" in msg, f"missing 'Hub Variables' in redirect: {msg}"
+            assert "not found in either the hub-variables namespace or the rule_engine namespace" in msg, f"wrong refusal text: {msg}"
 
     @test("developer_mode")
     def test_t226_delete_variable_no_confirm(self) -> None:


### PR DESCRIPTION
## Summary

- Three new tools under `manage_native_rules_and_apps` that wrap Hubitat's first-party `appCloner` system app for symmetric clone / export / import of any classic SmartApp (RM rule, Room Lighting, Button Controller, Basic Rule, Notifier, etc.).
- Replaces #140 with the **correct** wire format. Live BAT testing on firmware 2.5.0.x revealed the cloner is a multi-step wizard with several timing + escape gotchas, not a single button click — #140's implementation only fired step 1 of 5 and never produced any clones.
- Closes #154 (which proposed `export_native_app` + `import_native_app` as a follow-up to `clone_native_app`); bundled here because all three share infrastructure.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- **`clone_native_app(sourceAppId, newName?, confirm)`** — drives the appCloner's full Clone wizard.
- **`export_native_app(sourceAppId, saveAs?)`** — reads the canonical JSON out of the cloner's form-refresh response (`configPage.sections[].input[].filecontent`). Optional `saveAs` writes to File Manager.
- **`import_native_app(jsonContent | fromFile, parentHintAppId, newName?, confirm)`** — stages the JSON via `settings[ruleUpload]=` and drives the same `importNow` commit as clone. The cloner needs an existing rule under the target parent to seed itself (`parentHintAppId`) — has no semantic effect on the imported rule beyond placing it under the same parent app.
- Shared infrastructure: `_appClonerInit`, `_appClonerSubmitForm`, `_appClonerCommitImportRule`, `_appClonerDiscoverNewChild`, `_appClonerExtractJsonFromResponse`, `_appClonerFindActionHrefIdx`, plus a new `hubInternalPostFormRaw` helper for wire-safe URL encoding.
- Gateway / `biTools` / `hideGatewaySubTools` / dispatch / descriptor / long-form helper bullets all updated for the 3 new tools (`manage_native_rules_and_apps` is now 12 tools).

Closes #154. Supersedes #140.

### Native RM workflow note

Importing an existing rule's exported JSON re-creates the rule with all settings (logging multi-select, action chains, conditions, etc.) preserved bit-for-bit. This is **a more reliable path than the wizard-driving native RM CRUD tools for *modifying* an existing complex rule** — export to JSON, mutate the appropriate `appData[id].state` / `appSettings[]` entries, import as a new rule, swap the device-references over. It's not great for *creating* rules from scratch (the JSON shape is internal-undocumented and brittle), but for surgical edits to existing rules it sidesteps the wizard's many state-machine quirks.

## Release Notes

- New `clone_native_app` tool — clone any classic Hubitat automation app (RM rule, Room Lighting, Button Controller, Basic Rule, Notifier, etc.) without rebuilding it from scratch via the wizard. Returns the new app's id; pass `newName` to set a custom label in one call.
- New `export_native_app` tool — export any classic Hubitat app to its canonical JSON shape (the same format Hubitat's UI "Export" button produces). Returns the JSON content directly; optional `saveAs` also writes it to File Manager for backup or HPM-style distribution.
- New `import_native_app` tool — re-create a rule/app from a previously-exported JSON. Round-trips cleanly with `export_native_app`, enabling edit-as-text workflows (export → mutate JSON → import) that are more reliable than the wizard-driving CRUD path for complex rules.
- All three require the existing `Enable Built-in App Tools` toggle. Clone and import additionally require `Hub Admin Write` + `confirm=true`; export is read-only.
- The `manage_native_rules_and_apps` gateway now lists 12 sub-tools (was 9).

## Testing

**Wire format captured live via Chrome XHR sniffing on firmware 2.5.0.x:**

```
GET /installedapp/sysAppApi/appCloner/app/<sourceId>          -> 302
  Location: /apps/api/<clonerId>/app/<sourceId>?access_token=...
GET /apps/api/<clonerId>/app/<sourceId>?access_token=...      (source-context render)
GET /installedapp/configure/json/<clonerId>/main              (configPage prime — new!)
POST /installedapp/btn  name=<cloneRuleButton|exportRuleButton>
POST /installedapp/update/json  (form refresh)
POST /installedapp/update/json  _action_href_name|importRule|<idx>=
POST /installedapp/btn  name=importNow                         (clone+import only)
POST /installedapp/update/json  (form refresh — actual create commits here)
```

Five live-BAT-verified gotchas this PR works around:

1. **Cloner double-click race** — first `cloneRuleButton` click is silently dropped; same wizard race as `delete_variable`.
2. **Configure-JSON prime fetch** — `settings[ruleUpload]` writes are silently dropped (key registered, value stored as `null`) until the cloner's main page state has been fetched once via `/installedapp/configure/json/<clonerId>/main`. Browsers do this fetch as part of normal page rendering.
3. **Dynamic action_href index** — `_action_href_name|importRule|<N>` uses a session-scoped numeric id that's `0` on the post-clone confirmation page but `55` (or whatever the cloner's lifetime counter is at) on the post-upload restore-or-import page. Discovered dynamically by parsing the page state JSON.
4. **HTTPBuilder backslash mangle** — passing a Map body to `httpPost` with `application/x-www-form-urlencoded` mangles `\\\"` sequences in JSON values; multi-select enum values lose escapes on the wire and the cloner rejects the upload. New `hubInternalPostFormRaw` helper that takes a pre-URL-encoded String body works around this.
5. **Cloner export over-escape** — Hubitat's appCloner over-escapes multi-select enum values by one extra level when generating the download payload (`\\\"` source = `\"` parsed; cloner emits `\\\\\"` source = `\\\"` parsed = malformed). The `\\\"` triplet is unreachable in valid JSON, so we collapse it before returning the export string.

**Unit tests** (Spock specs in `ToolRmNativeCrudSpec`):
- `clone_native_app`: confirm-gate, missing sourceAppId, source-not-found, full wizard contract (cloneRuleButton + nav + importNow), rename writes `settings[newName<sourceId>]`.
- `export_native_app`: pulls JSON from cloner settings; saveAs uploads to File Manager.
- `import_native_app`: parentHintAppId+confirm gate, non-JSON rejection, missing-appReplacements rejection, full happy-path with `settings[ruleUpload]=` staging.

**Live-hub BAT** (verified):

| Path | Source | New rule | Settings preserved |
|---|---|---|---|
| Clone (empty rule) | 1442 | 1464 | yes |
| Clone (rule with log action) | 1440 | 1466 | yes |
| Clone (production rule, 163 settings, RE+stays) | 36 | 1468 | yes |
| Export (canonical JSON) | 1469 | — | 2833-byte JSON returned |
| Import via `jsonContent` (canonical) | — | 1534 | yes (incl. multi-select logging) |
| Import via `fromFile` (round-trip) | — | 1538, 1540 | yes (incl. multi-select logging) |

Error paths verified: missing source, malformed JSON, missing parentHintAppId.

## Checklist

- [x] **Unit tests added for any new MCP tools** (Spock specs in `ToolRmNativeCrudSpec`)
- [ ] Sandbox lint passes: `python tests/sandbox_lint.py` (CI will run)
- [ ] `./gradlew test` passes locally (or CI confirms)
- [x] Live-hub BAT tests verified — clone, export, import (jsonContent), import (fromFile round-trip), all three on real production rules
- [x] Documentation updated if user-facing behaviour or tool surface changed (gateway descriptors, search hints, long-form helper bullets)