### PR TITLE
ci(sync-future-plans): use SSH deploy key + harden against latent silent failures

### DIFF
--- a/.github/workflows/sync-future-plans.yml
+++ b/.github/workflows/sync-future-plans.yml
@@ -5,12 +5,23 @@ on:
     branches: [main]
     paths: [futureplans.md]
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
+      - name: Verify deploy key secret is set
+        env:
+          SECRET: ${{ secrets.SYNC_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SECRET:-}" ]; then
+            echo "::error::SYNC_DEPLOY_KEY secret is empty or unset — actions/checkout would silently fall back to GITHUB_TOKEN HTTPS, which is rejected by the main-required-checks ruleset. Re-add the secret per the deploy-key playbook."
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
         with:
           # SSH deploy key (write-enabled) so the bot's push satisfies the
@@ -20,6 +31,7 @@ jobs:
 
       - name: Sync futureplans.md into README
         run: |
+          set -euo pipefail
           # Read futureplans.md, strip the top-level heading (line 1),
           # and demote all headings by one level (## -> ###, ### -> ####)
           CONTENT=$(tail -n +2 futureplans.md | sed 's/^### /#### /; s/^## /### /')
@@ -35,7 +47,11 @@ jobs:
           REPLACEMENT+=$'\n\n'"</details>"
           REPLACEMENT+=$'\n'"<!-- FUTURE_PLANS_END -->"
 
-          # Replace everything between the markers in README.md
+          # Replace everything between the markers in README.md.
+          # The marker-existence guard distinguishes "regex matched but content
+          # identical" (legitimate no-op) from "markers missing" (broken README)
+          # so a future README edit that drops the markers fails loudly here
+          # instead of silently no-op'ing every subsequent sync run.
           python3 -c "
           import re, sys
 
@@ -46,6 +62,9 @@ jobs:
               replacement = f.read()
 
           pattern = r'<!-- FUTURE_PLANS_START -->.*?<!-- FUTURE_PLANS_END -->'
+          if not re.search(pattern, readme, flags=re.DOTALL):
+              sys.exit('ERROR: FUTURE_PLANS markers missing in README.md — restore the <!-- FUTURE_PLANS_START --> / <!-- FUTURE_PLANS_END --> comment pair before this workflow can run.')
+
           updated = re.sub(pattern, replacement, readme, flags=re.DOTALL)
 
           if updated == readme:
@@ -61,6 +80,7 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
+          set -euo pipefail
           if git diff --quiet README.md; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -70,8 +90,12 @@ jobs:
       - name: Commit and push
         if: steps.diff.outputs.changed == 'true'
         run: |
+          set -euo pipefail
+          # Canonical noreply form (with the bot's user-ID prefix) so GitHub's
+          # UI attributes the commit to github-actions[bot] rather than showing
+          # "unrecognized author".
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md
           git commit -m "docs: sync Future Plans from futureplans.md"
           git push

--- a/.github/workflows/sync-future-plans.yml
+++ b/.github/workflows/sync-future-plans.yml
@@ -12,6 +12,11 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          # SSH deploy key (write-enabled) so the bot's push satisfies the
+          # branch ruleset's DeployKey bypass actor — the default GITHUB_TOKEN
+          # identity has no bypass and gets rejected by required_status_checks.
+          ssh-key: ${{ secrets.SYNC_DEPLOY_KEY }}
 
       - name: Sync futureplans.md into README
         run: |

--- a/futureplans.md
+++ b/futureplans.md
@@ -643,3 +643,4 @@
 39. **Button Controller** — Use native app; MCP already has `button_event` triggers
 40. **Thermostat Scheduler** — Use native app; MCP already has `set_thermostat` actions
 41. **Lock Code Manager** — Use native app; review if `send_command` proves insufficient
+


### PR DESCRIPTION
## Summary

Restores the broken `Sync Future Plans to README` workflow (failing on every futureplans.md edit since the `main-required-checks` ruleset was tightened on 2026-04-24) and bundles five hardening fixes uncovered while reviewing the deploy-key change. PRs #150 and #151 both tripped the original failure on merge.

## Type of change

- [x] `ci` — CI/CD pipeline change

## Changes

**Primary fix — SSH deploy key for ruleset bypass (commit aef1683)**
The default `GITHUB_TOKEN` push gets rejected because required_status_checks (`test` + `guard`) only fire on PRs, not direct pushes, and the bot has no entry in the ruleset's `bypass_actors` list. The ruleset already has a `{actor_type: DeployKey, actor_id: null, bypass_mode: always}` entry — meaning any deploy key bypasses. Switched the `actions/checkout@v6` step to use a write-enabled SSH deploy key (`secrets.SYNC_DEPLOY_KEY`); the SSH-based push then satisfies the bypass without weakening the rule for any other actor.

Tried first via `PATCH /rulesets/15512332` adding `actor_type: Integration` for GitHub Actions (id 15368). API rejected with `422`: *"Actor GitHub Actions integration must be part of the ruleset source or owner organization"* — for personal-account repos that path isn't supported. Deploy-key bypass works on personal repos.

**Hardening fixes (commit 9bef50a)**

Pre-existing latent bugs (would survive the deploy-key fix unchanged):

- `set -euo pipefail` added to every `run:` block. Default GitHub Actions bash runner sets `-eo pipefail` but not `-u`; explicit triple makes the contract clear and protects against unbound-variable typos.
- Python sync step now asserts the `<!-- FUTURE_PLANS_START -->` / `<!-- FUTURE_PLANS_END -->` markers exist *before* the `re.sub`. Previously a broken/missing marker pair would silently no-op every subsequent run forever (regex matches nothing → "no changes needed" → exit 0 → no diff → skip commit). Now `sys.exit`s with a clear actionable error.
- Bot commit author normalized to canonical `41898282+github-actions[bot]@users.noreply.github.com` (with user-ID prefix). Without the prefix GitHub's UI attributes the commit as "unrecognized author"; matches the form used in `release.yml:155`.

Newly-relevant (introduced by the SSH-deploy-key switch):

- Pre-checkout secret-guard step. If `SYNC_DEPLOY_KEY` is ever unset/rotated/empty, `actions/checkout@v6` would silently fall back to GITHUB_TOKEN HTTPS — the exact failure shape this PR is designed to avoid. The new "Verify deploy key secret is set" step fails loudly with an actionable error before the fallback can re-introduce the original failure.
- `permissions: contents: write` → `contents: read`. Once the push goes through SSH (deploy-key authenticated), the GITHUB_TOKEN's write permission is dead config; tightening avoids misleading future readers into assuming HTTPS-via-token push.

**Smoke-test edit (commit 1105b87)** — single trailing newline appended to `futureplans.md`. On merge, the workflow's `paths:` filter triggers, the SSH-key path fires, and the push exercises the deploy-key bypass end-to-end. **Note:** the resulting README.md sync commit will be substantial (~17 lines of content drift), not a 1-newline cosmetic change — the README has been out of sync since 2026-04-24, and the workflow regenerates the entire `<!-- FUTURE_PLANS_* -->` block from current futureplans.md, so it catches up on PR #150 (ICMP) and PR #151 (variables) accumulated edits in one go. This is the *catch-up* part of the fix; a substantial diff is expected.

## Setup (out-of-band, manual; already completed)

- Ed25519 keypair generated locally
- Public key added to repo Settings → Deploy keys with **write access** (id 150870844, title `sync-future-plans`, verified `read_only: false`)
- Private key added as repo secret `SYNC_DEPLOY_KEY` (verified existence; value not exposed via API)
- SSH auth verified end-to-end against the repo with the local key

## Release Notes

- Internal CI fix; no end-user changes.

## Testing

- `gh api /repos/.../keys` confirms the deploy key is registered with `read_only: false` and `verified: true`.
- `ssh -i <key> -T git@github.com` returns "successfully authenticated".
- `git ls-remote` against `main` succeeds with the deploy key.
- YAML parses clean (`yaml.safe_load`).
- End-to-end push verification happens automatically on merge — the trailing-newline futureplans.md edit triggers the workflow at the merge commit, exercising the SSH-key path with the new hardening guards. If the secret pasted clean, you'll see one bot-authored "docs: sync Future Plans from futureplans.md" commit on main shortly after merge. If the secret is corrupt, the workflow fails red on the new pre-checkout guard step (cleanly identifies which thing is wrong) before the fallback would have re-introduced the original failure shape.

## Checklist

- [ ] Unit tests added for any new MCP tools (n/a)
- [x] Sandbox lint passes (n/a — workflow YAML, not Groovy)
- [x] `./gradlew test` passes (n/a)
- [ ] Live-hub BAT tests updated (n/a)
- [x] Documentation updated (inline workflow comments)