### PR TITLE
docs(futureplans): align rule-tool names with PR #134 custom_ rename

### DIFF
--- a/futureplans.md
+++ b/futureplans.md
@@ -69,7 +69,7 @@
   > 1. Define tree data structure with `operator` and `operands` fields
   > 2. Implement recursive `evaluateConditionTree()` method
   > 3. Support both legacy flat format and new tree format (migration path)
-  > 4. Update `create_rule`/`update_rule` tool schemas
+  > 4. Update `custom_create_rule`/`custom_update_rule` tool schemas
   > 5. Update `describeCondition()` for recursive formatting
 
 - [ ] **Private Boolean per rule** — `Difficulty: 2 | Effort: S`
@@ -219,19 +219,19 @@
 
 > **Philosophy: prefer native Hubitat apps.** The MCP server was built to complement Hubitat, not replace it. These native apps (Room Lighting, Mode Manager, Button Controller, etc.) are well-maintained, have proper UIs, and are battle-tested. The MCP can already interact with the *effects* of these apps — it can read/set modes, control devices, trigger on device events, and see virtual devices they create.
 >
-> **The AI assistant is the wizard.** Rather than building dedicated wizard tools that generate MCP rules to replicate what native apps already do, the AI can compose rules on the fly using existing `create_rule` and the full rule engine. Dedicated MCP tooling for these patterns is **low priority** and would only be implemented if the MCP genuinely cannot interact with the native app's functionality in some way. Each item will be reviewed on a case-by-case basis.
+> **The AI assistant is the wizard.** Rather than building dedicated wizard tools that generate MCP rules to replicate what native apps already do, the AI can compose rules on the fly using existing `custom_create_rule` and the full rule engine. Dedicated MCP tooling for these patterns is **low priority** and would only be implemented if the MCP genuinely cannot interact with the native app's functionality in some way. Each item will be reviewed on a case-by-case basis.
 
 - [ ] **Room Lighting (room-centric lighting with vacancy mode)** — `Low priority`
-  > *Native app preferred.* Hubitat's built-in Room Lighting app handles this well. The MCP can already control all the same devices, trigger on motion events, and use `if_then_else` / `delay` / `cancel_delayed` to build equivalent logic via `create_rule` if needed. No dedicated MCP tool required unless a gap is identified where MCP cannot interact with Room Lighting's behavior.
+  > *Native app preferred.* Hubitat's built-in Room Lighting app handles this well. The MCP can already control all the same devices, trigger on motion events, and use `if_then_else` / `delay` / `cancel_delayed` to build equivalent logic via `custom_create_rule` if needed. No dedicated MCP tool required unless a gap is identified where MCP cannot interact with Room Lighting's behavior.
 
 - [ ] **Zone Motion Controller (multi-sensor zones)** — `Low priority`
-  > *Native app preferred.* Hubitat's built-in Zone Motion Controller creates a virtual motion device that aggregates multiple sensors. If the user adds this virtual device to MCP's selected devices, MCP can already see and trigger on it. The AI can also replicate the logic using `create_virtual_device` + `create_rule` with multi-device triggers if needed. Only implement if MCP cannot adequately interact with the native app's output device.
+  > *Native app preferred.* Hubitat's built-in Zone Motion Controller creates a virtual motion device that aggregates multiple sensors. If the user adds this virtual device to MCP's selected devices, MCP can already see and trigger on it. The AI can also replicate the logic using `create_virtual_device` + `custom_create_rule` with multi-device triggers if needed. Only implement if MCP cannot adequately interact with the native app's output device.
 
 - [ ] **Mode Manager (automated mode changes)** — `Low priority`
   > *Native app preferred.* Hubitat's built-in Mode Manager handles time-based and presence-based mode changes. The MCP can already read/set modes via `get_modes`/`set_mode`, trigger on `mode_change`, and build time/presence-triggered rules that call `set_mode`. No dedicated tool needed unless a specific interaction gap is found.
 
 - [ ] **Button Controller (streamlined button-to-action mapping)** — `Low priority`
-  > *Native app preferred.* Hubitat's built-in Button Controller handles this natively. The MCP rule engine already has `button_event` triggers with full support for button numbers (1–20) and action types (pushed/held/doubleTapped/released). The AI can create these rules directly via `create_rule`. No dedicated tool needed.
+  > *Native app preferred.* Hubitat's built-in Button Controller handles this natively. The MCP rule engine already has `button_event` triggers with full support for button numbers (1–20) and action types (pushed/held/doubleTapped/released). The AI can create these rules directly via `custom_create_rule`. No dedicated tool needed.
 
 - [ ] **Thermostat Scheduler (schedule-based setpoints)** — `Low priority`
   > *Native app preferred.* Hubitat's built-in Thermostat Scheduler handles schedule-based setpoints. The MCP rule engine already has `time` triggers, `set_thermostat` actions, `mode` and `days_of_week` conditions — the AI can compose schedule rules directly. No dedicated tool needed unless MCP cannot interact with the native scheduler's effects.
@@ -417,10 +417,10 @@
 
 ## Advanced Automation Patterns
 
-> These patterns don't require new MCP tools — the AI assistant can already compose them using existing `create_rule`, `set_variable`, `create_virtual_device`, and other tools. They're documented here as reference patterns showing what's achievable today with the current rule engine. No dedicated wizard tools are planned unless a specific gap is identified.
+> These patterns don't require new MCP tools — the AI assistant can already compose them using existing `custom_create_rule`, `set_variable`, `create_virtual_device`, and other tools. They're documented here as reference patterns showing what's achievable today with the current rule engine. No dedicated wizard tools are planned unless a specific gap is identified.
 
 - [ ] **Occupancy / room state machine** — `No new tools needed`
-  > *Already achievable.* The AI can compose this using existing primitives: a hub variable `roomState_<room>` holds state (vacant/occupied/engaged/checking). `device_event` triggers on motion/contact sensors feed into `if_then_else` chains with `set_variable` actions for state transitions. Duration-based triggers handle timeouts. Other rules check room state via `variable` conditions. No dedicated tool required — the AI can build this pattern on request using `create_rule` and `set_variable`.
+  > *Already achievable.* The AI can compose this using existing primitives: a hub variable `roomState_<room>` holds state (vacant/occupied/engaged/checking). `device_event` triggers on motion/contact sensors feed into `if_then_else` chains with `set_variable` actions for state transitions. Duration-based triggers handle timeouts. Other rules check room state via `variable` conditions. No dedicated tool required — the AI can build this pattern on request using `custom_create_rule` and `set_variable`.
 
 - [ ] **Presence-based automation (first-to-arrive, last-to-leave)** — `No new tools needed`
   > *Already achievable.* The AI can compose this: a hub variable `homeCount` tracks present people. `device_event` triggers on presence sensors increment/decrement via `variable_math`. Rules with `variable` conditions fire when `homeCount` transitions 0→1 (first arrive) or 1→0 (last leave). All building blocks exist today.


### PR DESCRIPTION
## Summary

Updates 7 occurrences of bare `create_rule`/`update_rule` in `futureplans.md` to the `custom_`-prefixed names that have been canonical in the codebase since PR #134. The drift surfaced in v1.1.1's `chore(release)` commit when the consolidated post-merge workflow regenerated README from futureplans.md — direct README hand-edits had been keeping it current, but those got reverted on regeneration.

## Type of change

- [x] `docs` — documentation only

## Changes

`futureplans.md` — 7 lines, 8 references:
- Line 72: condition-tree implementation plan → `` `custom_create_rule`/`custom_update_rule` ``
- Line 222: "AI assistant is the wizard" intro → `` `custom_create_rule` ``
- Lines 225, 228, 234: native-app-preferred sections (Room Lighting, Zone Motion Controller, Button Controller) → `` `custom_create_rule` ``
- Lines 420, 423: room-state-aware automation patterns → `` `custom_create_rule` ``

`set_variable` and `create_virtual_device` were checked and left alone — those tools were not renamed in PR #134.

## Release Notes

- Internal docs only; no end-user changes.

## Testing

- Verified canonical tool names in `hubitat-mcp-server.groovy:1280-1601` are all `custom_*` (no bare `create_rule`/`update_rule` registered).
- Verified `futureplans.md` no longer has any bare `create_rule`/`update_rule` references.
- The next futureplans-edit-triggered sync will mirror these to README's FUTURE_PLANS block automatically.

## Checklist

- [ ] Unit tests added for any new MCP tools (n/a)
- [x] Sandbox lint passes (n/a — markdown only)
- [x] `./gradlew test` passes (n/a)
- [ ] Live-hub BAT tests updated (n/a)
- [x] Documentation updated (this PR _is_ the doc fix)