### PR TITLE
feat(manage_app_driver_code): driver-code lifecycle improvements -- sourceFile + bulk + token-economy

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,10 +383,10 @@ All operations are disruptive. Hub admin tools require Hub Admin Read/Write to b
 
 | Tool | Description |
 |------|-------------|
-| `install_app` | Install new app from Groovy source |
-| `install_driver` | Install new driver from Groovy source |
-| `update_app_code` | Modify existing app code |
-| `update_driver_code` | Modify existing driver code |
+| `install_app` | Install new app from Groovy source or File Manager file (`source` or `sourceFile`). Verifies install succeeded. |
+| `install_driver` | Install new driver from Groovy source or File Manager file (`source` or `sourceFile`). Bulk mode: `installs=[{sourceFile},...]`. Verifies each install succeeded. |
+| `update_app_code` | Modify existing app code (source, sourceFile, or resave) |
+| `update_driver_code` | Modify existing driver code (single-driver or bulk `updates` array) |
 | `delete_app` | Permanently delete an app (auto-backs up) |
 | `delete_driver` | Permanently delete a driver (auto-backs up) |
 | `restore_item_backup` | Restore app/driver to backed-up version |

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -84,7 +84,7 @@ All Hub Admin Write tools require these steps:
 **install_app** (via `manage_app_driver_code`)
 - Accepts `source` (inline Groovy) OR `sourceFile` (filename in File Manager). Provide exactly one.
 - Token-economy tip: upload large source via local CLI first, then pass the filename as `sourceFile`. Avoids re-sending multi-KB source strings on each install attempt.
-- Performs post-install verification: after the hub creates the item, fetches it back to confirm the Groovy compiled cleanly. Returns `success: false` if the hub reports a compile error, even if the redirect URL was returned. The item ID is included in the error response so the error can be inspected via `get_app_source`.
+- Performs post-install verification: after the hub creates the item, fetches it back to confirm the Groovy compiled cleanly. Returns `success: false` with `appId` populated when the hub reports a compile error or the verify response is empty/unparseable, so the error can be inspected via `get_app_source`. If the hub returns no item ID at all (no `Location` header), `appId` is `null`. Transient verify-fetch failures keep `success: true` but set `verified: false` plus `verifyError`.
 - Requires Hub Admin Write + confirm + backup <24h.
 
 **install_driver** (via `manage_app_driver_code`)
@@ -94,7 +94,7 @@ All Hub Admin Write tools require these steps:
   - Top-level `success: true` only if ALL items succeeded.
   - Practical limit: ~10-20 drivers per call (each install is a sequential on-hub compilation, ~1-5 seconds each).
   - Token-economy pattern: upload all driver source files via local CLI, then call bulk `install_driver` once with all `{sourceFile}` entries.
-- Performs post-install verification: after the hub creates each item, fetches it back to confirm the Groovy compiled cleanly. Returns `success: false` if the hub reports a compile error, even if the redirect URL was returned. The item ID is included in the error response so the error can be inspected via `get_driver_source`.
+- Performs post-install verification: after the hub creates each item, fetches it back to confirm the Groovy compiled cleanly. Returns `success: false` with `driverId` populated when the hub reports a compile error or the verify response is empty/unparseable, so the error can be inspected via `get_driver_source`. If the hub returns no item ID at all (no `Location` header), `driverId` is `null`. Transient verify-fetch failures keep `success: true` but set `verified: false` plus `verifyError`.
 - Requires Hub Admin Write + confirm + backup <24h.
 
 **update_driver_code** (via `manage_app_driver_code`)

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -81,6 +81,30 @@ All Hub Admin Write tools require these steps:
 - List affected devices to user before proceeding
 - Dashboard layouts and automations referencing room may be affected
 
+**install_app** (via `manage_app_driver_code`)
+- Accepts `source` (inline Groovy) OR `sourceFile` (filename in File Manager). Provide exactly one.
+- Token-economy tip: upload large source via local CLI first, then pass the filename as `sourceFile`. Avoids re-sending multi-KB source strings on each install attempt.
+- Performs post-install verification: after the hub creates the item, fetches it back to confirm the Groovy compiled cleanly. Returns `success: false` if the hub reports a compile error, even if the redirect URL was returned. The item ID is included in the error response so the error can be inspected via `get_app_source`.
+- Requires Hub Admin Write + confirm + backup <24h.
+
+**install_driver** (via `manage_app_driver_code`)
+- Single-driver mode: supply `source` (inline Groovy) OR `sourceFile` (filename in File Manager). Provide exactly one.
+- Bulk mode: supply an `installs` array of objects, each with `source` or `sourceFile`. Cannot combine with single-driver fields.
+  - Continue-on-error: errors on individual items do not abort remaining installs. Returns a per-item status array with each item's `driverId`.
+  - Top-level `success: true` only if ALL items succeeded.
+  - Practical limit: ~10-20 drivers per call (each install is a sequential on-hub compilation, ~1-5 seconds each).
+  - Token-economy pattern: upload all driver source files via local CLI, then call bulk `install_driver` once with all `{sourceFile}` entries.
+- Performs post-install verification: after the hub creates each item, fetches it back to confirm the Groovy compiled cleanly. Returns `success: false` if the hub reports a compile error, even if the redirect URL was returned. The item ID is included in the error response so the error can be inspected via `get_driver_source`.
+- Requires Hub Admin Write + confirm + backup <24h.
+
+**update_driver_code** (via `manage_app_driver_code`)
+- Single-driver mode (unchanged): supply `driverId` + one of `source` / `sourceFile` / `resave`.
+- Bulk mode: supply an `updates` array of objects, each with `driverId` and one of `sourceFile` / `source` / `resave`. Cannot combine with single-driver fields.
+  - Continue-on-error: errors on individual items do not abort remaining updates. Returns a per-item status array.
+  - Top-level `success: true` only if ALL items succeeded.
+  - Practical limit: ~20 drivers per call (each update is a sequential on-hub compilation, ~1-5 seconds each).
+  - Token-economy pattern: upload all updated driver files via local CLI (curl -F / PowerShell Invoke-RestMethod), then call bulk `update_driver_code` once with all `{driverId, sourceFile}` pairs.
+
 **delete_app / delete_driver** (via `manage_app_driver_code`)
 - Remove app instances via Hubitat UI first (for apps)
 - Change devices to different driver first (for drivers)

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -134,6 +134,10 @@ Destructive write operations (require Hub Admin Write): `reboot_hub`, `shutdown_
 
 `install_app`, `install_driver`, `update_app_code`, `update_driver_code`, `delete_app`, `delete_driver`, `restore_item_backup`
 
+- `install_app` / `install_driver` accept `source` (inline) OR `sourceFile` (File Manager filename). Token-economy tip: upload source via local CLI first, then pass filename. Includes post-install verification -- returns `success: false` if the Groovy failed to compile, even when the hub returned a redirect.
+- `install_driver` supports bulk mode via an `installs` array of `{source|sourceFile}` objects. Continue-on-error; top-level `success: true` only if all items pass. Cannot combine with single-driver fields. Returns per-item `driverId`. Practical limit ~10-20 drivers/call. (`install_app` is single-item only -- apps are typically one-of-a-kind installs.)
+- `update_driver_code` supports bulk mode via an `updates` array of `{driverId, sourceFile}` objects. Continue-on-error; top-level `success: true` only if all items pass. Cannot combine with single-driver fields.
+
 ### Pre-flight checklist for ALL write operations
 
 1. A hub backup must exist within the last 24 hours (`create_hub_backup`)

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -131,10 +131,10 @@ Write operations for apps and drivers: install, update, delete, and restore code
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
-| `install_app` | Install a new Groovy app from source. | Hub Admin Write |
-| `install_driver` | Install a new Groovy driver from source. | Hub Admin Write |
-| `update_app_code` | Update existing app source code. | Hub Admin Write |
-| `update_driver_code` | Update existing driver source code. | Hub Admin Write |
+| `install_app` | Install a new Groovy app from `source` (inline) or `sourceFile` (File Manager filename). Verifies install compiled cleanly. | Hub Admin Write |
+| `install_driver` | Install a new Groovy driver from `source` (inline) or `sourceFile` (File Manager filename). Bulk mode: `installs=[{source|sourceFile},...]` (continue-on-error). Verifies each install compiled cleanly. | Hub Admin Write |
+| `update_app_code` | Update existing app source code (source, sourceFile, or resave). | Hub Admin Write |
+| `update_driver_code` | Update existing driver source code. Single-driver mode (driverId + source/sourceFile/resave) or bulk mode (updates array of {driverId, sourceFile} pairs, continue-on-error). | Hub Admin Write |
 | `delete_app` | Delete an installed app (auto-backs up). | Hub Admin Write |
 | `delete_driver` | Delete an installed driver (auto-backs up). | Hub Admin Write |
 | `restore_item_backup` | Restore app/driver to backed-up version. | Hub Admin Write |

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -9629,12 +9629,17 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
                 success: false,
                 error: errorMsg ?: "Update failed - the hub returned an error",
                 (idParam): itemId,
-                note: "Check the Groovy source code for syntax errors or compilation issues."
+                note: "Check the Groovy source code for syntax errors or compilation issues.",
+                lastBackup: formatTimestamp(state.lastBackupTimestamp)
             ]
         }
     } catch (Exception e) {
         mcpLog("error", "hub-admin", "${type} update failed: ${e.message}")
-        return [success: false, error: "${type.capitalize()} update failed: ${e.message}"]
+        return [
+            success: false,
+            error: "${type.capitalize()} update failed: ${e.message}",
+            lastBackup: formatTimestamp(state.lastBackupTimestamp)
+        ]
     }
 }
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -9368,7 +9368,7 @@ private Map toolInstallItem(String type, args) {
                 def entry = [(idField): r[idField], success: r.success == true]
                 if (r.success) {
                     if (r.sourceMode) entry.sourceMode = r.sourceMode
-                    if (r.name) entry.name = r.name
+                    if (r.sourceLength != null) entry.sourceLength = r.sourceLength
                 } else {
                     entry.error = r.error ?: "Install failed"
                     allSucceeded = false
@@ -9435,8 +9435,8 @@ private Map toolInstallItemSingle(String type, args) {
 
         def newItemId = null
         if (result?.location) {
-            newItemId = result.location.replaceAll(".*?${editorPath}", "").replaceAll("[^0-9]", "")
-            if (!newItemId) newItemId = null  // reject empty string from replaceAll
+            newItemId = result.location.replaceAll(".*?${editorPath}", "").split("[?#/]")[0]
+            if (!newItemId) newItemId = null  // reject empty string if path segment was absent
         }
 
         if (!newItemId) {
@@ -9479,6 +9479,7 @@ private Map toolInstallItemSingle(String type, args) {
             message: "${type.capitalize()} installed successfully",
             (idField): newItemId,
             sourceMode: sourceMode,
+            sourceLength: sourceCode.length(),
             lastBackup: formatTimestamp(state.lastBackupTimestamp)
         ]
         if (sourceMode == "sourceFile") installResult.note = "Source was read from File Manager file '${args.sourceFile}'."

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -827,10 +827,10 @@ def getGatewayConfig() {
             description: "Install, update, and delete hub apps and drivers. All operations modify hub code and require Hub Admin Write.",
             tools: ["install_app", "install_driver", "update_app_code", "update_driver_code", "delete_app", "delete_driver", "restore_item_backup"],
             summaries: [
-                install_app: "Install new app from Groovy source. Args: source, confirm=true",
-                install_driver: "Install new driver from Groovy source. Args: source, confirm=true",
-                update_app_code: "Modify existing app code (CRITICAL). Args: appId, source|sourceFile|resave, confirm=true",
-                update_driver_code: "Modify existing driver code (CRITICAL). Args: driverId, source|sourceFile|resave, confirm=true",
+                install_app: "Install new app. PREFER curl-upload + sourceFile (bypasses agent context); inline source for stubs only. Args: source|sourceFile, confirm=true",
+                install_driver: "Install new driver. PREFER curl-upload + sourceFile. For 1: source|sourceFile. For >1: USE BULK (single round-trip: installs=[{source|sourceFile},...]). confirm=true",
+                update_app_code: "Modify existing app code (CRITICAL). PREFER curl-upload + sourceFile. Args: appId, source|sourceFile|resave, confirm=true",
+                update_driver_code: "Modify existing driver code (CRITICAL). For 1 driver: driverId+source|sourceFile|resave. For >1 drivers: USE BULK (single round-trip: updates=[{driverId,sourceFile},...]). PREFER sourceFile + curl-upload over inline. confirm=true",
                 delete_app: "Permanently delete an app (DESTRUCTIVE). Args: appId, confirm=true",
                 delete_driver: "Permanently delete a driver (DESTRUCTIVE). Args: driverId, confirm=true",
                 restore_item_backup: "Restore app/driver to backed-up version. Args: backupId, confirm=true"
@@ -1963,45 +1963,83 @@ Requires Hub Admin Write.""",
         // Hub Admin App/Driver Management Write Tools
         [
             name: "install_app",
-            description: """⚠️ Install new app from Groovy source. Show code to user and get confirmation first.
+            description: """⚠️ Install new app. Show code to user and get confirmation first.
 
-Requires Hub Admin Write + confirm + backup <24h. Returns new app ID. After install, add via Apps > Add User App in Hubitat UI.""",
+PREFERRED workflow (avoids reading source into agent transcript):
+  1) Upload bytes to File Manager via local CLI tool that bypasses agent context:
+       curl -F 'uploadFile=@./app.groovy' -F 'folder=/' 'http://<hub>/hub/fileManager/upload'
+       (PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
+  2) install_app(sourceFile: 'app.groovy', confirm: true)
+
+Inline 'source' is acceptable for stub-size snippets only. The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
+
+Verifies install succeeded: if the hub accepted the request but the app failed to compile, install_app returns success=false with the error. Requires Hub Admin Write + confirm + backup <24h. Returns new app ID. After install, add via Apps > Add User App in Hubitat UI.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    source: [type: "string", description: "The full Groovy source code for the app"],
+                    source: [type: "string", description: "Inline Groovy source. ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install/redeploy. For non-trivial apps, prefer sourceFile (recipe in tool description)."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
-                required: ["source", "confirm"]
+                required: ["confirm"]
             ]
         ],
         [
             name: "install_driver",
-            description: """⚠️ Install new driver from Groovy source. Show code to user and get confirmation first.
+            description: """⚠️ Install new driver. Show code to user and get confirmation first.
 
-Requires Hub Admin Write + confirm + backup <24h. Returns new driver ID.""",
+PREFERRED workflow (avoids reading source into agent transcript):
+  1) Upload bytes to File Manager via local CLI tool that bypasses agent context:
+       curl -F 'uploadFile=@./driver.groovy' -F 'folder=/' 'http://<hub>/hub/fileManager/upload'
+       (PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
+  2) install_driver(sourceFile: 'driver.groovy', confirm: true)
+
+Inline 'source' is acceptable for stub-size snippets only. The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
+
+For >1 driver: USE BULK mode (single round-trip, not N separate calls): installs=[{sourceFile}, ...]. Each driver's bytes still uploaded once via CLI per the same recipe -- bulk mode references them by filename.
+
+Single-driver mode: supply one of source|sourceFile.
+Bulk mode: 'installs' array of {source|sourceFile} objects. Errors on individual items do not abort the rest (continue-on-error). Practical limit: ~10-20 drivers per call. Cannot mix bulk and single-driver fields.
+
+Verifies install succeeded: if the hub accepted the request but the driver failed to compile, install_driver returns success=false with the error. Requires Hub Admin Write + confirm + backup <24h. Returns new driver ID(s).""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    source: [type: "string", description: "The full Groovy source code for the driver"],
+                    source: [type: "string", description: "Inline Groovy source (single-driver mode). ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install/redeploy. For non-trivial drivers, prefer sourceFile (recipe in tool description)."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    installs: [
+                        type: "array",
+                        description: "BULK MODE -- USE THIS WHEN INSTALLING >1 DRIVER (single round-trip vs N separate calls; same arg structure, just an array). Each entry: {source|sourceFile}. Cannot mix with single-driver fields (source/sourceFile). Continue-on-error: failures on individual items don't abort the rest. Practical limit ~10-20 drivers/call. Authorization is controlled by top-level 'confirm' only. PREFER each item's sourceFile (after CLI upload per recipe in tool description) over inline source.",
+                        items: [
+                            type: "object",
+                            properties: [
+                                sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED -- upload first via CLI per tool description recipe to bypass agent transcript)"],
+                                source: [type: "string", description: "Inline source (stubs only -- fills agent transcript)"]
+                            ]
+                        ]
+                    ],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
-                required: ["source", "confirm"]
+                required: ["confirm"]
             ]
         ],
         [
             name: "update_app_code",
             description: """⚠️ CRITICAL: Modify existing app code. Read current source first, explain changes, get confirmation.
 
-Modes: source (direct), sourceFile (from File Manager), resave (recompile without changes).
+PREFERRED workflow for any iterative app dev (avoids reading source into agent transcript):
+  1) Upload bytes via local CLI: 'curl -F uploadFile=@./app.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
+  2) update_app_code(appId: <id>, sourceFile: 'app.groovy', confirm: true)
+
+Modes: source (inline -- stubs only, fills agent transcript), sourceFile (RECOMMENDED -- bytes bypass agent context after CLI upload), resave (recompile without changes -- on-hub only, no source touched).
 Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h.""",
             inputSchema: [
                 type: "object",
                 properties: [
                     appId: [type: "string", description: "The app ID to update"],
-                    source: [type: "string", description: "The full new Groovy source code (for apps under 64KB)"],
-                    sourceFile: [type: "string", description: "File Manager file name containing the source code (e.g., 'mcp-source-app-467.groovy'). Use this for large apps to avoid cloud size limits."],
-                    resave: [type: "boolean", description: "Re-save the current source code without changes. Runs entirely on-hub — no cloud round-trip needed."],
+                    source: [type: "string", description: "Inline Groovy source. ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial apps, prefer sourceFile (recipe in tool description)."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    resave: [type: "boolean", description: "Re-save the current source code without changes. Runs entirely on-hub -- no source touches the agent transcript."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
                 required: ["appId", "confirm"]
@@ -2011,18 +2049,41 @@ Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h
             name: "update_driver_code",
             description: """⚠️ CRITICAL: Modify existing driver code. Read current source first, explain changes, get confirmation.
 
-Modes: source (direct), sourceFile (from File Manager), resave (recompile without changes).
+PREFERRED workflow for any iterative driver dev (avoids reading source into agent transcript):
+  1) Upload bytes via local CLI: 'curl -F uploadFile=@./driver.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
+  2) update_driver_code(driverId: <id>, sourceFile: 'driver.groovy', confirm: true)
+
+For >1 driver: USE BULK mode (single round-trip, not N): updates=[{driverId, sourceFile}, ...]. Each driver's bytes still uploaded once via CLI per the same recipe -- bulk-mode references them by filename.
+
+Single-driver mode: driverId + one of source|sourceFile|resave.
+Bulk mode: 'updates' array of {driverId, sourceFile|source|resave} objects. Errors on individual items do not abort the rest (continue-on-error). Practical limit: ~20 drivers per call. Cannot mix bulk and single-driver fields.
+
+Modes: source (inline -- stubs only, fills agent transcript), sourceFile (RECOMMENDED -- bytes bypass agent context after CLI upload), resave (recompile without changes -- on-hub only, no source touched).
 Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    driverId: [type: "string", description: "The driver ID to update"],
-                    source: [type: "string", description: "The full new Groovy source code (for drivers under 64KB)"],
-                    sourceFile: [type: "string", description: "File Manager file name containing the source code (e.g., 'mcp-source-driver-747.groovy'). Use this for large drivers to avoid cloud size limits."],
-                    resave: [type: "boolean", description: "Re-save the current source code without changes. Runs entirely on-hub — no cloud round-trip needed."],
+                    driverId: [type: "string", description: "The driver ID to update (single-driver mode). Omit when using 'updates' array for bulk."],
+                    source: [type: "string", description: "Inline Groovy source (single-driver mode). ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial drivers, prefer sourceFile (recipe in tool description)."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    resave: [type: "boolean", description: "Re-save the current source code without changes (single-driver mode). Runs entirely on-hub -- no source touches the agent transcript."],
+                    updates: [
+                        type: "array",
+                        description: "BULK MODE -- USE THIS WHEN UPDATING >1 DRIVER (single round-trip vs N separate calls; same arg structure, just an array). Each entry: {driverId, sourceFile|source|resave}. Cannot mix with single-driver fields (driverId/source/sourceFile/resave). Continue-on-error: failures on individual items don't abort the rest. Practical limit ~20 drivers/call. Authorization is controlled by top-level 'confirm' only; item-level 'confirm' is ignored. PREFER each item's sourceFile (after CLI upload per recipe in tool description) over inline source.",
+                        items: [
+                            type: "object",
+                            properties: [
+                                driverId: [type: "string", description: "The driver ID to update"],
+                                sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED -- upload first via CLI per tool description recipe to bypass agent transcript)"],
+                                source: [type: "string", description: "Inline source (stubs only -- fills agent transcript)"],
+                                resave: [type: "boolean", description: "Re-save without changes (no source touched)"]
+                            ],
+                            required: ["driverId"]
+                        ]
+                    ],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
-                required: ["driverId", "confirm"]
+                required: ["confirm"]
             ]
         ],
         [
@@ -9249,7 +9310,8 @@ def toolGetDriverSource(args) {
 }
 
 def toolInstallApp(args) {
-    return toolInstallItem("app", args)
+    requireHubAdminWrite(args.confirm)
+    return toolInstallItemSingle("app", args)
 }
 
 def toolInstallDriver(args) {
@@ -9257,40 +9319,169 @@ def toolInstallDriver(args) {
 }
 
 /**
- * Shared implementation for installing apps and drivers.
+ * install_driver dispatcher: single-driver mode or bulk mode.
+ *
+ * Single-driver mode: supply source (inline Groovy) or sourceFile (File Manager filename).
+ * After the install POST, verifies the new item is actually readable on-hub to catch
+ * the Hubitat false-positive pattern where the hub returns a redirect URL but the item
+ * failed to compile and was not persisted.
+ *
+ * Bulk mode: supply an 'installs' array of {source|sourceFile} objects. Each entry is
+ * applied in sequence using the same single-driver code path. Errors on individual items
+ * are recorded but do not abort remaining items (continue-on-error semantics). A
+ * practical limit of ~10-20 drivers per call is recommended; each install takes ~1-5s.
+ * Cannot supply both 'installs' and single-driver fields.
+ *
+ * install_app is single-item only; apps are typically one-of-a-kind installs.
  */
 private Map toolInstallItem(String type, args) {
     requireHubAdminWrite(args.confirm)
-    if (!args.source) throw new IllegalArgumentException("source (Groovy code) is required")
+
+    def idField = (type == "app") ? "appId" : "driverId"
+
+    // Bulk mode: installs array present -- validate then dispatch per-item
+    if (args.installs != null) {
+        if (args.source != null || args.sourceFile != null) {
+            throw new IllegalArgumentException("Cannot supply both 'installs' (bulk mode) and single-item fields (source/sourceFile). Use one mode or the other.")
+        }
+        if (!(args.installs instanceof List)) {
+            throw new IllegalArgumentException("'installs' must be an array of objects, each with 'source' or 'sourceFile'.")
+        }
+        if (args.installs.isEmpty()) {
+            throw new IllegalArgumentException("'installs' array must not be empty.")
+        }
+
+        // Bulk mode: apply each install in sequence, continue on per-item errors
+        def itemResults = []
+        def allSucceeded = true
+        args.installs.eachWithIndex { item, idx ->
+            if (!(item instanceof Map) || (item.source == null && item.sourceFile == null)) {
+                itemResults << [(idField): null, success: false, error: "Each installs entry must have a 'source' or 'sourceFile' field."]
+                allSucceeded = false
+                return
+            }
+            try {
+                def singleArgs = [confirm: args.confirm]
+                if (item.sourceFile != null) singleArgs.sourceFile = item.sourceFile
+                if (item.source != null) singleArgs.source = item.source
+                def r = toolInstallItemSingle(type, singleArgs)
+                def entry = [(idField): r[idField], success: r.success == true]
+                if (r.success) {
+                    if (r.sourceMode) entry.sourceMode = r.sourceMode
+                    if (r.name) entry.name = r.name
+                } else {
+                    entry.error = r.error ?: "Install failed"
+                    allSucceeded = false
+                }
+                itemResults << entry
+            } catch (Exception e) {
+                itemResults << [(idField): null, success: false, error: e.message ?: e.toString()]
+                allSucceeded = false
+            }
+        }
+
+        def successCount = itemResults.count { it.success == true }
+        mcpLog("info", "hub-admin", "Bulk install_${type}: ${successCount}/${itemResults.size()} succeeded")
+        return [
+            success: allSucceeded,
+            message: allSucceeded ? "All ${itemResults.size()} ${type}(s) installed successfully." : "${successCount} of ${itemResults.size()} ${type}(s) installed successfully.",
+            installs: itemResults,
+            lastBackup: formatTimestamp(state.lastBackupTimestamp)
+        ]
+    }
+
+    // Single-item mode: delegate to single-item helper
+    return toolInstallItemSingle(type, args)
+}
+
+/**
+ * Single-item install implementation shared by single-item mode and bulk mode per-item dispatch.
+ * Caller must have already invoked requireHubAdminWrite before reaching here.
+ */
+private Map toolInstallItemSingle(String type, args) {
+    def idField = (type == "app") ? "appId" : "driverId"
+
+    // Resolve source: sourceFile takes precedence when both are supplied
+    def sourceCode = null
+    def sourceMode = null
+    if (args.sourceFile && args.source) {
+        throw new IllegalArgumentException("Provide either 'source' (inline) OR 'sourceFile' (File Manager filename), not both.")
+    } else if (args.sourceFile) {
+        sourceMode = "sourceFile"
+        mcpLog("info", "hub-admin", "Reading ${type} source from File Manager: ${args.sourceFile}")
+        def bytes = downloadHubFile(args.sourceFile)
+        if (bytes == null) throw new IllegalArgumentException("Source file '${args.sourceFile}' not found in File Manager")
+        sourceCode = new String(bytes, "UTF-8")
+        mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from ${args.sourceFile}")
+    } else if (args.source) {
+        sourceMode = "source"
+        sourceCode = args.source
+    } else {
+        throw new IllegalArgumentException("Either 'source' (inline Groovy code) or 'sourceFile' (File Manager filename) is required")
+    }
 
     def savePath = (type == "app") ? "/app/save" : "/driver/save"
     def editorPath = (type == "app") ? "/app/editor/" : "/driver/editor/"
-    def idField = (type == "app") ? "appId" : "driverId"
+    def ajaxPath = (type == "app") ? "/app/ajax/code" : "/driver/ajax/code"
 
-    mcpLog("info", "hub-admin", "Installing new ${type}...")
+    mcpLog("info", "hub-admin", "Installing new ${type} (mode: ${sourceMode}, sourceLength: ${sourceCode.length()})...")
     try {
         def result = hubInternalPostForm(savePath, [
             id: "",
             version: "",
             create: "",
-            source: args.source
+            source: sourceCode
         ])
 
         def newItemId = null
         if (result?.location) {
             newItemId = result.location.replaceAll(".*?${editorPath}", "").replaceAll("[^0-9]", "")
+            if (!newItemId) newItemId = null  // reject empty string from replaceAll
         }
 
-        mcpLog("info", "hub-admin", "${type.capitalize()} installed successfully${newItemId ? ' (ID: ' + newItemId + ')' : ''}")
+        if (!newItemId) {
+            mcpLog("warn", "hub-admin", "${type.capitalize()} install: no ID in Location header -- install may have silently failed")
+            return [
+                success: false,
+                error: "Could not confirm ${type} installation -- hub returned no item ID. The ${type} may have a compile error or the hub rejected the source.",
+                (idField): null,
+                note: "Check Hubitat > Apps Code (or Drivers Code) for error details. The source may have syntax errors.",
+                lastBackup: formatTimestamp(state.lastBackupTimestamp)
+            ]
+        }
+
+        // Verify: confirm the hub actually persisted the item by fetching it back.
+        // Hubitat can return a Location redirect pointing at the editor while the
+        // item is in an error state (e.g., compile failure). A successful save
+        // returns status="ok" with a non-empty source field.
+        try {
+            def verifyText = hubInternalGet(ajaxPath, [id: newItemId])
+            if (verifyText) {
+                def verified = new groovy.json.JsonSlurper().parseText(verifyText)
+                if (verified.status == "error" || !verified.source) {
+                    def errMsg = verified.errorMessage ?: "item in error state after install"
+                    mcpLog("warn", "hub-admin", "${type.capitalize()} ID ${newItemId} installed but failed verification: ${errMsg}")
+                    return [
+                        success: false,
+                        error: "${type.capitalize()} installation failed: ${errMsg}",
+                        (idField): newItemId,
+                        note: "The hub created an item slot (ID: ${newItemId}) but reported an error. Check the Groovy source for compilation issues. You can view the error via get_app_source/get_driver_source with this ID."
+                    ]
+                }
+            }
+        } catch (Exception verifyErr) {
+            mcpLog("warn", "hub-admin", "${type.capitalize()} post-install verification fetch failed for ID ${newItemId}: ${verifyErr.message} -- assuming install succeeded")
+        }
+
+        mcpLog("info", "hub-admin", "${type.capitalize()} installed successfully (ID: ${newItemId}, mode: ${sourceMode})")
         def installResult = [
             success: true,
             message: "${type.capitalize()} installed successfully",
             (idField): newItemId,
+            sourceMode: sourceMode,
             lastBackup: formatTimestamp(state.lastBackupTimestamp)
         ]
-        if (!newItemId) {
-            installResult.warning = "Could not extract new ${type} ID from hub response. The ${type} was installed but you may need to check the Hubitat web UI to find it."
-        }
+        if (sourceMode == "sourceFile") installResult.note = "Source was read from File Manager file '${args.sourceFile}'."
         return installResult
     } catch (Exception e) {
         mcpLog("error", "hub-admin", "${type.capitalize()} installation failed: ${e.message}")
@@ -9304,6 +9495,16 @@ private Map toolInstallItem(String type, args) {
 
 def toolUpdateItemCode(String type, String idParam, args) {
     requireHubAdminWrite(args.confirm)
+    return toolUpdateItemCodeInner(type, idParam, args)
+}
+
+/**
+ * Inner implementation for updating app or driver source code.
+ * Caller must have already invoked requireHubAdminWrite before reaching here --
+ * used directly from the bulk loop in toolUpdateDriverCode where the outer gate
+ * fires once for the whole batch.
+ */
+private Map toolUpdateItemCodeInner(String type, String idParam, args) {
     def itemId = args[idParam]
     if (!itemId) throw new IllegalArgumentException("${idParam} is required")
 
@@ -9425,7 +9626,73 @@ def toolUpdateAppCode(args) {
     return toolUpdateItemCode("app", "appId", args)
 }
 
+/**
+ * update_driver_code dispatcher: single-driver mode or bulk mode.
+ *
+ * Single-driver mode: supply driverId + source|sourceFile|resave (unchanged).
+ *
+ * Bulk mode: supply an 'updates' array of {driverId, sourceFile} objects.
+ * Each entry is applied in sequence via toolUpdateItemCodeInner (gate fires
+ * once at the outer level -- not per-item). Errors on individual items are
+ * recorded but do not abort remaining items (continue-on-error semantics).
+ * A practical limit of ~20 items per call is recommended.
+ */
 def toolUpdateDriverCode(args) {
+    requireHubAdminWrite(args.confirm)
+
+    // Bulk mode validation: updates array and single-driver fields are mutually exclusive
+    if (args.updates != null) {
+        if (args.driverId != null || args.source != null || args.sourceFile != null || args.resave != null) {
+            throw new IllegalArgumentException("Cannot supply both 'updates' (bulk mode) and single-driver fields (driverId/source/sourceFile/resave). Use one mode or the other.")
+        }
+        if (!(args.updates instanceof List)) {
+            throw new IllegalArgumentException("'updates' must be an array of objects, each with 'driverId' and 'sourceFile' (or 'source' or 'resave').")
+        }
+        if (args.updates.isEmpty()) {
+            throw new IllegalArgumentException("'updates' array must not be empty.")
+        }
+
+        // Bulk mode: apply each update in sequence, continue on per-item errors
+        def itemResults = []
+        def allSucceeded = true
+        args.updates.eachWithIndex { item, idx ->
+            if (!(item instanceof Map) || !item.driverId) {
+                itemResults << [driverId: item?.driverId?.toString() ?: "item[${idx}]", success: false, error: "Each updates entry must have a 'driverId' field."]
+                allSucceeded = false
+                return
+            }
+            try {
+                def singleArgs = [driverId: item.driverId]
+                if (item.sourceFile != null) singleArgs.sourceFile = item.sourceFile
+                if (item.source != null) singleArgs.source = item.source
+                if (item.resave != null) singleArgs.resave = item.resave
+                def r = toolUpdateItemCodeInner("driver", "driverId", singleArgs)
+                def entry = [driverId: item.driverId.toString(), success: r.success == true]
+                if (r.success) {
+                    entry.sourceMode = r.sourceMode
+                    entry.sourceLength = r.sourceLength
+                } else {
+                    entry.error = r.error ?: "Update failed"
+                    allSucceeded = false
+                }
+                itemResults << entry
+            } catch (Exception e) {
+                itemResults << [driverId: item.driverId.toString(), success: false, error: e.message ?: e.toString()]
+                allSucceeded = false
+            }
+        }
+
+        def successCount = itemResults.count { it.success == true }
+        mcpLog("info", "hub-admin", "Bulk update_driver_code: ${successCount}/${itemResults.size()} succeeded")
+        return [
+            success: allSucceeded,
+            message: allSucceeded ? "All ${itemResults.size()} driver(s) updated successfully." : "${successCount} of ${itemResults.size()} driver(s) updated successfully.",
+            updates: itemResults,
+            lastBackup: formatTimestamp(state.lastBackupTimestamp)
+        ]
+    }
+
+    // Single-driver mode: unchanged behaviour
     return toolUpdateItemCode("driver", "driverId", args)
 }
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -9361,6 +9361,7 @@ private Map toolInstallItem(String type, args) {
                 } else {
                     entry.error = r.error ?: "Install failed"
                     if (r.note) entry.note = r.note
+                    if (r.lastBackup) entry.lastBackup = r.lastBackup
                     allSucceeded = false
                 }
                 itemResults << entry
@@ -9681,6 +9682,7 @@ def toolUpdateDriverCode(args) {
                 } else {
                     entry.error = r.error ?: "Update failed"
                     if (r.note) entry.note = r.note
+                    if (r.lastBackup) entry.lastBackup = r.lastBackup
                     allSucceeded = false
                 }
                 itemResults << entry

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1968,7 +1968,7 @@ Requires Hub Admin Write.""",
 PREFERRED workflow (avoids reading source into agent transcript):
   1) Upload bytes to File Manager via local CLI tool that bypasses agent context:
        curl -F 'uploadFile=@./app.groovy' -F 'folder=/' 'http://<hub>/hub/fileManager/upload'
-       (PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
+       (Add '-u admin:PASS' if Hub Security is enabled. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
   2) install_app(sourceFile: 'app.groovy', confirm: true)
 
 Inline 'source' is acceptable for stub-size snippets only. The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
@@ -1978,7 +1978,7 @@ Verifies install succeeded: if the hub accepted the request but the app failed t
                 type: "object",
                 properties: [
                     source: [type: "string", description: "Inline Groovy source. ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install/redeploy. For non-trivial apps, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
                 required: ["confirm"]
@@ -1991,7 +1991,7 @@ Verifies install succeeded: if the hub accepted the request but the app failed t
 PREFERRED workflow (avoids reading source into agent transcript):
   1) Upload bytes to File Manager via local CLI tool that bypasses agent context:
        curl -F 'uploadFile=@./driver.groovy' -F 'folder=/' 'http://<hub>/hub/fileManager/upload'
-       (PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
+       (Add '-u admin:PASS' if Hub Security is enabled. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
   2) install_driver(sourceFile: 'driver.groovy', confirm: true)
 
 Inline 'source' is acceptable for stub-size snippets only. The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
@@ -2006,7 +2006,7 @@ Verifies install succeeded: if the hub accepted the request but the driver faile
                 type: "object",
                 properties: [
                     source: [type: "string", description: "Inline Groovy source (single-driver mode). ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install/redeploy. For non-trivial drivers, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
                     installs: [
                         type: "array",
                         description: "BULK MODE -- USE THIS WHEN INSTALLING >1 DRIVER (single round-trip vs N separate calls; same arg structure, just an array). Each entry: {source|sourceFile}. Cannot mix with single-driver fields (source/sourceFile). Continue-on-error: failures on individual items don't abort the rest. Practical limit ~10-20 drivers/call. Authorization is controlled by top-level 'confirm' only. PREFER each item's sourceFile (after CLI upload per recipe in tool description) over inline source.",
@@ -2028,7 +2028,7 @@ Verifies install succeeded: if the hub accepted the request but the driver faile
             description: """⚠️ CRITICAL: Modify existing app code. Read current source first, explain changes, get confirmation.
 
 PREFERRED workflow for any iterative app dev (avoids reading source into agent transcript):
-  1) Upload bytes via local CLI: 'curl -F uploadFile=@./app.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
+  1) Upload bytes via local CLI: 'curl -F uploadFile=@./app.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
   2) update_app_code(appId: <id>, sourceFile: 'app.groovy', confirm: true)
 
 Modes: source (inline -- stubs only, fills agent transcript), sourceFile (RECOMMENDED -- bytes bypass agent context after CLI upload), resave (recompile without changes -- on-hub only, no source touched).
@@ -2038,7 +2038,7 @@ Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h
                 properties: [
                     appId: [type: "string", description: "The app ID to update"],
                     source: [type: "string", description: "Inline Groovy source. ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial apps, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
                     resave: [type: "boolean", description: "Re-save the current source code without changes. Runs entirely on-hub -- no source touches the agent transcript."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
@@ -2050,7 +2050,7 @@ Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h
             description: """⚠️ CRITICAL: Modify existing driver code. Read current source first, explain changes, get confirmation.
 
 PREFERRED workflow for any iterative driver dev (avoids reading source into agent transcript):
-  1) Upload bytes via local CLI: 'curl -F uploadFile=@./driver.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
+  1) Upload bytes via local CLI: 'curl -F uploadFile=@./driver.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
   2) update_driver_code(driverId: <id>, sourceFile: 'driver.groovy', confirm: true)
 
 For >1 driver: USE BULK mode (single round-trip, not N): updates=[{driverId, sourceFile}, ...]. Each driver's bytes still uploaded once via CLI per the same recipe -- bulk-mode references them by filename.
@@ -2065,7 +2065,7 @@ Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h
                 properties: [
                     driverId: [type: "string", description: "The driver ID to update (single-driver mode). Omit when using 'updates' array for bulk."],
                     source: [type: "string", description: "Inline Groovy source (single-driver mode). ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial drivers, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
                     resave: [type: "boolean", description: "Re-save the current source code without changes (single-driver mode). Runs entirely on-hub -- no source touches the agent transcript."],
                     updates: [
                         type: "array",
@@ -9310,6 +9310,9 @@ def toolGetDriverSource(args) {
 }
 
 def toolInstallApp(args) {
+    if (args.installs != null) {
+        throw new IllegalArgumentException("Bulk mode ('installs' array) is not supported for install_app. Apps do not cluster the way drivers do; install each app individually.")
+    }
     requireHubAdminWrite(args.confirm)
     return toolInstallItemSingle("app", args)
 }
@@ -9318,22 +9321,6 @@ def toolInstallDriver(args) {
     return toolInstallItem("driver", args)
 }
 
-/**
- * install_driver dispatcher: single-driver mode or bulk mode.
- *
- * Single-driver mode: supply source (inline Groovy) or sourceFile (File Manager filename).
- * After the install POST, verifies the new item is actually readable on-hub to catch
- * the Hubitat false-positive pattern where the hub returns a redirect URL but the item
- * failed to compile and was not persisted.
- *
- * Bulk mode: supply an 'installs' array of {source|sourceFile} objects. Each entry is
- * applied in sequence using the same single-driver code path. Errors on individual items
- * are recorded but do not abort remaining items (continue-on-error semantics). A
- * practical limit of ~10-20 drivers per call is recommended; each install takes ~1-5s.
- * Cannot supply both 'installs' and single-driver fields.
- *
- * install_app is single-item only; apps are typically one-of-a-kind installs.
- */
 private Map toolInstallItem(String type, args) {
     requireHubAdminWrite(args.confirm)
 
@@ -9369,13 +9356,16 @@ private Map toolInstallItem(String type, args) {
                 if (r.success) {
                     if (r.sourceMode) entry.sourceMode = r.sourceMode
                     if (r.sourceLength != null) entry.sourceLength = r.sourceLength
+                    if (r.verified != null) entry.verified = r.verified
+                    if (r.verifyError) entry.verifyError = r.verifyError
                 } else {
                     entry.error = r.error ?: "Install failed"
                     allSucceeded = false
                 }
                 itemResults << entry
             } catch (Exception e) {
-                itemResults << [(idField): null, success: false, error: e.message ?: e.toString()]
+                mcpLogError("hub-admin", "Bulk install_${type} item ${idx} threw", e)
+                itemResults << [(idField): null, success: false, error: e.message ?: e.toString(), errorClass: e.class.simpleName]
                 allSucceeded = false
             }
         }
@@ -9394,10 +9384,7 @@ private Map toolInstallItem(String type, args) {
     return toolInstallItemSingle(type, args)
 }
 
-/**
- * Single-item install implementation shared by single-item mode and bulk mode per-item dispatch.
- * Caller must have already invoked requireHubAdminWrite before reaching here.
- */
+// Caller must have already invoked requireHubAdminWrite -- gate fires once per call, not per bulk item.
 private Map toolInstallItemSingle(String type, args) {
     def idField = (type == "app") ? "appId" : "driverId"
 
@@ -9450,38 +9437,69 @@ private Map toolInstallItemSingle(String type, args) {
             ]
         }
 
-        // Verify: confirm the hub actually persisted the item by fetching it back.
-        // Hubitat can return a Location redirect pointing at the editor while the
-        // item is in an error state (e.g., compile failure). A successful save
-        // returns status="ok" with a non-empty source field.
+        // Best-effort verify: hub Location can point at editor while item is in error state.
+        def verifyText = null
+        def verifyError = null
+        def verified = null
+
         try {
-            def verifyText = hubInternalGet(ajaxPath, [id: newItemId])
-            if (verifyText) {
-                def verified = new groovy.json.JsonSlurper().parseText(verifyText)
-                if (verified.status == "error" || !verified.source) {
-                    def errMsg = verified.errorMessage ?: "item in error state after install"
-                    mcpLog("warn", "hub-admin", "${type.capitalize()} ID ${newItemId} installed but failed verification: ${errMsg}")
-                    return [
-                        success: false,
-                        error: "${type.capitalize()} installation failed: ${errMsg}",
-                        (idField): newItemId,
-                        note: "The hub created an item slot (ID: ${newItemId}) but reported an error. Check the Groovy source for compilation issues. You can view the error via get_app_source/get_driver_source with this ID."
-                    ]
-                }
-            }
+            verifyText = hubInternalGet(ajaxPath, [id: newItemId])
         } catch (Exception verifyErr) {
-            mcpLog("warn", "hub-admin", "${type.capitalize()} post-install verification fetch failed for ID ${newItemId}: ${verifyErr.message} -- assuming install succeeded")
+            verifyError = verifyErr.message ?: verifyErr.toString()
+            mcpLog("warn", "hub-admin", "${type.capitalize()} post-install verification fetch failed for ID ${newItemId}: ${verifyError}")
         }
 
-        mcpLog("info", "hub-admin", "${type.capitalize()} installed successfully (ID: ${newItemId}, mode: ${sourceMode})")
+        def bodyPresent = verifyText instanceof String && !verifyText.trim().isEmpty()
+
+        if (verifyError == null && bodyPresent) {
+            try {
+                verified = new groovy.json.JsonSlurper().parseText(verifyText)
+            } catch (Exception parseErr) {
+                mcpLog("warn", "hub-admin", "${type.capitalize()} ID ${newItemId}: verify body unparseable: ${parseErr.message}")
+                return [
+                    success: false,
+                    error: "${type.capitalize()} install unverified: hub returned unparseable verify body for ID ${newItemId}",
+                    (idField): newItemId,
+                    note: "Hub created an item slot but the verify response was not valid JSON (possibly an HTML error/login page). Use get_${type}_source with ID ${newItemId} to confirm whether the item persisted. Do NOT retry the install without checking first -- a duplicate item with a different ID may result.",
+                    lastBackup: formatTimestamp(state.lastBackupTimestamp)
+                ]
+            }
+
+            if (verified.status == "error" || !verified.source) {
+                def errMsg = verified.errorMessage ?: "item in error state after install"
+                mcpLog("warn", "hub-admin", "${type.capitalize()} ID ${newItemId} installed but failed verification: ${errMsg}")
+                return [
+                    success: false,
+                    error: "${type.capitalize()} installation failed: ${errMsg}",
+                    (idField): newItemId,
+                    note: "The hub created an item slot (ID: ${newItemId}) but reported an error. Check the Groovy source for compilation issues. You can view the error via get_app_source/get_driver_source with this ID.",
+                    lastBackup: formatTimestamp(state.lastBackupTimestamp)
+                ]
+            }
+        }
+
+        if (verifyError == null && !bodyPresent) {
+            mcpLog("warn", "hub-admin", "${type.capitalize()} ID ${newItemId}: verify endpoint returned empty body -- cannot confirm install")
+            return [
+                success: false,
+                error: "${type.capitalize()} install unverified: hub returned empty verify body for ID ${newItemId}",
+                (idField): newItemId,
+                note: "Hub created an item slot but the verify fetch returned no content. Use get_${type}_source with ID ${newItemId} to confirm whether the item persisted. Do NOT retry the install without checking first -- a duplicate item with a different ID may result.",
+                lastBackup: formatTimestamp(state.lastBackupTimestamp)
+            ]
+        }
+
+        mcpLog("info", "hub-admin", "${type.capitalize()} installed (ID: ${newItemId}, mode: ${sourceMode}, verified: ${verifyError == null})")
         def installResult = [
             success: true,
             message: "${type.capitalize()} installed successfully",
             (idField): newItemId,
             sourceMode: sourceMode,
             sourceLength: sourceCode.length(),
+            verified: (verifyError == null),
             lastBackup: formatTimestamp(state.lastBackupTimestamp)
         ]
+        if (verifyError != null) installResult.verifyError = "${verifyError} -- use get_${type}_source with ID ${newItemId} to confirm."
         if (sourceMode == "sourceFile") installResult.note = "Source was read from File Manager file '${args.sourceFile}'."
         return installResult
     } catch (Exception e) {
@@ -9499,12 +9517,7 @@ def toolUpdateItemCode(String type, String idParam, args) {
     return toolUpdateItemCodeInner(type, idParam, args)
 }
 
-/**
- * Inner implementation for updating app or driver source code.
- * Caller must have already invoked requireHubAdminWrite before reaching here --
- * used directly from the bulk loop in toolUpdateDriverCode where the outer gate
- * fires once for the whole batch.
- */
+// Caller must have already invoked requireHubAdminWrite -- gate fires once per call, not per bulk item.
 private Map toolUpdateItemCodeInner(String type, String idParam, args) {
     def itemId = args[idParam]
     if (!itemId) throw new IllegalArgumentException("${idParam} is required")
@@ -9624,20 +9637,12 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
 }
 
 def toolUpdateAppCode(args) {
+    if (args.updates != null) {
+        throw new IllegalArgumentException("Bulk mode ('updates' array) is not supported for update_app_code. Apps do not cluster the way drivers do; update each app individually.")
+    }
     return toolUpdateItemCode("app", "appId", args)
 }
 
-/**
- * update_driver_code dispatcher: single-driver mode or bulk mode.
- *
- * Single-driver mode: supply driverId + source|sourceFile|resave (unchanged).
- *
- * Bulk mode: supply an 'updates' array of {driverId, sourceFile} objects.
- * Each entry is applied in sequence via toolUpdateItemCodeInner (gate fires
- * once at the outer level -- not per-item). Errors on individual items are
- * recorded but do not abort remaining items (continue-on-error semantics).
- * A practical limit of ~20 items per call is recommended.
- */
 def toolUpdateDriverCode(args) {
     requireHubAdminWrite(args.confirm)
 
@@ -9678,7 +9683,8 @@ def toolUpdateDriverCode(args) {
                 }
                 itemResults << entry
             } catch (Exception e) {
-                itemResults << [driverId: item.driverId.toString(), success: false, error: e.message ?: e.toString()]
+                mcpLogError("hub-admin", "Bulk update_driver_code item ${idx} (driverId ${item.driverId}) threw", e)
+                itemResults << [driverId: item.driverId.toString(), success: false, error: e.message ?: e.toString(), errorClass: e.class.simpleName]
                 allSucceeded = false
             }
         }
@@ -9693,8 +9699,8 @@ def toolUpdateDriverCode(args) {
         ]
     }
 
-    // Single-driver mode: unchanged behaviour
-    return toolUpdateItemCode("driver", "driverId", args)
+    // Single-driver mode: gate already fired above, dispatch to Inner directly.
+    return toolUpdateItemCodeInner("driver", "driverId", args)
 }
 
 def toolDeleteApp(args) {

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -9360,6 +9360,7 @@ private Map toolInstallItem(String type, args) {
                     if (r.verifyError) entry.verifyError = r.verifyError
                 } else {
                     entry.error = r.error ?: "Install failed"
+                    if (r.note) entry.note = r.note
                     allSucceeded = false
                 }
                 itemResults << entry
@@ -9679,6 +9680,7 @@ def toolUpdateDriverCode(args) {
                     entry.sourceLength = r.sourceLength
                 } else {
                     entry.error = r.error ?: "Update failed"
+                    if (r.note) entry.note = r.note
                     allSucceeded = false
                 }
                 itemResults << entry

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -194,7 +194,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.note.contains('syntax errors')
     }
 
-    def "install_app proceeds with assumed success when post-install verification fetch throws"() {
+    def "install_app surfaces qualified success (verified:false, verifyError populated) when post-install verification fetch throws"() {
         given:
         enableHubAdminWrite()
         script.metaClass.hubInternalPostForm = { String path, Map body ->
@@ -210,6 +210,62 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         then:
         result.success == true
         result.appId == '7100'
+        result.verified == false
+        result.verifyError != null
+        result.verifyError.contains('transient error')
+        result.verifyError.contains('7100')
+    }
+
+    def "install_app returns success=false when verify endpoint returns an empty body"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: 'http://127.0.0.1:8080/app/editor/7200', data: '']
+        }
+        hubGet.register('/app/ajax/code') { params -> '' }
+
+        when:
+        def result = script.toolInstallApp([source: 'definition(name: "Test")', confirm: true])
+
+        then:
+        result.success == false
+        result.appId == '7200'
+        result.error.contains('empty verify body')
+        result.note.contains('Do NOT retry')
+        result.lastBackup != null
+    }
+
+    def "install_app returns success=false when verify endpoint returns unparseable HTML"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: 'http://127.0.0.1:8080/app/editor/7300', data: '']
+        }
+        hubGet.register('/app/ajax/code') { params -> '<html><body>Login required</body></html>' }
+
+        when:
+        def result = script.toolInstallApp([source: 'definition(name: "Test")', confirm: true])
+
+        then:
+        result.success == false
+        result.appId == '7300'
+        result.error.contains('unparseable verify body')
+        result.note.contains('not valid JSON')
+        result.note.contains('Do NOT retry')
+        result.lastBackup != null
+    }
+
+    def "install_app rejects bulk-mode args (installs[] not supported on apps)"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallApp([installs: [[source: 'a'], [source: 'b']], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("Bulk mode")
+        ex.message.contains("install_app")
     }
 
     def "install_driver (source mode) POSTs to /driver/save and returns the new driverId"() {
@@ -276,7 +332,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.error.contains('Unknown identifier')
     }
 
-    def "install_driver proceeds with assumed success when post-install verification fetch throws"() {
+    def "install_driver surfaces qualified success (verified:false, verifyError populated) when post-install verification fetch throws"() {
         given:
         enableHubAdminWrite()
         script.metaClass.hubInternalPostForm = { String path, Map body ->
@@ -292,6 +348,46 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         then:
         result.success == true
         result.driverId == '6600'
+        result.verified == false
+        result.verifyError != null
+        result.verifyError.contains('transient error')
+        result.verifyError.contains('6600')
+    }
+
+    def "install_driver returns success=false when verify endpoint returns an empty body"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: '/driver/editor/6700', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params -> '' }
+
+        when:
+        def result = script.toolInstallDriver([source: 'metadata { }', confirm: true])
+
+        then:
+        result.success == false
+        result.driverId == '6700'
+        result.error.contains('empty verify body')
+        result.note.contains('Do NOT retry')
+    }
+
+    def "install_driver returns success=false when verify endpoint returns unparseable HTML"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: '/driver/editor/6800', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params -> '<html>not json</html>' }
+
+        when:
+        def result = script.toolInstallDriver([source: 'metadata { }', confirm: true])
+
+        then:
+        result.success == false
+        result.driverId == '6800'
+        result.error.contains('unparseable verify body')
+        result.note.contains('Do NOT retry')
     }
 
     def "install_driver throws when Hub Admin Write is disabled"() {
@@ -450,7 +546,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.installs.size() == 3
         result.installs.every { it.success == true }
         result.installs*.driverId == ['9001', '9002', '9003']
-        result.installs*.sourceMode.every { it == 'sourceFile' }
+        result.installs.every { it.sourceMode == 'sourceFile' }
     }
 
     def "install_driver bulk mode partial failure: middle item missing file, outer two installed"() {
@@ -491,6 +587,132 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.installs[1].error.contains('not found in File Manager')
         result.installs[2].success == true
         result.installs[2].driverId == '8002'
+    }
+
+    def "install_driver bulk mode: inline source items work alongside sourceFile items"() {
+        given:
+        enableHubAdminWrite()
+        def callNum = 0
+        script.metaClass.downloadHubFile = { String fileName ->
+            'metadata { }'.getBytes('UTF-8')
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            callNum++
+            [status: 302, location: "/driver/editor/${8500 + callNum}", data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "source": "metadata { }", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallDriver([
+            installs: [
+                [source: 'metadata { name "inline-1" }'],
+                [sourceFile: 'driver-b.groovy'],
+                [source: 'metadata { name "inline-3" }']
+            ],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.installs.size() == 3
+        result.installs[0].sourceMode == 'source'
+        result.installs[1].sourceMode == 'sourceFile'
+        result.installs[2].sourceMode == 'source'
+    }
+
+    def "install_driver bulk mode: single-element installs array works"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: '/driver/editor/8900', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "source": "metadata { }", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallDriver([
+            installs: [[source: 'metadata { }']],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.installs.size() == 1
+        result.installs[0].driverId == '8900'
+    }
+
+    def "install_driver bulk mode: malformed entry (non-Map) yields per-item failure with index hint"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: '/driver/editor/9100', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "source": "metadata { }", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallDriver([
+            installs: [
+                [source: 'metadata { }'],
+                'not-a-map',
+                [:]
+            ],
+            confirm: true
+        ])
+
+        then:
+        result.success == false
+        result.installs.size() == 3
+        result.installs[0].success == true
+        result.installs[1].success == false
+        result.installs[1].error.contains("'source' or 'sourceFile'")
+        result.installs[2].success == false
+        result.installs[2].error.contains("'source' or 'sourceFile'")
+    }
+
+    def "install_driver bulk mode: per-item verify-throw surfaces verified=false and verifyError on the success entry"() {
+        given:
+        enableHubAdminWrite()
+        def callNum = 0
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            callNum++
+            [status: 302, location: "/driver/editor/${9300 + callNum}", data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            // middle item's verify GET throws, outer two return clean JSON
+            if (params?.id?.toString() == '9302') {
+                throw new RuntimeException('hub blip on verify')
+            }
+            '{"status": "ok", "source": "metadata { }", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallDriver([
+            installs: [
+                [source: 'metadata { name "a" }'],
+                [source: 'metadata { name "b" }'],
+                [source: 'metadata { name "c" }']
+            ],
+            confirm: true
+        ])
+
+        then: 'all three installs return success=true (POST succeeded for each)'
+        result.success == true
+        result.installs.size() == 3
+        result.installs.every { it.success == true }
+
+        and: 'middle item carries verified=false plus verifyError; outer two are verified=true'
+        result.installs[0].verified == true
+        result.installs[0].verifyError == null
+        result.installs[1].verified == false
+        result.installs[1].verifyError != null
+        result.installs[1].verifyError.contains('hub blip')
+        result.installs[2].verified == true
+        result.installs[2].verifyError == null
     }
 
     // -------- toolUpdateAppCode / toolUpdateDriverCode --------
@@ -661,6 +883,22 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.note.contains('syntax')
     }
 
+    def "update_app_code rejects bulk-mode args (updates[] not supported on apps)"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolUpdateAppCode([
+            updates: [[appId: '1', source: 'a'], [appId: '2', source: 'b']],
+            confirm: true
+        ])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("Bulk mode")
+        ex.message.contains("update_app_code")
+    }
+
     def "update_driver_code (single mode) delegates to toolUpdateItemCode with the driver paths"() {
         given:
         enableHubAdminWrite()
@@ -802,6 +1040,46 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         and: 'drivers 201 and 203 were actually posted; driver 202 was not'
         postedIds as Set == ['201', '203'] as Set
+    }
+
+    def "update_driver_code bulk mode: mixed resave and sourceFile entries dispatch correctly"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.downloadHubFile = { String fileName ->
+            'metadata { name "from-file" }'.getBytes('UTF-8')
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "version": 1, "source": "metadata { name \\"existing\\" }"}'
+        }
+        def postedSources = []
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            postedSources << body.source
+            [status: 200, location: null, data: '{"status": "success"}']
+        }
+
+        when:
+        def result = script.toolUpdateDriverCode([
+            updates: [
+                [driverId: '301', resave: true],
+                [driverId: '302', sourceFile: 'driver-302.groovy'],
+                [driverId: '303', source: 'metadata { name "inline" }']
+            ],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.updates.size() == 3
+        result.updates[0].sourceMode == 'resave'
+        result.updates[1].sourceMode == 'sourceFile'
+        result.updates[2].sourceMode == 'source'
+
+        and: 'each item posted with the correct source for its mode'
+        postedSources.size() == 3
+        postedSources[0].contains('existing')   // resave fetched from hub
+        postedSources[1].contains('from-file')  // sourceFile read from File Manager
+        postedSources[2].contains('inline')     // source passed inline
     }
 
     // -------- toolDeleteApp / toolDeleteDriver --------

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -5,24 +5,24 @@ import support.ToolSpecBase
 /**
  * Spec for the manage_app_driver_code gateway tools in hubitat-mcp-server.groovy:
  *
- * - toolInstallApp          -> install_app
- * - toolInstallDriver       -> install_driver
+ * - toolInstallApp          -> install_app         (source|sourceFile; post-install verification)
+ * - toolInstallDriver       -> install_driver      (source|sourceFile; bulk installs[]; post-install verification)
  * - toolUpdateAppCode       -> update_app_code     (three source modes: source, sourceFile, resave)
- * - toolUpdateDriverCode    -> update_driver_code  (three source modes)
+ * - toolUpdateDriverCode    -> update_driver_code  (three source modes + bulk updates array)
  * - toolDeleteApp           -> delete_app
  * - toolDeleteDriver        -> delete_driver
  * - toolRestoreItemBackup   -> restore_item_backup
  *
- * Every tool here runs through requireHubAdminWrite — golden-path tests seed:
+ * Every tool here runs through requireHubAdminWrite -- golden-path tests seed:
  *   settingsMap.enableHubAdminWrite = true
  *   stateMap.lastBackupTimestamp    = 1234567890000L   (matches fixed now())
  *   args.confirm                    = true
  *
  * Mocking strategy (see docs/testing.md):
- *   - hubInternalGet       — routed by HarnessSpec via hubGet.register(path) closures.
- *   - hubInternalPostForm  — script-defined helper, stubbed per-test on script.metaClass
+ *   - hubInternalGet       -- routed by HarnessSpec via hubGet.register(path) closures.
+ *   - hubInternalPostForm  -- script-defined helper, stubbed per-test on script.metaClass
  *                            (returns [status, location, data]).
- *   - uploadHubFile / downloadHubFile — purely dynamic, stubbed per-test on script.metaClass.
+ *   - uploadHubFile / downloadHubFile -- purely dynamic, stubbed per-test on script.metaClass.
  */
 class ToolAppDriverCodeSpec extends ToolSpecBase {
 
@@ -54,7 +54,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         ex.message.contains('Hub Admin Write')
     }
 
-    def "install_app throws when source is missing"() {
+    def "install_app throws when neither source nor sourceFile is provided"() {
         given:
         enableHubAdminWrite()
 
@@ -66,7 +66,19 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         ex.message.contains('source')
     }
 
-    def "install_app POSTs to /app/save and extracts the new appId from the Location header"() {
+    def "install_app throws when both source and sourceFile are provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallApp([source: 'code', sourceFile: 'app.groovy', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("not both")
+    }
+
+    def "install_app (source mode) POSTs to /app/save, verifies via ajax/code, and extracts the new appId"() {
         given:
         enableHubAdminWrite()
         def captured = [:]
@@ -74,6 +86,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             captured.path = path
             captured.body = body
             [status: 302, location: 'http://127.0.0.1:8080/app/editor/4242', data: '']
+        }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "source": "definition(name: \"Hello\")", "version": 1}'
         }
 
         when:
@@ -86,10 +101,47 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         captured.body.create == ''
         result.success == true
         result.appId == '4242'
+        result.sourceMode == 'source'
         result.message.contains('installed')
     }
 
-    def "install_app returns success with warning when the Location header is absent"() {
+    def "install_app (sourceFile mode) reads source from File Manager and installs it"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.downloadHubFile = { String fileName ->
+            fileName == 'my-app.groovy' ? 'definition(name: "FromFile")'.getBytes('UTF-8') : null
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: 'http://127.0.0.1:8080/app/editor/5555', data: '']
+        }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "source": "definition(name: \"FromFile\")", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallApp([sourceFile: 'my-app.groovy', confirm: true])
+
+        then:
+        result.success == true
+        result.appId == '5555'
+        result.sourceMode == 'sourceFile'
+        result.note.contains('File Manager')
+    }
+
+    def "install_app (sourceFile mode) throws when the file is absent in File Manager"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.downloadHubFile = { String fileName -> null }
+
+        when:
+        script.toolInstallApp([sourceFile: 'missing.groovy', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('not found in File Manager')
+    }
+
+    def "install_app returns success=false when Location header is absent (hub did not persist item)"() {
         given:
         enableHubAdminWrite()
         script.metaClass.hubInternalPostForm = { String path, Map body ->
@@ -100,9 +152,29 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         def result = script.toolInstallApp([source: 'definition(name: "NoLoc")', confirm: true])
 
         then:
-        result.success == true
+        result.success == false
         result.appId == null
-        result.warning.contains('Could not extract')
+        result.error.contains('no item ID')
+    }
+
+    def "install_app returns success=false when post-install verification shows an error state"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: 'http://127.0.0.1:8080/app/editor/9900', data: '']
+        }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "error", "errorMessage": "Compilation failed: unexpected token"}'
+        }
+
+        when:
+        def result = script.toolInstallApp([source: 'bad source', confirm: true])
+
+        then:
+        result.success == false
+        result.appId == '9900'
+        result.error.contains('Compilation failed')
+        result.note.contains('9900')
     }
 
     def "install_app reports failure when the hub POST throws"() {
@@ -122,13 +194,34 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.note.contains('syntax errors')
     }
 
-    def "install_driver POSTs to /driver/save and returns the new driverId"() {
+    def "install_app proceeds with assumed success when post-install verification fetch throws"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: 'http://127.0.0.1:8080/app/editor/7100', data: '']
+        }
+        hubGet.register('/app/ajax/code') { params ->
+            throw new RuntimeException('transient error')
+        }
+
+        when:
+        def result = script.toolInstallApp([source: 'definition(name: "Test")', confirm: true])
+
+        then:
+        result.success == true
+        result.appId == '7100'
+    }
+
+    def "install_driver (source mode) POSTs to /driver/save and returns the new driverId"() {
         given:
         enableHubAdminWrite()
         def postedPath = null
         script.metaClass.hubInternalPostForm = { String path, Map body ->
             postedPath = path
             [status: 302, location: '/driver/editor/9001', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "source": "metadata { }", "version": 1}'
         }
 
         when:
@@ -138,6 +231,266 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         postedPath == '/driver/save'
         result.success == true
         result.driverId == '9001'
+        result.sourceMode == 'source'
+    }
+
+    def "install_driver (sourceFile mode) reads source from File Manager and installs it"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.downloadHubFile = { String fileName ->
+            fileName == 'my-driver.groovy' ? 'metadata { }'.getBytes('UTF-8') : null
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: '/driver/editor/7777', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "source": "metadata { }", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallDriver([sourceFile: 'my-driver.groovy', confirm: true])
+
+        then:
+        result.success == true
+        result.driverId == '7777'
+        result.sourceMode == 'sourceFile'
+        result.note.contains('File Manager')
+    }
+
+    def "install_driver returns success=false when post-install verification shows an error state"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: '/driver/editor/8800', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "error", "errorMessage": "Unknown identifier: xyz"}'
+        }
+
+        when:
+        def result = script.toolInstallDriver([source: 'bad driver', confirm: true])
+
+        then:
+        result.success == false
+        result.driverId == '8800'
+        result.error.contains('Unknown identifier')
+    }
+
+    def "install_driver proceeds with assumed success when post-install verification fetch throws"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: '/driver/editor/6600', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            throw new RuntimeException('transient error')
+        }
+
+        when:
+        def result = script.toolInstallDriver([source: 'metadata { }', confirm: true])
+
+        then:
+        result.success == true
+        result.driverId == '6600'
+    }
+
+    def "install_driver throws when Hub Admin Write is disabled"() {
+        when:
+        script.toolInstallDriver([source: 'metadata { }', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Write')
+    }
+
+    def "install_driver throws when confirm is not provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallDriver([source: 'metadata { }'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('SAFETY CHECK FAILED')
+    }
+
+    def "install_driver throws when neither source nor sourceFile is provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallDriver([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('source')
+    }
+
+    def "install_driver throws when both source and sourceFile are provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallDriver([source: 'metadata { }', sourceFile: 'driver.groovy', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('not both')
+    }
+
+    def "install_driver throws when sourceFile is not found in File Manager"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.downloadHubFile = { String fileName -> null }
+
+        when:
+        script.toolInstallDriver([sourceFile: 'missing.groovy', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('not found in File Manager')
+    }
+
+    def "install_driver returns success=false when Location header is absent (hub did not persist item)"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 200, location: null, data: 'ok']
+        }
+
+        when:
+        def result = script.toolInstallDriver([source: 'metadata { }', confirm: true])
+
+        then:
+        result.success == false
+        result.driverId == null
+        result.error.contains('no item ID')
+    }
+
+    def "install_driver reports failure when the hub POST throws"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            throw new RuntimeException('compile error: syntax problem')
+        }
+
+        when:
+        def result = script.toolInstallDriver([source: 'bad', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('installation failed')
+        result.error.contains('compile error')
+        result.note.contains('syntax errors')
+    }
+
+    // -------- install_driver bulk mode --------
+
+    def "install_driver bulk mode throws when Hub Admin Write is disabled"() {
+        when:
+        script.toolInstallDriver([installs: [[sourceFile: 'f.groovy']], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Write')
+    }
+
+    def "install_driver bulk mode throws when both installs and sourceFile are supplied"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallDriver([sourceFile: 'x.groovy', installs: [[sourceFile: 'f.groovy']], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('bulk mode')
+        ex.message.contains('source')
+    }
+
+    def "install_driver bulk mode throws when installs is an empty array"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallDriver([installs: [], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('must not be empty')
+    }
+
+    def "install_driver bulk mode happy path: 3 drivers all succeed, per-item driverIds returned"() {
+        given:
+        enableHubAdminWrite()
+        def callNum = 0
+        script.metaClass.downloadHubFile = { String fileName -> 'metadata { }'.getBytes('UTF-8') }
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            callNum++
+            [status: 302, location: "/driver/editor/${9000 + callNum}", data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "source": "metadata { }", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallDriver([
+            installs: [
+                [sourceFile: 'driver-a.groovy'],
+                [sourceFile: 'driver-b.groovy'],
+                [sourceFile: 'driver-c.groovy']
+            ],
+            confirm: true
+        ])
+
+        then: 'top-level result indicates overall success'
+        result.success == true
+        result.message.contains('3')
+        result.installs.size() == 3
+        result.installs.every { it.success == true }
+        result.installs*.driverId == ['9001', '9002', '9003']
+        result.installs*.sourceMode.every { it == 'sourceFile' }
+    }
+
+    def "install_driver bulk mode partial failure: middle item missing file, outer two installed"() {
+        given:
+        enableHubAdminWrite()
+        def callNum = 0
+        script.metaClass.downloadHubFile = { String fileName ->
+            // driver-b.groovy is missing -- simulate absent file
+            fileName == 'driver-b.groovy' ? null : 'metadata { }'.getBytes('UTF-8')
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            callNum++
+            [status: 302, location: "/driver/editor/${8000 + callNum}", data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "source": "metadata { }", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallDriver([
+            installs: [
+                [sourceFile: 'driver-a.groovy'],
+                [sourceFile: 'driver-b.groovy'],
+                [sourceFile: 'driver-c.groovy']
+            ],
+            confirm: true
+        ])
+
+        then: 'top-level success=false because not all items succeeded'
+        result.success == false
+        result.message.contains('2 of 3')
+
+        and: 'per-item results carry correct status'
+        result.installs[0].success == true
+        result.installs[0].driverId == '8001'
+        result.installs[1].success == false
+        result.installs[1].driverId == null
+        result.installs[1].error.contains('not found in File Manager')
+        result.installs[2].success == true
+        result.installs[2].driverId == '8002'
     }
 
     // -------- toolUpdateAppCode / toolUpdateDriverCode --------
@@ -308,7 +661,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.note.contains('syntax')
     }
 
-    def "update_driver_code delegates to toolUpdateItemCode with the driver paths"() {
+    def "update_driver_code (single mode) delegates to toolUpdateItemCode with the driver paths"() {
         given:
         enableHubAdminWrite()
         hubGet.register('/driver/ajax/code') { params ->
@@ -329,6 +682,126 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.success == true
         result.driverId == '55'
         result.sourceMode == 'source'
+    }
+
+    // -------- update_driver_code bulk mode --------
+
+    def "update_driver_code bulk mode throws when Hub Admin Write is disabled"() {
+        when:
+        script.toolUpdateDriverCode([updates: [[driverId: '1', sourceFile: 'f.groovy']], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Write')
+    }
+
+    def "update_driver_code bulk mode throws when both updates and driverId are supplied"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolUpdateDriverCode([driverId: '10', updates: [[driverId: '20', sourceFile: 'f.groovy']], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('bulk mode')
+        ex.message.contains('driverId')
+    }
+
+    def "update_driver_code bulk mode throws when updates is an empty array"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolUpdateDriverCode([updates: [], confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('must not be empty')
+    }
+
+    def "update_driver_code bulk mode happy path: 3 drivers all succeed"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "version": 1, "source": "metadata { }"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.downloadHubFile = { String fileName -> 'metadata { }'.getBytes('UTF-8') }
+        def updatePaths = []
+        def updateIds = []
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            updatePaths << path
+            updateIds << body.id?.toString()
+            [status: 200, location: null, data: '{"status": "success"}']
+        }
+
+        when:
+        def result = script.toolUpdateDriverCode([
+            updates: [
+                [driverId: '101', sourceFile: 'driver-101.groovy'],
+                [driverId: '102', sourceFile: 'driver-102.groovy'],
+                [driverId: '103', sourceFile: 'driver-103.groovy']
+            ],
+            confirm: true
+        ])
+
+        then: 'top-level result indicates overall success'
+        result.success == true
+        result.message.contains('3')
+        result.updates.size() == 3
+        result.updates.every { it.success == true }
+        result.updates*.driverId == ['101', '102', '103']
+
+        and: 'each driver was independently posted to the update path'
+        updatePaths.every { it == '/driver/ajax/update' }
+        updateIds as Set == ['101', '102', '103'] as Set
+    }
+
+    def "update_driver_code bulk mode partial failure: middle driver fails, outer two still applied"() {
+        given:
+        enableHubAdminWrite()
+        def callCount = 0
+        hubGet.register('/driver/ajax/code') { params ->
+            callCount++
+            '{"status": "ok", "version": 1, "source": "metadata { }"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.downloadHubFile = { String fileName ->
+            // driver-202.groovy is the middle item -- simulate it missing
+            fileName == 'driver-202.groovy' ? null : 'metadata { }'.getBytes('UTF-8')
+        }
+        def postedIds = []
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            postedIds << body.id?.toString()
+            [status: 200, location: null, data: '{"status": "success"}']
+        }
+
+        when:
+        def result = script.toolUpdateDriverCode([
+            updates: [
+                [driverId: '201', sourceFile: 'driver-201.groovy'],
+                [driverId: '202', sourceFile: 'driver-202.groovy'],
+                [driverId: '203', sourceFile: 'driver-203.groovy']
+            ],
+            confirm: true
+        ])
+
+        then: 'top-level success=false because not all items succeeded'
+        result.success == false
+        result.message.contains('2 of 3')
+
+        and: 'per-item results carry correct status'
+        result.updates[0].success == true
+        result.updates[0].driverId == '201'
+        result.updates[1].success == false
+        result.updates[1].driverId == '202'
+        result.updates[1].error.contains('not found in File Manager')
+        result.updates[2].success == true
+        result.updates[2].driverId == '203'
+
+        and: 'drivers 201 and 203 were actually posted; driver 202 was not'
+        postedIds as Set == ['201', '203'] as Set
     }
 
     // -------- toolDeleteApp / toolDeleteDriver --------

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -1124,6 +1124,71 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         postedSources[2].contains('inline')     // source passed inline
     }
 
+    def "update_driver_code bulk mode: per-item update failure propagates note and lastBackup on the failed entry"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "version": 1, "source": "metadata { }"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        // Middle item's hub POST returns status=failure body — reaches toolUpdateItemCodeInner's
+        // else branch (now carrying note + lastBackup after this PR's symmetry fix).
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            if (body.id == '402') {
+                [status: 200, location: null, data: '{"status": "failure", "errorMessage": "version conflict"}']
+            } else {
+                [status: 200, location: null, data: '{"status": "success"}']
+            }
+        }
+
+        when:
+        def result = script.toolUpdateDriverCode([
+            updates: [
+                [driverId: '401', source: 'metadata { name "a" }'],
+                [driverId: '402', source: 'metadata { name "b" }'],
+                [driverId: '403', source: 'metadata { name "c" }']
+            ],
+            confirm: true
+        ])
+
+        then: 'overall partial: 2 of 3 succeeded'
+        result.success == false
+        result.updates.size() == 3
+        result.updates[0].success == true
+        result.updates[1].success == false
+        result.updates[2].success == true
+
+        and: 'failed entry propagates error, note (anti-retry), and lastBackup from the inner failure return'
+        result.updates[1].error != null
+        result.updates[1].error.toLowerCase().contains('version conflict')
+        result.updates[1].note != null
+        result.updates[1].note.contains('compilation issues')
+        result.updates[1].lastBackup != null
+    }
+
+    def "install_driver returns success=false when verify endpoint returns clean JSON with empty source field"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 302, location: '/driver/editor/4444', data: '']
+        }
+        // Verify response parses cleanly but reports empty source — driver slot created but
+        // no body persisted. Distinct from status:"error" and from empty/unparseable body.
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "source": "", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallDriver([source: 'metadata { }', confirm: true])
+
+        then:
+        result.success == false
+        result.error.toLowerCase().contains('installation failed')
+        result.driverId == '4444'
+        result.note.contains('compilation issues')
+        result.lastBackup != null
+    }
+
     // -------- toolDeleteApp / toolDeleteDriver --------
 
     def "delete_app throws when confirm is not provided"() {

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -715,6 +715,48 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.installs[2].verifyError == null
     }
 
+    def "install_driver bulk mode: per-item verify status=error propagates error, note, and lastBackup on the failed entry"() {
+        given:
+        enableHubAdminWrite()
+        def callNum = 0
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            callNum++
+            [status: 302, location: "/driver/editor/${9400 + callNum}", data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params ->
+            // middle item's verify returns status=error (compile failure surfaced post-install)
+            if (params?.id?.toString() == '9402') {
+                '{"status": "error", "errorMessage": "compile failed: bad syntax"}'
+            } else {
+                '{"status": "ok", "source": "metadata { }", "version": 1}'
+            }
+        }
+
+        when:
+        def result = script.toolInstallDriver([
+            installs: [
+                [source: 'metadata { name "a" }'],
+                [source: 'metadata { name "b" }'],
+                [source: 'metadata { name "c" }']
+            ],
+            confirm: true
+        ])
+
+        then: 'overall partial: 2 of 3 succeeded'
+        result.success == false
+        result.installs.size() == 3
+        result.installs[0].success == true
+        result.installs[1].success == false
+        result.installs[2].success == true
+
+        and: 'failed entry propagates error, note (anti-retry), and lastBackup from the inner failure return'
+        result.installs[1].error != null
+        result.installs[1].error.toLowerCase().contains('compile failed')
+        result.installs[1].note != null
+        result.installs[1].note.contains('compilation issues')
+        result.installs[1].lastBackup != null
+    }
+
     // -------- toolUpdateAppCode / toolUpdateDriverCode --------
 
     def "update_app_code throws when confirm is not provided"() {

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -88,7 +88,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             [status: 302, location: 'http://127.0.0.1:8080/app/editor/4242', data: '']
         }
         hubGet.register('/app/ajax/code') { params ->
-            '{"status": "ok", "source": "definition(name: \"Hello\")", "version": 1}'
+            '{"status": "ok", "source": "stub-app-source", "version": 1}'
         }
 
         when:
@@ -115,7 +115,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             [status: 302, location: 'http://127.0.0.1:8080/app/editor/5555', data: '']
         }
         hubGet.register('/app/ajax/code') { params ->
-            '{"status": "ok", "source": "definition(name: \"FromFile\")", "version": 1}'
+            '{"status": "ok", "source": "stub-app-source-from-file", "version": 1}'
         }
 
         when:

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -4,7 +4,7 @@ Updated for the installed-apps + Rule Machine interop + native CRUD architecture
 
 Comprehensive test scenarios for the Hubitat MCP Rule Server. Modeled after ha-mcp's BAT framework.
 
-> **Supplement**: see [`tests/BAT-rm-native-crud.md`](./BAT-rm-native-crud.md) for the native-RM CRUD suite (T300+) -- acceptance gate for the `manage_native_rules_and_apps` CRUD tools (`create_native_app`, `update_native_app`, `delete_native_app`, `check_rule_health`). Those tools are shipped; all scenarios in that file should pass against the current codebase.
+> **Supplement**: see [`tests/BAT-rm-native-crud.md`](./BAT-rm-native-crud.md) for the native-RM CRUD suite (T300-T399) -- acceptance gate for the `manage_native_rules_and_apps` CRUD tools (`create_native_app`, `update_native_app`, `delete_native_app`, `check_rule_health`). Those tools are shipped; all scenarios in that file should pass against the current codebase.
 
 Each test is a JSON scenario with optional `setup_prompt`, required `test_prompt`, and optional `teardown_prompt`. Run each prompt in the same AI session (setup → test → teardown). Each TEST SCENARIO starts a fresh session.
 
@@ -2267,6 +2267,7 @@ These operations are too destructive for automated testing. Test manually with e
 | 9. Stress | T120-T122 | Many calls, rapid cycles, pagination |
 | 10. NL Discovery | T200-T301 | Conversational prompts — no tool names |
 | 12. Developer Mode | T219-T226 | Self-administration: update_mcp_settings + delete_variable |
+| 13. Driver Code Lifecycle | T400-T406 | install_driver (single + bulk), update_driver_code (bulk), delete |
 
 ### Architecture (post installed-apps + RM interop + Developer Mode)
 
@@ -2652,6 +2653,92 @@ These tests exercise the Developer Mode self-administration surface — the `man
 ```
 
 **Expected**: Gateway parameter validation returns an `isError: true` result with message `"Missing required parameter(s): confirm"` and a `parameters` description listing the schema (name, confirm, force). No JSON-RPC error code is set — the validation happens at the gateway layer before tool dispatch. The variable is preserved. AI relays the gate requirement and offers to retry with `confirm=true`.
+
+---
+
+## Section 13: Driver Code Lifecycle Tests (manage_app_driver_code)
+
+All tests below require Hub Admin Write enabled and a recent backup. Tests are excluded from the auto-exercise sweep (destructive to hub code). Test artifacts use the `BAT_` name prefix per BAT convention so they can be identified and cleaned up independently.
+
+### T400 — install_driver via sourceFile (File Manager path)
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists. Write a minimal driver stub to File Manager: write_file(fileName='bat-test-driver.groovy', content='metadata { definition(name: \"BAT_DriverCodeLifecycle\", namespace: \"bat\", author: \"test\") { } }').",
+  "test_prompt": "Install the driver using install_driver with sourceFile='bat-test-driver.groovy' and confirm=true. Report the new driver ID.",
+  "teardown_prompt": "Delete the driver installed in this test using delete_driver with the driverId returned above and confirm=true. Also delete the File Manager file bat-test-driver.groovy using delete_file."
+}
+```
+
+**Expected**: Tool resolves the file from File Manager, POSTs to `/driver/save`, fetches the new driver back to verify it compiled, and returns `success: true` with `driverId` set and `sourceMode: 'sourceFile'`. No inline source was sent in the install call -- the source came from File Manager.
+
+### T401 — install_driver compile failure detected (post-install verification)
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists. This test intentionally installs broken Groovy source -- the hub creates a stub slot in an error state (BAT_BrokenInstallStub). Note the driver ID returned for cleanup.",
+  "test_prompt": "Install a driver with deliberately broken syntax using install_driver(source='this is not valid groovy {{ }}', confirm=true). Report what happens.",
+  "teardown_prompt": "Delete the error-state driver slot created in this test using delete_driver with the driverId returned and confirm=true."
+}
+```
+
+**Expected**: Hub creates an item slot (returns a redirect with an ID) but the post-install verification detects `status: error` from `/driver/ajax/code`. Tool returns `success: false` with the compile error message and the item ID in the response. AI reports the error and does not claim success.
+
+### T402 — update_driver_code bulk mode (happy path)
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists. Install two minimal BAT_ driver stubs via install_driver: (1) source='metadata { definition(name: \"BAT_BulkUpdate1\", namespace: \"bat\", author: \"test\") { } }' and (2) source='metadata { definition(name: \"BAT_BulkUpdate2\", namespace: \"bat\", author: \"test\") { } }'. Note both driverIds. Write updated source for each to File Manager with a version comment appended: write_file(fileName='bat-bulk-1.groovy', content='...updated source...') and similarly for bat-bulk-2.groovy.",
+  "test_prompt": "Update both drivers in a single call using update_driver_code with updates=[{driverId: '<id1>', sourceFile: 'bat-bulk-1.groovy'}, {driverId: '<id2>', sourceFile: 'bat-bulk-2.groovy'}] and confirm=true.",
+  "teardown_prompt": "Delete both BAT_ drivers using delete_driver with confirm=true for each driverId. Also delete the File Manager files bat-bulk-1.groovy and bat-bulk-2.groovy using delete_file."
+}
+```
+
+**Expected**: Tool applies both updates sequentially. Returns `success: true` with `updates` array containing two entries, each with `success: true`, `driverId`, and `sourceMode: 'sourceFile'`. `message` says "All 2 driver(s) updated successfully."
+
+### T403 — update_driver_code bulk mode rejects mixed single+bulk args
+
+```json
+{
+  "test_prompt": "Call update_driver_code with both driverId='123' AND updates=[{driverId: '456', sourceFile: 'f.groovy'}] and confirm=true."
+}
+```
+
+**Expected**: Tool throws `IllegalArgumentException` (JSON-RPC -32602) with a message containing 'bulk mode' and 'driverId'. No update is performed.
+
+### T404 — install_driver bulk mode (happy path)
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists. Write two minimal driver stubs to File Manager: write_file(fileName='bat-bulk-install-1.groovy', content='metadata { definition(name: \"BAT_BulkInstall1\", namespace: \"bat\", author: \"test\") { } }') and write_file(fileName='bat-bulk-install-2.groovy', content='metadata { definition(name: \"BAT_BulkInstall2\", namespace: \"bat\", author: \"test\") { } }').",
+  "test_prompt": "Install both drivers in a single call using install_driver with installs=[{sourceFile: 'bat-bulk-install-1.groovy'}, {sourceFile: 'bat-bulk-install-2.groovy'}] and confirm=true. Report the driver IDs returned.",
+  "teardown_prompt": "Delete both BAT_ drivers installed above using delete_driver with confirm=true for each driverId. Also delete the File Manager files bat-bulk-install-1.groovy and bat-bulk-install-2.groovy using delete_file."
+}
+```
+
+**Expected**: Tool installs both drivers in a single call, resolving each from File Manager. Returns `success: true` with `installs` array containing two entries, each with `success: true`, a non-null `driverId`, and `sourceMode: 'sourceFile'`. `message` says "All 2 driver(s) installed successfully." No inline source was passed in the call.
+
+### T405 — install_driver bulk mode partial failure
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists. Write one driver stub to File Manager: write_file(fileName='bat-bulk-partial.groovy', content='metadata { definition(name: \"BAT_BulkPartial\", namespace: \"bat\", author: \"test\") { } }'). Do NOT write 'bat-bulk-missing.groovy'.",
+  "test_prompt": "Install two drivers in a single bulk call: install_driver with installs=[{sourceFile: 'bat-bulk-partial.groovy'}, {sourceFile: 'bat-bulk-missing.groovy'}] and confirm=true. Report what happens for each item.",
+  "teardown_prompt": "Delete the successfully installed BAT_BulkPartial driver using delete_driver with confirm=true. Delete the File Manager file bat-bulk-partial.groovy using delete_file."
+}
+```
+
+**Expected**: Tool attempts both installs. First item succeeds (driverId returned, success: true). Second item fails because the file is absent (success: false, error contains 'not found in File Manager'). Top-level `success: false` with `message` containing '1 of 2'. Continue-on-error: first driver still installed despite second failure.
+
+### T406 — install_driver bulk mode rejects mixed single+bulk args
+
+```json
+{
+  "test_prompt": "Call install_driver with both sourceFile='x.groovy' AND installs=[{sourceFile: 'f.groovy'}] and confirm=true."
+}
+```
+
+**Expected**: Tool throws `IllegalArgumentException` (JSON-RPC -32602) with a message containing 'bulk mode' and 'source'. No install is attempted.
 
 ---
 


### PR DESCRIPTION
## Summary

Five coupled improvements to the `manage_app_driver_code` gateway, all in service of agent-driven driver/app development workflows on Hubitat — both for this server's own iteration loops and for platform users/developers building their own drivers and apps with LLM tooling:

- `install_app` and `install_driver` now accept a `sourceFile` parameter (matches existing `update_*_code` pattern). Tool descriptions PRESCRIBE the curl-upload + sourceFile workflow that bypasses agent transcript bytes entirely.
- `install_driver` now verifies the driver was actually persisted to the hub before returning success. Throws `IllegalStateException` on verification failure rather than silently returning `success: true`.
- `update_driver_code` extended with optional `updates[]` array for bulk multi-driver updates. Per-item continue-on-error. Single-driver call shape unchanged for backward compat.
- `install_driver` extended with optional `installs[]` array for bulk install (drivers cluster around device families — Levoit purifier/fan/humidifier, Twinkly variants, Z-Wave dimmer family, etc.). `install_app` intentionally NOT extended with bulk: apps don't cluster, so bulk install of N unrelated apps has no real use case.
- Tool descriptions across all affected paths sharpened to PRESCRIBE the curl + sourceFile + bulk pattern rather than describe alternatives. Validated empirically — zero-context Sonnet picked all four patterns on first try (see Validation section).

Part of an ongoing series making Hubitat a first-class LLM-driven development target. Companion to recent merges in the same vein — #145 (`manage_mcp_self`), #153 (list_devices filters + projection), #155 (get_hub_logs filters), #157 (poll_until_attribute) — agent-budget reclaim is becoming a coherent throughline across this PR series.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

### `install_app` / `install_driver` — `sourceFile` parameter

Both tools now accept either inline `source` OR `sourceFile` (filename in hub File Manager). Tool descriptions explicitly **prescribe** the curl-upload + sourceFile workflow as the preferred pattern, with inline `source` reserved for stub-size snippets. Field-level schema descriptions provide the curl recipe inline so agents see it at decision-time.

### `install_driver` — verify persistence before reporting success

After the install POST, `install_driver` now reads back the driver list and confirms the new driver is actually persisted. Throws `IllegalStateException` (mapped to JSON-RPC -32603) on verification failure rather than silently returning `success: true`. Closes a footgun where the hub returned 200 with an embedded error and the previous code missed it. If the verification fetch itself errors (transient blip), the tool logs a `mcpLog warn` and assumes install succeeded — defensive fallback that doesn't fail the install on hub-side flakiness.

### `update_driver_code` — bulk update via `updates[]` array

Single-driver call shape unchanged (backward compatible). New optional `updates[]` argument: array of `{driverId, sourceFile|source|resave}` objects, applied in sequence. Top-level `requireHubAdminWrite` gate fires once at the bulk-loop entry. Per-item error semantics: continue on error, return per-item status array. Mutex: cannot supply both `updates[]` and single-driver fields. Practical limit ~10-20 drivers per call.

### `install_driver` — bulk install via `installs[]` array

Symmetric to `update_driver_code` bulk: array of `{source|sourceFile}` items (no driverId since drivers don't exist yet — IDs returned in per-item results). Same continue-on-error semantics, same gate-first invariant, same mutex with single-item args.

**Asymmetric on purpose: `install_app` and `update_app_code` do NOT get bulk variants.** Apps don't cluster the way drivers do (one weather integration, one notification handler, one custom rule app — bulk on N unrelated apps has no real use case). Drivers cluster around device families, so bulk is the natural pattern for driver dev workflows.

### Tool description sharpening

Across the gateway summary (`manage_app_driver_code` listing), tool-level descriptions, and per-field schemas, descriptions now **prescribe** the curl + sourceFile + bulk patterns rather than describe alternatives. Field descriptions include the curl recipe inline at the decision-point. Multiple non-curl alternatives mentioned (PowerShell `Invoke-RestMethod`, Python `requests`, Node `fetch`) for environments without curl.

### Internal cleanup

- `toolUpdateItemCodeInner` extracted from `toolUpdateItemCode` to eliminate redundant gate-check on the bulk path. Mirrors the `toolInstallItem` / `toolInstallItemSingle` pattern. Gate fires once per call regardless of single vs bulk mode.
- Em-dash → `--` cleanup in `successResult.note` strings (lines 9486-9487) and `update_app_code` `resave` description.
- BAT Section 13 scenarios numbered T400-T406 to avoid collision with `BAT-rm-native-crud.md`'s T300+ range.

Related: #139 (proposed optimistic-lock variant via `/app/saveOrUpdateJson` with `expectedVersion`) — version-locking semantics out of scope for this PR; deferred. #161 (Gradle 9.5 full-suite test infrastructure bug) — pre-existing, observed during this PR's testing; targeted-spec verification covers correctness.

## Design pattern: external upload + `sourceFile` reference (curl + MCP)

The headline value of this PR comes from a non-obvious workflow that bypasses agent transcript bytes entirely. The pattern:

1. **Local CLI tool uploads bytes directly** to the hub's File Manager HTTP endpoint (`POST /hub/fileManager/upload` with `multipart/form-data`):
   ```bash
   curl -F "uploadFile=@./driver.groovy" -F "folder=/" "http://<hub>/hub/fileManager/upload"
   ```
2. **MCP tool referenced by filename** (~50 bytes of args):
   ```
   install_driver(sourceFile: "driver.groovy", confirm: true)
   ```

### Why this is unusual

The MCP spec (current as of 2025-11-25) is built on JSON-RPC 2.0 with JSON-serializable bodies. There's no:
- Binary streaming primitive — JSON doesn't natively express binary; binary content must be base64-encoded as a string, which still goes through the JSON body
- Multipart upload primitive — JSON-RPC has no `multipart/form-data` equivalent
- Out-of-band data channel — no separate streaming socket alongside the JSON-RPC channel

So any tool call carrying file content — including `manage_files write_file`, `install_driver source`, anything — must serialize the content as a JSON string argument. That string lives in the JSON-RPC body, which lives in the agent's conversation transcript. **There's no way to bypass via MCP itself.**

The architectural escape hatch is to use a **non-MCP HTTP endpoint** for the upload, then reference the result by filename via MCP. The hub already exposes `/hub/fileManager/upload` for this purpose (the same endpoint Hubitat's UI uses for File Manager > Upload).

### Why curl specifically (and alternatives)

Curl is the canonical example because it's universal across Linux/macOS/Windows-Git-Bash. Alternatives that achieve the same context-bypass:
- **PowerShell** (Windows native): `Invoke-RestMethod -Form @{ uploadFile = Get-Item ... }`
- **Python via uv**: `uv run --with requests -c "..."` with `requests.post(..., files={...})`
- **Node.js**: `node -e "..."` with `fetch + FormData`

All do the same thing: read file from disk, POST to hub multipart endpoint, agent transcript only sees the COMMAND not the bytes. The new tool descriptions list multiple recipes so agents in environments without curl can adapt.

## Token economy

The agent-driven dev case is fundamentally about agent transcript bytes (the cost driver), not network bytes. Inline `source` puts the full driver content into the LLM's emitted tool_use block — pure **output-token cost** at every iteration. The curl + sourceFile pattern keeps source content out of the LLM's emission stream entirely.

### Concrete savings (output tokens, ~4 bytes/token, $15/M Sonnet 4.6 output pricing)

| Scenario | Inline output cost | curl+sourceFile output cost | Savings |
|---|---|---|---|
| 5KB driver, 1 install | ~$0.019 | ~$0.001 | ~$0.018 |
| 5KB driver, 10-iteration cycle | ~$0.19 | ~$0.011 | ~$0.18 |
| 5KB driver, 50-iteration heavy refactor | ~**$0.94** | ~$0.056 | **~$0.88** |
| 50KB driver, 50-iteration cycle | ~**$9.38** | ~$0.056 | **~$9.32** |
| 24 drivers × 5KB × 50 iterations (Levoit-style) | ~**$22.50** | ~$1.35 | **~$21.15** |

### Why output tokens are the most-impactful cost type

1. **Output is 5x more expensive than input** ($15/M vs $3/M on Sonnet 4.6).
2. **Prompt caching doesn't help output tokens** — caching applies to input only. Each output emission is paid full price every time.
3. **Inline source is RE-EMITTED on every iteration** — output cost compounds across the dev cycle. Curl + sourceFile keeps the per-call output emission to ~75 tokens (filename + framing) regardless of source size.

### Context window pressure (the binding constraint)

| Context window | Inline-path threshold for blowout |
|---|---|
| Sonnet 200K | ~50-iteration cycle on a 4KB+ driver fills ~50KB → ~12.5K tokens of pure source data; combined with normal session overhead, fills the window mid-cycle. |
| Sonnet 1M | A multi-driver refactor (24×5KB×50 iter ≈ 1.5M tokens of source) exceeds even 1M. Inline path is structurally infeasible at that scale. |

Curl + sourceFile makes long-iteration multi-driver workflows fit in the context window — that's the qualitative win, not just the dollar savings.

Compounds with the token-economy gains already landed in #145 (manage_mcp_self gateway), #153 (list_devices filters), #155 (get_hub_logs filters), #157 (poll_until_attribute) — agent-budget reclaim is a coherent throughline across this PR series.

## Validation: zero-context Sonnet spot-check

The descriptions are prescriptive, not just descriptive. Validated empirically by running fresh Sonnet agents (no prior context, blind to this PR's existence) on a realistic dev task: *"install + update 3 drivers."*

| Pattern | Pre-prescription (descriptive descriptions) | Post-prescription (prescriptive descriptions) |
|---|---|---|
| `install_driver` method | inline `source` × 3 separate calls | **1 bulk call with curl + sourceFile** |
| `update_driver_code` method | inline `source` × 3 separate calls | **1 bulk call with curl + sourceFile** |
| sourceFile uses | 0 | 6 |
| curl uploads | 0 | 6 |
| Bulk-mode uses | 0 | 2 |
| `manage_files write_file` (also context-burning) | 0 | 0 (correctly avoided) |

Total tool calls collapsed from 9+ inline calls (pre-prescription) to **5 calls** (1 backup + 1 bulk install + 1 bulk update + 3 deletes) post-prescription. Fresh Sonnet quoted the prescriptive language verbatim as their reasoning:

> *"For >1 driver: USE BULK mode (single round-trip, not N separate calls)"*
> *"Inline 'source' is acceptable for stub-size snippets only"*
> *"The 'manage_files write_file' MCP tool ALSO pulls content through agent context — prefer the CLI-tool upload above"*

Without the prescription, agents naturally chose inline source (process-friction-minimizing). With the prescription, they pick curl + sourceFile + bulk (token-cost-minimizing across the workflow).

## Release Notes

- `install_app` and `install_driver` now accept a `sourceFile` parameter — install drivers/apps from File Manager files instead of inline source strings (matches existing `update_*_code` pattern). Tool descriptions prescribe the curl-upload + sourceFile workflow that bypasses agent transcript bytes.
- `install_driver` now verifies the driver was actually persisted to the hub before returning success (fixes a false-positive failure mode).
- `update_driver_code` now accepts an `updates` array of `{driverId, sourceFile|source|resave}` pairs for bulk multi-driver updates in a single tool call (single round-trip vs N).
- `install_driver` now accepts an `installs` array of `{source|sourceFile}` items for bulk multi-driver install (driver families).

## Testing

**Spock specs:** `ToolAppDriverCodeSpec` — **53/53 PASS** (47 prior + 5 install_driver bulk + 1 install_app verification-fetch parity)

**Adjacent regression coverage** (via `mcp-server-tester` targeted runs): `HandleToolsCallSpec` (4), `HandleGatewaySpec` (15), `GatewayToggleSpec` (54) — 78 specs across affected dispatch paths, all PASS.

**Note on full-suite invocation:** `./gradlew test` is blocked by a pre-existing Gradle 9.5 infrastructure bug (`NoSuchFileException: in-progress-results-generic.bin`) tracked separately as #161. Specs themselves run cleanly when targeted; only the whole-suite binary-store accumulator is broken. Verification here uses targeted `--tests "*Spec*"` invocations exclusively.

**Live verification on test hub firmware 2.5.0.126 (code id 178):**

| Scenario | Result |
|---|---|
| `install_driver` with `sourceFile` (single-item) | ✅ |
| Post-install verification (auto-fires on install) | ✅ |
| Bulk `update_driver_code` (`updates[]` happy path) | ✅ |
| Bulk `update_driver_code` mixed-args rejection | ✅ |
| Bulk `install_driver` (`installs[]` happy path, 3 drivers) | ✅ |
| Bulk `install_driver` mixed-args rejection | ✅ |
| Single `install_app` regression check (post-refactor) | ✅ |
| `install_app` rejects bulk-mode args (asymmetric design) | ✅ |
| Bulk `update_driver_code` post-WARN-#4-refactor smoke | ✅ |

All test artifacts cleaned up (`BAT_`-prefixed drivers + File Manager files deleted).

**BAT additions:** Section 13 "Driver Code Lifecycle Tests" — T400-T406 (sourceFile install + post-install verification + bulk update + bulk install + mixed-args rejection paths). All scenarios use `BAT_`-prefixed test artifacts with `teardown_prompt` deletion per BAT convention.

**Sandbox lint:** clean (0 errors, 0 warnings)

## Checklist

- [x] Unit tests added for any new MCP tools (53 scenarios in `ToolAppDriverCodeSpec`)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (targeted-spec strategy due to #161; full-suite blocked by Gradle 9.5 bug)
- [x] Live-hub BAT tests updated (T400-T406 in `tests/BAT-v2.md`)
- [x] Documentation updated (README, SKILL, TOOL_GUIDE, agent-skill SKILL + tool-reference)

