### PR TITLE
feat(manage_app_driver_code): library management (install/update/delete/get_source)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hubitat MCP Server
 
-A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 90 MCP tools (35 on `tools/list` via category gateways).
+A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 94 MCP tools (35 on `tools/list` via category gateways).
 
 > **BETA SOFTWARE**: This project is ~99% AI-generated ("vibe coded") using Claude. It's a work in progress — contributions and [bug reports](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues) are welcome!
 
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 90 tools total — 23 core tools are always visible, while 67 additional tools are organized behind 12 domain-named gateways to keep the tool list manageable. If your client handles long tool lists well, you can disable the gateways via the **Consolidate tools behind category gateways** setting and every tool is exposed individually instead. (Counts here describe the shipped catalog; the runtime count on `tools/list` varies based on enabled settings.)
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 94 tools total — 23 core tools are always visible, while 71 additional tools are organized behind 12 domain-named gateways to keep the tool list manageable. If your client handles long tool lists well, you can disable the gateways via the **Consolidate tools behind category gateways** setting and every tool is exposed individually instead. (Counts here describe the shipped catalog; the runtime count on `tools/list` varies based on enabled settings.)
 
 ## Requirements
 
@@ -221,9 +221,9 @@ For free remote access without a Hubitat Cloud subscription:
 
 ## Features
 
-### MCP Tools (90 total — 35 on tools/list)
+### MCP Tools (98 total — 35 on tools/list)
 
-The server has 90 tools total. To keep the MCP `tools/list` manageable, **23 core tools** are always visible and **67 additional tools** are organized behind **12 domain-named gateways**. The AI sees 35 items on `tools/list` (23 + 12 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
+The server has 98 tools total. To keep the MCP `tools/list` manageable, **23 core tools** are always visible and **75 additional tools** are organized behind **12 domain-named gateways**. The AI sees 35 items on `tools/list` (23 + 12 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
 
 #### Core Tools (23) — Always visible on tools/list
 
@@ -327,14 +327,18 @@ Call a gateway with no arguments to see full parameter schemas. Call with `tool=
 </details>
 
 <details>
-<summary><b>manage_hub_variables</b> (4) — Hub variables</summary>
+<summary><b>manage_hub_variables</b> (8) — Hub variables</summary>
 
 | Tool | Description |
 |------|-------------|
 | `list_variables` | List all hub connector and rule engine variables |
-| `get_variable` | Get a variable value |
-| `set_variable` | Set a variable value (creates if doesn't exist) |
-| `delete_variable` | Permanently delete a rule engine variable (DESTRUCTIVE) |
+| `get_variable` | Get a variable value and metadata |
+| `set_variable` | Set a variable value |
+| `create_variable` | Create a new hub variable |
+| `delete_variable` | Permanently delete a hub variable (DESTRUCTIVE) |
+| `create_connector` | Create a virtual-device connector for a hub variable |
+| `remove_connector` | Remove the connector device for a hub variable |
+| `get_variable_history` | Recent hub-variable changes since the MCP app last started |
 
 </details>
 
@@ -365,7 +369,7 @@ All operations are disruptive. Hub admin tools require Hub Admin Read/Write to b
 </details>
 
 <details>
-<summary><b>manage_apps_drivers</b> (6) — App/driver listing, source code, and backups (read-only)</summary>
+<summary><b>manage_apps_drivers</b> (7) — App/driver/library listing, source code, and backups (read-only)</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -373,13 +377,14 @@ All operations are disruptive. Hub admin tools require Hub Admin Read/Write to b
 | `list_hub_drivers` | List all installed drivers on the hub |
 | `get_app_source` | Get app Groovy source code |
 | `get_driver_source` | Get driver Groovy source code |
+| `get_library_source` | Get library Groovy source code with chunked reading support |
 | `list_item_backups` | List auto-created source code backups |
 | `get_item_backup` | Get source from a backup |
 
 </details>
 
 <details>
-<summary><b>manage_app_driver_code</b> (7) — Install, update, delete apps/drivers and restore backups</summary>
+<summary><b>manage_app_driver_code</b> (10) — Install, update, delete apps/drivers/libraries and restore backups</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -389,7 +394,10 @@ All operations are disruptive. Hub admin tools require Hub Admin Read/Write to b
 | `update_driver_code` | Modify existing driver code (single-driver or bulk `updates` array) |
 | `delete_app` | Permanently delete an app (auto-backs up) |
 | `delete_driver` | Permanently delete a driver (auto-backs up) |
-| `restore_item_backup` | Restore app/driver to backed-up version |
+| `restore_item_backup` | Restore app/driver to backed-up version (libraries: see `update_library_code`) |
+| `install_library` | Install new Groovy library (#include namespace.Name) |
+| `update_library_code` | Modify existing library code |
+| `delete_library` | Permanently delete a library (auto-backs up) |
 
 Source code is automatically backed up before any modify/delete operation.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hubitat-mcp-server
-description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 90 tools (35 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver management, installed-app visibility, Rule Machine interoperability, native rule CRUD, and Developer Mode self-administration.
+description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 98 tools (35 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver/library management, installed-app visibility, Rule Machine interoperability, native rule CRUD, and Developer Mode self-administration.
 license: MIT
 ---
 
@@ -32,7 +32,7 @@ The Hubitat-runtime code has no external dependencies -- everything runs inside 
 │  │  MCP Rule Server (parent app)             │  │
 │  │  - OAuth endpoint: /apps/api/<id>/mcp     │  │
 │  │  - JSON-RPC 2.0 handler                   │  │
-│  │  - 90 tools (35 on tools/list + gateways) │  │
+│  │  - 98 tools (35 on tools/list + gateways) │  │
 │  │  - Device access gate (selectedDevices)   │  │
 │  │  - Hub Admin tools (internal API calls)   │  │
 │  │  - Hub Security cookie auth               │  │
@@ -98,22 +98,22 @@ The server uses a **category gateway proxy** pattern to reduce the MCP `tools/li
 **Architecture:**
 - `getGatewayConfig()` — defines 12 gateways, each with a description, tools list, and summaries map
 - `getToolDefinitions()` — returns 23 core tools + 12 gateway tool definitions (client-visible)
-- `getAllToolDefinitions()` — returns all 90 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
+- `getAllToolDefinitions()` — returns all 98 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
 - `handleGateway(gatewayName, toolName, toolArgs)` — catalog mode (no args → full schemas) or execute mode (tool + args → dispatch)
 
 **Gateway calling convention:**
 1. AI calls `manage_<domain>()` with no args → gets full tool schemas (catalog mode)
 2. AI calls `manage_<domain>(tool="tool_name", args={...})` → executes the proxied tool
 
-**12 gateways (67 proxied tools):**
+**12 gateways (75 proxied tools):**
 | Gateway | Tools | Domain |
 |---------|-------|--------|
 | `manage_rules_admin` | 5 | Rule delete/test/export/import/clone |
-| `manage_hub_variables` | 4 | Hub connector and rule engine variables (incl. delete) |
+| `manage_hub_variables` | 8 | Hub connector and rule engine variables (CRUD + connector + history) |
 | `manage_rooms` | 5 | Room CRUD |
 | `manage_destructive_hub_ops` | 3 | Hub reboot, shutdown, device deletion (write) |
-| `manage_apps_drivers` | 6 | List/get apps, drivers, backups (read-only) |
-| `manage_app_driver_code` | 7 | Install/update/delete apps+drivers, restore backup (write) |
+| `manage_apps_drivers` | 7 | List/get apps, drivers, libraries, backups (read-only) |
+| `manage_app_driver_code` | 10 | Install/update/delete apps+drivers+libraries, restore backup (write) |
 | `manage_logs` | 8 | Logs, monitoring, performance stats, hub jobs, debug tools |
 | `manage_diagnostics` | 11 | Diagnostics, state capture, zwave/zigbee details, zwave repair, memory history, GC |
 | `manage_files` | 4 | File Manager CRUD |
@@ -308,6 +308,7 @@ All three:
 | `buildRuleExport(ruleData)` | Build portable rule export map (used by export and delete backup) |
 | `toolInstallItem(type, args)` | Shared install logic for apps and drivers |
 | `toolDeleteItem(type, idParam, deletePath, args)` | Shared delete logic for apps and drivers |
+| `hubInternalPostJson(path, jsonBody, isRetry?)` | POST to hub internal API with JSON body (used by library endpoints); returns parsed Map/List or null |
 | `updateRuleFromParent(data)` | Child app method — handles all rule updates including enable/disable via `enabled=true/false` |
 | `shouldRetryWithFreshCookie(e, isRetry)` | Hub Security auth retry detection |
 | `clampPercent(value)` | Clamp integer to 0-100 range (in rule.groovy) |
@@ -341,7 +342,7 @@ The cookie is cached in `state.hubSecurityCookie` with expiry in `state.hubSecur
 | `hubSecurityCookie` | String | Cached auth cookie |
 | `hubSecurityCookieExpiry` | Long | Cookie expiry epoch ms |
 | `lastBackupTimestamp` | Long | Last hub backup epoch ms (24-hour write safety gate) |
-| `itemBackupManifest` | Map | Metadata for source code backups stored in File Manager, keyed by `"app_<id>"` / `"driver_<id>"`, max 20 entries |
+| `itemBackupManifest` | Map | Metadata for source code backups stored in File Manager, keyed by `"app_<id>"` / `"driver_<id>"` / `"library_<id>"`, max 20 entries |
 | `updateCheck` | Map | `{latestVersion, checkedAt, updateAvailable}` |
 
 **Child app uses `atomicState`** for `triggers`, `conditions`, `actions`, `localVariables`, `durationTimers`, `durationFired`, and `cancelledDelayIds`. This is critical — `atomicState` provides immediate persistence and prevents race conditions when scheduled callbacks (`runIn`) fire in separate execution contexts. Always use read-modify-write pattern with atomicState maps:
@@ -491,6 +492,8 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 | `/hub2/zigbeeInfo` | Zigbee radio details (JSON) |
 | `/app/ajax/code` with query `id=<id>` | App source code (JSON: source, version, status) |
 | `/driver/ajax/code` with query `id=<id>` | Driver source code (JSON: source, version, status) |
+| `/hub2/userLibraries` | Installed user libraries (JSON array: id, version, name, namespace, author, description, usedByAppTypes, usedByDeviceTypes -- no source field) |
+| `/library/list/single/data/<id>` | Single library with full source (JSON array of one: id, version, name, namespace, source, lastModified, usedByDeviceTypes, etc.) |
 | `/hub/backupDB` with query `fileName=latest` | Creates fresh backup and returns .lzf binary |
 | `/hub/fileManager/json` | Lists all files in File Manager (JSON array: name, size, date) |
 | `/hub2/roomsList` | List of rooms as JSON (alternative to `getRooms()` SDK method) |
@@ -509,6 +512,7 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 | `/driver/save` | `id="", version="", create="", source=<code>` | Install new driver |
 | `/app/ajax/update` | `id=<id>, version=<ver>, source=<code>` | Update app code |
 | `/driver/ajax/update` | `id=<id>, version=<ver>, source=<code>` | Update driver code |
+| `/library/saveOrUpdateJson` | JSON: `{"id": null, "source": "<code>", "version": null}` | Install new library (id=null creates; id=N updates with version=N for optimistic lock). Returns `{success, message, id, version}`. MUST use `Content-Type: application/json`. |
 | `/login` | `username=<u>, password=<p>, submit=Login` | Hub Security login |
 | `/device/save` | `id=<deviceId>, label=<label>, name=<name>, deviceNetworkId=<dni>, type.id=<typeId>` | Update device properties (flat field names, Grails convention). NOTE: silently ignores `roomId` — use `/room/save` instead |
 | `/device/disable` | `id=<deviceId>, disable=<true\|false>` | Enable or disable a device (MUST be POST, not GET) |
@@ -519,6 +523,7 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 |------|--------|---------|
 | `/app/edit/deleteJsonSafe/<id>` | GET | Delete app (returns JSON with `status: true`) |
 | `/driver/editor/deleteJson/<id>` | GET | Delete driver (returns JSON with `status: true`) |
+| `/library/edit/deleteJson/<id>` | GET | Delete library (returns JSON with `success: true, message: null`) |
 | `/room/delete/<roomId>` | POST or GET | Delete room (try POST first, fall back to GET) |
 
 ### MCP Protocol Implementation

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -4,13 +4,13 @@ Detailed reference for MCP Rule Server tools. Consult this when tool description
 
 ## Category Gateway Proxy (v0.8.0+)
 
-As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 35 items (23 core + 12 gateways) covering 90 total tools. Use `search_tools` to find any tool by natural language query.
+As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 35 items (23 core + 12 gateways) covering 98 total tools. Use `search_tools` to find any tool by natural language query.
 
 **How to use a gateway:**
 1. Call the gateway with no arguments to see full parameter schemas for all its tools
 2. Call with `tool='<tool_name>'` and `args={...}` to execute a specific tool
 
-**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (4), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_native_rules_and_apps` (9), `manage_mcp_self` (1)
+**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (8), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (7), `manage_app_driver_code` (10), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_native_rules_and_apps` (9), `manage_mcp_self` (1)
 
 All safety gates (Hub Admin Read/Write, confirm, backup checks) are preserved — they are enforced in the handler functions, not the dispatch layer.
 
@@ -105,9 +105,10 @@ All Hub Admin Write tools require these steps:
   - Practical limit: ~20 drivers per call (each update is a sequential on-hub compilation, ~1-5 seconds each).
   - Token-economy pattern: upload all updated driver files via local CLI (curl -F / PowerShell Invoke-RestMethod), then call bulk `update_driver_code` once with all `{driverId, sourceFile}` pairs.
 
-**delete_app / delete_driver** (via `manage_app_driver_code`)
+**delete_app / delete_driver / delete_library** (via `manage_app_driver_code`)
 - Remove app instances via Hubitat UI first (for apps)
 - Change devices to different driver first (for drivers)
+- Ensure no drivers/apps reference the library via #include before deleting (for libraries)
 - Source code auto-backed up before deletion
 
 ---
@@ -230,11 +231,11 @@ Offset is in minutes (positive = after, negative = before)
 
 ---
 
-## App/Driver Code Management
+## App/Driver/Library Code Management
 
 ### Reading Source Code
-- `get_app_source` / `get_driver_source` support chunked reading for large files
-- Large files auto-saved to File Manager as `mcp-source-app-{id}.groovy` or `mcp-source-driver-{id}.groovy`
+- `get_app_source` / `get_driver_source` (via `manage_apps_drivers`) / `get_library_source` (via `manage_apps_drivers`) support chunked reading for large files
+- Large files auto-saved to File Manager as `mcp-source-app-{id}.groovy`, `mcp-source-driver-{id}.groovy`, or `mcp-source-library-{id}.groovy`
 - Use this saved file with `sourceFile` parameter in update tools
 
 ### Updating Code
@@ -245,9 +246,32 @@ Three modes available:
 
 Auto-backs up before modifying. Rapid edits within 1 hour preserve the original.
 
+### Libraries
+Hubitat Groovy libraries are shared code modules included by drivers and apps via `#include namespace.LibraryName`. The library management tools mirror the app/driver pattern:
+- `install_library` - Install a new library from Groovy source (inline or via File Manager file)
+- `update_library_code` - Update existing library source (source/sourceFile/resave modes)
+- `delete_library` - Delete a library (auto-backs up source first)
+- `get_library_source` - Read library source with chunked reading support
+
+Libraries must include a valid `library()` definition block. Before deleting a library, ensure no installed drivers or apps reference it via `#include` -- deleting a library in use causes compilation errors in the referencing code.
+
+PREFER curl-upload + sourceFile (bypasses agent context, no transcript size limits). Use inline `source` only for stub-size snippets:
+```bash
+# Without Hub Security:
+curl -F "uploadFile=@mylib.groovy" -F "folder=/" http://<HUB_IP>/hub/fileManager/upload
+
+# With Hub Security enabled (cookie-based):
+curl -c cookies.txt -d "username=USER&password=PASS" http://<HUB_IP>/login
+curl -b cookies.txt -F "uploadFile=@mylib.groovy" -F "folder=/" http://<HUB_IP>/hub/fileManager/upload
+```
+Then call `install_library` or `update_library_code` with `sourceFile: 'mylib.groovy'`.
+
+Note: `get_library_source` (read-only, Hub Admin Read) lives in `manage_apps_drivers` alongside `get_app_source` and `get_driver_source`. The write operations (`install_library`, `update_library_code`, `delete_library`) live in `manage_app_driver_code` (Hub Admin Write).
+
 ### After Installation
 - Apps: Add via Apps > Add User App in Hubitat web UI
 - Drivers: Can be assigned to devices immediately
+- Libraries: Available immediately for `#include` in driver/app source
 
 ---
 
@@ -259,7 +283,7 @@ Auto-backs up before modifying. Rapid edits within 1 hour preserve the original.
 - Only Hub Admin Write tool that doesn't require a prior backup
 
 ### Source Code Backups (Automatic)
-- Created automatically when using update_app_code, update_driver_code, delete_app, delete_driver
+- Created automatically when using update_app_code, update_driver_code, update_library_code, delete_app, delete_driver, delete_library
 - Stored in File Manager as `.groovy` files
 - Persist even if MCP uninstalled
 - Max 20 kept, oldest pruned

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Smart home assistant for Hubitat Elevation hubs via MCP. Use when c
 
 # Hubitat MCP Server - Smart Home Assistant
 
-You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 90 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, Rule Machine interop, native rule CRUD, and Developer Mode self-administration. The tools are organized as **23 core tools** (always visible) plus **12 domain-named gateways** that proxy 67 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
+You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 94 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, Rule Machine interop, native rule CRUD, library management, and Developer Mode self-administration. The tools are organized as **23 core tools** (always visible) plus **12 domain-named gateways** that proxy 71 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
 
 ## Core Principles
 
@@ -126,13 +126,13 @@ Additional hub admin tools are accessed via gateways:
 
 Destructive write operations (require Hub Admin Write): `reboot_hub`, `shutdown_hub`, `delete_device`
 
-### Via `manage_apps_drivers` gateway (6 tools — read-only)
+### Via `manage_apps_drivers` gateway (7 tools — read-only)
 
-`list_hub_apps`, `list_hub_drivers`, `get_app_source`, `get_driver_source`, `list_item_backups`, `get_item_backup`
+`list_hub_apps`, `list_hub_drivers`, `get_app_source`, `get_driver_source`, `get_library_source`, `list_item_backups`, `get_item_backup`
 
-### Via `manage_app_driver_code` gateway (7 tools — write operations)
+### Via `manage_app_driver_code` gateway (10 tools — write operations)
 
-`install_app`, `install_driver`, `update_app_code`, `update_driver_code`, `delete_app`, `delete_driver`, `restore_item_backup`
+`install_app`, `install_driver`, `update_app_code`, `update_driver_code`, `delete_app`, `delete_driver`, `restore_item_backup`, `install_library`, `update_library_code`, `delete_library`
 
 - `install_app` / `install_driver` accept `source` (inline) OR `sourceFile` (File Manager filename). Token-economy tip: upload source via local CLI first, then pass filename. Includes post-install verification -- returns `success: false` if the Groovy failed to compile, even when the hub returned a redirect.
 - `install_driver` supports bulk mode via an `installs` array of `{source|sourceFile}` objects. Continue-on-error; top-level `success: true` only if all items pass. Cannot combine with single-driver fields. Returns per-item `driverId`. Practical limit ~10-20 drivers/call. (`install_app` is single-item only -- apps are typically one-of-a-kind installs.)
@@ -158,14 +158,14 @@ For complete safety protocols and tool-specific requirements, see [safety-guide.
 
 Core tool: `get_device_events` (always visible)
 
-Via `manage_logs` gateway (6 tools):
+Via `manage_logs` gateway (8 tools):
 - `get_hub_logs` - Hub log entries, most recent first; filter by level/source/pattern (regex) or multi-pattern AND/OR (`patternMode`); time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`, max 30d -- throws if exceeded; use ISO-8601 for longer ranges); or scope server-side to a single `deviceId` / `appId` (mutually exclusive). `pattern` matches the message field only (not source/name). Pathological regex like `(.*)*` may hang the matcher; prefer simple alternation.
 - `get_device_history` - Device event history (up to 7 days)
 - `get_debug_logs` / `clear_debug_logs` - MCP-specific debug logs
 - `set_log_level` - Set MCP log level
 - `get_logging_status` - View logging system statistics
 
-Via `manage_diagnostics` gateway (9 tools):
+Via `manage_diagnostics` gateway (11 tools):
 - `get_set_hub_metrics` - Record/retrieve hub metrics with CSV trend history
 - `device_health_check` - Find stale/offline devices
 - `get_rule_diagnostics` - Comprehensive diagnostics for a specific rule
@@ -179,7 +179,7 @@ Via `manage_files` gateway: `list_files`, `read_file`, `write_file`, `delete_fil
 
 ## Item Backup System
 
-Source code is automatically backed up before modify/delete operations. Use `list_item_backups`, `get_item_backup` (via `manage_apps_drivers` gateway) to view backups, and `restore_item_backup` (via `manage_app_driver_code` gateway) to restore.
+Source code is automatically backed up before modify/delete operations. Use `list_item_backups`, `get_item_backup` (via `manage_apps_drivers` gateway) to view backups, and `restore_item_backup` (via `manage_app_driver_code` gateway) to restore apps and drivers. For libraries, restore via `update_library_code` with the backup file.
 
 ## System Tools
 

--- a/agent-skill/hubitat-mcp/safety-guide.md
+++ b/agent-skill/hubitat-mcp/safety-guide.md
@@ -72,6 +72,11 @@ ALL Hub Admin Write tools require these steps in order:
 - For apps: Remind user to remove app instances via Hubitat UI first
 - For drivers: Remind user to switch devices to a different driver first
 
+#### delete_library
+- Source code is auto-backed up before deletion
+- Check that no apps or drivers reference the library via `#include namespace.LibraryName` before deleting -- deletion breaks any code that still includes it
+- Deletion is permanent; restore requires `update_library_code` with the backup source
+
 #### delete_room
 - Devices become unassigned (not deleted)
 - List affected devices to the user before proceeding
@@ -81,8 +86,17 @@ ALL Hub Admin Write tools require these steps in order:
 - Verify source code looks reasonable before installing
 - Warn about namespace conflicts with existing apps/drivers
 
+#### install_library
+- Verify source includes a valid `library()` definition block before installing
+- Warn about namespace conflicts with existing libraries (`#include namespace.LibraryName` references must match exactly)
+
 #### update_app_code / update_driver_code
 - Source is auto-backed up before update (1-hour protection window preserves original)
+- Uses optimistic locking to prevent concurrent edit conflicts
+- Supports three modes: `source` (direct), `sourceFile` (from File Manager), `resave` (recompile)
+
+#### update_library_code
+- Source is auto-backed up before update (1-hour protection window preserves original); backup failure aborts the update
 - Uses optimistic locking to prevent concurrent edit conflicts
 - Supports three modes: `source` (direct), `sourceFile` (from File Manager), `resave` (recompile)
 
@@ -144,9 +158,9 @@ Source code backups are created automatically before modify/delete operations.
 
 If MCP itself is broken:
 1. Go to Hubitat web UI > Settings > File Manager
-2. Find backup files (named `mcp-backup-app-<id>.groovy` or `mcp-backup-driver-<id>.groovy`)
+2. Find backup files (named `mcp-backup-app-<id>.groovy`, `mcp-backup-driver-<id>.groovy`, or `mcp-backup-library-<id>.groovy`)
 3. Download the file
-4. Go to Apps Code (or Drivers Code) > select the item > paste source > Save
+4. Go to Apps Code (or Drivers Code, or FOR DEVELOPERS > Libraries code) > select the item > paste source > Save
 
 ---
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-Quick reference for all 90 MCP tools. The server exposes **35 items on `tools/list`**: 23 core tools + 12 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
+Quick reference for all 94 MCP tools. The server exposes **35 items on `tools/list`**: 23 core tools + 12 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
 
 For the most authoritative reference, call `get_tool_guide` via MCP.
 
@@ -57,7 +57,7 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `get_tool_guide` | Full tool reference from the MCP server itself. | None |
-| `search_tools` | BM25 natural language search across all 90 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
+| `search_tools` | BM25 natural language search across all 94 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
 
 ---
 
@@ -79,16 +79,20 @@ Rule administration: delete, test, export, import, and clone rules.
 
 > **Built-in rule redirect:** `custom_get_rule`, `custom_export_rule`, `custom_update_rule`, `custom_delete_rule`, `custom_test_rule`, and `custom_clone_rule` operate only on MCP-native rules. If you pass an id belonging to a Hubitat built-in rule (Rule Machine, Room Lighting, Basic Rules, Visual Rules), the error message includes a redirect hint pointing to `manage_installed_apps -> get_app_config(appId=<id>)` (read) or, for write and delete verbs, the appropriate `manage_native_rules_and_apps` CRUD tool. The test verb hint includes `run_rm_rule` only for Rule Machine rules; other built-in rule-likes receive `get_app_config` for inspection because `run_rm_rule` is RM-only. This redirect fires only when Built-in App Tools are enabled. See `TOOL_GUIDE.md` "Hubitat Built-in Rule Redirect" for full details.
 
-### manage_hub_variables (4 tools)
+### manage_hub_variables (8 tools)
 
 Manage hub connector and rule engine variables.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `list_variables` | List all hub connector and rule engine variables. | None |
-| `get_variable` | Get a specific variable value. | None |
-| `set_variable` | Set a variable value (creates if doesn't exist). | None |
-| `delete_variable` | Permanently delete a rule engine variable (DESTRUCTIVE — no undo). Connector-namespace deletion not yet supported via MCP. | Hub Admin Write + recent backup |
+| `get_variable` | Get a specific variable value and metadata. | None |
+| `set_variable` | Set a variable value. | None |
+| `create_variable` | Create a new hub variable (type: Number/Decimal/String/Boolean/DateTime). | Hub Admin Write |
+| `delete_variable` | Permanently delete a hub variable (DESTRUCTIVE). | Hub Admin Write + recent backup |
+| `create_connector` | Create a virtual-device connector for a hub variable. | Hub Admin Write |
+| `remove_connector` | Remove the connector device for a hub variable. | Hub Admin Write |
+| `get_variable_history` | Recent hub-variable changes since the MCP app started. | None |
 
 ### manage_rooms (5 tools)
 
@@ -112,9 +116,9 @@ Destructive hub operations: reboot, shutdown, and device deletion.
 | `shutdown_hub` | Power off hub (needs manual restart). | Hub Admin Write |
 | `delete_device` | Permanently delete a device. **NO UNDO.** For ghost/orphaned devices only. | Hub Admin Write |
 
-### manage_apps_drivers (6 tools)
+### manage_apps_drivers (7 tools)
 
-Read-only access to hub apps and drivers: list, view source, and browse backups.
+Read-only access to hub apps, drivers, and libraries: list, view source, and browse backups.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
@@ -122,12 +126,13 @@ Read-only access to hub apps and drivers: list, view source, and browse backups.
 | `list_hub_drivers` | List installed user drivers. | Hub Admin Read |
 | `get_app_source` | Get app source code. Large files auto-saved to File Manager. | Hub Admin Read |
 | `get_driver_source` | Get driver source code. Large files auto-saved to File Manager. | Hub Admin Read |
+| `get_library_source` | Get library source code with chunked reading. Large files auto-saved to File Manager. | Hub Admin Read |
 | `list_item_backups` | List all source code backups. | None |
 | `get_item_backup` | Retrieve source from a backup. | None |
 
-### manage_app_driver_code (7 tools)
+### manage_app_driver_code (10 tools)
 
-Write operations for apps and drivers: install, update, delete, and restore code.
+Write operations for apps, drivers, and libraries: install, update, delete, and restore code.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
@@ -137,7 +142,10 @@ Write operations for apps and drivers: install, update, delete, and restore code
 | `update_driver_code` | Update existing driver source code. Single-driver mode (driverId + source/sourceFile/resave) or bulk mode (updates array of {driverId, sourceFile} pairs, continue-on-error). | Hub Admin Write |
 | `delete_app` | Delete an installed app (auto-backs up). | Hub Admin Write |
 | `delete_driver` | Delete an installed driver (auto-backs up). | Hub Admin Write |
-| `restore_item_backup` | Restore app/driver to backed-up version. | Hub Admin Write |
+| `restore_item_backup` | Restore app/driver to backed-up version (libraries: see `update_library_code`). | Hub Admin Write |
+| `install_library` | Install a new Groovy library (#include namespace.Name). | Hub Admin Write |
+| `update_library_code` | Update existing library source (source/sourceFile/resave modes). | Hub Admin Write |
+| `delete_library` | Delete a library (auto-backs up source). | Hub Admin Write |
 
 ### manage_logs (8 tools)
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -804,13 +804,14 @@ def getGatewayConfig() {
         ],
         // Option B: manage_apps_drivers split into browse (read) + changes (write)
         manage_apps_drivers: [
-            description: "Browse installed apps and drivers: list, view source code, and view code backups.",
-            tools: ["list_hub_apps", "list_hub_drivers", "get_app_source", "get_driver_source", "list_item_backups", "get_item_backup"],
+            description: "Browse installed apps, drivers, and libraries: list, view source code, and view code backups. All operations are read-only. Write operations (install, update, delete) live in the manage_app_driver_code gateway.",
+            tools: ["list_hub_apps", "list_hub_drivers", "get_app_source", "get_driver_source", "get_library_source", "list_item_backups", "get_item_backup"],
             summaries: [
                 list_hub_apps: "List all installed apps on the hub",
                 list_hub_drivers: "List all installed drivers on the hub",
                 get_app_source: "Get app Groovy source code. Args: appId",
                 get_driver_source: "Get driver Groovy source code. Args: driverId",
+                get_library_source: "Get library Groovy source with chunked reading support. Args: libraryId, offset?, length?",
                 list_item_backups: "List auto-created source code backups",
                 get_item_backup: "Get source from a backup. Args: backupId"
             ],
@@ -819,13 +820,14 @@ def getGatewayConfig() {
                 list_hub_drivers: "show installed device handlers types",
                 get_app_source: "view read application groovy code",
                 get_driver_source: "view read device handler type groovy code",
+                get_library_source: "view read groovy library shared code namespace include",
                 list_item_backups: "show saved previous versions revisions",
                 get_item_backup: "view read saved previous version revision"
             ]
         ],
         manage_app_driver_code: [
-            description: "Install, update, and delete hub apps and drivers. All operations modify hub code and require Hub Admin Write.",
-            tools: ["install_app", "install_driver", "update_app_code", "update_driver_code", "delete_app", "delete_driver", "restore_item_backup"],
+            description: "Install, update, and delete hub apps, drivers, and libraries. All operations modify hub code and require Hub Admin Write. Read-only counterparts (get_app_source, get_driver_source, get_library_source, list_*) live in the manage_apps_drivers gateway.",
+            tools: ["install_app", "install_driver", "update_app_code", "update_driver_code", "delete_app", "delete_driver", "restore_item_backup", "install_library", "update_library_code", "delete_library"],
             summaries: [
                 install_app: "Install new app. PREFER curl-upload + sourceFile (bypasses agent context); inline source for stubs only. Args: source|sourceFile, confirm=true",
                 install_driver: "Install new driver. PREFER curl-upload + sourceFile. For 1: source|sourceFile. For >1: USE BULK (single round-trip: installs=[{source|sourceFile},...]). confirm=true",
@@ -833,7 +835,10 @@ def getGatewayConfig() {
                 update_driver_code: "Modify existing driver code (CRITICAL). For 1 driver: driverId+source|sourceFile|resave. For >1 drivers: USE BULK (single round-trip: updates=[{driverId,sourceFile},...]). PREFER sourceFile + curl-upload over inline. confirm=true",
                 delete_app: "Permanently delete an app (DESTRUCTIVE). Args: appId, confirm=true",
                 delete_driver: "Permanently delete a driver (DESTRUCTIVE). Args: driverId, confirm=true",
-                restore_item_backup: "Restore app/driver to backed-up version. Args: backupId, confirm=true"
+                restore_item_backup: "Restore app/driver to backed-up version. Args: backupId, confirm=true",
+                install_library: "Install new Groovy library (#include namespace.Name). PREFER curl-upload + sourceFile (bypasses agent context); inline source for stubs only. Args: source|sourceFile, confirm=true",
+                update_library_code: "Modify existing library code. PREFER curl-upload + sourceFile. Args: libraryId, source|sourceFile|resave, confirm=true",
+                delete_library: "Permanently delete a library (DESTRUCTIVE). Args: libraryId, confirm=true"
             ],
             searchHints: [
                 install_app: "add new application integration groovy",
@@ -842,7 +847,10 @@ def getGatewayConfig() {
                 update_driver_code: "modify change edit device handler type groovy push deploy",
                 delete_app: "remove uninstall application integration",
                 delete_driver: "remove uninstall device handler type",
-                restore_item_backup: "rollback revert undo previous version"
+                restore_item_backup: "rollback revert undo previous version",
+                install_library: "add new shared groovy library include namespace",
+                update_library_code: "modify change edit groovy library shared code push deploy",
+                delete_library: "remove uninstall groovy library shared"
             ]
         ],
         // Option B: manage_logs_diagnostics split into logs + diagnostics
@@ -1968,7 +1976,7 @@ Requires Hub Admin Write.""",
 PREFERRED workflow (avoids reading source into agent transcript):
   1) Upload bytes to File Manager via local CLI tool that bypasses agent context:
        curl -F 'uploadFile=@./app.groovy' -F 'folder=/' 'http://<hub>/hub/fileManager/upload'
-       (Add '-u admin:PASS' if Hub Security is enabled. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
+       (Hub Security: first run 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload command. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
   2) install_app(sourceFile: 'app.groovy', confirm: true)
 
 Inline 'source' is acceptable for stub-size snippets only. The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
@@ -1978,7 +1986,7 @@ Verifies install succeeded: if the hub accepted the request but the app failed t
                 type: "object",
                 properties: [
                     source: [type: "string", description: "Inline Groovy source. ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install/redeploy. For non-trivial apps, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
                 required: ["confirm"]
@@ -1991,7 +1999,7 @@ Verifies install succeeded: if the hub accepted the request but the app failed t
 PREFERRED workflow (avoids reading source into agent transcript):
   1) Upload bytes to File Manager via local CLI tool that bypasses agent context:
        curl -F 'uploadFile=@./driver.groovy' -F 'folder=/' 'http://<hub>/hub/fileManager/upload'
-       (Add '-u admin:PASS' if Hub Security is enabled. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
+       (Hub Security: first run 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload command. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
   2) install_driver(sourceFile: 'driver.groovy', confirm: true)
 
 Inline 'source' is acceptable for stub-size snippets only. The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
@@ -2006,7 +2014,7 @@ Verifies install succeeded: if the hub accepted the request but the driver faile
                 type: "object",
                 properties: [
                     source: [type: "string", description: "Inline Groovy source (single-driver mode). ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install/redeploy. For non-trivial drivers, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
                     installs: [
                         type: "array",
                         description: "BULK MODE -- USE THIS WHEN INSTALLING >1 DRIVER (single round-trip vs N separate calls; same arg structure, just an array). Each entry: {source|sourceFile}. Cannot mix with single-driver fields (source/sourceFile). Continue-on-error: failures on individual items don't abort the rest. Practical limit ~10-20 drivers/call. Authorization is controlled by top-level 'confirm' only. PREFER each item's sourceFile (after CLI upload per recipe in tool description) over inline source.",
@@ -2028,7 +2036,7 @@ Verifies install succeeded: if the hub accepted the request but the driver faile
             description: """⚠️ CRITICAL: Modify existing app code. Read current source first, explain changes, get confirmation.
 
 PREFERRED workflow for any iterative app dev (avoids reading source into agent transcript):
-  1) Upload bytes via local CLI: 'curl -F uploadFile=@./app.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
+  1) Upload bytes via local CLI: 'curl -F uploadFile=@./app.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
   2) update_app_code(appId: <id>, sourceFile: 'app.groovy', confirm: true)
 
 Modes: source (inline -- stubs only, fills agent transcript), sourceFile (RECOMMENDED -- bytes bypass agent context after CLI upload), resave (recompile without changes -- on-hub only, no source touched).
@@ -2038,7 +2046,7 @@ Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h
                 properties: [
                     appId: [type: "string", description: "The app ID to update"],
                     source: [type: "string", description: "Inline Groovy source. ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial apps, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
                     resave: [type: "boolean", description: "Re-save the current source code without changes. Runs entirely on-hub -- no source touches the agent transcript."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
@@ -2050,7 +2058,7 @@ Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h
             description: """⚠️ CRITICAL: Modify existing driver code. Read current source first, explain changes, get confirmation.
 
 PREFERRED workflow for any iterative driver dev (avoids reading source into agent transcript):
-  1) Upload bytes via local CLI: 'curl -F uploadFile=@./driver.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
+  1) Upload bytes via local CLI: 'curl -F uploadFile=@./driver.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
   2) update_driver_code(driverId: <id>, sourceFile: 'driver.groovy', confirm: true)
 
 For >1 driver: USE BULK mode (single round-trip, not N): updates=[{driverId, sourceFile}, ...]. Each driver's bytes still uploaded once via CLI per the same recipe -- bulk-mode references them by filename.
@@ -2065,7 +2073,7 @@ Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h
                 properties: [
                     driverId: [type: "string", description: "The driver ID to update (single-driver mode). Omit when using 'updates' array for bulk."],
                     source: [type: "string", description: "Inline Groovy source (single-driver mode). ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial drivers, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (add '-u admin:PASS' if Hub Security is enabled; PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
                     resave: [type: "boolean", description: "Re-save the current source code without changes (single-driver mode). Runs entirely on-hub -- no source touches the agent transcript."],
                     updates: [
                         type: "array",
@@ -2115,6 +2123,88 @@ Tell user driver name/ID, warn it's permanent, get confirmation. Requires Hub Ad
             ]
         ],
 
+        // Hub Admin Library Management Tools
+        [
+            name: "get_library_source",
+            description: "Get library Groovy source. Supports chunked reading (offset/length). Large files auto-saved to File Manager for use with update_library_code sourceFile mode. Requires Hub Admin Read.",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    libraryId: [type: "string", description: "The library ID (from install_library response, or check Hubitat web UI > FOR DEVELOPERS > Libraries code for installed library IDs)"],
+                    offset: [type: "integer", description: "Character offset to start reading from (for chunked reading of large sources). Default: 0"],
+                    length: [type: "integer", description: "Max characters to return in this chunk. Default/max: 64000"]
+                ],
+                required: ["libraryId"]
+            ]
+        ],
+        [
+            name: "install_library",
+            description: """⚠️ Install new Groovy library code. Libraries are shared code modules included by drivers/apps via the #include namespace.LibraryName directive. Show code to user and get confirmation first.
+
+PREFERRED workflow (avoids reading source into agent transcript):
+  1) Upload bytes to File Manager via a local CLI tool that bypasses agent context:
+       curl -F "uploadFile=@library.groovy" -F "folder=/" "http://<HUB_IP>/hub/fileManager/upload"
+       (Hub Security: first run 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload command. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
+  2) install_library(sourceFile: 'library.groovy', confirm: true)
+
+Inline 'source' is acceptable for stub-size snippets only.
+The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
+
+Library source must include a library() definition block with these 4 required fields: name, namespace, author, description. The `category` field is optional. Hubitat rejects missing required fields with errors like "author cannot be empty in library section" or "description,author cannot be empty in library section". NOTE: the hub does NOT compile-check libraries at install time -- syntax errors only surface later when an app or driver tries to #include the library. install_library returns verified:true when the library record exists in the hub catalog; that does NOT guarantee the Groovy compiles. Requires Hub Admin Write + confirm + backup <24h. Returns new libraryId.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    source: [type: "string", description: "ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install. For non-trivial libraries, prefer sourceFile (curl recipe in tool description). Must include a library() definition block with these 4 required fields: name, namespace, author, description (category is optional). Install fails with 'author cannot be empty in library section' (or similar for the missing field) if any required field is absent."],
+                    sourceFile: [type: "string", description: "PREFERRED: File Manager filename after curl upload (e.g., 'my-library.groovy'). Upload first: curl -F 'uploadFile=@mylib.groovy' -F 'folder=/' http://<HUB_IP>/hub/fileManager/upload (Hub Security: run 'curl -c cookies.txt -d username=USER&password=PASS http://<HUB_IP>/login' first, then add '-b cookies.txt' to the upload; no auth needed without Hub Security)"],
+                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
+                ],
+                required: ["confirm"]
+            ]
+        ],
+        [
+            name: "update_library_code",
+            description: """⚠️ CRITICAL: Modify existing library code. Read current source first, explain changes, get confirmation.
+
+PREFERRED workflow for any iterative library dev (avoids reading source into agent transcript):
+  1) Upload bytes to File Manager via a local CLI tool that bypasses agent context:
+       curl -F "uploadFile=@library.groovy" -F "folder=/" "http://<HUB_IP>/hub/fileManager/upload"
+       (Hub Security: first run 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload command. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
+  2) update_library_code(libraryId: '<id>', sourceFile: 'library.groovy', confirm: true)
+
+Inline 'source' is acceptable for stub-size snippets only.
+The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
+
+Modes: source (inline -- stubs only, fills agent transcript), sourceFile (RECOMMENDED -- bytes bypass agent context after CLI upload), resave (recompile without changes -- on-hub only, no source touched).
+Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    libraryId: [type: "string", description: "The library ID to update"],
+                    source: [type: "string", description: "ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial libraries, prefer sourceFile (curl recipe in tool description)."],
+                    sourceFile: [type: "string", description: "PREFERRED: File Manager filename after curl upload (e.g., 'mcp-source-library-123.groovy'). Upload first: curl -F 'uploadFile=@mylib.groovy' -F 'folder=/' http://<HUB_IP>/hub/fileManager/upload (Hub Security: run 'curl -c cookies.txt -d username=USER&password=PASS http://<HUB_IP>/login' first, then add '-b cookies.txt' to the upload; no auth needed without Hub Security)"],
+                    resave: [type: "boolean", description: "Re-save the current source code without changes. Runs entirely on-hub -- no cloud round-trip needed."],
+                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
+                ],
+                required: ["libraryId", "confirm"]
+            ]
+        ],
+        [
+            name: "delete_library",
+            description: """⚠️ DESTRUCTIVE: Permanently delete a library. Auto-backs up source before deletion.
+
+Ensure no drivers or apps include this library before deleting (#include namespace.LibraryName references). Deleting a library used by installed code causes compilation errors.
+
+Tell user library name/ID, warn it's permanent, get confirmation. Requires Hub Admin Write + confirm + backup <24h.""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    libraryId: [type: "string", description: "The library ID to delete"],
+                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
+                ],
+                required: ["libraryId", "confirm"]
+            ]
+        ],
+
         // ==================== Item Backup Tools ====================
         [
             name: "list_item_backups",
@@ -2131,18 +2221,18 @@ Tell user driver name/ID, warn it's permanent, get confirmation. Requires Hub Ad
             inputSchema: [
                 type: "object",
                 properties: [
-                    backupKey: [type: "string", description: "The backup key from list_item_backups (e.g., 'app_123' or 'driver_456')"]
+                    backupKey: [type: "string", description: "The backup key from list_item_backups (e.g., 'app_123', 'driver_456', or 'library_42')"]
                 ],
                 required: ["backupKey"]
             ]
         ],
         [
             name: "restore_item_backup",
-            description: "⚠️ Restore app/driver to backed-up version. Tell user first. If item was DELETED, use install_app/install_driver instead. Requires Hub Admin Write + confirm.",
+            description: "⚠️ Restore app/driver to backed-up version. Tell user first. If item was DELETED, use install_app/install_driver/install_library instead. Library backups return a clear error directing you to update_library_code. Requires Hub Admin Write + confirm.",
             inputSchema: [
                 type: "object",
                 properties: [
-                    backupKey: [type: "string", description: "The backup key from list_item_backups (e.g., 'app_123' or 'driver_456')"],
+                    backupKey: [type: "string", description: "The backup key from list_item_backups (e.g., 'app_123', 'driver_456', or 'library_42')"],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms user approved the restore."]
                 ],
                 required: ["backupKey", "confirm"]
@@ -2915,6 +3005,12 @@ def executeTool(toolName, args) {
         case "update_driver_code": return toolUpdateDriverCode(args)
         case "delete_app": return toolDeleteApp(args)
         case "delete_driver": return toolDeleteDriver(args)
+
+        // Hub Admin Library Management
+        case "get_library_source": return toolGetLibrarySource(args)
+        case "install_library": return toolInstallLibrary(args)
+        case "update_library_code": return toolUpdateLibraryCode(args)
+        case "delete_library": return toolDeleteLibrary(args)
 
         // Item Backup Tools
         case "list_item_backups": return toolListItemBackups()
@@ -6280,6 +6376,57 @@ def hubInternalPostForm(String path, Map body, int timeout = 420, boolean isRetr
 }
 
 /**
+ * POST to the hub's internal API with a JSON body. Used by library management endpoints
+ * which accept Content-Type: application/json (unlike app/driver endpoints that use form-encoded).
+ * Returns a parsed Map/List from the JSON response body, or null on empty response.
+ */
+def hubInternalPostJson(String path, String jsonBody, boolean isRetry = false) {
+    def cookie = getHubSecurityCookie()
+    def params = [
+        uri: "http://127.0.0.1:8080",
+        path: path,
+        requestContentType: "application/json",
+        textParser: true, // Prevent sandbox from auto-parsing JSON response; read raw text then parse ourselves
+        headers: [
+            "Connection": "keep-alive"
+        ],
+        body: jsonBody,
+        timeout: 420,
+        ignoreSSLIssues: true
+    ]
+    if (cookie) {
+        params.headers["Cookie"] = cookie
+    }
+
+    def result = null
+    try {
+        httpPost(params) { resp ->
+            def responseData = resp.data
+            try {
+                responseData = responseData.text
+            } catch (Exception readErr) {
+                responseData = responseData?.toString()
+            }
+            if (responseData) {
+                try {
+                    result = new groovy.json.JsonSlurper().parseText(responseData)
+                } catch (Exception parseErr) {
+                    mcpLog("warn", "hub-admin", "hubInternalPostJson response not JSON: ${responseData?.take(200)}")
+                    result = null
+                }
+            }
+        }
+    } catch (Exception e) {
+        if (shouldRetryWithFreshCookie(e, isRetry)) {
+            mcpLog("debug", "hub-admin", "Retrying with fresh cookie after auth failure on POST-json ${path}")
+            return hubInternalPostJson(path, jsonBody, true)
+        }
+        throw e
+    }
+    return result
+}
+
+/**
  * Check if Hub Admin Read access is enabled. Throws if not.
  */
 def requireHubAdminRead() {
@@ -6401,10 +6548,10 @@ def toolListItemBackups() {
         return [
             backups: [],
             total: 0,
-            message: "No item backups exist yet. Backups are created automatically when you use update_app_code, update_driver_code, delete_app, or delete_driver.",
+            message: "No item backups exist yet. Backups are created automatically when you use update_app_code, update_driver_code, update_library_code, delete_app, delete_driver, or delete_library.",
             maxBackups: 20,
             storage: "Backups are stored as .groovy files in the hub's File Manager. You can access them at http://<HUB_IP>/local/<filename> or via Hubitat > Settings > File Manager.",
-            howToRestore: "Use 'get_item_backup' to retrieve source code, then 'restore_item_backup' to restore. For deleted items, use 'install_app' or 'install_driver' with the backup source."
+            howToRestore: "Use 'get_item_backup' to retrieve source code, then 'restore_item_backup' to restore (apps/drivers). For deleted apps or drivers, use 'install_app' or 'install_driver' with the backup source. For deleted libraries, use 'install_library' with the backup source."
         ]
     }
 
@@ -6439,8 +6586,8 @@ def toolListItemBackups() {
         total: backupList.size(),
         maxBackups: 20,
         storage: "Backup files are stored in the hub's local File Manager (Settings > File Manager). Files persist even if MCP is uninstalled.",
-        howToRestore: "Use 'restore_item_backup' with a backupKey to restore via MCP. Or download the .groovy file from File Manager and paste it into Apps Code / Drivers Code manually.",
-        manualRestore: "Go to Hubitat > Settings > File Manager to see backup files. Download a file, then go to Apps Code (or Drivers Code) > select the app/driver > paste the source > click Save."
+        howToRestore: "Use 'restore_item_backup' with a backupKey to restore apps/drivers via MCP. For library backups, use 'update_library_code' with sourceFile mode instead. Or download the .groovy file from File Manager and paste it into Apps Code / Drivers Code / Libraries code manually.",
+        manualRestore: "Go to Hubitat > Settings > File Manager to see backup files. Download a file, then go to Apps Code (or Drivers Code, or FOR DEVELOPERS > Libraries code) > select the item > paste the source > click Save."
     ]
 }
 
@@ -6450,7 +6597,7 @@ def toolListItemBackups() {
  * Does not require Hub Admin Read/Write.
  */
 def toolGetItemBackup(args) {
-    if (!args.backupKey) throw new IllegalArgumentException("backupKey is required (e.g., 'app_123' or 'driver_456')")
+    if (!args.backupKey) throw new IllegalArgumentException("backupKey is required (e.g., 'app_123', 'driver_456', or 'library_42')")
 
     def manifest = atomicState.itemBackupManifest ?: [:]
     def entry = manifest[args.backupKey]
@@ -6503,9 +6650,13 @@ def toolGetItemBackup(args) {
         result.manualDownload = "Go to http://<HUB_IP>/local/${entry.fileName} in your browser, or find it in Hubitat > Settings > File Manager."
     }
 
-    result.howToRestore = (entry.type == "app")
-        ? "To restore via MCP: call 'restore_item_backup' with backupKey='${args.backupKey}' and confirm=true. To restore manually: download ${entry.fileName} from File Manager, go to Hubitat > Apps Code > app ID ${entry.id} > paste source > Save."
-        : "To restore via MCP: call 'restore_item_backup' with backupKey='${args.backupKey}' and confirm=true. To restore manually: download ${entry.fileName} from File Manager, go to Hubitat > Drivers Code > driver ID ${entry.id} > paste source > Save."
+    if (entry.type == "app") {
+        result.howToRestore = "To restore via MCP: call 'restore_item_backup' with backupKey='${args.backupKey}' and confirm=true. To restore manually: download ${entry.fileName} from File Manager, go to Hubitat > Apps Code > app ID ${entry.id} > paste source > Save."
+    } else if (entry.type == "library") {
+        result.howToRestore = "Library backups cannot be restored via restore_item_backup. To restore: call 'update_library_code' with libraryId='${entry.id}' and sourceFile='${entry.fileName}' (confirm=true). To restore manually: download ${entry.fileName} from File Manager, go to Hubitat > FOR DEVELOPERS > Libraries code > library ID ${entry.id} > paste source > Save."
+    } else {
+        result.howToRestore = "To restore via MCP: call 'restore_item_backup' with backupKey='${args.backupKey}' and confirm=true. To restore manually: download ${entry.fileName} from File Manager, go to Hubitat > Drivers Code > driver ID ${entry.id} > paste source > Save."
+    }
 
     return result
 }
@@ -6519,7 +6670,7 @@ def toolGetItemBackup(args) {
 def toolRestoreItemBackup(args) {
     requireHubAdminWrite(args.confirm)
 
-    if (!args.backupKey) throw new IllegalArgumentException("backupKey is required (e.g., 'app_123', 'driver_456', or 'rm-rule_<id>_<ts>')")
+    if (!args.backupKey) throw new IllegalArgumentException("backupKey is required (e.g., 'app_123', 'driver_456', 'library_42', or 'rm-rule_<id>_<ts>')")
 
     def manifest = atomicState.itemBackupManifest ?: [:]
     def entry = manifest[args.backupKey]
@@ -6531,6 +6682,20 @@ def toolRestoreItemBackup(args) {
             success: false,
             error: "No backup found for key '${args.backupKey}'",
             availableBackups: availableKeys.isEmpty() ? "None" : availableKeys.join(", ")
+        ]
+    }
+
+    // Library backups cannot be restored via the app/driver ajax/update endpoint.
+    // Direct the caller to use install_library or update_library_code with the backup source.
+    if (entry.type == "library") {
+        return [
+            success: false,
+            error: "Library backups cannot be restored via restore_item_backup -- use install_library or update_library_code with the backup source from '${entry.fileName}' instead.",
+            backupKey: args.backupKey,
+            type: "library",
+            backupFile: entry.fileName,
+            directDownload: "http://<HUB_IP>/local/${entry.fileName}",
+            hint: "Download the backup from File Manager or use get_item_backup to retrieve the source, then call update_library_code with sourceFile mode."
         ]
     }
 
@@ -9777,6 +9942,523 @@ private Map toolDeleteItem(String type, String idParam, String deletePath, args)
     } catch (Exception e) {
         mcpLog("error", "hub-admin", "${type.capitalize()} deletion failed: ${e.message}")
         return [success: false, error: "${type.capitalize()} deletion failed: ${e.message}"]
+    }
+}
+
+// ==================== HUB ADMIN LIBRARY MANAGEMENT ====================
+
+/**
+ * Backs up a library's current source to File Manager, recording metadata in
+ * atomicState.itemBackupManifest. Throws on empty or unparseable hub response,
+ * matching backupItemSource semantics for apps and drivers. Respects the 1-hour
+ * dedup window to preserve the pre-edit baseline through rapid successive updates.
+ * Returns the manifest entry on success.
+ */
+private Map backupLibrarySource(String libraryId) {
+    def manifest = atomicState.itemBackupManifest ?: [:]
+    def key = "library_${libraryId}"
+    def existing = manifest[key]
+
+    if (existing?.timestamp && (now() - existing.timestamp) < 3600000) {
+        mcpLog("debug", "hub-admin", "Library backup for ${key} already exists (${formatTimestamp(existing.timestamp)}), skipping")
+        return existing
+    }
+
+    def responseText = hubInternalGet("/library/list/single/data/${libraryId}")
+    if (!responseText) {
+        throw new IllegalArgumentException("Cannot back up library ID ${libraryId}: empty response from hub")
+    }
+
+    def parsed
+    try {
+        parsed = new groovy.json.JsonSlurper().parseText(responseText)
+    } catch (Exception parseEx) {
+        throw new IllegalArgumentException("Cannot back up library ID ${libraryId}: failed to parse hub response: ${parseEx.message}")
+    }
+
+    if (!(parsed instanceof List) || parsed.isEmpty()) {
+        throw new IllegalArgumentException("Cannot back up library ID ${libraryId}: library not found")
+    }
+
+    def libData = parsed[0]
+    def backupSource = libData.source ?: ""
+    def fileName = "mcp-backup-library-${libraryId}.groovy"
+    try {
+        uploadHubFile(fileName, backupSource.getBytes("UTF-8"))
+    } catch (Exception e) {
+        mcpLog("error", "hub-admin", "Failed to save library backup file '${fileName}': ${e.message}")
+        throw new IllegalArgumentException("Cannot back up library ID ${libraryId}: file upload failed -- ${e.message}")
+    }
+
+    def entry = [
+        type: "library",
+        id: libraryId.toString(),
+        fileName: fileName,
+        version: libData.version,
+        timestamp: now(),
+        sourceLength: backupSource.length()
+    ]
+    manifest[key] = entry
+
+    if (manifest.size() > 20) {
+        def sortedKeys = manifest.entrySet().sort { a, b -> a.value.timestamp <=> b.value.timestamp }*.key
+        def toRemove = sortedKeys.take(manifest.size() - 20)
+        toRemove.each { k ->
+            def e2 = manifest[k]
+            if (e2?.fileName) {
+                try { deleteHubFile(e2.fileName) } catch (Exception ex) { mcpLog("warn", "hub-admin", "Could not delete pruned library backup file '${e2.fileName}': ${ex.message}") }
+            }
+            manifest.remove(k)
+        }
+    }
+
+    atomicState.itemBackupManifest = manifest
+    mcpLog("info", "hub-admin", "Backed up library ID ${libraryId} source to File Manager: ${fileName} (version ${libData.version}, ${backupSource.length()} chars)")
+    return entry
+}
+
+/**
+ * Get library Groovy source. Supports chunked reading (offset/length).
+ * Large files are auto-saved to File Manager for use with update_library_code sourceFile mode.
+ * Hub endpoint: GET /library/list/single/data/<id> returns [{id, source, version, ...}]
+ */
+def toolGetLibrarySource(args) {
+    requireHubAdminRead()
+    def libraryId = args.libraryId
+    if (!libraryId) throw new IllegalArgumentException("libraryId is required")
+    if (!libraryId.toString().isInteger() || libraryId.toString().toInteger() <= 0) throw new IllegalArgumentException("libraryId must be a positive integer (got: '${libraryId}')")
+
+    def maxChunkSize = 64000
+    def requestedOffset = args.offset ? args.offset as int : 0
+    def requestedLength = args.length ? Math.min(args.length as int, maxChunkSize) : maxChunkSize
+
+    try {
+        def responseText = hubInternalGet("/library/list/single/data/${libraryId}")
+        if (!responseText) return [success: false, error: "Empty response from hub for library ${libraryId}"]
+
+        def parsed
+        try {
+            parsed = new groovy.json.JsonSlurper().parseText(responseText)
+        } catch (Exception parseErr) {
+            return [success: false, error: "Failed to parse library response: ${parseErr.message}"]
+        }
+
+        if (!(parsed instanceof List) || parsed.isEmpty()) {
+            return [success: false, error: "Library ${libraryId} not found"]
+        }
+
+        def libraryData = parsed[0]
+        def fullSource = libraryData?.source ?: ""
+        def totalLength = fullSource.length()
+
+        // For large sources, save full copy to File Manager so update can use sourceFile
+        def savedToFile = null
+        def savedToFileError = null
+        if (totalLength > maxChunkSize) {
+            def sourceFileName = "mcp-source-library-${libraryId}.groovy"
+            try {
+                uploadHubFile(sourceFileName, fullSource.getBytes("UTF-8"))
+                savedToFile = sourceFileName
+                mcpLog("info", "hub-admin", "Saved full library ID ${libraryId} source to File Manager: ${sourceFileName} (${totalLength} chars)")
+            } catch (Exception saveErr) {
+                savedToFileError = saveErr.message ?: saveErr.toString()
+                mcpLog("warn", "hub-admin", "Could not save library source to File Manager: ${savedToFileError}")
+            }
+        }
+
+        // Extract the requested chunk
+        def endIndex = Math.min(requestedOffset + requestedLength, totalLength)
+        def chunk = (requestedOffset < totalLength) ? fullSource.substring(requestedOffset, endIndex) : ""
+        def hasMore = endIndex < totalLength
+
+        mcpLog("info", "hub-admin", "Retrieved library ID ${libraryId} source: ${totalLength} chars total, returning offset ${requestedOffset}..${endIndex}${hasMore ? ' (more available)' : ''}")
+
+        def result = [
+            success: true,
+            libraryId: libraryId,
+            source: chunk,
+            version: libraryData?.version,
+            name: libraryData?.name,
+            namespace: libraryData?.namespace,
+            totalLength: totalLength,
+            offset: requestedOffset,
+            chunkLength: chunk.length(),
+            hasMore: hasMore
+        ]
+        if (hasMore) {
+            result.nextOffset = endIndex
+            result.remainingChars = totalLength - endIndex
+            result.hint = "Call again with offset: ${endIndex} to get the next chunk."
+        }
+        if (savedToFile) {
+            result.sourceFile = savedToFile
+            result.sourceFileHint = "Full source saved to File Manager. Use update_library_code with sourceFile: '${savedToFile}' to update without cloud size limits."
+        }
+        if (savedToFileError) {
+            result.sourceFileError = "Failed to auto-save full source to File Manager: ${savedToFileError}. Use chunked reads (offset/length) to retrieve the full source."
+        }
+        return result
+    } catch (Exception e) {
+        mcpLog("error", "hub-admin", "Failed to get library source: ${e.message}")
+        return [success: false, error: "Failed to get library source: ${e.message}"]
+    }
+}
+
+/**
+ * Install a new Groovy library from inline source or a File Manager file.
+ * Hub endpoint: POST /library/saveOrUpdateJson with {id: null, source, version: null}
+ * Returns: {success, message, id, version}
+ */
+def toolInstallLibrary(args) {
+    requireHubAdminWrite(args.confirm)
+
+    // Resolve source: sourceFile takes precedence over inline source
+    def sourceCode = null
+    def sourceMode = null
+
+    if (args.sourceFile && args.source) {
+        throw new IllegalArgumentException("Provide either 'source' or 'sourceFile', not both")
+    }
+    if (args.sourceFile) {
+        sourceMode = "sourceFile"
+        mcpLog("info", "hub-admin", "Reading library source from File Manager: ${args.sourceFile}")
+        def bytes = downloadHubFile(args.sourceFile)
+        if (bytes == null) throw new IllegalArgumentException("Source file '${args.sourceFile}' not found in File Manager")
+        sourceCode = new String(bytes, "UTF-8")
+        mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from ${args.sourceFile}")
+    } else if (args.source) {
+        sourceMode = "source"
+        sourceCode = args.source
+    } else {
+        throw new IllegalArgumentException("One of 'source' or 'sourceFile' is required")
+    }
+
+    mcpLog("info", "hub-admin", "Installing new library (mode: ${sourceMode}, sourceLength: ${sourceCode.length()})")
+    try {
+        def body = groovy.json.JsonOutput.toJson([id: null, source: sourceCode, version: null])
+        def result = hubInternalPostJson("/library/saveOrUpdateJson", body)
+
+        def newLibraryId = result?.id?.toString()
+        def newVersion = result?.version
+
+        if (result?.success == false) {
+            def msg = result?.message ?: "Hub returned failure"
+            mcpLog("warn", "hub-admin", "Library install failed: ${msg}")
+            return [
+                success: false,
+                error: "Library installation failed: ${msg}",
+                note: "Check that the Groovy source includes a valid library() definition block and has no syntax errors.",
+                lastBackup: formatTimestamp(state.lastBackupTimestamp)
+            ]
+        }
+
+        // Fail-closed when hub gives us nothing concrete to confirm the install:
+        // either no response at all, or a response without an id. The library
+        // may or may not have persisted -- the agent must check the UI rather
+        // than retry blindly (which could create a duplicate at a fresh id).
+        if (result == null || !newLibraryId) {
+            def detail = result == null ? "empty/null response" : "response missing id field"
+            mcpLog("warn", "hub-admin", "Library install: hub returned ${detail} -- cannot confirm install")
+            return [
+                success: false,
+                error: "Library install unverified: hub returned ${detail}",
+                note: "Check Hubitat web UI (FOR DEVELOPERS > Libraries code) to confirm whether the library was actually persisted. Do NOT retry without checking first -- a duplicate library may result.",
+                lastBackup: formatTimestamp(state.lastBackupTimestamp)
+            ]
+        }
+
+        mcpLog("info", "hub-admin", "Library installed successfully (ID: ${newLibraryId}, version: ${newVersion})")
+
+        // Post-install verification: confirm library persists in the hub list.
+        // Mirrors toolInstallItemSingle semantics: empty/unparseable verify response or a hub
+        // compile-error signal both return success=false (with libraryId populated so the
+        // caller can inspect via get_library_source). Transient fetch failures return
+        // success=true with verified=false + verifyError.
+        def verifyText = null
+        def verifyError = null
+        try {
+            verifyText = hubInternalGet("/hub2/userLibraries")
+        } catch (Exception verifyErr) {
+            verifyError = verifyErr.message ?: verifyErr.toString()
+            mcpLog("warn", "hub-admin", "Library post-install verification fetch failed for ID ${newLibraryId}: ${verifyError}")
+        }
+
+        if (verifyError == null) {
+            if (!verifyText) {
+                mcpLog("warn", "hub-admin", "Library ID ${newLibraryId}: verify endpoint returned empty body -- cannot confirm install")
+                return [
+                    success: false,
+                    error: "Library install unverified: hub returned empty verify body for ID ${newLibraryId}",
+                    libraryId: newLibraryId,
+                    note: "Hub created a library slot but the verify fetch returned no content. Use get_library_source with ID ${newLibraryId} to confirm whether the library persisted. Do NOT retry without checking first -- a duplicate library at a new ID may result.",
+                    lastBackup: formatTimestamp(state.lastBackupTimestamp)
+                ]
+            }
+            def libraries
+            try {
+                libraries = new groovy.json.JsonSlurper().parseText(verifyText)
+            } catch (Exception parseErr) {
+                mcpLog("warn", "hub-admin", "Library ID ${newLibraryId}: verify body unparseable: ${parseErr.message}")
+                return [
+                    success: false,
+                    error: "Library install unverified: hub returned unparseable verify body for ID ${newLibraryId}",
+                    libraryId: newLibraryId,
+                    note: "Hub created a library slot but the verify response was not valid JSON. Use get_library_source with ID ${newLibraryId} to confirm whether the library persisted. Do NOT retry without checking first -- a duplicate library at a new ID may result.",
+                    lastBackup: formatTimestamp(state.lastBackupTimestamp)
+                ]
+            }
+            def found = (libraries instanceof List) && libraries.any { it.id?.toString() == newLibraryId }
+            if (!found) {
+                mcpLog("warn", "hub-admin", "Library ID ${newLibraryId} not found in post-install library list")
+                return [
+                    success: false,
+                    error: "Library install unverified: ID ${newLibraryId} not found in post-install library list",
+                    libraryId: newLibraryId,
+                    note: "Hub created a library slot but the verify list did not include it. Use get_library_source with ID ${newLibraryId} to confirm. Do NOT retry without checking first -- a duplicate library at a new ID may result.",
+                    lastBackup: formatTimestamp(state.lastBackupTimestamp)
+                ]
+            }
+        }
+
+        mcpLog("info", "hub-admin", "Library installed (ID: ${newLibraryId}, mode: ${sourceMode}, verified: ${verifyError == null})")
+        def installResult = [
+            success: true,
+            message: "Library installed successfully",
+            libraryId: newLibraryId,
+            version: newVersion,
+            sourceMode: sourceMode,
+            sourceLength: sourceCode.length(),
+            verified: (verifyError == null),
+            lastBackup: formatTimestamp(state.lastBackupTimestamp)
+        ]
+        if (verifyError != null) installResult.verifyError = "${verifyError} -- use get_library_source with ID ${newLibraryId} to confirm."
+        return installResult
+    } catch (Exception e) {
+        mcpLog("error", "hub-admin", "Library installation failed: ${e.message}")
+        return [
+            success: false,
+            error: "Library installation failed: ${e.message}",
+            note: "Check that the Groovy source includes a valid library() definition block and has no syntax errors."
+        ]
+    }
+}
+
+/**
+ * Update an existing library's source code.
+ * Hub endpoint: POST /library/saveOrUpdateJson with {id, source, version}
+ * Three modes: source (direct), sourceFile (from File Manager), resave (re-save current).
+ * Backs up current source before modifying.
+ */
+def toolUpdateLibraryCode(args) {
+    requireHubAdminWrite(args.confirm)
+    def libraryId = args.libraryId
+    if (!libraryId) throw new IllegalArgumentException("libraryId is required")
+    if (!libraryId.toString().isInteger() || libraryId.toString().toInteger() <= 0) throw new IllegalArgumentException("libraryId must be a positive integer (got: '${libraryId}')")
+
+    // Resolve source from one of three modes: source, sourceFile, or resave
+    def sourceCode = null
+    def sourceMode = null
+    def freshVersion = null
+
+    if (args.resave) {
+        sourceMode = "resave"
+        mcpLog("info", "hub-admin", "Resave mode: fetching current library ID ${libraryId} source locally")
+        def responseText = hubInternalGet("/library/list/single/data/${libraryId}")
+        if (!responseText) throw new IllegalArgumentException("Could not fetch current source for library ID ${libraryId}")
+        def parsed
+        try {
+            parsed = new groovy.json.JsonSlurper().parseText(responseText)
+        } catch (Exception parseEx) {
+            throw new IllegalArgumentException("Could not parse library source response for ID ${libraryId}: ${parseEx.message}")
+        }
+        if (!(parsed instanceof List) || parsed.isEmpty()) {
+            throw new IllegalArgumentException("Library ID ${libraryId} not found")
+        }
+        def lib = parsed[0]
+        sourceCode = lib.source
+        freshVersion = lib.version
+        if (!sourceCode) throw new IllegalArgumentException("Library ID ${libraryId} has no source to resave")
+    } else if (args.sourceFile) {
+        sourceMode = "sourceFile"
+        mcpLog("info", "hub-admin", "Reading library source from File Manager: ${args.sourceFile}")
+        def bytes = downloadHubFile(args.sourceFile)
+        if (bytes == null) throw new IllegalArgumentException("Source file '${args.sourceFile}' not found in File Manager")
+        sourceCode = new String(bytes, "UTF-8")
+        mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from ${args.sourceFile}")
+    } else if (args.source) {
+        sourceMode = "source"
+        sourceCode = args.source
+    } else {
+        throw new IllegalArgumentException("One of 'source', 'sourceFile', or 'resave' is required")
+    }
+
+    // Check 1-hour dedup BEFORE any backup-related fetch -- preserves the original
+    // pre-edit baseline through rapid edits AND avoids an unnecessary network round-trip.
+    // Fail-closed: backup-fetch failure (when needed) aborts the update, matching
+    // toolUpdateItemCodeInner which calls backupItemSource() without try/catch.
+    def backupFileName = null
+    def existingEntry = (atomicState.itemBackupManifest ?: [:])["library_${libraryId}"]
+    def skipBackup = (existingEntry?.timestamp && (now() - existingEntry.timestamp) < 3600000)
+
+    def versionFetchError = null
+    if (skipBackup) {
+        mcpLog("debug", "hub-admin", "Library backup for library_${libraryId} already exists (${formatTimestamp(existingEntry.timestamp)}), skipping")
+        backupFileName = existingEntry.fileName
+        // Still need fresh version for optimistic locking when the source-resolution path
+        // didn't provide it (i.e., source/sourceFile modes -- resave already set it).
+        if (freshVersion == null) {
+            try {
+                def versionText = hubInternalGet("/library/list/single/data/${libraryId}")
+                if (versionText) {
+                    def versionParsed = new groovy.json.JsonSlurper().parseText(versionText)
+                    if (versionParsed instanceof List && !versionParsed.isEmpty()) {
+                        freshVersion = versionParsed[0]?.version
+                    }
+                }
+            } catch (Exception vErr) {
+                versionFetchError = vErr.message ?: vErr.toString()
+                mcpLog("warn", "hub-admin", "Could not fetch fresh version for library ID ${libraryId}, falling back to backup version: ${versionFetchError}")
+            }
+            // Fall back to cached backup version (matching toolUpdateItemCodeInner fallback)
+            if (freshVersion == null) freshVersion = existingEntry.version
+        }
+    } else {
+        // Backup needed. backupLibrarySource handles fetch, upload, manifest update, and pruning.
+        // Fail-closed: any throw propagates up and aborts the update -- same contract as
+        // toolUpdateItemCodeInner calling backupItemSource() without try/catch.
+        def backupEntry = backupLibrarySource(libraryId.toString())
+        backupFileName = backupEntry.fileName
+        if (freshVersion == null) freshVersion = backupEntry.version
+    }
+
+    if (freshVersion == null) {
+        // This path is only reachable when skipBackup=true (dedup window), freshVersion was null
+        // after the source-resolution step, AND the version-refetch failed AND existingEntry.version
+        // was also null. Surface the actual failure so the agent can diagnose.
+        throw new IllegalArgumentException("Could not determine current version for library ID ${libraryId} -- version fetch failed (${versionFetchError ?: 'unknown'}) and cached backup has no version. Check that the library exists.")
+    }
+    def currentVersion = freshVersion
+
+    mcpLog("info", "hub-admin", "Updating library ID: ${libraryId} (version: ${currentVersion}, mode: ${sourceMode}, sourceLength: ${sourceCode.length()})")
+    try {
+        def body = groovy.json.JsonOutput.toJson([id: libraryId as Integer, source: sourceCode, version: currentVersion as Integer])
+        def result = hubInternalPostJson("/library/saveOrUpdateJson", body)
+
+        if (result?.success == false) {
+            def msg = result?.message ?: "Hub returned failure"
+            mcpLog("warn", "hub-admin", "Library update failed: ${msg}")
+            return [
+                success: false,
+                error: "Library update failed: ${msg}",
+                libraryId: libraryId,
+                note: "Check the Groovy source code for syntax errors or compilation issues."
+            ]
+        }
+
+        mcpLog("info", "hub-admin", "Library ID ${libraryId} updated successfully (mode: ${sourceMode})")
+        def successResult = [
+            success: true,
+            message: "Library code updated successfully",
+            libraryId: libraryId,
+            previousVersion: currentVersion,
+            newVersion: result?.version,
+            sourceMode: sourceMode,
+            sourceLength: sourceCode.length(),
+            lastBackup: formatTimestamp(state.lastBackupTimestamp)
+        ]
+        if (sourceMode == "resave") successResult.note = "Source was fetched and re-saved entirely on-hub -- no cloud round-trip."
+        if (sourceMode == "sourceFile") successResult.note = "Source was read from File Manager file '${args.sourceFile}' -- no cloud size limits."
+        return successResult
+    } catch (Exception e) {
+        mcpLog("error", "hub-admin", "Library update failed: ${e.message}")
+        return [success: false, error: "Library update failed: ${e.message}"]
+    }
+}
+
+/**
+ * Delete a library from the hub.
+ * Backs up source to File Manager before deletion via backupLibrarySource().
+ * Hub endpoint: GET /library/edit/deleteJson/<id>
+ * Returns: {success, message: null}
+ */
+def toolDeleteLibrary(args) {
+    requireHubAdminWrite(args.confirm)
+    def libraryId = args.libraryId
+    if (!libraryId) throw new IllegalArgumentException("libraryId is required")
+    if (!libraryId.toString().isInteger() || libraryId.toString().toInteger() <= 0) throw new IllegalArgumentException("libraryId must be a positive integer (got: '${libraryId}')")
+
+    // Initialize to false -- assume backup failed; only flip to true on confirmed completion so the success message and backupFile field stay consistent on every exit path.
+    def backupSucceeded = false
+    def backupFileName = null
+    try {
+        def backupEntry = backupLibrarySource(libraryId.toString())
+        backupFileName = backupEntry.fileName
+        backupSucceeded = true
+    } catch (Exception backupErr) {
+        mcpLog("warn", "hub-admin", "Pre-delete backup failed for library ${libraryId}: ${backupErr.message} -- proceeding with delete")
+    }
+
+    mcpLog("warn", "hub-admin", "Deleting library ID: ${libraryId}")
+    try {
+        def responseText = hubInternalGet("/library/edit/deleteJson/${libraryId}")
+        mcpLog("debug", "hub-admin", "Delete library ${libraryId} response: ${responseText?.take(200)}")
+
+        // Fail-closed: only treat the delete as successful when the hub returns parseable
+        // JSON with an explicit success==true. Substring fallback is unsafe -- hub rejection
+        // bodies like "Library is in use by..." don't contain the word "error" and would
+        // produce a false success.
+        def success = false
+        if (responseText) {
+            try {
+                def parsed = new groovy.json.JsonSlurper().parseText(responseText)
+                // Hub returns {success: true, message: null} on success
+                if (parsed?.success == true) {
+                    success = true
+                } else {
+                    def hubMsg = parsed?.message ?: parsed?.error ?: "Hub returned success=false"
+                    mcpLog("warn", "hub-admin", "Delete library ${libraryId}: hub indicated failure: ${hubMsg}")
+                    return [
+                        success: false,
+                        error: hubMsg,
+                        libraryId: libraryId,
+                        note: "Hub rejected the delete request. If the library is in use, remove all #include references from apps and drivers before deleting."
+                    ]
+                }
+            } catch (Exception parseErr) {
+                mcpLog("warn", "hub-admin", "Delete library ${libraryId}: response not parseable as JSON -- treating as failure. Response: ${responseText?.take(200)}")
+                return [
+                    success: false,
+                    error: "Delete response was not valid JSON -- cannot confirm deletion. Response: ${responseText?.take(200)}",
+                    libraryId: libraryId,
+                    note: "Check Hubitat web UI (FOR DEVELOPERS > Libraries code) to verify whether the library was deleted."
+                ]
+            }
+        }
+
+        if (success) {
+            mcpLog("info", "hub-admin", "Library ID ${libraryId} deleted successfully")
+            def backupEntry = (atomicState.itemBackupManifest ?: [:])?.get("library_${libraryId}".toString())
+            def result = [
+                success: true,
+                message: backupSucceeded ? "Library deleted successfully. Source code backed up to File Manager." : "Library deleted successfully. WARNING: Pre-delete backup failed -- source code may not be recoverable.",
+                libraryId: libraryId,
+                lastBackup: formatTimestamp(state.lastBackupTimestamp),
+                backupFile: backupEntry?.fileName ?: backupFileName,
+                restoreHint: backupEntry ? "To restore: use 'install_library' with the backup source, or download ${backupEntry.fileName} from Hubitat > Settings > File Manager and re-install manually." : null
+            ]
+            if (!backupSucceeded) result.backupWarning = "Pre-delete backup could not be created. The source code may be permanently lost."
+            return result
+        } else {
+            return [
+                success: false,
+                error: "Delete may have failed - check the Hubitat web UI (FOR DEVELOPERS > Libraries code) to verify",
+                libraryId: libraryId,
+                response: responseText?.take(500)
+            ]
+        }
+    } catch (Exception e) {
+        mcpLog("error", "hub-admin", "Library deletion failed: ${e.message}")
+        return [success: false, error: "Library deletion failed: ${e.message}"]
     }
 }
 
@@ -18786,7 +19468,7 @@ All Hub Admin Write tools require these steps:
 
 **delete_room** - Devices become unassigned (not deleted). List affected devices first.
 
-**delete_app/delete_driver** - Remove app instances via Hubitat UI first (apps). Change devices to different driver first (drivers). Auto-backs up before deletion.''',
+**delete_app/delete_driver/delete_library** - Remove app instances via Hubitat UI first (apps). Change devices to different driver first (drivers). For libraries, check that no apps/drivers reference the library via #include namespace.Name before deleting -- deletion breaks any code that still includes it. Auto-backs up before deletion.''',
 
         virtual_devices: '''## Virtual Device Types
 
@@ -18886,7 +19568,7 @@ MCP-managed virtual devices:
 - Only write tool that doesn't require a prior backup
 
 ### Source Code Backups (Automatic)
-- Created when using update_app_code, update_driver_code, delete_app, delete_driver
+- Created when using update_app_code, update_driver_code, update_library_code, delete_app, delete_driver, delete_library
 - Stored in File Manager as .groovy files
 - Persist even if MCP uninstalled
 - Max 20 kept, oldest pruned

--- a/src/test/groovy/server/RegressionsFromHistorySpec.groovy
+++ b/src/test/groovy/server/RegressionsFromHistorySpec.groovy
@@ -345,4 +345,85 @@ class RegressionsFromHistorySpec extends ToolSpecBase {
         result.success == true
         result.previousVersion == 5
     }
+
+    // --- update_library_code dedup-path version correctness ------------------
+    //
+    // When the 1-hour backup dedup window is active, update_library_code must
+    // still fetch the CURRENT version from the hub (via /library/list/single/data/<id>)
+    // for the optimistic-locking POST field -- not reuse the stale version
+    // stored in the backup manifest. If the fresh fetch fails, it falls back
+    // to the cached manifest version rather than aborting.
+    //
+    // These two tests pin both branches of that version-resolution path,
+    // mirroring the v0.4.6 regression tests for update_app_code above.
+
+    def "update_library_code dedup path uses the fresh version from the hub, not the stale backup-manifest cache"() {
+        given: 'a recent cached backup whose manifest carries a stale version=1'
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L
+        atomicStateMap.itemBackupManifest = [library_42: [
+            type: 'library', id: '42',
+            fileName: 'mcp-backup-library-42.groovy',
+            version: 1,                                    // stale -- hub has been edited since
+            timestamp: 1234567890000L - 60_000L,           // 1 minute ago -- inside the 1-hour window
+            sourceLength: 100
+        ]]
+
+        and: '/library/list/single/data/42 returns version=9 -- the current value'
+        hubGet.register('/library/list/single/data/42') { params ->
+            groovy.json.JsonOutput.toJson([[id: 42, version: 9, source: 'library(name:"L")', name: 'L', namespace: 'n']])
+        }
+
+        and: 'capture the JSON body posted to saveOrUpdateJson'
+        def capturedBody = null
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            capturedBody = new groovy.json.JsonSlurper().parseText(body)
+            [success: true, message: '', id: 42, version: 10]
+        }
+
+        when:
+        def result = script.toolUpdateLibraryCode([libraryId: '42', source: 'new source', confirm: true])
+
+        then: 'POST body carries the fresh version=9, NOT the cached stale version=1'
+        capturedBody.version == 9
+
+        and: 'the tool reports the fresh previousVersion'
+        result.success == true
+        result.previousVersion == 9
+    }
+
+    def "update_library_code dedup path falls back to the cached backup version when the fresh-fetch fails"() {
+        given: 'a recent cached backup with version=7 (stale, but the only value available)'
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L
+        atomicStateMap.itemBackupManifest = [library_42: [
+            type: 'library', id: '42',
+            fileName: 'mcp-backup-library-42.groovy',
+            version: 7,
+            timestamp: 1234567890000L - 60_000L,
+            sourceLength: 100
+        ]]
+
+        and: '/library/list/single/data/42 throws (hub transiently offline)'
+        hubGet.register('/library/list/single/data/42') { params ->
+            throw new RuntimeException('hub offline')
+        }
+
+        and: 'capture the version in the update POST'
+        def capturedBody = null
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            capturedBody = new groovy.json.JsonSlurper().parseText(body)
+            [success: true, message: '', id: 42, version: 8]
+        }
+
+        when:
+        def result = script.toolUpdateLibraryCode([libraryId: '42', source: 'new source', confirm: true])
+
+        then: 'best-effort fallback -- use the cached version=7 rather than aborting'
+        capturedBody.version == 7
+
+        and: 'tool still reports success using the fallback version'
+        result.success == true
+        result.previousVersion == 7
+    }
 }

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -1440,4 +1440,22 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.message.contains('preserved')
         atomicStateMap.itemBackupManifest.containsKey('driver_88')
     }
+
+    def "restore_item_backup returns clear error for library type and directs user to update_library_code"() {
+        given:
+        enableHubAdminWrite()
+        atomicStateMap.itemBackupManifest = [
+            'library_42': [type: 'library', id: '42', fileName: 'mcp-backup-library-42.groovy',
+                           version: 3, timestamp: 1L, sourceLength: 200]
+        ]
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'library_42', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('use install_library or update_library_code')
+        result.backupFile == 'mcp-backup-library-42.groovy'
+        result.type == 'library'
+    }
 }

--- a/src/test/groovy/server/ToolAppsDriversSpec.groovy
+++ b/src/test/groovy/server/ToolAppsDriversSpec.groovy
@@ -372,4 +372,36 @@ class ToolAppsDriversSpec extends ToolSpecBase {
         result.message.contains('60001')
         result.manualDownload.contains('mcp-backup-driver-9.groovy')
     }
+
+    def "get_item_backup library-type uses update_library_code restore path, not restore_item_backup"() {
+        given:
+        // Library backups cannot go through restore_item_backup -- that tool only handles
+        // apps and drivers. The howToRestore text must point to update_library_code.
+        atomicStateMap.itemBackupManifest = [
+            'library_42': [type: 'library', id: '42', fileName: 'mcp-backup-library-42.groovy',
+                           version: 3, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        script.metaClass.downloadHubFile = { String fileName ->
+            fileName == 'mcp-backup-library-42.groovy' ? 'library(name:"Foo")'.getBytes('UTF-8') : null
+        }
+
+        when:
+        def result = script.toolGetItemBackup([backupKey: 'library_42'])
+
+        then: 'standard fields are present'
+        result.backupKey == 'library_42'
+        result.type == 'library'
+        result.id == '42'
+        result.version == 3
+        result.source == 'library(name:"Foo")'
+        result.directDownload.contains('mcp-backup-library-42.groovy')
+
+        and: 'restore path names update_library_code as the action; restore_item_backup mentioned only as not applicable'
+        result.howToRestore.contains('update_library_code')
+        result.howToRestore.contains('cannot be restored via restore_item_backup')
+
+        and: 'restore path includes the correct library ID and file reference'
+        result.howToRestore.contains("libraryId='42'")
+        result.howToRestore.contains("sourceFile='mcp-backup-library-42.groovy'")
+    }
 }

--- a/src/test/groovy/server/ToolLibraryCodeSpec.groovy
+++ b/src/test/groovy/server/ToolLibraryCodeSpec.groovy
@@ -1,0 +1,921 @@
+package server
+
+import support.ToolSpecBase
+
+/**
+ * Spec for the library management tools in manage_app_driver_code gateway:
+ *
+ * - toolGetLibrarySource   -> get_library_source
+ * - toolInstallLibrary     -> install_library
+ * - toolUpdateLibraryCode  -> update_library_code
+ * - toolDeleteLibrary      -> delete_library
+ *
+ * Hub API contracts verified here:
+ *   GET  /library/list/single/data/<id>  -- returns [{id, version, source, name, namespace, ...}]
+ *   GET  /hub2/userLibraries             -- returns [{id, name, namespace, ...}] (no source)
+ *   POST /library/saveOrUpdateJson       -- JSON body {id, source, version}; returns {success, message, id, version}
+ *   GET  /library/edit/deleteJson/<id>   -- returns {success: true, message: null}
+ *
+ * Mocking strategy:
+ *   - hubInternalGet        -- routed by HarnessSpec via hubGet.register(path) closures.
+ *   - hubInternalPostJson   -- purely dynamic helper, stubbed per-test on script.metaClass.
+ *   - uploadHubFile / downloadHubFile -- purely dynamic, stubbed per-test on script.metaClass.
+ */
+class ToolLibraryCodeSpec extends ToolSpecBase {
+
+    private static final String SAMPLE_SOURCE = '''\
+library(
+    name: "TestLib",
+    namespace: "level99",
+    author: "Test",
+    description: "Test library"
+)
+
+def helperMethod() { return "ok" }
+'''
+
+    private static final String SAMPLE_RESPONSE_JSON = '''\
+[{"id":42,"version":1,"author":"Test","category":null,"description":"A test library",
+  "name":"TestLib","namespace":"level99","type":"usr","documentationLink":null,
+  "updateTime":"2026-05-08T00:00:00+0000","usedByAppTypes":"","usedByDeviceTypes":"",
+  "private":false,"lastModified":"2026-05-08T00:00:00+0000",
+  "source":"library(\\n    name: \\"TestLib\\"\\n)\\n\\ndef helperMethod() { return \\"ok\\" }\\n"}]'''
+
+    private void enableHubAdminRead() {
+        settingsMap.enableHubAdminRead = true
+    }
+
+    private void enableHubAdminWrite() {
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L  // matches fixed now()
+    }
+
+    // -------- toolGetLibrarySource --------
+
+    def "get_library_source throws when Hub Admin Read is disabled"() {
+        when:
+        script.toolGetLibrarySource([libraryId: '42'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Read')
+    }
+
+    def "get_library_source throws when libraryId is missing"() {
+        given:
+        enableHubAdminRead()
+
+        when:
+        script.toolGetLibrarySource([:])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('libraryId is required')
+    }
+
+    def "get_library_source returns source and metadata for a known library"() {
+        given:
+        enableHubAdminRead()
+        hubGet.register('/library/list/single/data/42') { params ->
+            SAMPLE_RESPONSE_JSON
+        }
+
+        when:
+        def result = script.toolGetLibrarySource([libraryId: '42'])
+
+        then:
+        result.success == true
+        result.libraryId == '42'
+        result.version == 1
+        result.name == 'TestLib'
+        result.namespace == 'level99'
+        result.totalLength > 0
+        result.offset == 0
+        result.hasMore == false
+        result.source != null
+    }
+
+    def "get_library_source returns error when library not found"() {
+        given:
+        enableHubAdminRead()
+        hubGet.register('/library/list/single/data/999') { params -> '[]' }
+
+        when:
+        def result = script.toolGetLibrarySource([libraryId: '999'])
+
+        then:
+        result.success == false
+        result.error.contains('999')
+        result.error.toLowerCase().contains('not found')
+    }
+
+    def "get_library_source returns error on empty hub response"() {
+        given:
+        enableHubAdminRead()
+        hubGet.register('/library/list/single/data/42') { params -> null }
+
+        when:
+        def result = script.toolGetLibrarySource([libraryId: '42'])
+
+        then:
+        result.success == false
+        result.error.contains('Empty response')
+    }
+
+    def "get_library_source saves full source to File Manager and returns chunk when source exceeds 64KB"() {
+        given:
+        enableHubAdminRead()
+        // Build a source string slightly over the 64000-char chunk limit
+        def bigSource = 'x' * 65000
+        def bigLibJson = groovy.json.JsonOutput.toJson([
+            [id: 10, version: 1, name: 'BigLib', namespace: 'ns', source: bigSource]
+        ])
+        hubGet.register('/library/list/single/data/10') { params -> bigLibJson }
+        def uploadedFiles = [:]
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploadedFiles[name] = new String(content, 'UTF-8')
+        }
+
+        when:
+        def result = script.toolGetLibrarySource([libraryId: '10'])
+
+        then:
+        result.success == true
+        result.totalLength == 65000
+        result.hasMore == true
+        result.sourceFile == 'mcp-source-library-10.groovy'
+        result.sourceFileHint.contains('update_library_code')
+        uploadedFiles.containsKey('mcp-source-library-10.groovy')
+    }
+
+    def "get_library_source respects offset and length for chunked reading"() {
+        given:
+        enableHubAdminRead()
+        def source = 'A' * 200
+        def libJson = groovy.json.JsonOutput.toJson([[id: 5, version: 1, name: 'L', namespace: 'n', source: source]])
+        hubGet.register('/library/list/single/data/5') { params -> libJson }
+
+        when:
+        def result = script.toolGetLibrarySource([libraryId: '5', offset: 100, length: 50])
+
+        then:
+        result.success == true
+        result.offset == 100
+        result.chunkLength == 50
+        result.source == 'A' * 50
+        result.hasMore == true
+        result.nextOffset == 150
+    }
+
+    // -------- toolInstallLibrary --------
+
+    def "install_library throws when Hub Admin Write is disabled"() {
+        when:
+        script.toolInstallLibrary([source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Write')
+    }
+
+    def "install_library throws when confirm is not provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallLibrary([source: SAMPLE_SOURCE])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('SAFETY CHECK FAILED')
+    }
+
+    def "install_library throws when neither source nor sourceFile is supplied"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallLibrary([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('source')
+        ex.message.contains('sourceFile')
+    }
+
+    def "install_library throws when both source and sourceFile are supplied"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallLibrary([source: SAMPLE_SOURCE, sourceFile: 'foo.groovy', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('not both')
+    }
+
+    def "install_library (source mode) POSTs JSON to /library/saveOrUpdateJson and returns libraryId"() {
+        given:
+        enableHubAdminWrite()
+        def capturedBody = null
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            capturedBody = new groovy.json.JsonSlurper().parseText(body)
+            [success: true, message: '', id: 100, version: 1]
+        }
+        hubGet.register('/hub2/userLibraries') { params ->
+            groovy.json.JsonOutput.toJson([[id: 100, name: 'TestLib', namespace: 'level99']])
+        }
+
+        when:
+        def result = script.toolInstallLibrary([source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        capturedBody.id == null
+        capturedBody.version == null
+        capturedBody.source == SAMPLE_SOURCE
+        result.success == true
+        result.libraryId == '100'
+        result.version == 1
+        result.sourceMode == 'source'
+        result.sourceLength == SAMPLE_SOURCE.length()
+        result.message.contains('installed')
+    }
+
+    def "install_library (sourceFile mode) reads source from File Manager and posts it"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.downloadHubFile = { String fileName ->
+            fileName == 'mylib.groovy' ? SAMPLE_SOURCE.getBytes('UTF-8') : null
+        }
+        def capturedBody = null
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            capturedBody = new groovy.json.JsonSlurper().parseText(body)
+            [success: true, message: '', id: 101, version: 1]
+        }
+        hubGet.register('/hub2/userLibraries') { params ->
+            groovy.json.JsonOutput.toJson([[id: 101, name: 'TestLib', namespace: 'level99']])
+        }
+
+        when:
+        def result = script.toolInstallLibrary([sourceFile: 'mylib.groovy', confirm: true])
+
+        then:
+        capturedBody.source == SAMPLE_SOURCE
+        result.success == true
+        result.libraryId == '101'
+        result.sourceMode == 'sourceFile'
+    }
+
+    def "install_library throws when sourceFile is not found in File Manager"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.downloadHubFile = { String fileName -> null }
+
+        when:
+        script.toolInstallLibrary([sourceFile: 'missing.groovy', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('not found in File Manager')
+    }
+
+    def "install_library reports hub failure when saveOrUpdateJson returns success=false"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'Cannot parse library definition']
+        }
+
+        when:
+        def result = script.toolInstallLibrary([source: 'bad source', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('installation failed')
+        result.error.contains('Cannot parse library definition')
+        result.note.contains('library() definition block')
+    }
+
+    def "install_library reports failure when hub POST throws"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            throw new RuntimeException('connection refused')
+        }
+
+        when:
+        def result = script.toolInstallLibrary([source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('installation failed')
+        result.error.contains('connection refused')
+    }
+
+    def "install_library fails closed when post-install verification finds the library absent from the list"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true, message: '', id: 200, version: 1]
+        }
+        // Verification fetch returns non-empty list but does NOT include the new library
+        hubGet.register('/hub2/userLibraries') { params -> '[]' }
+
+        when:
+        def result = script.toolInstallLibrary([source: SAMPLE_SOURCE, confirm: true])
+
+        then: 'fail-closed: success=false with libraryId populated so caller can inspect'
+        result.success == false
+        result.libraryId == '200'
+        result.error.contains('unverified')
+        result.error.contains('200')
+        result.note.contains('Do NOT retry')
+        result.lastBackup != null
+    }
+
+    def "install_library returns success with verified=true when post-install library list includes the new library"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true, message: '', id: 201, version: 1]
+        }
+        hubGet.register('/hub2/userLibraries') { params ->
+            groovy.json.JsonOutput.toJson([[id: 201, name: 'TestLib', namespace: 'level99']])
+        }
+
+        when:
+        def result = script.toolInstallLibrary([source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        result.success == true
+        result.libraryId == '201'
+        result.verified == true
+        result.verifyError == null
+        result.message.contains('installed')
+    }
+
+    def "install_library returns success with verifyError when post-install verification fetch throws"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true, message: '', id: 202, version: 1]
+        }
+        // Verification fetch throws (transient failure)
+        hubGet.register('/hub2/userLibraries') { params ->
+            throw new RuntimeException('verify endpoint unavailable')
+        }
+
+        when:
+        def result = script.toolInstallLibrary([source: SAMPLE_SOURCE, confirm: true])
+
+        then: 'transient verify failure keeps success=true but sets verified=false + verifyError'
+        result.success == true
+        result.libraryId == '202'
+        result.verified == false
+        result.verifyError != null
+        result.verifyError.contains('verify endpoint unavailable')
+    }
+
+    def "install_library fails closed with anti-retry note when verify returns unparseable body"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true, message: '', id: 203, version: 1]
+        }
+        hubGet.register('/hub2/userLibraries') { params -> '<html>login page</html>' }
+
+        when:
+        def result = script.toolInstallLibrary([source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        result.success == false
+        result.libraryId == '203'
+        result.error.contains('unverified')
+        result.note.contains('Do NOT retry')
+    }
+
+    def "install_library fails closed with anti-retry note when hub returns null/empty response"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostJson = { String path, String body -> null }
+
+        when:
+        def result = script.toolInstallLibrary([source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('unverified')
+        result.error.contains('empty/null response')
+        result.note.contains('FOR DEVELOPERS > Libraries code')
+        result.note.contains('Do NOT retry')
+        result.lastBackup != null
+    }
+
+    def "install_library fails closed with anti-retry note when hub response has no id field"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true, message: 'persisted', version: 5]  // missing id
+        }
+
+        when:
+        def result = script.toolInstallLibrary([source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('unverified')
+        result.error.contains('missing id field')
+        result.note.contains('FOR DEVELOPERS > Libraries code')
+        result.note.contains('Do NOT retry')
+        result.lastBackup != null
+    }
+
+    // -------- toolUpdateLibraryCode --------
+
+    def "update_library_code throws when Hub Admin Write is disabled"() {
+        when:
+        script.toolUpdateLibraryCode([libraryId: '42', source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Write')
+    }
+
+    def "update_library_code throws when confirm is not provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolUpdateLibraryCode([libraryId: '42', source: SAMPLE_SOURCE])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('SAFETY CHECK FAILED')
+    }
+
+    def "update_library_code throws when libraryId is missing"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolUpdateLibraryCode([source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('libraryId is required')
+    }
+
+    def "update_library_code throws when none of source, sourceFile, or resave is supplied"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolUpdateLibraryCode([libraryId: '42', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("'source'")
+    }
+
+    def "update_library_code (source mode) backs up, fetches version, POSTs to saveOrUpdateJson"() {
+        given:
+        enableHubAdminWrite()
+        // Backup + version fetch use /library/list/single/data/42
+        hubGet.register('/library/list/single/data/42') { params ->
+            SAMPLE_RESPONSE_JSON
+        }
+        def uploads = []
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploads << name
+        }
+        def capturedBody = null
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            capturedBody = new groovy.json.JsonSlurper().parseText(body)
+            [success: true, message: '', id: 42, version: 2]
+        }
+
+        when:
+        def result = script.toolUpdateLibraryCode([libraryId: '42', source: SAMPLE_SOURCE, confirm: true])
+
+        then: 'backup created before update'
+        uploads.size() == 1
+        uploads[0] == 'mcp-backup-library-42.groovy'
+
+        and: 'POST body carries the correct id, version and new source'
+        capturedBody.id == 42
+        capturedBody.version == 1
+        capturedBody.source == SAMPLE_SOURCE
+
+        and: 'result reports success with source mode'
+        result.success == true
+        result.libraryId == '42'
+        result.previousVersion == 1
+        result.newVersion == 2
+        result.sourceMode == 'source'
+        result.sourceLength == SAMPLE_SOURCE.length()
+
+        and: 'backup manifest entry was created'
+        atomicStateMap.itemBackupManifest?.containsKey('library_42')
+    }
+
+    def "update_library_code skips re-uploading backup when an entry exists within the 1-hour dedup window"() {
+        given:
+        enableHubAdminWrite()
+        // Pre-populate manifest with a recent backup (60s ago, well inside 1-hour window).
+        // Original baseline must be preserved through rapid edits — second update should NOT
+        // overwrite the existing backup file.
+        atomicStateMap.itemBackupManifest = [
+            'library_42': [
+                type: 'library', id: '42',
+                version: 1,
+                timestamp: 1234567890000L - 60_000L,
+                fileName: 'mcp-backup-library-42.groovy',
+                sourceLength: SAMPLE_SOURCE.length()
+            ]
+        ]
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        def uploads = []
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploads << name
+        }
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true, message: '', id: 42, version: 2]
+        }
+
+        when:
+        def result = script.toolUpdateLibraryCode([libraryId: '42', source: SAMPLE_SOURCE + ' // edit', confirm: true])
+
+        then: 'no new backup upload occurred (dedup window held)'
+        uploads == []
+
+        and: 'existing manifest entry was preserved (fileName + original timestamp unchanged)'
+        atomicStateMap.itemBackupManifest['library_42'].fileName == 'mcp-backup-library-42.groovy'
+        atomicStateMap.itemBackupManifest['library_42'].timestamp == (1234567890000L - 60_000L)
+
+        and: 'update itself still succeeded'
+        result.success == true
+        result.libraryId == '42'
+        result.newVersion == 2
+    }
+
+    def "update_library_code (sourceFile mode) reads source from File Manager"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.downloadHubFile = { String fileName ->
+            fileName == 'updated-lib.groovy' ? SAMPLE_SOURCE.getBytes('UTF-8') : null
+        }
+        def capturedBody = null
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            capturedBody = new groovy.json.JsonSlurper().parseText(body)
+            [success: true, message: '', id: 42, version: 2]
+        }
+
+        when:
+        def result = script.toolUpdateLibraryCode([libraryId: '42', sourceFile: 'updated-lib.groovy', confirm: true])
+
+        then:
+        capturedBody.source == SAMPLE_SOURCE
+        result.success == true
+        result.sourceMode == 'sourceFile'
+        result.note.contains('File Manager')
+    }
+
+    def "update_library_code (sourceFile mode) throws when File Manager file is absent"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.downloadHubFile = { String fileName -> null }
+
+        when:
+        script.toolUpdateLibraryCode([libraryId: '42', sourceFile: 'missing.groovy', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('not found in File Manager')
+    }
+
+    def "update_library_code (resave mode) fetches source and version, then re-saves without external source"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        def capturedBody = null
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            capturedBody = new groovy.json.JsonSlurper().parseText(body)
+            [success: true, message: '', id: 42, version: 2]
+        }
+
+        when:
+        def result = script.toolUpdateLibraryCode([libraryId: '42', resave: true, confirm: true])
+
+        then: 'submitted source matches the source fetched from the hub'
+        capturedBody.version == 1
+        result.success == true
+        result.sourceMode == 'resave'
+        result.note.contains('no cloud round-trip')
+    }
+
+    def "update_library_code throws when resave mode cannot fetch the library"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/library/list/single/data/999') { params -> '[]' }
+
+        when:
+        script.toolUpdateLibraryCode([libraryId: '999', resave: true, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('not found')
+    }
+
+    def "update_library_code reports hub failure when saveOrUpdateJson returns success=false"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'Compilation error']
+        }
+
+        when:
+        def result = script.toolUpdateLibraryCode([libraryId: '42', source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('Compilation error')
+        result.note.contains('syntax errors')
+    }
+
+    def "update_library_code throws when pre-update backup fails"() {
+        given:
+        enableHubAdminWrite()
+        // Backup GET throws -- update must abort (fail-closed, matching apps/drivers update path)
+        hubGet.register('/library/list/single/data/42') { params ->
+            throw new RuntimeException('storage unavailable')
+        }
+
+        when:
+        script.toolUpdateLibraryCode([libraryId: '42', source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        thrown(Exception)
+    }
+
+    // -------- toolDeleteLibrary --------
+
+    def "delete_library throws when Hub Admin Write is disabled"() {
+        when:
+        script.toolDeleteLibrary([libraryId: '42', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('Hub Admin Write')
+    }
+
+    def "delete_library throws when confirm is not provided"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolDeleteLibrary([libraryId: '42'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('SAFETY CHECK FAILED')
+    }
+
+    def "delete_library throws when libraryId is missing"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolDeleteLibrary([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('libraryId is required')
+    }
+
+    def "delete_library backs up source then deletes and reports backup file"() {
+        given:
+        enableHubAdminWrite()
+        def uploads = []
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploads << name
+        }
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        hubGet.register('/library/edit/deleteJson/42') { params ->
+            '{"success":true,"message":null}'
+        }
+
+        when:
+        def result = script.toolDeleteLibrary([libraryId: '42', confirm: true])
+
+        then:
+        result.success == true
+        result.libraryId == '42'
+        result.backupFile == 'mcp-backup-library-42.groovy'
+        uploads == ['mcp-backup-library-42.groovy']
+        result.restoreHint.contains('install_library')
+    }
+
+    def "delete_library skips re-uploading backup when an entry exists within the 1-hour dedup window"() {
+        given:
+        enableHubAdminWrite()
+        // Pre-populate manifest with a recent backup (60s ago).
+        atomicStateMap.itemBackupManifest = [
+            'library_42': [
+                type: 'library', id: '42',
+                version: 1,
+                timestamp: 1234567890000L - 60_000L,
+                fileName: 'mcp-backup-library-42.groovy',
+                sourceLength: SAMPLE_SOURCE.length()
+            ]
+        ]
+        def uploads = []
+        script.metaClass.uploadHubFile = { String name, byte[] content ->
+            uploads << name
+        }
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        hubGet.register('/library/edit/deleteJson/42') { params ->
+            '{"success":true,"message":null}'
+        }
+
+        when:
+        def result = script.toolDeleteLibrary([libraryId: '42', confirm: true])
+
+        then: 'no new backup upload occurred (dedup window held)'
+        uploads == []
+
+        and: 'response still references the existing backup file'
+        result.success == true
+        result.libraryId == '42'
+        result.backupFile == 'mcp-backup-library-42.groovy'
+        result.restoreHint.contains('install_library')
+    }
+
+    def "delete_library proceeds with backupWarning when pre-delete backup fails"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/library/list/single/data/42') { params ->
+            throw new RuntimeException('source unavailable')
+        }
+        hubGet.register('/library/edit/deleteJson/42') { params ->
+            '{"success":true,"message":null}'
+        }
+
+        when:
+        def result = script.toolDeleteLibrary([libraryId: '42', confirm: true])
+
+        then:
+        result.success == true
+        result.message.contains('backup failed')
+        result.backupWarning.contains('permanently lost')
+    }
+
+    def "delete_library reports failure when hub returns success=false"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        hubGet.register('/library/edit/deleteJson/42') { params ->
+            '{"success":false,"message":"Library is in use"}'
+        }
+
+        when:
+        def result = script.toolDeleteLibrary([libraryId: '42', confirm: true])
+
+        then:
+        result.success == false
+        // Fail-closed path: hub message returned directly, not a generic "Delete may have failed" string
+        result.error.contains('Library is in use')
+        result.libraryId == '42'
+        result.note.contains('#include')
+    }
+
+    def "delete_library reports failure when hub delete endpoint throws"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        hubGet.register('/library/edit/deleteJson/42') { params ->
+            throw new RuntimeException('connection reset')
+        }
+
+        when:
+        def result = script.toolDeleteLibrary([libraryId: '42', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('deletion failed')
+        result.error.contains('connection reset')
+    }
+
+    def "delete_library reports failure when hub delete endpoint returns empty response"() {
+        given:
+        // Empty response -- responseText is falsy in Groovy, so the JSON-parse block is skipped.
+        // success stays false and the generic "check the Hubitat web UI" path fires.
+        enableHubAdminWrite()
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        hubGet.register('/library/edit/deleteJson/42') { params -> '' }
+
+        when:
+        def result = script.toolDeleteLibrary([libraryId: '42', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('Delete may have failed')
+        result.libraryId == '42'
+        result.response == ''
+    }
+
+    def "delete_library reports failure when hub delete endpoint returns non-JSON body"() {
+        given:
+        // Non-JSON (e.g. a login-redirect page) -- JsonSlurper throws, caught and returned
+        // as the parse-failure path with "Delete response was not valid JSON".
+        enableHubAdminWrite()
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        hubGet.register('/library/list/single/data/42') { params -> SAMPLE_RESPONSE_JSON }
+        hubGet.register('/library/edit/deleteJson/42') { params ->
+            '<html><body>Login required</body></html>'
+        }
+
+        when:
+        def result = script.toolDeleteLibrary([libraryId: '42', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('Delete response was not valid JSON')
+        result.libraryId == '42'
+        result.note.contains('verify whether the library was deleted')
+    }
+
+    // -------- libraryId integer validation (Finding #10) --------
+    //
+    // Three tools share the same positive-integer guard for libraryId:
+    // get_library_source, update_library_code, delete_library.
+    // All three should reject the same bad-input cases identically.
+
+    @spock.lang.Unroll
+    def "get_library_source rejects invalid libraryId: #description"() {
+        given:
+        enableHubAdminRead()
+
+        when:
+        script.toolGetLibrarySource([libraryId: badId])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('positive integer')
+
+        where:
+        badId  | description
+        'abc'  | 'non-integer string'
+        '-5'   | 'negative integer'
+        '0'    | 'zero'
+        '1.5'  | 'decimal string'
+    }
+
+    @spock.lang.Unroll
+    def "update_library_code rejects invalid libraryId: #description"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolUpdateLibraryCode([libraryId: badId, source: SAMPLE_SOURCE, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('positive integer')
+
+        where:
+        badId  | description
+        'abc'  | 'non-integer string'
+        '-5'   | 'negative integer'
+        '0'    | 'zero'
+        '1.5'  | 'decimal string'
+    }
+
+    @spock.lang.Unroll
+    def "delete_library rejects invalid libraryId: #description"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolDeleteLibrary([libraryId: badId, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('positive integer')
+
+        where:
+        badId  | description
+        'abc'  | 'non-integer string'
+        '-5'   | 'negative integer'
+        '0'    | 'zero'
+        '1.5'  | 'decimal string'
+    }
+}

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -1,6 +1,6 @@
 # Bot Acceptance Test (BAT) Suite — v2
 
-Updated for the installed-apps + Rule Machine interop + native CRUD architecture (23 core + 12 gateways = 35 on tools/list, 67 proxied, 90 total).
+Updated for the installed-apps + Rule Machine interop + native CRUD + library management architecture (23 core + 12 gateways = 35 on tools/list, 75 proxied, 98 total).
 
 Comprehensive test scenarios for the Hubitat MCP Rule Server. Modeled after ha-mcp's BAT framework.
 
@@ -2268,6 +2268,7 @@ These operations are too destructive for automated testing. Test manually with e
 | 10. NL Discovery | T200-T301 | Conversational prompts — no tool names |
 | 12. Developer Mode | T219-T226 | Self-administration: update_mcp_settings + delete_variable |
 | 13. Driver Code Lifecycle | T400-T406 | install_driver (single + bulk), update_driver_code (bulk), delete |
+| 14. Library Management | T500-T508 | Library CRUD: install, update, delete, get_source |
 
 ### Architecture (post installed-apps + RM interop + Developer Mode)
 
@@ -2276,18 +2277,18 @@ These operations are too destructive for automated testing. Test manually with e
 | Core tools on `tools/list` | 23 |
 | Gateways on `tools/list` | 12 |
 | Total visible on `tools/list` | 35 |
-| Tools proxied behind gateways | 67 |
-| Total tools in codebase | 90 |
+| Tools proxied behind gateways | 71 |
+| Total tools in codebase | 94 |
 
-**12 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (4), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (7), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_native_rules_and_apps` (9), `manage_mcp_self` (1)
+**12 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (4), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (11), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_native_rules_and_apps` (9), `manage_mcp_self` (1)
 
 ### Tool Coverage (non-destructive tools only)
 
-All 86 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
+All 94 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
 
 Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
 
-**Total: 193 test scenarios** (107 explicit + 65 natural language + 21 built-in-app integration) plus 13 excluded destructive operations documented for manual testing
+**Total: 202 test scenarios** (107 explicit + 65 natural language + 21 built-in-app integration + 9 library management) plus 13 excluded destructive operations documented for manual testing
 
 ---
 
@@ -2742,16 +2743,126 @@ All tests below require Hub Admin Write enabled and a recent backup. Tests are e
 
 ---
 
+## Section 14: Library Management Tests
+
+Write tools (`install_library`, `update_library_code`, `delete_library`) live in the `manage_app_driver_code` gateway and require Hub Admin Write + confirm + a hub backup within the last 24 hours. `get_library_source` (read-only) lives in the `manage_apps_drivers` gateway and requires Hub Admin Read only. Tests use the `BAT_` prefix and clean up after themselves.
+
+**Pre-flight (manual one-time):**
+1. Enable **Hub Admin Read Tools** and **Hub Admin Write Tools** in MCP Rule Server settings.
+2. Create a hub backup via `create_hub_backup`.
+
+**Safety note:** Tests only create/modify/delete test-prefixed libraries. They do not touch any library with `usedByDeviceTypes` or `usedByAppTypes` populated.
+
+### T500 — get_library_source reads library source
+
+```json
+{
+  "setup_prompt": "Check Hubitat web UI (FOR DEVELOPERS > Libraries code) for an installed library ID, or install a test library first using install_library.",
+  "test_prompt": "Get the source of the first library returned by hub2/userLibraries. Use manage_apps_drivers -> get_library_source."
+}
+```
+
+**Expected**: AI calls `manage_apps_drivers(tool='get_library_source', args={libraryId:'<id>'})`. Result includes `success: true`, `source` (non-empty string), `version`, `name`, `namespace`, `totalLength`. If total length exceeds 64KB, `sourceFile` and `sourceFileHint` fields are present.
+
+### T501 — install_library installs new library from inline source
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists.",
+  "test_prompt": "Install a new Groovy library with name='BATTestLibInstall', namespace='bat_test', description='BAT test library for install scenario'. The library should define a single method `batHelper()` that returns 'bat_ok'.",
+  "teardown_prompt": "Delete the BATTestLibInstall library (find it by name in the library list)."
+}
+```
+
+**Expected**: AI calls `manage_app_driver_code(tool='install_library', args={source:'library(...) { } def batHelper() { return "bat_ok" }', confirm:true})`. Result: `{success:true, libraryId:'<id>', version:<positive integer>, sourceMode:'source', message:'Library installed successfully'}`. No `verifyWarning` or `verifyError` field if verification succeeds. `verified: true`.
+
+### T502 — update_library_code updates existing library source
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists. Use install_library to create a library named 'BATTestLibUpdate', namespace='bat_test', with method `v1Method()` returning 'v1'.",
+  "test_prompt": "Update the BATTestLibUpdate library to add a `v2Method()` that returns 'v2'. Use update_library_code with source mode.",
+  "teardown_prompt": "Delete BATTestLibUpdate library."
+}
+```
+
+**Expected**: AI finds the library ID, calls `manage_app_driver_code(tool='update_library_code', args={libraryId:'<id>', source:'<updated source with v2Method>', confirm:true})`. Result: `{success:true, previousVersion:<N>, newVersion:<N+1>, sourceMode:'source'}` where `newVersion > previousVersion` (both positive integers). Pre-update backup appears in `list_item_backups` as a `library_<id>` key.
+
+### T503 — update_library_code resave mode recompiles without external source
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists. A library named 'BATTestLibResave' exists (install it if not).",
+  "test_prompt": "Use update_library_code with resave=true on BATTestLibResave to trigger recompilation without changing the source.",
+  "teardown_prompt": "Delete BATTestLibResave library."
+}
+```
+
+**Expected**: AI calls `manage_app_driver_code(tool='update_library_code', args={libraryId:'<id>', resave:true, confirm:true})`. Result: `{success:true, sourceMode:'resave', note:'...no cloud round-trip...'}`. `newVersion` is a positive integer greater than `previousVersion`.
+
+### T504 — delete_library deletes and auto-backs up source
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists. Install a library named 'BATTestLibDelete', namespace='bat_test'.",
+  "test_prompt": "Delete the BATTestLibDelete library. Confirm it no longer appears in the hub library list.",
+  "teardown_prompt": "(Library is already deleted — no teardown needed.)"
+}
+```
+
+**Expected**: AI calls `manage_app_driver_code(tool='delete_library', args={libraryId:'<id>', confirm:true})`. Result: `{success:true, backupFile:'mcp-backup-library-<id>.groovy', restoreHint:...}`. Backup file appears in `list_item_backups`. Subsequent `get_library_source` for the same ID returns `success:false` with "not found".
+
+### T505 — install_library refuses without confirm flag
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled.",
+  "test_prompt": "Try to install a library with valid source but without setting confirm=true. Observe the error."
+}
+```
+
+**Expected**: Gateway (or tool) returns an error (isError or -32602) containing "SAFETY CHECK FAILED" or "confirm". No library is created. AI explains the confirm requirement and the mandatory pre-flight checklist (backup).
+
+### T506 — get_library_source returns error for non-existent library
+
+```json
+{
+  "test_prompt": "Try to get library source for libraryId='999999'. What does the tool return?"
+}
+```
+
+**Expected**: AI calls `manage_apps_drivers(tool='get_library_source', args={libraryId:'999999'})`. Result: `{success:false, error:'...not found...'}` or similar. AI reports the error clearly and suggests using hub2/userLibraries or the Hubitat web UI (FOR DEVELOPERS > Libraries code) to find valid library IDs.
+
+### T507 — update_library_code sourceFile mode reads from File Manager
+
+```json
+{
+  "setup_prompt": "Hub Admin Write enabled, recent backup exists. Install 'BATTestLibSourceFile' library. Upload a file named 'bat-lib-update.groovy' to File Manager via write_file with updated library source.",
+  "test_prompt": "Update BATTestLibSourceFile library using update_library_code with sourceFile='bat-lib-update.groovy'.",
+  "teardown_prompt": "Delete BATTestLibSourceFile library. Delete bat-lib-update.groovy from File Manager."
+}
+```
+
+**Expected**: AI calls `manage_app_driver_code(tool='update_library_code', args={libraryId:'<id>', sourceFile:'bat-lib-update.groovy', confirm:true})`. Result: `{success:true, sourceMode:'sourceFile', note:'...File Manager...'}`.
+
+### T508 — delete_library proceeds with warning when backup fails
+
+(Manual test -- not automatable without simulating File Manager failure.)
+
+**Expected behavior**: If `uploadHubFile` fails during pre-delete backup, `delete_library` still proceeds and sets `backupWarning` in the response. The deletion is not blocked by a backup failure. The response message contains "WARNING: Pre-delete backup failed".
+
+---
+
 ## Changes from BAT v1
 
 Key differences from the original BAT.md (which targets the pre-v0.8.0 architecture):
 
-1. **Architecture**: 18 core + 8 gateways (26 total) → **23 core + 12 gateways (35 total, 90 tools)** post installed-apps + RM interop + native CRUD + list_app_pages + poll_until_attribute (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
+1. **Architecture**: 18 core + 8 gateways (26 total) → **23 core + 12 gateways (35 total, 98 tools)** post installed-apps + RM interop + native CRUD + list_app_pages + poll_until_attribute + library management (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
 2. **Merged tools**: `enable_rule`/`disable_rule` → `custom_update_rule` (enabled=true/false); `create_virtual_device`/`delete_virtual_device` → `manage_virtual_device` (action enum)
 3. **Promoted to core**: `create_hub_backup`, `check_for_update`, `generate_bug_report`
 4. **Dissolved gateway**: `manage_hub_info` — radio details moved to `manage_diagnostics`, other tools merged into `get_hub_info` (core) or promoted
-5. **Gateway renames**: `manage_hub_maintenance` → `manage_destructive_hub_ops` (3 tools); `manage_code_changes` → `manage_app_driver_code` (7 tools)
-6. **Gateway splits from v1**: `manage_apps_drivers` → `manage_apps_drivers` (6 read) + `manage_app_driver_code` (7 write); `manage_logs_diagnostics` → `manage_logs` (6) + `manage_diagnostics` (9)
+5. **Gateway renames**: `manage_hub_maintenance` → `manage_destructive_hub_ops` (3 tools); `manage_code_changes` → `manage_app_driver_code` (11 tools, 7 original + 4 library tools)
+6. **Gateway splits from v1**: `manage_apps_drivers` → `manage_apps_drivers` (6 read) + `manage_app_driver_code` (11 write); `manage_logs_diagnostics` → `manage_logs` (8) + `manage_diagnostics` (11)
 7. **T62 rewritten**: Was testing `manage_virtual_devices` catalog (removed gateway) → now tests `manage_diagnostics` catalog
 8. **T104 updated**: Anti-recursion test uses `manage_diagnostics` gateway
 9. **Excluded tests expanded**: 10 → 13 (separate rows for each app/driver operation, added gateway column)


### PR DESCRIPTION
## Summary

- Adds 4 new tools to `manage_app_driver_code` for Hubitat Groovy library management:
  - `install_library` — inline source or sourceFile, post-install verification, fail-closed on null/no-id
  - `update_library_code` — 3 modes (source/sourceFile/resave), auto-backup with 1-hour dedup, optimistic-lock on version
  - `delete_library` — auto-backs up source to File Manager before deletion
  - `get_library_source` — chunked reading, large-file auto-save for sourceFile-mode round-trip
- Library-aware branches added to existing `restore_item_backup` / `list_item_backups` / `get_item_backup` (library backups can't be restored via `restore_item_backup` — helper redirects to `update_library_code` since library IDs persist across source updates)
- Gateway grows 7 → 11 tools; total 90 → 94; proxied 67 → 71
- Closes #74

**Part of the LLM-driven-development tooling series** (#145 Developer Mode + manage_mcp_self → #153 list_devices server-side filters → #155 get_hub_logs filters → #157 poll_until_attribute → #163 driver-code lifecycle). Bundle B applies the same `curl + sourceFile` token-economy pattern Bundle A (#163) established for drivers, extended to libraries. Same fail-closed verify semantics (mirrors #163's F1 4-bucket pattern), same 1-hour backup dedup, same anti-retry guidance. Enables agents to manage library lifecycle (often a prerequisite for non-trivial driver/app development) without overflowing context with source bytes.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix`
- [ ] `chore`
- [ ] `refactor`
- [ ] `docs`
- [ ] `test`
- [ ] `ci`

## Changes

### `install_library(source | sourceFile, confirm)`
- 2-mode dispatch: inline `source` for stub-size, `sourceFile` (curl-uploaded) for non-trivial
- Post-install verification against `/hub2/userLibraries`
- **Fail-closed when hub returns null/no-id** with anti-retry `note` + `lastBackup` (mirrors Bundle A's F1 4-bucket pattern)
- Description names required `library()` fields (`name`, `namespace`, `author`, `description`, `category`) — caught during cold-LLM validation; otherwise platform rejects with cryptic `description cannot be empty`

### `update_library_code(libraryId, source | sourceFile | resave, confirm)`
- 3 source modes including `resave` (re-saves current source on-hub without round-trip)
- Pre-edit backup with **1-hour dedup guard** (preserves original baseline through rapid edits)
- Optimistic-lock on version, backup-failure fail-closed (matches apps/drivers update path)

### `delete_library(libraryId, confirm)`
- Auto-backs up source to File Manager before deletion
- 20-entry FIFO prune on backup manifest
- Backup failure surfaces as `backupWarning` but proceeds (deletion not blocked)

### `get_library_source(libraryId, offset?, length?)`
- Chunked reading (max 64KB chunk)
- Large-file auto-save to File Manager with `sourceFileHint` for `update_library_code sourceFile` round-trip
- Hub Admin Read gating (vs Hub Admin Write for the write tools)

### Backup integration
- `list_item_backups` / `get_item_backup` enumerate library backups alongside app/driver
- `restore_item_backup` for library type returns clear error redirecting to `update_library_code`

### Validation gates
- `libraryId` validated as integer in update/delete/get (clear `IllegalArgumentException` with the actual value, vs cryptic `NumberFormatException`)

### Opportunistic doc fixes
- `agent-skill/hubitat-mcp/SKILL.md` had pre-existing drift: `manage_logs (6 tools)` → 8, `manage_diagnostics (9 tools)` → 11. Fixed while doing the tool-count sweep.

## Release Notes

- New `install_library` tool — install Hubitat Groovy libraries via inline source or curl-uploaded File Manager file. Post-install verification + fail-closed on hub null/no-id response with anti-retry guidance.
- New `update_library_code` tool — 3 modes (source/sourceFile/resave). Auto-backup with 1-hour dedup (preserves original baseline through rapid edits) + optimistic-lock.
- New `delete_library` tool — auto-backs up source to File Manager before deletion.
- New `get_library_source` tool — chunked reading with large-file auto-save for round-trip workflows.
- `restore_item_backup` now handles library entries — returns redirect to `update_library_code` (libraries don't delete-then-recreate; IDs persist across source updates).
- Tool count: 90 → 94. `manage_app_driver_code` gateway: 7 → 11 sub-tools.

## Testing

### Unit tests

`ToolLibraryCodeSpec.groovy` — **39 scenarios** covering all 4 tools across gate-disabled / missing-args / mode-dispatch / success / hub-failure / network-failure / fail-closed / verification-warning / both-args-conflict / 1-hour-dedup-skip. Plus 1 scenario added to `ToolAppDriverCodeSpec` for the `restore_item_backup` library-aware branch. Both specs PASS targeted-run (Gradle 9.5 full-suite has a pre-existing `NoSuchFileException` infra bug on Windows; CI will run full suite).

### Live-hub smoke

Validated against test hub (deploy v68 → v69 clean, no errors):

| Scenario | Result |
|---|---|
| `install_library` (real `library()` block with description+category) | libraryId returned, no `verifyWarning` |
| `get_library_source` | source + version + name + namespace + chunked-read fields |
| `update_library_code` source mode | version 1→2, sourceMode='source' |
| `update_library_code` resave mode | version 2→3, sourceMode='resave', on-hub note |
| `delete_library` | backup file created in File Manager |
| Edge: `libraryId='abc'` (new `.isInteger()` validation) | `-32602: libraryId must be a positive integer (got: 'abc')` |
| Edge: `libraryId='999999'` (non-existent) | `success:false, error:"Library 999999 not found"` |

### Zero-context cold LLM validation

Fresh Sonnet subagent (no project context, just live MCP catalog) tasked with the full library lifecycle:
- All 4 tools discovered via catalog
- Chose inline `source` for stub correctly (quoted "Inline 'source' is acceptable for stub-size snippets only")
- Recognized `-u admin:PASS` curl recipe for hub-security workflow
- Distinguished inline-source bypasses File Manager (Hub Security N/A there)
- Full lifecycle PASS
- **Surfaced one real description gap** — `library()` definition block required fields not enumerated. Hubitat platform rejects with cryptic `description cannot be empty` if `description`/`category` omitted. Fixed in this PR.

## Checklist

- [x] Unit tests added — `ToolLibraryCodeSpec.groovy` (39 scenarios) + 1 in `ToolAppDriverCodeSpec`
- [ ] Sandbox lint passes — verified clean locally; CI will confirm
- [ ] `./gradlew test` passes locally — full suite has Gradle 9.5 `NoSuchFileException` on this Windows host (pre-existing infra bug); targeted spec PASS; CI will confirm full suite
- [x] Live-hub validation against test hub — 8/8 scenarios verified including new `.isInteger()` validation path
- [x] Zero-context cold-LLM validation surfaced + fixed library() required-fields documentation gap
- [x] Documentation updated — gateway descriptors, search hints, README/SKILL/TOOL_GUIDE/agent-skill/BAT all synced (94 total / 71 proxied / `manage_app_driver_code` 11 sub-tools); also fixed pre-existing drift on `manage_logs` (6→8) and `manage_diagnostics` (9→11) in agent-skill/SKILL.md
