### PR TITLE
chore(sandbox_lint): enforce tool-count consistency + sync doc drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hubitat MCP Server
 
-A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 94 MCP tools (35 on `tools/list` via category gateways).
+A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 101 MCP tools (35 on `tools/list` via category gateways).
 
 > **BETA SOFTWARE**: This project is ~99% AI-generated ("vibe coded") using Claude. It's a work in progress — contributions and [bug reports](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues) are welcome!
 
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 94 tools total — 23 core tools are always visible, while 71 additional tools are organized behind 12 domain-named gateways to keep the tool list manageable. If your client handles long tool lists well, you can disable the gateways via the **Consolidate tools behind category gateways** setting and every tool is exposed individually instead. (Counts here describe the shipped catalog; the runtime count on `tools/list` varies based on enabled settings.)
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 101 tools total — 23 core tools are always visible, while 78 additional tools are organized behind 12 domain-named gateways to keep the tool list manageable. If your client handles long tool lists well, you can disable the gateways via the **Consolidate tools behind category gateways** setting and every tool is exposed individually instead. (Counts here describe the shipped catalog; the runtime count on `tools/list` varies based on enabled settings.)
 
 ## Requirements
 
@@ -221,9 +221,9 @@ For free remote access without a Hubitat Cloud subscription:
 
 ## Features
 
-### MCP Tools (98 total — 35 on tools/list)
+### MCP Tools (101 total — 35 on tools/list)
 
-The server has 98 tools total. To keep the MCP `tools/list` manageable, **23 core tools** are always visible and **75 additional tools** are organized behind **12 domain-named gateways**. The AI sees 35 items on `tools/list` (23 + 12 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
+The server has 101 tools total. To keep the MCP `tools/list` manageable, **23 core tools** are always visible and **78 additional tools** are organized behind **12 domain-named gateways**. The AI sees 35 items on `tools/list` (23 + 12 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
 
 #### Core Tools (23) — Always visible on tools/list
 
@@ -430,7 +430,7 @@ Monitoring tools require Hub Admin Read to be enabled.
 | `get_memory_history` | Free OS memory and CPU load history with summary stats (Hub Admin Read) |
 | `force_garbage_collection` | Force JVM garbage collection; returns before/after free memory (Hub Admin Read) |
 | `device_health_check` | Find stale/offline devices |
-| `get_rule_diagnostics` | Comprehensive diagnostics for a specific rule |
+| `custom_get_rule_diagnostics` | Comprehensive diagnostics for a specific custom rule |
 | `get_zwave_details` | Z-Wave radio info (firmware, devices) |
 | `get_zigbee_details` | Zigbee radio info (channel, PAN ID, devices) |
 | `zwave_repair` | Z-Wave network repair (5-30 min) |
@@ -469,7 +469,7 @@ Write/delete require Hub Admin Write + confirm.
 </details>
 
 <details>
-<summary><b>manage_native_rules_and_apps</b> (9) — Rule Machine interop (RMUtils) + native CRUD on any classic SmartApp (RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.)</summary>
+<summary><b>manage_native_rules_and_apps</b> (12) — Rule Machine interop (RMUtils) + native CRUD on any classic SmartApp (RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.)</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -481,6 +481,9 @@ Write/delete require Hub Admin Write + confirm.
 | `create_native_app` | Create a new empty native automation app (RM 5.1 by default; `appType` enum extends to Room Lighting / Button Controllers / etc.). Returns `appId`. |
 | `update_native_app` | Modify any classic native app by appId (triggers, actions, settings, structured shortcuts). Auto-snapshots before every write. |
 | `delete_native_app` | Delete a classic native app (auto-snapshot to File Manager before deleting). |
+| `clone_native_app` | Clone an existing classic SmartApp via Hubitat's `appCloner` endpoint. Returns the new `appId`. |
+| `export_native_app` | Export a classic SmartApp to JSON (round-trippable with `import_native_app`). |
+| `import_native_app` | Import previously-exported app JSON into a new instance. Returns the new `appId`. |
 | `check_rule_health` | Read-only health check on any installed app — surfaces broken markers, multiple-flag poison, configPage errors. |
 
 Requires opt-in **Enable Built-in App Tools** setting. Create/update/delete additionally requires Hub Admin Write.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hubitat-mcp-server
-description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 98 tools (35 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver/library management, installed-app visibility, Rule Machine interoperability, native rule CRUD, and Developer Mode self-administration.
+description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 101 tools (35 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver/library management, installed-app visibility, Rule Machine interoperability, native rule CRUD, and Developer Mode self-administration.
 license: MIT
 ---
 
@@ -32,7 +32,7 @@ The Hubitat-runtime code has no external dependencies -- everything runs inside 
 │  │  MCP Rule Server (parent app)             │  │
 │  │  - OAuth endpoint: /apps/api/<id>/mcp     │  │
 │  │  - JSON-RPC 2.0 handler                   │  │
-│  │  - 98 tools (35 on tools/list + gateways) │  │
+│  │  - 101 tools (35 on tools/list + gateways) │  │
 │  │  - Device access gate (selectedDevices)   │  │
 │  │  - Hub Admin tools (internal API calls)   │  │
 │  │  - Hub Security cookie auth               │  │
@@ -93,19 +93,19 @@ New code should be placed in the appropriate section. New sections should follow
 
 ### Category Gateway Proxy (v0.8.0+)
 
-The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 90 items to 35. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
+The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 101 items to 35. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
 
 **Architecture:**
 - `getGatewayConfig()` — defines 12 gateways, each with a description, tools list, and summaries map
 - `getToolDefinitions()` — returns 23 core tools + 12 gateway tool definitions (client-visible)
-- `getAllToolDefinitions()` — returns all 98 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
+- `getAllToolDefinitions()` — returns all 101 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
 - `handleGateway(gatewayName, toolName, toolArgs)` — catalog mode (no args → full schemas) or execute mode (tool + args → dispatch)
 
 **Gateway calling convention:**
 1. AI calls `manage_<domain>()` with no args → gets full tool schemas (catalog mode)
 2. AI calls `manage_<domain>(tool="tool_name", args={...})` → executes the proxied tool
 
-**12 gateways (75 proxied tools):**
+**12 gateways (78 proxied tools):**
 | Gateway | Tools | Domain |
 |---------|-------|--------|
 | `manage_rules_admin` | 5 | Rule delete/test/export/import/clone |
@@ -118,7 +118,7 @@ The server uses a **category gateway proxy** pattern to reduce the MCP `tools/li
 | `manage_diagnostics` | 11 | Diagnostics, state capture, zwave/zigbee details, zwave repair, memory history, GC |
 | `manage_files` | 4 | File Manager CRUD |
 | `manage_installed_apps` | 4 | Built-in + user app visibility, device-in-use-by lookup, app config inspection, page-name directory |
-| `manage_native_rules_and_apps` | 9 | Rule Machine interop (RMUtils: list/run/pause/resume/boolean) + admin-layer CRUD on any classic SmartApp (create/update/delete_native_app + check_rule_health — works on RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.) |
+| `manage_native_rules_and_apps` | 12 | Rule Machine interop (RMUtils: list/run/pause/resume/boolean) + admin-layer CRUD on any classic SmartApp (create/update/delete/clone/export/import_native_app + check_rule_health — works on RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.) |
 | `manage_mcp_self` | 1 | Developer Mode self-administration — update MCP rule app's own settings (allowlist-gated, requires `enableDeveloperMode`) |
 
 **Core tools:** `list_devices`, `get_device`, `get_attribute`, `send_command`, `get_device_events`, `poll_until_attribute` (block-poll attribute until expected value or timeout; `timeoutMs` in MILLISECONDS, default 5000ms = 5 seconds, max 60000ms; at least one of `expectedValue`/`expectedValues` required; BLOCKS the MCP request -- use sparingly, prefer event-driven flows), `custom_list_rules`, `custom_get_rule`, `custom_create_rule`, `custom_update_rule` (the MCP custom rule engine — distinct from native Rule Machine; native-RM CRUD (and Room Lighting, Button Controllers, Basic Rules, etc.) is in the `manage_native_rules_and_apps` gateway via `create_native_app` / `update_native_app` / `delete_native_app` / `check_rule_health`), `update_device`, `manage_virtual_device` (action enum: "create", "delete"), `list_virtual_devices`, `get_hub_info` (comprehensive: hardware, health — memory, temp, DB size — and MCP stats always available; PII/location data — name, IP, timezone, coordinates, zip — gated behind Hub Admin Read), `get_modes`, `set_mode`, `get_hsm_status`, `set_hsm`, `create_hub_backup`, `check_for_update`, `generate_bug_report`, `get_tool_guide`, `search_tools` (BM25 natural language search across all tools)

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -4,13 +4,13 @@ Detailed reference for MCP Rule Server tools. Consult this when tool description
 
 ## Category Gateway Proxy (v0.8.0+)
 
-As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 35 items (23 core + 12 gateways) covering 98 total tools. Use `search_tools` to find any tool by natural language query.
+As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 35 items (23 core + 12 gateways) covering 101 total tools. Use `search_tools` to find any tool by natural language query.
 
 **How to use a gateway:**
 1. Call the gateway with no arguments to see full parameter schemas for all its tools
 2. Call with `tool='<tool_name>'` and `args={...}` to execute a specific tool
 
-**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (8), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (7), `manage_app_driver_code` (10), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_native_rules_and_apps` (9), `manage_mcp_self` (1)
+**Gateways:** `manage_rules_admin` (5), `manage_hub_variables` (8), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (7), `manage_app_driver_code` (10), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_native_rules_and_apps` (12), `manage_mcp_self` (1)
 
 All safety gates (Hub Admin Read/Write, confirm, backup checks) are preserved — they are enforced in the handler functions, not the dispatch layer.
 
@@ -415,7 +415,7 @@ Tools in `manage_installed_apps` and `manage_native_rules_and_apps` gateways hav
   - Use this before `get_app_config` on multi-page apps to avoid guessing page names
   - Args: `appId` (required)
 
-### manage_native_rules_and_apps (9 tools)
+### manage_native_rules_and_apps (12 tools)
 
 Two surfaces under one gateway: RMUtils-based runtime control for RM rules (RM-only because RMUtils is RM-only) plus admin-layer CRUD that works uniformly across any classic SmartApp (RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.).
 
@@ -429,15 +429,21 @@ Two surfaces under one gateway: RMUtils-based runtime control for RM rules (RM-o
 - **`pause_rm_rule`** / **`resume_rm_rule`** — reversible toggle; paused rules don't fire on triggers
 - **`set_rm_rule_boolean`** — set an RM rule's private boolean (true or false only; string values must be lowercase `"true"`/`"false"`). RM rules can use "Private Boolean" in conditions — this lets MCP flip that flag from outside.
 
-**Admin-layer CRUD (3 tools, generic across all classic SmartApps):**
+**Admin-layer CRUD (7 tools, generic across all classic SmartApps):**
 
 If a user asks "create a new RM rule" or "modify this Room Lighting instance":
 
 1. **`create_native_app(appType, name, confirm)`** — creates an empty classic SmartApp. `appType` is enum-driven (initially `rule_machine`; expand `_appTypeRegistry` for other types). Returns `appId`.
 2. **`update_native_app(appId, settings|button, ...)`** — modifies any classic SmartApp instance by appId. Multi-device capability `multiple=true` contract emitted automatically. Auto-snapshots before every write.
-3. **`get_app_config`** (in `manage_installed_apps`) — read any installed app's current page schema, settings, and child apps. Use BEFORE every `update_native_app` to discover the right input names.
-4. **`delete_native_app(appId, force, confirm)`** — soft delete (default) or `force=true` for `forcedelete/quiet` (the path the hub UI uses). Auto-snapshots first.
-5. **`list_item_backups`** + **`restore_item_backup`** (in `manage_apps_drivers`) — enumerate and restore native-app snapshots (`type="rm-rule"` entries). Restore re-applies settings in place if the app exists, or recreates the app and replays settings if it was deleted.
+3. **`delete_native_app(appId, force, confirm)`** — soft delete (default) or `force=true` for `forcedelete/quiet` (the path the hub UI uses). Auto-snapshots first.
+4. **`clone_native_app(appId, newName, confirm)`** — clone an existing classic SmartApp via Hubitat's `appCloner` endpoint. Returns the new `appId`.
+5. **`export_native_app(appId)`** — export a classic SmartApp to JSON (round-trippable with `import_native_app`). Useful for the export-mutate-import editing pattern when the wizard surface is too lossy to drive directly.
+6. **`import_native_app(appType, exportData, name, confirm)`** — import previously-exported app JSON into a new instance. Returns the new `appId`.
+7. **`check_rule_health(appId)`** — read-only health check on any installed app. Surfaces broken markers, multiple-flag poison, configPage errors. Use after a destructive operation to confirm the app is still well-formed.
+
+**Cross-references** (live in other gateways but commonly used together):
+- **`get_app_config`** (in `manage_installed_apps`) — read any installed app's current page schema, settings, and child apps. Use BEFORE every `update_native_app` to discover the right input names.
+- **`list_item_backups`** + **`restore_item_backup`** (in `manage_apps_drivers` / `manage_app_driver_code`) — enumerate and restore native-app snapshots (`type="rm-rule"` entries). Restore re-applies settings in place if the app exists, or recreates the app and replays settings if it was deleted.
 
 For Room Lighting / Button Controllers / Basic Rules: `update_native_app` and `delete_native_app` already work today (they take any classic-app appId). `create_native_app` will work for them once their entries are added to `_appTypeRegistry()` — same endpoint family, just need namespace + appName + parentTypeName per type.
 

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Smart home assistant for Hubitat Elevation hubs via MCP. Use when c
 
 # Hubitat MCP Server - Smart Home Assistant
 
-You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 94 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, Rule Machine interop, native rule CRUD, library management, and Developer Mode self-administration. The tools are organized as **23 core tools** (always visible) plus **12 domain-named gateways** that proxy 71 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
+You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 101 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, Rule Machine interop, native rule CRUD, library management, and Developer Mode self-administration. The tools are organized as **23 core tools** (always visible) plus **12 domain-named gateways** that proxy 78 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
 
 ## Core Principles
 
@@ -161,14 +161,18 @@ Core tool: `get_device_events` (always visible)
 Via `manage_logs` gateway (8 tools):
 - `get_hub_logs` - Hub log entries, most recent first; filter by level/source/pattern (regex) or multi-pattern AND/OR (`patternMode`); time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`, max 30d -- throws if exceeded; use ISO-8601 for longer ranges); or scope server-side to a single `deviceId` / `appId` (mutually exclusive). `pattern` matches the message field only (not source/name). Pathological regex like `(.*)*` may hang the matcher; prefer simple alternation.
 - `get_device_history` - Device event history (up to 7 days)
+- `get_performance_stats` - Device/app performance stats (count, % busy, total ms, state size, events). Sortable by pct/count/stateSize/totalMs/name
+- `get_hub_jobs` - Scheduled jobs, running jobs, and hub actions
 - `get_debug_logs` / `clear_debug_logs` - MCP-specific debug logs
 - `set_log_level` - Set MCP log level
 - `get_logging_status` - View logging system statistics
 
 Via `manage_diagnostics` gateway (11 tools):
 - `get_set_hub_metrics` - Record/retrieve hub metrics with CSV trend history
-- `device_health_check` - Find stale/offline devices
-- `get_rule_diagnostics` - Comprehensive diagnostics for a specific rule
+- `get_memory_history` - Free OS memory and CPU load history with summary stats (Hub Admin Read)
+- `force_garbage_collection` - Force JVM GC; returns before/after free memory (Hub Admin Read)
+- `device_health_check` - Find stale/offline devices; optional ICMP ping for arbitrary IPs
+- `custom_get_rule_diagnostics` - Comprehensive diagnostics for a specific rule
 - `get_zwave_details` / `get_zigbee_details` - Radio info (Z-Wave and Zigbee)
 - `zwave_repair` - Start Z-Wave network repair (5-30 min)
 - `list_captured_states` / `delete_captured_state` / `clear_captured_states` - State snapshots

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-Quick reference for all 94 MCP tools. The server exposes **35 items on `tools/list`**: 23 core tools + 12 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
+Quick reference for all 101 MCP tools. The server exposes **35 items on `tools/list`**: 23 core tools + 12 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
 
 For the most authoritative reference, call `get_tool_guide` via MCP.
 
@@ -57,7 +57,7 @@ For the most authoritative reference, call `get_tool_guide` via MCP.
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `get_tool_guide` | Full tool reference from the MCP server itself. | None |
-| `search_tools` | BM25 natural language search across all 94 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
+| `search_tools` | BM25 natural language search across all 101 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
 
 ---
 
@@ -81,18 +81,18 @@ Rule administration: delete, test, export, import, and clone rules.
 
 ### manage_hub_variables (8 tools)
 
-Manage hub connector and rule engine variables.
+Manage hub variables (every type — Number, Decimal, String, Boolean, DateTime), their connector devices, and rule-engine variables. Full read/write CRUD via the modern Hub Variable API; observe changes via `get_variable_history`.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
-| `list_variables` | List all hub connector and rule engine variables. | None |
-| `get_variable` | Get a specific variable value and metadata. | None |
-| `set_variable` | Set a variable value. | None |
-| `create_variable` | Create a new hub variable (type: Number/Decimal/String/Boolean/DateTime). | Hub Admin Write |
-| `delete_variable` | Permanently delete a hub variable (DESTRUCTIVE). | Hub Admin Write + recent backup |
-| `create_connector` | Create a virtual-device connector for a hub variable. | Hub Admin Write |
-| `remove_connector` | Remove the connector device for a hub variable. | Hub Admin Write |
-| `get_variable_history` | Recent hub-variable changes since the MCP app started. | None |
+| `list_variables` | List all hub variables (with type/connector linkage) and rule-engine variables. | None |
+| `get_variable` | Get a variable's value + metadata (type, deviceId, attribute). | None |
+| `set_variable` | Set an existing variable's value. Falls back to rule_engine namespace when no hub var matches. | None |
+| `create_variable` | Create a new hub variable. Type enum: Number / Decimal / String / Boolean / DateTime. | Hub Admin Write |
+| `delete_variable` | Permanently delete a variable (DESTRUCTIVE — also removes its connector if any). `force=true` if rules reference it. | Hub Admin Write + recent backup |
+| `create_connector` | Create a virtual-device connector for an existing hub variable. | Hub Admin Write |
+| `remove_connector` | Remove the connector device for a hub variable (the variable itself is unchanged). | Hub Admin Write |
+| `get_variable_history` | Recent hub-variable changes since the MCP app last started. Filter by name, sinceMs, limit. | None |
 
 ### manage_rooms (5 tools)
 
@@ -126,7 +126,7 @@ Read-only access to hub apps, drivers, and libraries: list, view source, and bro
 | `list_hub_drivers` | List installed user drivers. | Hub Admin Read |
 | `get_app_source` | Get app source code. Large files auto-saved to File Manager. | Hub Admin Read |
 | `get_driver_source` | Get driver source code. Large files auto-saved to File Manager. | Hub Admin Read |
-| `get_library_source` | Get library source code with chunked reading. Large files auto-saved to File Manager. | Hub Admin Read |
+| `get_library_source` | Get library source code with chunked-read support (`offset`/`length`). Large files auto-saved to File Manager. | Hub Admin Read |
 | `list_item_backups` | List all source code backups. | None |
 | `get_item_backup` | Retrieve source from a backup. | None |
 
@@ -138,14 +138,14 @@ Write operations for apps, drivers, and libraries: install, update, delete, and 
 |------|-------------|-------------|
 | `install_app` | Install a new Groovy app from `source` (inline) or `sourceFile` (File Manager filename). Verifies install compiled cleanly. | Hub Admin Write |
 | `install_driver` | Install a new Groovy driver from `source` (inline) or `sourceFile` (File Manager filename). Bulk mode: `installs=[{source|sourceFile},...]` (continue-on-error). Verifies each install compiled cleanly. | Hub Admin Write |
+| `install_library` | Install a new Groovy library (`#include namespace.Name`). Library source must include a `library()` block with `name`, `namespace`, `author`, `description` (4 required; `category` optional). | Hub Admin Write |
 | `update_app_code` | Update existing app source code (source, sourceFile, or resave). | Hub Admin Write |
 | `update_driver_code` | Update existing driver source code. Single-driver mode (driverId + source/sourceFile/resave) or bulk mode (updates array of {driverId, sourceFile} pairs, continue-on-error). | Hub Admin Write |
+| `update_library_code` | Update existing library source code (libraryId + source/sourceFile/resave). Auto-backs up before modifying. | Hub Admin Write |
 | `delete_app` | Delete an installed app (auto-backs up). | Hub Admin Write |
 | `delete_driver` | Delete an installed driver (auto-backs up). | Hub Admin Write |
-| `restore_item_backup` | Restore app/driver to backed-up version (libraries: see `update_library_code`). | Hub Admin Write |
-| `install_library` | Install a new Groovy library (#include namespace.Name). | Hub Admin Write |
-| `update_library_code` | Update existing library source (source/sourceFile/resave modes). | Hub Admin Write |
-| `delete_library` | Delete a library (auto-backs up source). | Hub Admin Write |
+| `delete_library` | Delete an installed library (auto-backs up). Ensure no apps/drivers `#include` it first. | Hub Admin Write |
+| `restore_item_backup` | Restore app/driver to backed-up version. | Hub Admin Write |
 
 ### manage_logs (8 tools)
 
@@ -170,7 +170,7 @@ Performance monitoring, health checks, diagnostics, radio info, memory / GC, and
 |------|-------------|-------------|
 | `get_set_hub_metrics` | Record/retrieve hub metrics with CSV trend history. | Hub Admin Read |
 | `device_health_check` | Find stale/offline devices. | Hub Admin Read |
-| `get_rule_diagnostics` | Comprehensive diagnostics for a specific rule. | None |
+| `custom_get_rule_diagnostics` | Comprehensive diagnostics for a specific custom rule. | None |
 | `get_zwave_details` | Z-Wave radio info. | Hub Admin Read |
 | `get_zigbee_details` | Zigbee radio info. | Hub Admin Read |
 | `get_memory_history` | Free OS memory + CPU load history (with Java heap + NIO buffer tracking for leak detection). | Hub Admin Read |
@@ -202,7 +202,7 @@ Read-only visibility into all installed apps (built-in + user): enumerate with p
 | `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.). Returns sections/inputs/values; multi-page apps via `pageName`. Workflow: list_installed_apps or list_rm_rules -> get_app_config with appId; multi-page apps accept pageName (HPM: prefPkgUninstall for full list). Read-only. | Hub Admin Read |
 | `list_app_pages` | List known page names for a multi-page app (HPM, Room Lighting, etc.). Returns curated directory + live primary page. Use before get_app_config on multi-page apps. | Hub Admin Read |
 
-### manage_native_rules_and_apps (9 tools)
+### manage_native_rules_and_apps (12 tools)
 
 Two surfaces: RMUtils-based runtime control for RM rules (read/trigger/pause/resume) plus admin-layer CRUD that works uniformly across any classic SmartApp (RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.). Requires Built-in App Tools enabled; CRUD operations additionally require Hub Admin Write.
 
@@ -216,6 +216,9 @@ Two surfaces: RMUtils-based runtime control for RM rules (read/trigger/pause/res
 | `create_native_app` | Create a new empty classic SmartApp (RM 5.1 by default; `appType` enum extends to other types). Returns `appId`. | Built-in App Tools + Hub Admin Write |
 | `update_native_app` | Modify any classic native app by appId. Structured shortcuts: addTrigger, addAction, addRequiredExpression, clearActions, replaceActions, patches, etc. Auto-snapshots before writing. | Built-in App Tools + Hub Admin Write |
 | `delete_native_app` | Delete a classic native app (auto-snapshot to File Manager before deleting). `force=true` for hard delete. | Built-in App Tools + Hub Admin Write |
+| `clone_native_app` | Clone an existing classic SmartApp via Hubitat's `appCloner` endpoint. Returns the new `appId`. | Built-in App Tools + Hub Admin Write |
+| `export_native_app` | Export a classic SmartApp to JSON, round-trippable with `import_native_app`. Useful for backup, sharing, or export-mutate-import editing of complex rules. | Built-in App Tools |
+| `import_native_app` | Import previously-exported app JSON into a new instance. Pairs with `export_native_app`. Returns the new `appId`. | Built-in App Tools + Hub Admin Write |
 | `check_rule_health` | Read-only health check on any installed app -- surfaces broken markers, multiple-flag poison, configPage errors. | Built-in App Tools |
 
 ### manage_mcp_self (1 tool)

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -1,6 +1,6 @@
 # Bot Acceptance Test (BAT) Suite — v2
 
-Updated for the installed-apps + Rule Machine interop + native CRUD + library management architecture (23 core + 12 gateways = 35 on tools/list, 75 proxied, 98 total).
+Updated for the installed-apps + Rule Machine interop + native CRUD + library management architecture (23 core + 12 gateways = 35 on tools/list, 78 proxied, 101 total).
 
 Comprehensive test scenarios for the Hubitat MCP Rule Server. Modeled after ha-mcp's BAT framework.
 
@@ -1343,7 +1343,7 @@ Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (21 + 10 gate
 
 ## Section 9: Stress Tests
 
-### T120 — All 10 gateways in one session (v0.8.0)
+### T120 — Many-gateway stress (7 of 12 gateways)
 
 ```json
 {
@@ -1353,7 +1353,7 @@ Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (21 + 10 gate
 }
 ```
 
-**Expected**: 10 calls across core tools and gateways (manage_rooms, manage_hub_variables, get_hub_info (core), create_hub_backup (core), manage_files, manage_apps_drivers, manage_diagnostics, manage_logs, check_for_update (core), manage_rules_admin). `manage_app_driver_code` excluded — all its tools are destructive. All should succeed.
+**Expected**: 10 calls across core tools and gateways (manage_rooms, manage_hub_variables, get_hub_info (core), create_hub_backup (core), manage_files, manage_apps_drivers, manage_diagnostics, manage_logs, check_for_update (core), manage_rules_admin). Excluded: `manage_app_driver_code` (all tools destructive), `manage_destructive_hub_ops` (destructive ops), `manage_installed_apps` (separate T205 scenarios), `manage_native_rules_and_apps` (separate T200-series scenarios), `manage_mcp_self` (separate T102 scenarios). All 7 exercised gateways should succeed.
 
 ### T121 — Rapid rule create-delete cycles
 
@@ -2256,7 +2256,7 @@ These operations are too destructive for automated testing. Test manually with e
 
 | Section | Tests | Purpose |
 |---------|-------|---------|
-| 1. Core Tools | T01-T19c | 21 core tools work directly |
+| 1. Core Tools | T01-T19c | 23 core tools work directly |
 | 2. Gateway Discovery | T20-T31, T35-T59 | LLM finds all proxied tools without hints |
 | 3. Gateway Behavior | T60-T65 | Catalog mode, skip-catalog, errors |
 | 4. Natural Language | T70-T79 | Casual prompts route correctly |
@@ -2277,14 +2277,14 @@ These operations are too destructive for automated testing. Test manually with e
 | Core tools on `tools/list` | 23 |
 | Gateways on `tools/list` | 12 |
 | Total visible on `tools/list` | 35 |
-| Tools proxied behind gateways | 71 |
-| Total tools in codebase | 94 |
+| Tools proxied behind gateways | 78 |
+| Total tools in codebase | 101 |
 
-**12 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (4), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (6), `manage_app_driver_code` (11), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_native_rules_and_apps` (9), `manage_mcp_self` (1)
+**12 Gateways**: `manage_rules_admin` (5), `manage_hub_variables` (8), `manage_rooms` (5), `manage_destructive_hub_ops` (3), `manage_apps_drivers` (7), `manage_app_driver_code` (10), `manage_logs` (8), `manage_diagnostics` (11), `manage_files` (4), `manage_installed_apps` (4), `manage_native_rules_and_apps` (12), `manage_mcp_self` (1)
 
 ### Tool Coverage (non-destructive tools only)
 
-All 94 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
+All 101 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
 
 Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
 
@@ -2361,7 +2361,7 @@ Tools in this section have mixed gate requirements. `list_installed_apps` and `g
 }
 ```
 
-**Expected**: AI calls `manage_installed_apps` with no args, sees catalog of 2 tools (`list_installed_apps`, `get_device_in_use_by`) with full parameter schemas.
+**Expected**: AI calls `manage_installed_apps` with no args, sees catalog of 4 tools (`list_installed_apps`, `get_device_in_use_by`, `get_app_config`, `list_app_pages`) with full parameter schemas.
 
 ### T206 — Gateway catalog discovery (manage_native_rules_and_apps)
 
@@ -2371,7 +2371,7 @@ Tools in this section have mixed gate requirements. `list_installed_apps` and `g
 }
 ```
 
-**Expected**: AI calls `manage_native_rules_and_apps` with no args, sees 9 tools. AI describes them (list/run/pause/resume/set_boolean + create/update/delete native app + check_rule_health).
+**Expected**: AI calls `manage_native_rules_and_apps` with no args, sees 12 tools. AI describes them (list/run/pause/resume/set_boolean + create/update/delete/clone/export/import_native_app + check_rule_health).
 
 ### T207 — AI uses native RM rule creation via manage_native_rules_and_apps
 
@@ -2857,12 +2857,12 @@ Write tools (`install_library`, `update_library_code`, `delete_library`) live in
 
 Key differences from the original BAT.md (which targets the pre-v0.8.0 architecture):
 
-1. **Architecture**: 18 core + 8 gateways (26 total) → **23 core + 12 gateways (35 total, 98 tools)** post installed-apps + RM interop + native CRUD + list_app_pages + poll_until_attribute + library management (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
+1. **Architecture**: 18 core + 8 gateways (26 total) → **23 core + 12 gateways (35 on tools/list, 101 total)** post installed-apps + RM interop + native CRUD + list_app_pages + poll_until_attribute + library management (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
 2. **Merged tools**: `enable_rule`/`disable_rule` → `custom_update_rule` (enabled=true/false); `create_virtual_device`/`delete_virtual_device` → `manage_virtual_device` (action enum)
 3. **Promoted to core**: `create_hub_backup`, `check_for_update`, `generate_bug_report`
 4. **Dissolved gateway**: `manage_hub_info` — radio details moved to `manage_diagnostics`, other tools merged into `get_hub_info` (core) or promoted
-5. **Gateway renames**: `manage_hub_maintenance` → `manage_destructive_hub_ops` (3 tools); `manage_code_changes` → `manage_app_driver_code` (11 tools, 7 original + 4 library tools)
-6. **Gateway splits from v1**: `manage_apps_drivers` → `manage_apps_drivers` (6 read) + `manage_app_driver_code` (11 write); `manage_logs_diagnostics` → `manage_logs` (8) + `manage_diagnostics` (11)
+5. **Gateway renames**: `manage_hub_maintenance` → `manage_destructive_hub_ops` (3 tools); `manage_code_changes` → `manage_app_driver_code` (10 tools, 7 original + 3 library tools)
+6. **Gateway splits from v1**: `manage_apps_drivers` → `manage_apps_drivers` (7 read) + `manage_app_driver_code` (10 write); `manage_logs_diagnostics` → `manage_logs` (8) + `manage_diagnostics` (11)
 7. **T62 rewritten**: Was testing `manage_virtual_devices` catalog (removed gateway) → now tests `manage_diagnostics` catalog
 8. **T104 updated**: Anti-recursion test uses `manage_diagnostics` gateway
 9. **Excluded tests expanded**: 10 → 13 (separate rows for each app/driver operation, added gateway column)

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -15,6 +15,19 @@ import sys
 import os
 from pathlib import Path
 
+# Force UTF-8 on stdout/stderr so prints containing em dashes, arrows, and
+# other non-ASCII characters in messages don't crash on Windows consoles
+# whose default codepage is cp1252. The lint runs cleanly on Linux/macOS
+# (already UTF-8), CI (also UTF-8), and Windows terminals that respect
+# the env var; the only failure mode this fixes is a Windows local run
+# where the contributor doesn't pre-set PYTHONIOENCODING. errors=replace
+# (rather than strict) keeps a single mis-encoded character from masking
+# whatever the lint was actually trying to report.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -515,6 +528,647 @@ def check_versions() -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Tool-count consistency check
+# ---------------------------------------------------------------------------
+#
+# Tool counts are quoted across many docs (README, SKILL, TOOL_GUIDE,
+# agent-skill mirrors, BAT-v2). Without a check, every tool-adding PR has
+# to manually update them in lockstep, and drift is silent until someone
+# notices. This check derives the canonical counts from the Groovy source
+# (getGatewayConfig + getAllToolDefinitions) and flags any current-state
+# claim in docs that disagrees.
+#
+# Historical references in version-history sections, migration tables, and
+# version-pinned phrasings (e.g. "v0.8.0 had 21 core tools") are skipped
+# so the lint doesn't false-fire on accurate history.
+
+DOC_FILES_FOR_COUNTS = [
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "SKILL.md",
+    REPO_ROOT / "TOOL_GUIDE.md",
+    REPO_ROOT / "agent-skill" / "hubitat-mcp" / "SKILL.md",
+    REPO_ROOT / "agent-skill" / "hubitat-mcp" / "tool-reference.md",
+    REPO_ROOT / "tests" / "BAT-v2.md",
+    # tests/e2e_test.py hardcodes a tools/list count assertion + descriptive
+    # message; the message string contains "(N core + M gateways)" forms
+    # the existing patterns match.
+    REPO_ROOT / "tests" / "e2e_test.py",
+    # tests/BAT.md is intentionally NOT in scope. It's the legacy v1 suite,
+    # explicitly documented at the top as describing the pre-v0.8.0
+    # architecture for historical reference. Every count there is meant to
+    # be a snapshot of an older release, and the prose phrasings ("pre-v0.8.0
+    # architecture (8 gateways, ...)") don't fit clean line-level historical
+    # patterns without false negatives elsewhere. BAT-v2.md is the current
+    # source of truth and remains in scope.
+]
+
+# Two tiers of historical-line markers:
+#
+# WIDE (line-scope) — markers that essentially never appear on a live
+# count line. A line containing one of these is almost certainly
+# documenting historical state, so we skip the entire line.
+#   - Version-pin markers like `**v0.7.7**:` or `(v0.8.0)` always scope
+#     a count to a past release.
+# NARROW (window-scope) — markers that CAN legitimately appear on a
+# live-count line, scoping only a nearby clause. We check these only
+# within the HISTORICAL_NEAR_MATCH_WINDOW chars that PRECEDE the matched
+# count (look-back only). Historical markers describe past state that
+# comes before a live claim; checking forward would silently swallow live
+# counts whose trailing clause references old values — e.g.
+# "22 core tools today, was 18 previously" would incorrectly skip the
+# live "22 core" if the window extended past match_start into the "was 18"
+# that follows.
+HISTORICAL_NEAR_MATCH_WINDOW = 20  # chars of look-back window ending immediately before the matched count
+HISTORICAL_LINE_PATTERNS_WIDE = [
+    # "v0.7.7 (all 74 tools)" — version followed by paren-count is the
+    # canonical historical scoping shape; counts within the parens are
+    # always scoped to the version.
+    re.compile(r"\bv\d+\.\d+(?:\.\d+)?\s*\("),
+    # "**v0.7.7**: 74 tools listed" — bold-version + colon is also a
+    # canonical historical-scoping shape (definitional clause).
+    re.compile(r"\*\*v\d+\.\d+(?:\.\d+)?\*\*\s*:"),
+]
+HISTORICAL_LINE_PATTERNS_NARROW = [
+    re.compile(r"→"),                              # migration arrows
+    re.compile(r"\bwas\s+\d+\b", re.IGNORECASE),  # "was 90"
+    re.compile(r"\bpreviously\s+\d+\b", re.IGNORECASE),
+    re.compile(r"\bbefore\s*[:=]\s*\d+\b", re.IGNORECASE),
+    # `(v0.7.7` / `(v0.8.0)` — bare parenthesized version. NARROW because
+    # this shape ALSO appears as a feature-availability marker in live
+    # text (e.g. "T120 — All N gateways in one session (v0.8.0)" where
+    # the version-pin is just provenance, not historical scoping). Only
+    # treat as historical if the version-paren sits within ±window of
+    # the count it would scope.
+    re.compile(r"\(v\d+\.\d+(?:\.\d+)?"),
+]
+# Backward-compat alias: the union exists for any external caller that
+# imports HISTORICAL_LINE_PATTERNS directly.
+HISTORICAL_LINE_PATTERNS = HISTORICAL_LINE_PATTERNS_WIDE + HISTORICAL_LINE_PATTERNS_NARROW
+
+# Section headings that flip the file into "history mode" — counts inside
+# the section (or any DESCENDANT subsection) are historical. The ancestor
+# walk in `_is_historical_at` traverses the full heading stack so a `###
+# v1.0.0 (2026-01-15)` sub-section under `## Version History` correctly
+# inherits historical status. We deliberately do NOT include a
+# parenthesized-version-anywhere pattern here — that flagged live
+# scenario titles like the original "T120 — All N gateways in one session
+# (v0.8.0)". When a real version-pinned subsection exists, the ancestor
+# walk picks up the parent Version History / Changelog heading.
+HISTORICAL_SECTION_HEADINGS = [
+    re.compile(r"^#+\s*Version\s+History\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^#+\s*Changelog\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^#+\s*Changes\s+from\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^#+\s*Migration\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^#+\s*Release\s+Notes\b", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"^#+\s*History\b", re.IGNORECASE | re.MULTILINE),
+]
+
+
+def _extract_canonical_counts() -> dict | None:
+    """Parse hubitat-mcp-server.groovy to derive canonical tool counts.
+
+    Returns a dict {total, core, gateways, tools_list, proxied,
+    per_gateway: {name: op_count}} or None if extraction fails.
+    """
+    srv_path = REPO_ROOT / "hubitat-mcp-server.groovy"
+    if not srv_path.exists():
+        return None
+    src = srv_path.read_text(encoding="utf-8", errors="replace")
+
+    # Comment-stripping intentionally NOT done. Reasoning: this codebase's
+    # tool description heredocs commonly contain both `//` (URLs like
+    # `https://...`) and `/* ... */`-shaped tokens (regex example syntax,
+    # quoted Hubitat doc snippets). A naive regex strip mangles those
+    # strings and breaks the canonical extraction more often than it helps.
+    # The hypothetical case of "tool definition commented out for
+    # deprecation" would produce an over-count (lint reports doc N vs
+    # canonical N+1, which is loud and recoverable), so the trade-off
+    # favors a simpler parser. A real Groovy AST walk would be the right
+    # fix if commented-out definitions ever become a recurring class.
+
+    # Carve out the getGatewayConfig() body
+    gw_match = re.search(
+        r"^def getGatewayConfig\(\) \{(.*?)^}",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    if not gw_match:
+        return None
+    gw_block = gw_match.group(1)
+
+    per_gateway: dict[str, int] = {}
+    proxied_names: set[str] = set()
+    # Two-stage anchor:
+    #   1. `^\s+([a-z_]+):\s*\[\s*description:` — gateway-key indented
+    #      AND immediately opens with `description:`. This is the
+    #      structural anchor that prevents matching nested map keys
+    #      like `summaries:` or `searchHints:` as gateways (every
+    #      gateway in this codebase opens with description; the inner
+    #      maps don't).
+    #   2. `\".*?\".*?\btools:\s*\[([^\]]+)\]` — capture the tools
+    #      array regardless of what other keys (`category:`, comments,
+    #      etc.) appear between description and tools. `\btools:` with
+    #      word-boundary avoids false matches on suffixes like
+    #      `subtools:`.
+    # Escaped quotes inside description aren't currently used in this
+    # codebase; if a future maintainer adds one, the inner `\".*?\"`
+    # would terminate early — flag it then if it actually breaks.
+    for m in re.finditer(
+        r"^\s+([a-z_]+):\s*\[\s*description:\s*\".*?\".*?\btools:\s*\[([^\]]+)\]",
+        gw_block,
+        re.MULTILINE | re.DOTALL,
+    ):
+        name = m.group(1)
+        # Strip line-comments BEFORE comma-splitting. A trailing `//`
+        # comment on a tool line (e.g. `"foo", // disabled\n "bar"`)
+        # would otherwise put part of the comment AND the next entry
+        # into the same comma-separated chunk; per-entry split-on-`//`
+        # would then keep only the empty pre-comment whitespace and
+        # silently drop the next tool. Today's source has no inline
+        # comments inside tools[], but this is forward-compat.
+        no_comments = re.sub(r"//[^\n]*", "", m.group(2))
+        tool_list = [
+            t.strip().strip("\"'")
+            for t in no_comments.split(",")
+            if t.strip()
+        ]
+        per_gateway[name] = len(tool_list)
+        proxied_names.update(tool_list)
+
+    if not per_gateway:
+        return None
+
+    # Carve out getAllToolDefinitions() and extract tool names
+    all_match = re.search(
+        r"^def getAllToolDefinitions\(\) \{(.*?)^}",
+        src,
+        re.DOTALL | re.MULTILINE,
+    )
+    if not all_match:
+        return None
+    # Keep raw list separate from the set so a duplicate `name:` entry
+    # in getAllToolDefinitions() is detectable: the count check sees
+    # total = len(list) > len(docs) and fires; the self-test cross-
+    # checks list-len vs set-len. If we collapsed both into len(set),
+    # duplicate-name regressions would be silent on both gates.
+    raw_name_list = re.findall(r"^\s*name:\s*['\"]([a-z_]+)['\"]", all_match.group(1), re.MULTILINE)
+    tool_names: set[str] = set(raw_name_list)
+    total = len(raw_name_list)
+
+    proxied = sum(per_gateway.values())
+    core = total - proxied
+    gateways = len(per_gateway)
+    tools_list = core + gateways
+
+    return {
+        "total": total,
+        "core": core,
+        "gateways": gateways,
+        "tools_list": tools_list,
+        "proxied": proxied,
+        "per_gateway": per_gateway,
+        # Name sets for tool-name consistency check (separate from counts):
+        "tool_names": tool_names,           # all tool identifiers in getAllToolDefinitions()
+        "gateway_names": set(per_gateway.keys()),  # gateway facade identifiers (manage_X)
+        "proxied_names": proxied_names,     # tools enumerated under any gateway's `tools:` list
+    }
+
+
+def _is_historical_at(content: str, match_start: int, match_end: int | None = None) -> bool:
+    """Return True if the match falls inside a historical / migration
+    context that should be skipped by the count lint.
+
+    Two layers:
+      (1) Per-match window: HISTORICAL_LINE_PATTERNS are checked only
+          within ±HISTORICAL_NEAR_MATCH_WINDOW chars of the match itself,
+          NOT the entire enclosing line. A live count line that happens
+          to mention "was 90" elsewhere should not silently disable lint
+          for the live count next to it.
+      (2) Section-level ancestor walk: walks backward through ALL
+          preceding headings tracking heading level. Any ancestor (a
+          heading at strictly lower level than the smallest level seen
+          so far) matching HISTORICAL_SECTION_HEADINGS marks the match
+          as historical. This correctly handles `### v1.0.0 ...` sub-
+          headings under a `## Version History` parent.
+    """
+    if match_end is None:
+        match_end = match_start
+
+    # Layer 1a: WIDE markers — version-pins anywhere on the line. These
+    # scope the entire line to historical context.
+    line_start = content.rfind("\n", 0, match_start) + 1
+    line_end_pos = content.find("\n", match_start)
+    if line_end_pos == -1:
+        line_end_pos = len(content)
+    line = content[line_start:line_end_pos]
+    for pat in HISTORICAL_LINE_PATTERNS_WIDE:
+        if pat.search(line):
+            return True
+
+    # Layer 1b: NARROW markers — only inside the look-back window ending at
+    # match_start. Historical markers describe PAST state that precedes a live
+    # claim; a trailing "was N" or "previously N" appearing AFTER the count
+    # describes the live count's own history and should not suppress the live
+    # count. Anchoring the window to [match_start - window, match_start]
+    # (look-back only) correctly reflects this semantic.
+    win_start = max(0, match_start - HISTORICAL_NEAR_MATCH_WINDOW)
+    win_end = match_start  # exclusive — do not extend past the count itself
+    window = content[win_start:win_end]
+    for pat in HISTORICAL_LINE_PATTERNS_NARROW:
+        if pat.search(window):
+            return True
+
+    # Layer 2: ancestor walk through preceding headings. Track the
+    # smallest level seen so far — only a heading at strictly smaller
+    # level (i.e. an ancestor section) can mark this match as historical.
+    # Sibling/descendant historical headings don't propagate.
+    preceding = content[:match_start]
+    min_level = float("inf")
+    for m in reversed(list(re.finditer(r"^(#+)\s+\S", preceding, re.MULTILINE))):
+        level = len(m.group(1))
+        if level >= min_level:
+            continue  # sibling or descendant; not an ancestor of the match
+        min_level = level
+        line_end = preceding.find("\n", m.start())
+        if line_end == -1:
+            line_end = len(preceding)
+        heading_line = preceding[m.start():line_end]
+        for pat in HISTORICAL_SECTION_HEADINGS:
+            if pat.match(heading_line):
+                return True
+    return False
+
+
+# Backward-compat alias: callers that pass only match_start still work.
+_is_historical_line = _is_historical_at
+
+
+# Patterns to scan in docs. Each entry: (regex, count_kind).
+# count_kind keys map to canonical fields above ("total", "core",
+# "gateways", "tools_list", "proxied").
+COUNT_PATTERNS: list[tuple[re.Pattern, str]] = [
+    # Total
+    (re.compile(r"\((\d+)\s+total\b"), "total"),
+    (re.compile(r"\b(\d+)\s+tools?\s+total\b", re.IGNORECASE), "total"),
+    (re.compile(r"\bcovering\s+(\d+)\s+(?:total\s+)?tools?\b", re.IGNORECASE), "total"),
+    (re.compile(r"\bMCP\s+Tools?\s+\((\d+)\s+total\b", re.IGNORECASE), "total"),
+    (re.compile(r"\bexposes?\s+(\d+)\s+tools?\b", re.IGNORECASE), "total"),
+    (re.compile(r"\bexposing\s+(\d+)\s+tools?\b", re.IGNORECASE), "total"),
+    (re.compile(r"\bhas\s+(\d+)\s+tools?\s+total\b", re.IGNORECASE), "total"),
+    (re.compile(r"\b(\d+)\s+MCP\s+tools?\b", re.IGNORECASE), "total"),
+    # "search across all N tools" / "for all N tools" — catalog references.
+    (re.compile(r"\b(?:across|for|reference\s+for)\s+all\s+(\d+)\s+(?:MCP\s+)?tools?\b", re.IGNORECASE), "total"),
+    # "All N tools are covered" — BAT test-coverage claim that tracks the
+    # total tool count (covered = total minus excluded destructives).
+    (re.compile(r"\bAll\s+(\d+)\s+tools?\s+are\s+covered\b", re.IGNORECASE), "total"),
+    (re.compile(r"\b(\d+)\s+additional\s+tools?\b", re.IGNORECASE), "proxied"),
+    # "returns all N tool definitions" — getAllToolDefinitions() phrasing.
+    (re.compile(r"\b(\d+)\s+tool\s+definitions?\b", re.IGNORECASE), "total"),
+    # "from N items to M" — gateway-pattern explanation phrasing.
+    (re.compile(r"\bfrom\s+(\d+)\s+items?\s+to\s+\d+\b", re.IGNORECASE), "total"),
+    # "N proxied" anywhere (not just paren-prefix) — covers compact-summary
+    # phrasings like "(... 78 proxied, 101 total)".
+    (re.compile(r"\b(\d+)\s+proxied\b(?!\s+tools)", re.IGNORECASE), "proxied"),
+    # "N total" when followed by punctuation or end-of-clause — catches
+    # the BAT-v2 header-style "78 proxied, 101 total)" without firing on
+    # "30 total scenarios" / "13 total messages" qualifying-noun forms.
+    (re.compile(r"\b(\d+)\s+total\b(?=\s*[.)\n,])"), "total"),
+    # Core
+    (re.compile(r"\b(\d+)\s+core\s+tools?\b", re.IGNORECASE), "core"),
+    (re.compile(r"\b(\d+)\s+core\s*\+\s*\d+\s+gateways?\b", re.IGNORECASE), "core"),
+    # Gateways
+    (re.compile(r"\b\d+\s+core\s*\+\s*(\d+)\s+gateways?\b", re.IGNORECASE), "gateways"),
+    (re.compile(r"(?<!\.)\b(\d+)\s+gateways?\b", re.IGNORECASE), "gateways"),
+    # tools/list count
+    (re.compile(r"\b(\d+)\s+on\s+`?tools/list`?\b"), "tools_list"),
+    (re.compile(r"\b(\d+)\s+items?\s+on\s+`?tools/list`?\b"), "tools_list"),
+    # Proxied count
+    (re.compile(r"\((\d+)\s+proxied\b"), "proxied"),
+    (re.compile(r"\b(\d+)\s+proxied\s+tools?\b"), "proxied"),
+    # Table-row form: "Total tools in codebase | 90", etc. Each fixes the
+    # phrasing tightly so a stray two-column table elsewhere can't match
+    # by accident.
+    (re.compile(r"\btotal\s+tools?\s+in\s+codebase\s*\|?\s*(\d+)\b", re.IGNORECASE), "total"),
+    (re.compile(r"\btools?\s+proxied\s+behind\s+gateways?\s*\|?\s*(\d+)\b", re.IGNORECASE), "proxied"),
+    (re.compile(r"\btotal\s+visible\s+on\s+`?tools/list`?\s*\|?\s*(\d+)\b", re.IGNORECASE), "tools_list"),
+    # Architecture-table component-row phrasings used in BAT-v2 §
+    # "Architecture": "Core tools on `tools/list` | 23" and "Gateways on
+    # `tools/list` | 12". Requires either the pipe table separator or the
+    # backtick around tools/list so bare prose like "core tools on
+    # tools/list 23" (no anchor) doesn't false-fire on future doc drift.
+    (re.compile(r"\bcore\s+tools?\s+on\s+(?:`tools/list`|\|?\s*tools/list\s*\|)\s*\|?\s*(\d+)\b", re.IGNORECASE), "core"),
+    (re.compile(r"\bgateways?\s+on\s+(?:`tools/list`|\|?\s*tools/list\s*\|)\s*\|?\s*(\d+)\b", re.IGNORECASE), "gateways"),
+]
+
+# Per-gateway pattern: "manage_X (N)", "`manage_X` (N)", "<b>manage_X</b> (N)",
+# "### manage_X (N tools)", "manage_X (N tools, 7 original + 3 library tools)".
+# The 0-10 char window between the gateway name and the open paren
+# tolerates backticks and short HTML tags without matching across
+# unrelated text. The trailing class allows `)` (bare or `(N tools)`),
+# `,` (qualifier follows like "(N tools, 7 original + ...)"), or
+# whitespace + non-paren (e.g. "(N tools generic across...)").
+PER_GATEWAY_PATTERN = re.compile(
+    r"\b(manage_[a-z_]+)\b[^(\n]{0,10}\((\d+)(?:\s+tools?)?(?:[,)]|\s+(?:tools?|original|library|read|write))"
+)
+
+# Per-gateway in markdown tables: "| `manage_X` | N |" — the count lives
+# in a separate column from the name, so the parenthesis-anchored pattern
+# above misses these.
+PER_GATEWAY_TABLE_PATTERN = re.compile(
+    r"\|\s*`?(manage_[a-z_]+)`?\s*\|\s*(\d+)\s*\|"
+)
+
+# "AI calls `manage_X` ... sees N tools" — gateway op-count claim where
+# the gateway name and the count are separated by descriptive prose. The
+# 1-80 char window is loose enough to cover phrasings like "AI calls
+# `manage_native_rules_and_apps` with no args, sees 12 tools" without
+# crossing sentence boundaries (terminated by `.` or newline).
+PER_GATEWAY_SEES_PATTERN = re.compile(
+    r"`(manage_[a-z_]+)`[^.\n]{1,80}\bsees?\s+(?:catalog\s+of\s+)?(\d+)\s+tools?\b"
+)
+
+
+def check_tool_counts() -> list[dict]:
+    """Verify documented tool counts match the canonical counts derived
+    from hubitat-mcp-server.groovy. Skips historical / migration
+    contexts."""
+    findings: list[dict] = []
+    canonical = _extract_canonical_counts()
+    if canonical is None:
+        findings.append(
+            {
+                "file": "hubitat-mcp-server.groovy",
+                "line": 0,
+                "rule": "TOOL_COUNT",
+                "message": (
+                    "Could not extract canonical tool counts from "
+                    "getGatewayConfig() / getAllToolDefinitions(). The "
+                    "lint can't verify doc consistency until the parser "
+                    "is updated to handle the current source layout."
+                ),
+                "severity": "error",
+                "source": "",
+            }
+        )
+        return findings
+
+    for doc_path in DOC_FILES_FOR_COUNTS:
+        if not doc_path.exists():
+            continue
+        rel = str(doc_path.relative_to(REPO_ROOT)).replace("\\", "/")
+        content = doc_path.read_text(encoding="utf-8", errors="replace")
+
+        # High-level counts. Track (line, kind, actual) so the same drift
+        # surfaced by two overlapping patterns doesn't dupe.
+        seen: set[tuple[int, str, int]] = set()
+        for pat, kind in COUNT_PATTERNS:
+            expected = canonical[kind]
+            for m in pat.finditer(content):
+                if _is_historical_at(content, m.start(), m.end()):
+                    continue
+                actual = int(m.group(1))
+                if actual == expected:
+                    continue
+                line_no = content[:m.start()].count("\n") + 1
+                dedup_key = (line_no, kind, actual)
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                line_start = content.rfind("\n", 0, m.start()) + 1
+                line_end = content.find("\n", m.start())
+                if line_end == -1:
+                    line_end = len(content)
+                line_text = content[line_start:line_end].strip()
+                findings.append(
+                    {
+                        "file": rel,
+                        "line": line_no,
+                        "rule": "TOOL_COUNT",
+                        "message": (
+                            f"{kind} count claims {actual}, canonical is "
+                            f"{expected}. Update doc or check that the "
+                            "claim isn't historical (add a v0.X.Y marker, "
+                            "→ migration arrow, or 'was N' phrasing to "
+                            "skip)."
+                        ),
+                        "severity": "error",
+                        "source": line_text[:200],
+                    }
+                )
+
+        # Per-gateway op counts: parenthesized form, markdown table form,
+        # and "AI ... sees N tools" gateway-context form.
+        per_gw_seen: set[tuple[int, str, int]] = set()
+        for m in (
+            list(PER_GATEWAY_PATTERN.finditer(content))
+            + list(PER_GATEWAY_TABLE_PATTERN.finditer(content))
+            + list(PER_GATEWAY_SEES_PATTERN.finditer(content))
+        ):
+            if _is_historical_at(content, m.start(), m.end()):
+                continue
+            gw_name = m.group(1)
+            actual = int(m.group(2))
+            line_no_dedup = content[:m.start()].count("\n") + 1
+            dedup_key = (line_no_dedup, gw_name, actual)
+            if dedup_key in per_gw_seen:
+                continue
+            per_gw_seen.add(dedup_key)
+            expected = canonical["per_gateway"].get(gw_name)
+            if expected is None:
+                # Unknown gateway name in docs — likely a renamed or
+                # removed gateway; surface the canonical list to make
+                # the typo / stale-rename obvious.
+                line_no = content[:m.start()].count("\n") + 1
+                known = ", ".join(sorted(canonical["per_gateway"].keys()))
+                findings.append(
+                    {
+                        "file": rel,
+                        "line": line_no,
+                        "rule": "TOOL_COUNT",
+                        "message": (
+                            f"Doc references unknown gateway {gw_name!r}. "
+                            "Either the gateway was renamed/removed in "
+                            "the Groovy source, or the doc reference is "
+                            f"stale. Known gateways: {{{known}}}."
+                        ),
+                        "severity": "error",
+                        "source": "",
+                    }
+                )
+                continue
+            if actual != expected:
+                line_no = content[:m.start()].count("\n") + 1
+                line_start = content.rfind("\n", 0, m.start()) + 1
+                line_end = content.find("\n", m.start())
+                if line_end == -1:
+                    line_end = len(content)
+                line_text = content[line_start:line_end].strip()
+                findings.append(
+                    {
+                        "file": rel,
+                        "line": line_no,
+                        "rule": "TOOL_COUNT",
+                        "message": (
+                            f"{gw_name} claims {actual} ops, canonical "
+                            f"is {expected}."
+                        ),
+                        "severity": "error",
+                        "source": line_text[:200],
+                    }
+                )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Tool-name consistency check
+# ---------------------------------------------------------------------------
+#
+# Catches a different drift class than tool-counts: stale tool-name
+# references in docs (e.g., `get_rule_diagnostics` after the v0.X rename
+# to `custom_get_rule_diagnostics`). Tool-counts are silent on names —
+# the count was right but the rename wasn't propagated. This check scans
+# markdown table rows that reference a tool by backtick-wrapped identifier
+# in first-column position, and flags any name not in the canonical set
+# extracted from `getAllToolDefinitions()` + `getGatewayConfig()`.
+
+# Files in scope: ones with proper tool tables. BAT-v2 excluded — it
+# references tools by name in test prose (not first-column table position),
+# so a first-column scan would miss its mentions and a prose scan would
+# false-positive on intentional historical references.
+DOC_FILES_FOR_TOOL_NAMES = [
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "TOOL_GUIDE.md",
+    REPO_ROOT / "agent-skill" / "hubitat-mcp" / "tool-reference.md",
+]
+
+# Markdown table row in the form `| `name` | description |` — the leading
+# `|` + whitespace + backtick + snake_case identifier + closing backtick
+# anchors the tool-table-cell shape. Lookahead for `|` ensures we're in
+# table column 1, not just any backtick-wrapped reference in prose.
+TOOL_TABLE_ROW_PATTERN = re.compile(
+    r"^\s*\|\s*`([a-z_]+)`\s*(?=\|)",
+    re.MULTILINE,
+)
+
+# Markdown table separator (`|---|---|`) — anchors backward search for the
+# header row. Tolerant of optional `:` alignment markers and varying dash
+# counts.
+TABLE_SEPARATOR_PATTERN = re.compile(
+    r"^\s*\|(?:\s*:?-{2,}:?\s*\|)+\s*$",
+    re.MULTILINE,
+)
+
+# Header text in column 1 that signals "this table lists MCP tools" —
+# matched case-insensitively, whole-cell. RM action/condition/comparison
+# tables use "Type"/"Comparison"/etc. and are correctly excluded.
+TOOL_TABLE_HEADER_NAMES = {"tool", "name", "mcp tool", "tool name"}
+
+# Identifiers that legitimately appear in tool-table-shaped rows even
+# under a "Tool"/"Name" header but are not in getAllToolDefinitions(). Add
+# entries here when a future doc legitimately uses a tool-table shape for
+# non-tool entries. Keep small — every entry here is a blind spot for
+# the lint.
+TOOL_NAME_ALLOWLIST: set[str] = set()
+
+
+def _table_header_for_match(content: str, match_start: int) -> str | None:
+    """Return the column-1 header text for the markdown table containing
+    `match_start`, or None if no table-header context is found.
+
+    Scans backward for the nearest table-separator line (`|---|---|`).
+    The line immediately above the separator is the header row; column 1
+    is everything between the leading `|` and the next `|`. Returns the
+    header text lowercased and stripped of `**` emphasis."""
+    sep_match = None
+    for m in TABLE_SEPARATOR_PATTERN.finditer(content, 0, match_start):
+        sep_match = m
+    if sep_match is None:
+        return None
+    header_end = content.rfind("\n", 0, sep_match.start())
+    if header_end == -1:
+        return None
+    header_start = content.rfind("\n", 0, header_end) + 1
+    header_line = content[header_start:header_end]
+    cells = header_line.split("|")
+    if len(cells) < 2:
+        return None
+    col1 = cells[1].strip().strip("*").strip().lower()
+    return col1
+
+
+def check_tool_name_consistency() -> list[dict]:
+    """Verify tool-name references in doc tables match canonical names.
+
+    For each markdown table row in the form `| `<name>` | ...`, check
+    that `<name>` is a valid tool name (in `getAllToolDefinitions()`),
+    a gateway name (in `getGatewayConfig()`), or in the explicit
+    allowlist. Flag stale references that look like renamed tools.
+
+    HTML-comment scope (`<!-- ... -->`) is NOT respected — same trade-off
+    as the comment-stripping decision documented in
+    `_extract_canonical_counts()`. A future doc author who wraps a tool
+    table in an HTML comment to suppress it would still have its rows
+    linted; today's docs don't trigger this."""
+    findings: list[dict] = []
+    canonical = _extract_canonical_counts()
+    if canonical is None:
+        # check_tool_counts already flagged this with a clearer message.
+        return findings
+
+    valid_names = canonical["tool_names"] | canonical["gateway_names"] | TOOL_NAME_ALLOWLIST
+
+    for doc_path in DOC_FILES_FOR_TOOL_NAMES:
+        if not doc_path.exists():
+            continue
+        rel = str(doc_path.relative_to(REPO_ROOT)).replace("\\", "/")
+        content = doc_path.read_text(encoding="utf-8", errors="replace")
+
+        seen: set[tuple[int, str]] = set()
+        for m in TOOL_TABLE_ROW_PATTERN.finditer(content):
+            if _is_historical_line(content, m.start()):
+                continue
+            name = m.group(1)
+            if name in valid_names:
+                continue
+            header_col1 = _table_header_for_match(content, m.start())
+            if header_col1 not in TOOL_TABLE_HEADER_NAMES:
+                # This row is in a non-tool table (RM action types,
+                # condition operators, gateway op lists with their own
+                # naming scheme, etc.). Skip — outside scope of this lint.
+                continue
+            line_no = content[:m.start()].count("\n") + 1
+            dedup_key = (line_no, name)
+            if dedup_key in seen:
+                continue
+            seen.add(dedup_key)
+            line_start = content.rfind("\n", 0, m.start()) + 1
+            line_end = content.find("\n", m.start())
+            if line_end == -1:
+                line_end = len(content)
+            line_text = content[line_start:line_end].strip()
+            findings.append(
+                {
+                    "file": rel,
+                    "line": line_no,
+                    "rule": "TOOL_NAME",
+                    "message": (
+                        f"Tool table references `{name}` which is not in "
+                        f"`getAllToolDefinitions()` or `getGatewayConfig()`. "
+                        "Likely a stale rename or typo. If this is "
+                        "intentionally a non-tool identifier in a tool-"
+                        "table-shaped row, add to TOOL_NAME_ALLOWLIST in "
+                        "tests/sandbox_lint.py."
+                    ),
+                    "severity": "error",
+                    "source": line_text[:200],
+                }
+            )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
 # Output formatting
 # ---------------------------------------------------------------------------
 
@@ -692,6 +1346,463 @@ SELF_TEST_CASES = [
 ]
 
 
+# Doc-content fixtures for the count-pattern + historical-skip
+# machinery. Each fixture pairs a doc-shaped string with a synthetic
+# canonical-counts dict and asserts which TOOL_COUNT findings should
+# appear when `_check_doc_against_canonical` is run.
+#
+# Run via `_run_count_self_test` (separate from `SELF_TEST_CASES` which
+# only covers Groovy `scan_source` rules). The runner mutates the
+# canonical dict to verify each pattern fires on real drift, and
+# verifies historical-skip rules with paired pos/neg cases per pattern.
+COUNT_SELF_TEST_CASES = [
+    # === Headline count patterns: each phrasing should fire on a stale value ===
+    (
+        "total in `(N total)`",
+        "Surface area: (101 total) tools currently exposed.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "total in `N tools total`",
+        "The MCP exposes 101 tools total across the surface.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "total in `MCP Tools (N total)`",
+        "## MCP Tools (101 total)",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "total in `exposes N tools`",
+        "The server exposes 101 tools across 12 gateways.",
+        {"total": 102, "gateways": 12}, ["total"],
+    ),
+    (
+        "total in `All N tools are covered`",
+        "All 101 tools are covered by at least one BAT scenario.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "total in `N tool definitions`",
+        "getAllToolDefinitions() returns all 101 tool definitions.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "total in table-row form",
+        "| Total tools in codebase | 101 |",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "core in `N core tools`",
+        "There are 23 core tools plus the gateway proxies.",
+        {"core": 24}, ["core"],
+    ),
+    (
+        "core in `N core + N gateways`",
+        "Architecture: 23 core + 12 gateways on tools/list.",
+        {"core": 24, "gateways": 12}, ["core"],
+    ),
+    (
+        "core in `Core tools on tools/list | N` table-row",
+        "| Core tools on `tools/list` | 23 |",
+        {"core": 24}, ["core"],
+    ),
+    (
+        "gateways in `N gateways`",
+        "Currently 12 gateways are registered.",
+        {"gateways": 13}, ["gateways"],
+    ),
+    (
+        "gateways in `Gateways on tools/list | N` table-row",
+        "| Gateways on `tools/list` | 12 |",
+        {"gateways": 13}, ["gateways"],
+    ),
+    (
+        "tools_list in `N on tools/list`",
+        "There are 35 on tools/list (the visible surface).",
+        {"tools_list": 36}, ["tools_list"],
+    ),
+    (
+        "tools_list in `Total visible on tools/list | N` table-row",
+        "| Total visible on `tools/list` | 35 |",
+        {"tools_list": 36}, ["tools_list"],
+    ),
+    (
+        "proxied in `(N proxied)`",
+        "Architecture: 35 visible (78 proxied) tools.",
+        {"proxied": 79}, ["proxied"],
+    ),
+    (
+        "proxied in `Tools proxied behind gateways | N` table-row",
+        "| Tools proxied behind gateways | 78 |",
+        {"proxied": 79}, ["proxied"],
+    ),
+
+    # === Historical-skip: WIDE markers (line-scope) ===
+    # Each WIDE marker should let the count escape lint even with a
+    # stale value, regardless of how far it sits from the count.
+    (
+        "WIDE skip: `**vN.N.N**:` anywhere on the line",
+        "**v0.7.7**: 74 tools listed at that point in the codebase history.",
+        {"total": 99}, [],   # 74 != 99 but skipped
+    ),
+    (
+        "WIDE skip: `vN.N.N (` parenthetical",
+        "Run prompts on v0.7.7 (all 74 on tools/list) and v0.8.0 to compare.",
+        {"total": 99}, [],
+    ),
+    (
+        "NARROW skip: `(vN.N.N` close to a count scopes that count only",
+        # `(v0.7.7)` is within ±20 of `74` (chars 13→23) but ~16 chars
+        # from `9 gateways` (chars 13→39, end of `(v0.7.7` at char 19).
+        # `9 gateways` is OUTSIDE the window relative to either bound,
+        # so the count fires; `74` would too if any pattern matched it
+        # (no current pattern catches bare `N tools` without context).
+        "Architecture (v0.7.7): 74 tools across 9 gateways.",
+        {"total": 99, "gateways": 12}, ["gateways"],
+    ),
+
+    # === Historical-skip: NARROW markers (window-scope) ===
+    # Each NARROW marker scopes only a count within ±20 chars; a
+    # live count further out should still fire.
+    (
+        "NARROW skip: `was N` near match scopes the nearby count",
+        "We support 78 proxied tools (was 75 before bundling).",
+        # 78 is correct (skipped here), 75 is historical (skipped by `was N`)
+        {"proxied": 78}, [],
+    ),
+    (
+        "NARROW skip does NOT swallow a live count further away",
+        "23 core tools are exposed today, but it was 18 in v0.7.",
+        # 23 is live → fire on stale canonical; 18 has `was` near it → skip
+        {"core": 24}, ["core"],
+    ),
+    (
+        "NARROW skip: `→` migration arrow scopes nearby count",
+        "Migration: was 21 core → 23 core after the gateway split.",
+        # 21 historical (within window of `→`); 23 is also within window → both skip
+        {"core": 25}, [],
+    ),
+    (
+        "NARROW skip: `previously N` near match",
+        "There are 12 gateways (previously 9 before split).",
+        {"gateways": 12}, [],
+    ),
+    (
+        "NARROW skip: `before: N` near match",
+        "(Before: 98) now 101 MCP tools registered.",
+        # 101 MCP tools would drift (canonical=102) but `Before: 98` sits fully
+        # in its look-back window → the `before\s*[:=]\s*\d+` pattern matches → skip.
+        {"total": 102}, [],
+    ),
+
+    # === Section-level: ancestor walk ===
+    (
+        "Section skip: `## Version History` ancestor flips contained counts to historical",
+        "## Version History\n\n- v1.0.0: was 99 tools.\n- v0.9.0: 95 tools.\n",
+        {"total": 102}, [],
+    ),
+    (
+        "Section skip: `### vN.N.N` UNDER Version History inherits historical via ancestor walk",
+        "## Version History\n\n### v1.0.0 (2026-01-01)\n\n95 tools listed.\n",
+        {"total": 102}, [],
+    ),
+    (
+        "Section skip: `## Changelog` ancestor flips contained counts",
+        "## Changelog\n\n- 95 tools at last release.\n",
+        {"total": 102}, [],
+    ),
+    (
+        "Section skip: `## Migration` ancestor flips contained counts",
+        "## Migration\n\n9 gateways became 12 gateways after the split.\n",
+        {"gateways": 12}, [],
+    ),
+    (
+        "NEGATIVE: a live test scenario heading with `(vN.N.N)` is NOT historical",
+        "### T120 — All N gateways in one session (v0.8.0)\n\nThe LLM sees 12 gateways live.\n",
+        # If the old over-aggressive HISTORICAL_SECTION_HEADINGS regex still
+        # treated `(v0.8.0)` headings as historical, this would skip silently.
+        # With the ancestor-walk-only design, we expect the count to fire.
+        {"gateways": 13}, ["gateways"],
+    ),
+    (
+        "NEGATIVE: stale count IN the `(v0.8.0)`-suffixed live heading itself fires",
+        # Pin the maintainer's specific regression: a live test scenario
+        # whose title carries a `(v0.8.0)` provenance suffix should NOT
+        # cause a stale count earlier in the same title to be skipped.
+        # Validates that `\(v\d+...` is NARROW (window-scope), not WIDE.
+        "### T120 — All 10 gateways in one session (v0.8.0)\n",
+        {"gateways": 12}, ["gateways"],
+    ),
+
+    # === Per-gateway extraction patterns ===
+    (
+        "Per-gateway: `manage_X (N tools)` parenthesized",
+        "The `manage_logs` (8 tools) gateway covers system-log access.",
+        {"per_gateway": {"manage_logs": 9}}, ["per_gateway:manage_logs"],
+    ),
+    (
+        "Per-gateway: `manage_X (N tools, qualifier)` allows trailing qualifier",
+        "manage_app_driver_code (10 tools, 7 original + 3 library tools)",
+        {"per_gateway": {"manage_app_driver_code": 11}}, ["per_gateway:manage_app_driver_code"],
+    ),
+    (
+        "Per-gateway: markdown-table form",
+        "| `manage_logs` | 8 |",
+        {"per_gateway": {"manage_logs": 9}}, ["per_gateway:manage_logs"],
+    ),
+    (
+        "Per-gateway: `sees N tools` after backticked gateway name",
+        "AI calls `manage_native_rules_and_apps` with no args, sees 12 tools.",
+        {"per_gateway": {"manage_native_rules_and_apps": 13}}, ["per_gateway:manage_native_rules_and_apps"],
+    ),
+    (
+        "Per-gateway: `sees catalog of N tools` phrasing (catalog-of variant)",
+        "AI calls `manage_installed_apps` with no args, sees catalog of 4 tools.",
+        {"per_gateway": {"manage_installed_apps": 5}}, ["per_gateway:manage_installed_apps"],
+    ),
+
+    # === Required #2 — asymmetric window: trailing `was N` must not suppress live count ===
+    # The maintainer's concrete miss: "22 core tools today, was 18 previously."
+    # With a symmetric ±20 window the `was` at pos 21 fell inside the forward
+    # half and silently swallowed the live count. The look-back-only window
+    # (ending at match_start) keeps `was` outside and lets the drift fire.
+    (
+        "NARROW asymmetric: trailing `was N` does NOT suppress preceding live count",
+        "22 core tools today, was 18 previously.",
+        {"core": 23}, ["core"],
+    ),
+
+    # === Required #3 — positive fixtures for every COUNT_PATTERN ===
+    (
+        "total in `covering N tools`",
+        "This release is covering 101 tools across all gateways.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "total in `exposing N tools`",
+        "The server is exposing 101 tools to the AI consumer.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "total in `has N tools total`",
+        "The implementation has 101 tools total in the registry.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "total in `N MCP tools`",
+        "There are 101 MCP tools registered for dispatch.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "total in `across all N tools`",
+        "The search index spans across all 101 tools in the catalog.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "proxied in `N additional tools`",
+        "Each gateway exposes 78 additional tools beyond the core set.",
+        {"proxied": 79}, ["proxied"],
+    ),
+    (
+        "total in `from N items to M`",
+        "The client goes from 35 items to 101 after gateway expansion.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "proxied in bare `N proxied` (not paren-prefix, named fixture)",
+        "Summary: 23 core + 12 gateways, 78 proxied, 101 total tools.",
+        {"proxied": 79}, ["proxied"],
+    ),
+    (
+        "total in `N total` punctuation-bounded (named fixture)",
+        "The surface area is 101 total, split across core and gateways.",
+        {"total": 102}, ["total"],
+    ),
+    (
+        "tools_list in `N items on tools/list`",
+        "There are 35 items on tools/list for the AI to discover.",
+        {"tools_list": 36}, ["tools_list"],
+    ),
+    (
+        "proxied in `N proxied tools` (named fixture)",
+        "The server routes calls to 78 proxied tools inside gateways.",
+        {"proxied": 79}, ["proxied"],
+    ),
+    (
+        "total in `total tools in codebase` table-row (named fixture)",
+        "| Total tools in codebase | 101 |",
+        {"total": 102}, ["total"],
+    ),
+
+    # === Required #4 — sibling section does NOT propagate historical status ===
+    # A `## Version History` heading and `## Live API` heading are siblings.
+    # A count under `## Live API` must not inherit historical status from the
+    # sibling; only an ANCESTOR heading (strictly lower level) does that.
+    (
+        "Section skip: sibling `## Version History` does NOT silence count in sibling `## Live API`",
+        "## Version History\n\n- v0.7: 90 tools, 8 gateways\n\n## Live API\n\n23 core tools listed.\n",
+        {"core": 24}, ["core"],
+    ),
+
+    # === Required #5 — ancestor inheritance across two heading levels ===
+    # A `####`-level heading under `### vN.N.N` under `## Version History`
+    # should still inherit historical status via the ancestor walk.
+    (
+        "Section skip: `####` UNDER `### vN.N.N` UNDER `## Version History` inherits via two levels",
+        "## Version History\n\n### v1.0.0 (2026-01-15)\n\n#### Old release details\n\n95 tools in release.\n",
+        {"total": 102}, [],
+    ),
+
+    # === Required #6 — NARROW ±20 boundary fixtures for each marker ===
+    # After the asymmetric-window change the meaningful threshold is the
+    # look-BACK direction only: [match_start - 20, match_start).
+    # Each pair below has:
+    #   "inside"  (marker at match_start-20 = win_start): skip
+    #   "outside" (marker at match_start-21 < win_start): fire
+    #
+    # Arrow `→` (1 char + 19 dots = 20 chars to match_start → inside):
+    (
+        "NARROW boundary: `→` 20 chars before match (inside window, skip)",
+        "→" + "." * 19 + "23 core tools here.",
+        {"core": 24}, [],
+    ),
+    (
+        "NARROW boundary: `→` 21 chars before match (outside window, fire)",
+        "→" + "." * 20 + "23 core tools here.",
+        {"core": 24}, ["core"],
+    ),
+    # `previously N` (13 chars + 7 filler = 20 chars to match_start → inside):
+    (
+        "NARROW boundary: `previously N` 20 chars before match (inside window, skip)",
+        "previously 8 " + "." * 7 + "23 core tools here.",
+        {"core": 24}, [],
+    ),
+    (
+        "NARROW boundary: `previously N` 21 chars before match (outside window, fire)",
+        "previously 8 " + "." * 8 + "23 core tools here.",
+        {"core": 24}, ["core"],
+    ),
+    # `before: N` (10 chars + 10 filler = 20 chars to match_start → inside):
+    (
+        "NARROW boundary: `before: N` 20 chars before match (inside window, skip)",
+        "before: 8 " + "." * 10 + "23 core tools here.",
+        {"core": 24}, [],
+    ),
+    (
+        "NARROW boundary: `before: N` 21 chars before match (outside window, fire)",
+        "before: 8 " + "." * 11 + "23 core tools here.",
+        {"core": 24}, ["core"],
+    ),
+    # `(vN.N.N` (8 chars + 12 filler = 20 chars to match_start → inside):
+    (
+        "NARROW boundary: `(vN.N.N` 20 chars before match (inside window, skip)",
+        "(v0.7.7 " + "." * 12 + "23 core tools here.",
+        {"core": 24}, [],
+    ),
+    (
+        "NARROW boundary: `(vN.N.N` 21 chars before match (outside window, fire)",
+        "(v0.7.7 " + "." * 13 + "23 core tools here.",
+        {"core": 24}, ["core"],
+    ),
+
+    # === Nit C — additional HISTORICAL_SECTION_HEADINGS variants ===
+    (
+        "Section skip: `## Release Notes` ancestor flips contained counts",
+        "## Release Notes\n\n- 95 tools at last release.\n",
+        {"total": 102}, [],
+    ),
+    (
+        "Section skip: `## History` ancestor flips contained counts",
+        "## History\n\n9 gateways registered in earlier versions.\n",
+        {"gateways": 12}, [],
+    ),
+]
+
+
+def _check_doc_against_canonical(content: str, canonical_override: dict) -> set[str]:
+    """Run the doc-scanning checks against `content` with a synthetic
+    canonical dict overlaid on the real extractor result. Returns the
+    set of finding-kinds reported (e.g. {'total', 'core',
+    'per_gateway:manage_logs'}). Used by `_run_count_self_test` to
+    verify each pattern fires on drift and each historical-skip rule
+    holds.
+    """
+    real = _extract_canonical_counts() or {
+        "total": 0, "core": 0, "gateways": 0, "tools_list": 0,
+        "proxied": 0, "per_gateway": {}, "tool_names": set(),
+        "gateway_names": set(), "proxied_names": set(),
+    }
+    canonical = dict(real)
+    canonical.update(canonical_override)
+    if "per_gateway" in canonical_override:
+        # When overriding per-gateway, merge with real per_gateway so other
+        # gateways referenced incidentally in the fixture text don't all
+        # spuriously fire.
+        merged = dict(real["per_gateway"])
+        merged.update(canonical_override["per_gateway"])
+        canonical["per_gateway"] = merged
+
+    kinds: set[str] = set()
+    seen: set[tuple[int, str, int]] = set()
+
+    # COUNT_PATTERNS scan
+    for pat, kind in COUNT_PATTERNS:
+        expected = canonical[kind]
+        for m in pat.finditer(content):
+            if _is_historical_at(content, m.start(), m.end()):
+                continue
+            actual = int(m.group(1))
+            if actual == expected:
+                continue
+            line_no = content[:m.start()].count("\n") + 1
+            dedup = (line_no, kind, actual)
+            if dedup in seen:
+                continue
+            seen.add(dedup)
+            kinds.add(kind)
+
+    # Per-gateway scans
+    per_gw_seen: set[tuple[int, str, int]] = set()
+    for m in (
+        list(PER_GATEWAY_PATTERN.finditer(content))
+        + list(PER_GATEWAY_TABLE_PATTERN.finditer(content))
+        + list(PER_GATEWAY_SEES_PATTERN.finditer(content))
+    ):
+        if _is_historical_at(content, m.start(), m.end()):
+            continue
+        gw_name = m.group(1)
+        actual = int(m.group(2))
+        line_no = content[:m.start()].count("\n") + 1
+        dedup = (line_no, gw_name, actual)
+        if dedup in per_gw_seen:
+            continue
+        per_gw_seen.add(dedup)
+        expected = canonical["per_gateway"].get(gw_name)
+        if expected is None or actual != expected:
+            kinds.add(f"per_gateway:{gw_name}")
+
+    return kinds
+
+
+def _run_count_self_test() -> int:
+    failures = 0
+    for i, (desc, content, override, expected_kinds) in enumerate(
+        COUNT_SELF_TEST_CASES, start=1
+    ):
+        actual_kinds = _check_doc_against_canonical(content, override)
+        expected_set = set(expected_kinds)
+        if actual_kinds != expected_set:
+            failures += 1
+            print(
+                f"COUNT-SELF-TEST FAIL [{i}] {desc}\n"
+                f"  expected kinds: {sorted(expected_set)}\n"
+                f"  actual kinds:   {sorted(actual_kinds)}\n"
+                f"  content: {content!r}"
+            )
+    return failures
+
+
 def run_self_test() -> int:
     """Scan inline fixtures through scan_source and confirm each rule
     triggers where expected. Uses scan_source (not strip_comments_and_strings
@@ -714,10 +1825,87 @@ def run_self_test() -> int:
                     f"  stripped: {stripped!r}"
                 )
 
+    # Sanity-check the canonical tool-count extractor: must succeed and
+    # return a self-consistent count breakdown. Extractor failure here
+    # would otherwise only surface as opaque "could not extract" errors
+    # during real lint runs.
+    canonical = _extract_canonical_counts()
+    if canonical is None:
+        failures += 1
+        print(
+            "SELF-TEST FAIL [tool-count extractor]\n"
+            "  _extract_canonical_counts() returned None — getGatewayConfig() "
+            "or getAllToolDefinitions() format may have changed in the "
+            "Groovy source."
+        )
+    else:
+        derived = canonical["core"] + sum(canonical["per_gateway"].values())
+        if derived != canonical["total"]:
+            failures += 1
+            print(
+                f"SELF-TEST FAIL [tool-count extractor]\n"
+                f"  derived total {derived} != reported total "
+                f"{canonical['total']} — internal inconsistency in "
+                "_extract_canonical_counts()"
+            )
+        # Compare the raw list length against the de-duplicated set size.
+        # `total` is intentionally len(list); `tool_names` is set(list).
+        # A duplicate `name:` entry in the Groovy source diverges them,
+        # which is the regression class this assertion catches.
+        if canonical["total"] != len(canonical["tool_names"]):
+            failures += 1
+            print(
+                f"SELF-TEST FAIL [tool-name extractor]\n"
+                f"  raw `name:` count {canonical['total']} != "
+                f"unique-names count {len(canonical['tool_names'])} — "
+                "duplicate `name:` entries in getAllToolDefinitions()."
+            )
+        # gateway_names and tool_names should be disjoint by construction:
+        # getAllToolDefinitions() lists every tool the dispatcher routes to
+        # (core tools + every gateway's proxied operations), while
+        # getGatewayConfig() registers the parent facades separately.
+        # Gateways are NEVER entries in getAllToolDefinitions(); a name
+        # appearing in both would mean a naming collision the dispatcher
+        # would resolve in undefined order.
+        if canonical["gateway_names"] & canonical["tool_names"]:
+            overlap = canonical["gateway_names"] & canonical["tool_names"]
+            failures += 1
+            print(
+                f"SELF-TEST FAIL [tool-name extractor]\n"
+                f"  gateway names overlap tool_names: {sorted(overlap)} — "
+                "a gateway should not also have a getAllToolDefinitions() "
+                "entry; check for naming collision."
+            )
+        # Every tool listed in a gateway's `tools:` array must exist in
+        # getAllToolDefinitions() — gateways are facades, not registries.
+        # A gateway pointing at a non-existent tool is dead-on-arrival:
+        # the gateway dispatch path lazy-expands into the tool's schema
+        # and signature, both pulled from getAllToolDefinitions(). This
+        # catches the "removed a tool but forgot the gateway entry" and
+        # "renamed a tool but missed the gateway entry" regressions.
+        ghost_proxies = canonical["proxied_names"] - canonical["tool_names"]
+        if ghost_proxies:
+            failures += 1
+            print(
+                f"SELF-TEST FAIL [tool-name extractor]\n"
+                f"  gateways reference ghost tools (not in "
+                f"getAllToolDefinitions()): {sorted(ghost_proxies)} — "
+                "either remove the gateway entry or add the tool to "
+                "getAllToolDefinitions()."
+            )
+
+    # Doc-content fixtures for COUNT_PATTERNS + historical-skip rules.
+    count_failures = _run_count_self_test()
+    failures += count_failures
+
     if failures:
         print(f"--- {failures} self-test failure(s) ---")
         return 1
-    print(f"Self-test: {len(SELF_TEST_CASES)} case(s) passed.")
+    total_cases = len(SELF_TEST_CASES) + len(COUNT_SELF_TEST_CASES)
+    print(
+        f"Self-test: {total_cases} case(s) passed "
+        f"({len(SELF_TEST_CASES)} sandbox, {len(COUNT_SELF_TEST_CASES)} count)."
+    )
     return 0
 
 
@@ -736,6 +1924,12 @@ def main() -> int:
 
     # Check version consistency
     all_findings.extend(check_versions())
+
+    # Check tool-count consistency between Groovy source and docs
+    all_findings.extend(check_tool_counts())
+
+    # Check tool-name references in doc tables match canonical tool names
+    all_findings.extend(check_tool_name_consistency())
 
     # Sort by file, then line
     all_findings.sort(key=lambda f: (f["file"], f["line"]))


### PR DESCRIPTION
## Summary

- Adds tool-count consistency check to `tests/sandbox_lint.py`, parallel to the existing version-string check
- Syncs accumulated tool-count drift across 6 docs (README, SKILL, TOOL_GUIDE, agent-skill SKILL+tool-reference, BAT-v2) — addresses the 5-surface gap from your APPROVED review on #164 plus ~20 more drift instances beyond those
- Picked up from your request on #158: *"if you want to follow up on the tool count I'd appreciate it."*

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [x] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- Extends `tests/sandbox_lint.py` with `check_tool_counts()`. Canonical counts derived from `getGatewayConfig()` + `getAllToolDefinitions()` in `hubitat-mcp-server.groovy`. Pattern set covers 5 high-level counts (total, core, gateways, tools_list, proxied), per-gateway counts in parenthesized + markdown-table forms, and variant phrasings ("MCP Tools (N total)", "across all N tools", "for all N MCP tools", "from N items to M", "all N tool definitions", "(N proxied, M total)", "N additional tools").
- Skips historical-context lines: `(v0.X.Y)` parenthesized scoping headings, `**v0.X.Y**:` definitional bold-colon lines, migration arrows `→`, `was N` / `previously N` / `before: N` phrasings, Version History sections.
- Adds self-test that validates the canonical extractor produces a self-consistent breakdown — future Groovy refactors that change the parser-target format fail loudly.
- Files in scope: README, SKILL, TOOL_GUIDE, agent-skill/hubitat-mcp SKILL+tool-reference, BAT-v2, tests/e2e_test.py (catches the descriptive message string in its hardcoded count assertion). `tests/BAT.md` excluded — legacy v1 suite, all content historical. `CHANGELOG.md` excluded — bot-managed. `AGENTS.md` excluded — no count claims.
- Doc sync: 101 total / 23 core / 12 gateways / 35 on tools/list / 78 proxied (canonical at HEAD). Pre-fix state ranged across files: 90/94/97 total, 67/71/74 proxied, 4 for manage_hub_variables, 6/7 for apps_drivers/app_driver_code.
- Added missing tool rows in the README and agent-skill `manage_apps_drivers` and `manage_app_driver_code` tables (rows for `get_library_source`, `install_library`, `update_library_code`, `delete_library` were absent despite being in the gateway).

Part of #158 (post-merge follow-up on tool counts maintainer asked about).

## Release Notes

- Sandbox lint now enforces tool-count consistency between Groovy source-of-truth and docs. Drift fails CI the same way version-string drift does today.
- All quoted tool counts across user-facing docs are now synced to canonical (101 total / 35 on `tools/list`, 23 core + 12 gateway tools).

## Testing

- `python tests/sandbox_lint.py` — clean (0 errors, 0 warnings)
- `python tests/sandbox_lint.py --self-test` — passes (extractor sanity-check + the existing inline-fixture cases)
- Manual grep across all 6 in-scope docs for any remaining stale `90/94/97/67/71/74` numbers — only `~90%` percentage in unrelated prose remains
- Mutation-tested: temporary perturbations of canonical (total +1, core +1, manage_diagnostics +1) confirmed lint surfaces drift across all in-scope files
- No code changes to `hubitat-mcp-server.groovy` or `hubitat-mcp-rule.groovy` → no e2e/Spock impact, no hub deploy needed

## Checklist

- [ ] **Unit tests added for any new MCP tools** — N/A (no new tools; only lint extension + doc sync)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (no Groovy changes; targeted spec runs across recent rounds remain green)
- [ ] Live-hub BAT tests updated if tool behaviour changed — N/A (no behaviour change)
- [x] Documentation updated if user-facing behaviour or tool surface changed (the doc sync IS the user-facing change)
