### PR TITLE
feat: rework generate_bug_report for issue templates, scoped logs, public-safe mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_behavior.yml
+++ b/.github/ISSUE_TEMPLATE/agent_behavior.yml
@@ -1,0 +1,24 @@
+name: Agent behavior / tool description issue
+description: The LLM picked the wrong tool, was confused by a tool description, or followed a bad workflow. The server isn't broken — the agent surface is.
+title: "[agent-behavior] "
+labels: ["agent-behavior"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the *agent* did the wrong thing — wrong tool choice, schema confusion, bad workflow — rather than when the server crashed or returned bad data. For server defects, please use the Bug report form.
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What the agent did wrong (in your own words)
+      description: What did you ask for, what did the agent do, and why was it the wrong call?
+    validations:
+      required: true
+  - type: textarea
+    id: agent_report
+    attributes:
+      label: Agent report output
+      description: Paste the full output of the `generate_bug_report` tool with `issueType=agent_behavior` here.
+      render: markdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,25 @@
+name: Bug report
+description: Report a bug in the Hubitat MCP server (a tool crashed, returned wrong output, or left broken state).
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing! If you used the `generate_bug_report` MCP tool, the title is already pre-filled — just paste the agent's report below.
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened (in your own words)
+      description: Briefly describe what you were trying to do and what went wrong.
+      placeholder: I asked the agent to add a trigger to a native RM rule and it failed with...
+    validations:
+      required: true
+  - type: textarea
+    id: agent_report
+    attributes:
+      label: Agent report output
+      description: Paste the full output of the `generate_bug_report` tool here.
+      render: markdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions, support, or general discussion
+    url: https://github.com/kingpanther13/Hubitat-local-MCP-server/discussions
+    about: Please ask questions in Discussions, not Issues.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,20 @@
+name: Enhancement / feature request
+description: Suggest a new feature or behavior change for the Hubitat MCP server.
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: what_request
+    attributes:
+      label: What feature or behavior change you'd like
+      description: Describe the enhancement in your own words. What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: agent_report
+    attributes:
+      label: Agent report output (optional)
+      description: If you used the `generate_bug_report` tool with issueType=enhancement, paste its output here.
+      render: markdown
+    validations:
+      required: false

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -7588,8 +7588,8 @@ def toolGetLoggingStatus(args) {
 def toolGenerateBugReport(args) {
     def issueType = _bugReportNormalizeIssueType(args.issueType)
     def privacyMode = args.privacyMode?.toString()?.toLowerCase() == "public" ? "public" : "private"
-    def includeRawLogs = args.includeRawLogs == null ? (privacyMode == "private") : (args.includeRawLogs as Boolean)
-    def windowMs = ((args.logWindowSeconds ?: 120) as Integer) * 1000L
+    def includeRawLogs = args.includeRawLogs == null ? (privacyMode == "private") : (args.includeRawLogs == true)
+    def windowMs = ((args.logWindowSeconds == null ? 120 : args.logWindowSeconds) as Integer) * 1000L
 
     initDebugLogs()
     def allEntries = (state.debugLogs.entries ?: []).findAll { it.level == "error" || it.level == "warn" }
@@ -7613,7 +7613,6 @@ def toolGenerateBugReport(args) {
         success: true,
         issueType: issueType,
         privacyMode: privacyMode,
-        sanitizationApplied: privacyMode == "public",
         suggestedTitle: suggestedTitle,
         submitUrl: submitUrl,
         report: report,
@@ -7661,6 +7660,9 @@ private Map _bugReportResolveAnchor(args, List entries) {
 
 private Map _bugReportScopedLogs(args, List entries, Map anchor, long windowMs) {
     def lastN = entries.takeRight(20)
+    def safeTs = { entry ->
+        try { return entry?.timestamp as Long } catch (Throwable ignored) { return null }
+    }
     if (anchor.entry == null) {
         return [
             relevant: lastN,
@@ -7670,7 +7672,16 @@ private Map _bugReportScopedLogs(args, List entries, Map anchor, long windowMs) 
             includedUnrelated: true
         ]
     }
-    def anchorTs = anchor.entry.timestamp as Long
+    def anchorTs = safeTs(anchor.entry)
+    if (anchorTs == null) {
+        return [
+            relevant: lastN,
+            other: [],
+            otherCount: 0,
+            scoped: false,
+            includedUnrelated: true
+        ]
+    }
     def windowStart = anchorTs - windowMs
     def windowEnd = anchorTs + windowMs
     def matchesContext = { entry ->
@@ -7682,7 +7693,8 @@ private Map _bugReportScopedLogs(args, List entries, Map anchor, long windowMs) 
     def relevant = []
     def other = []
     entries.each { entry ->
-        def ts = entry.timestamp as Long
+        def ts = safeTs(entry)
+        if (ts == null) return
         if (ts >= windowStart && ts <= windowEnd && matchesContext(entry)) {
             relevant << entry
         } else {
@@ -7708,7 +7720,9 @@ private Map _bugReportEnvironmentSummary(args, String privacyMode) {
         hubModel = location.hub?.hardwareID?.toString() ?: location.hub?.type?.toString() ?: "Unknown"
         hubFirmware = location.hub?.firmwareVersionString?.toString() ?: "Unknown"
         timeZone = location.timeZone?.ID?.toString() ?: "Unknown"
-    } catch (Throwable ignored) {}
+    } catch (Throwable e) {
+        mcpLog("warn", "bug-report", "_bugReportEnvironmentSummary: location access threw (${e.message}); env fields may be incomplete")
+    }
     return [
         version: currentVersion(),
         hubName: privacyMode == "public" ? "<hub-name>" : hubName,
@@ -7717,23 +7731,47 @@ private Map _bugReportEnvironmentSummary(args, String privacyMode) {
         timeZone: timeZone,
         logLevel: getConfiguredLogLevel(),
         customMcpRuleCount: getChildApps()?.size() ?: 0,
-        nativeRmRuleCount: _bugReportNativeRmCount(),
+        nativeRm: _bugReportNativeRmStatus(),
         deviceCount: selectedDevices?.size() ?: 0,
         llmClient: args.llmClient?.toString() ?: "Not provided"
     ]
 }
 
-private Integer _bugReportNativeRmCount() {
+private Map _bugReportNativeRmStatus() {
     def ids = [] as Set
+    def v4Error = null
+    def v5Error = null
     try {
         def v4 = hubitat.helper.RMUtils.getRuleList() ?: []
         v4.each { r -> if (r?.id != null) ids << r.id.toString() }
-    } catch (Throwable ignored) {}
+    } catch (Throwable e) {
+        v4Error = e.toString()
+    }
     try {
         def v5 = hubitat.helper.RMUtils.getRuleList("5.0") ?: []
         v5.each { r -> if (r?.id != null) ids << r.id.toString() }
-    } catch (Throwable ignored) {}
-    return ids.size()
+    } catch (Throwable e) {
+        v5Error = e.toString()
+    }
+    def classMissingHint = { String msg ->
+        if (!msg) return false
+        if (msg.contains("NoClassDefFoundError") || msg.contains("ClassNotFoundException") || msg.contains("unable to resolve class")) return true
+        if (msg.contains("Cannot get property") && msg.contains("'helper'")) return true
+        if ((msg.contains("MissingMethodException") || msg.contains("No signature of method")) && msg.contains("getRuleList")) return true
+        return false
+    }
+    def bothMissing = v4Error && v5Error && classMissingHint(v4Error) && classMissingHint(v5Error)
+    if (bothMissing) {
+        return [installed: false, count: 0]
+    }
+    def hardErrors = []
+    if (v4Error && !classMissingHint(v4Error)) hardErrors << "v4=${v4Error}"
+    if (v5Error && !classMissingHint(v5Error)) hardErrors << "v5=${v5Error}"
+    if (hardErrors) {
+        mcpLog("warn", "bug-report", "_bugReportNativeRmStatus: RMUtils errors — ${hardErrors.join('; ')}; count may be inaccurate")
+        return [installed: true, count: ids.size(), error: hardErrors.join("; ")]
+    }
+    return [installed: true, count: ids.size()]
 }
 
 private Map _bugReportRuleInfo(args) {
@@ -7753,7 +7791,8 @@ private Map _bugReportRuleInfo(args) {
             executionCount: ruleData.executionCount ?: 0
         ]
     } catch (Throwable e) {
-        return [id: args.ruleId, error: "Could not retrieve rule info: ${e.message}"]
+        mcpLog("warn", "bug-report", "_bugReportRuleInfo: getRuleData(${args.ruleId}) failed (${e.message}) — id may not refer to a custom MCP rule")
+        return [id: args.ruleId, lookupError: e.message ?: e.toString()]
     }
 }
 
@@ -7796,7 +7835,18 @@ private String _bugReportBuildMarkdown(Map params) {
     def failingToolLine = args.failingTool ? "- **Failing tool:** ${args.failingTool}\n" : ""
     def nativeAppLine = args.nativeAppId ? "- **Native RM app id:** ${args.nativeAppId}\n" : ""
     def reproSection = args.stepsToReproduce ? "\n### Steps to Reproduce\n${args.stepsToReproduce}\n" : ""
-    def ruleSection = ruleInfo ? """
+    def ruleSection
+    if (!ruleInfo) {
+        ruleSection = ""
+    } else if (ruleInfo.lookupError) {
+        ruleSection = """
+## Related Rule (lookup failed)
+- **Rule ID:** ${ruleInfo.id}
+- **Lookup error:** ${ruleInfo.lookupError}
+- **Note:** This id may not refer to a custom MCP rule (e.g. it's a native RM rule or Notifier — those don't expose getRuleData). If you meant a native rule, pass it as `nativeAppId` instead.
+"""
+    } else {
+        ruleSection = """
 ## Related Custom MCP Rule
 - **Rule ID:** ${ruleInfo.id}
 - **Rule Name:** ${ruleInfo.name ?: 'Unknown'}
@@ -7806,7 +7856,8 @@ private String _bugReportBuildMarkdown(Map params) {
 - **Actions:** ${ruleInfo.actionCount}
 - **Last Triggered:** ${ruleInfo.lastTriggered}
 - **Execution Count:** ${ruleInfo.executionCount}
-""" : ""
+"""
+    }
     def logSection
     if (!includeRawLogs) {
         def n = relevantLines.size()
@@ -7837,8 +7888,8 @@ private String _bugReportBuildMarkdown(Map params) {
 - **Hub firmware:** ${env.hubFirmware}
 - **Time zone:** ${env.timeZone}
 - **MCP log level:** ${env.logLevel}
-- **Custom MCP rules:** ${env.customMcpRuleCount}
-- **Native Rule Machine rules:** ${env.nativeRmRuleCount}
+- **Rules in legacy custom rule engine:** ${env.customMcpRuleCount}
+- ${env.nativeRm.installed == false ? "**Native Rule Machine:** not installed (Rule Machine not detected on this hub)" : "**Native Rule Machine rules:** ${env.nativeRm.count}${env.nativeRm.error ? ' (RMUtils partial failure — count may be inaccurate)' : ''}"}
 - **Devices exposed to MCP:** ${env.deviceCount}
 - **LLM / client:** ${env.llmClient}
 ${failingToolLine}${nativeAppLine}

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1585,15 +1585,23 @@ Verify rule after creation.""",
         ],
         [
             name: "generate_bug_report",
-            description: "Generate a formatted GitHub bug report with system info, error logs, and issue description.",
+            description: "File a bug, report a bug, open an issue, open a github issue, request a feature/enhancement, or flag agent-behavior issues. Returns a prefilled GitHub issue link (template + title).",
             inputSchema: [
                 type: "object",
                 properties: [
-                    title: [type: "string", description: "Brief title describing the bug (e.g., 'Rule not triggering when motion detected')"],
-                    expected: [type: "string", description: "What should have happened"],
-                    actual: [type: "string", description: "What actually happened"],
-                    stepsToReproduce: [type: "string", description: "Steps to reproduce the issue (optional)"],
-                    ruleId: [type: "string", description: "If related to a specific rule, provide the rule ID (optional)"]
+                    title: [type: "string", description: "Short bug/issue narrative. Seeds GitHub title."],
+                    expected: [type: "string", description: "What should have happened."],
+                    actual: [type: "string", description: "What actually happened."],
+                    stepsToReproduce: [type: "string"],
+                    issueType: [type: "string", enum: ["bug", "enhancement", "agent_behavior"], description: "Default bug."],
+                    failingTool: [type: "string", description: "MCP tool that failed; scopes logs + titles issue."],
+                    ruleId: [type: "string"],
+                    nativeAppId: [type: "string"],
+                    llmClient: [type: "string", description: "Claude / ChatGPT / Gemini / etc."],
+                    privacyMode: [type: "string", enum: ["private", "public"], description: "'public' placeholders hub name, suppresses raw logs."],
+                    includeRawLogs: [type: "boolean", description: "Default: true private, false public."],
+                    includeUnrelatedRecentLogs: [type: "boolean"],
+                    logWindowSeconds: [type: "integer", description: "Default 120."]
                 ],
                 required: ["title", "expected", "actual"]
             ]
@@ -7578,85 +7586,218 @@ def toolGetLoggingStatus(args) {
 }
 
 def toolGenerateBugReport(args) {
-    def version = currentVersion()
-    def timestamp = formatTimestamp(now())
+    def issueType = _bugReportNormalizeIssueType(args.issueType)
+    def privacyMode = args.privacyMode?.toString()?.toLowerCase() == "public" ? "public" : "private"
+    def includeRawLogs = args.includeRawLogs == null ? (privacyMode == "private") : (args.includeRawLogs as Boolean)
+    def windowMs = ((args.logWindowSeconds ?: 120) as Integer) * 1000L
 
-    // Gather system info
-    def hubInfo = [:]
-    try {
-        hubInfo = [
-            hubModel: location.hub?.firmwareVersionString ?: "Unknown",
-            hubId: location.hub?.id ?: "Unknown",
-            timeZone: location.timeZone?.ID ?: "Unknown",
-            zipCode: location.zipCode ?: "Not set"
-        ]
-    } catch (e) {
-        hubInfo = [error: "Could not retrieve hub info"]
-    }
-
-    // Get recent error logs
     initDebugLogs()
-    def recentErrors = (state.debugLogs.entries ?: [])
-        .findAll { it.level == "error" || it.level == "warn" }
-        .takeRight(10)
-        .collect { entry ->
-            "[${formatTimestamp(entry.timestamp)}] ${entry.level.toUpperCase()}: ${entry.message}" +
-            (entry.ruleId ? " (Rule: ${entry.ruleId})" : "") +
-            (entry.error ? "\n  Error: ${entry.error}" : "")
-        }
+    def allEntries = (state.debugLogs.entries ?: []).findAll { it.level == "error" || it.level == "warn" }
+    def anchor = _bugReportResolveAnchor(args, allEntries)
+    def scopedLogs = _bugReportScopedLogs(args, allEntries, anchor, windowMs)
+    def env = _bugReportEnvironmentSummary(args, privacyMode)
+    def ruleInfo = _bugReportRuleInfo(args)
+    def suggestedTitle = _bugReportSuggestedTitle(args, issueType)
+    def submitUrl = _bugReportSubmitUrl(issueType, suggestedTitle)
+    def report = _bugReportBuildMarkdown(
+        args: args,
+        issueType: issueType,
+        privacyMode: privacyMode,
+        includeRawLogs: includeRawLogs,
+        env: env,
+        ruleInfo: ruleInfo,
+        scopedLogs: scopedLogs
+    )
 
-    // Get rule info if provided
-    def ruleInfo = null
+    def result = [
+        success: true,
+        issueType: issueType,
+        privacyMode: privacyMode,
+        sanitizationApplied: privacyMode == "public",
+        suggestedTitle: suggestedTitle,
+        submitUrl: submitUrl,
+        report: report,
+        logs: [
+            scoped: scopedLogs.scoped,
+            relevantCount: scopedLogs.relevant.size(),
+            otherRecentLogCount: scopedLogs.scoped && !scopedLogs.includedUnrelated ? scopedLogs.otherCount : 0
+        ],
+        instructions: "Click submitUrl — the GitHub issue title is pre-filled. In the issue form, type a short description of what you were doing in the 'What happened' field, then paste the 'report' content into the 'Agent report output' field. If you are an LLM, attempt to replace any identifiable hub names, rule names, device names, app IDs, hub variable names, IPs, and filenames with placeholders before sharing this report. Either way, the user MUST review the final report for sensitive details before submitting — public mode is a best-effort assist, not a guarantee."
+    ]
+    if (scopedLogs.scoped && !scopedLogs.includedUnrelated && scopedLogs.otherCount > 0) {
+        result.logs.hint = "Pass includeUnrelatedRecentLogs=true to include the ${scopedLogs.otherCount} omitted recent log entr${scopedLogs.otherCount == 1 ? 'y' : 'ies'}."
+    }
+    if (state.updateCheck?.updateAvailable) {
+        result.updateAvailable = state.updateCheck.latestVersion
+    }
+    return result
+}
+
+private String _bugReportNormalizeIssueType(raw) {
+    def s = raw?.toString()?.toLowerCase()?.trim()
+    if (s in ["bug", "enhancement", "agent_behavior"]) return s
+    if (s in ["feature", "feature_request", "feat"]) return "enhancement"
+    if (s in ["agent-behavior", "agent", "tool_description"]) return "agent_behavior"
+    return "bug"
+}
+
+private Map _bugReportResolveAnchor(args, List entries) {
+    if (!entries) return [entry: null, matchedOn: "none"]
+    def reversed = entries.reverse()
+    if (args.failingTool) {
+        def hit = reversed.find { it.details?.tool == args.failingTool }
+        if (hit) return [entry: hit, matchedOn: "tool"]
+    }
     if (args.ruleId) {
-        try {
-            def childApp = getChildAppById(args.ruleId)
-            if (childApp) {
-                def ruleData = childApp.getRuleData()
-                ruleInfo = [
-                    id: args.ruleId,
-                    name: ruleData.name,
-                    enabled: ruleData.enabled,
-                    triggerCount: ruleData.triggers?.size() ?: 0,
-                    conditionCount: ruleData.conditions?.size() ?: 0,
-                    actionCount: ruleData.actions?.size() ?: 0,
-                    lastTriggered: ruleData.lastTriggered ? formatTimestamp(ruleData.lastTriggered) : "Never",
-                    executionCount: ruleData.executionCount ?: 0
-                ]
-            }
-        } catch (e) {
-            ruleInfo = [error: "Could not retrieve rule info: ${e.message}"]
+        def hit = reversed.find { it.ruleId?.toString() == args.ruleId?.toString() }
+        if (hit) return [entry: hit, matchedOn: "ruleId"]
+    }
+    if (args.nativeAppId) {
+        def hit = reversed.find { it.details?.appId?.toString() == args.nativeAppId?.toString() }
+        if (hit) return [entry: hit, matchedOn: "nativeAppId"]
+    }
+    return [entry: null, matchedOn: "none"]
+}
+
+private Map _bugReportScopedLogs(args, List entries, Map anchor, long windowMs) {
+    def lastN = entries.takeRight(20)
+    if (anchor.entry == null) {
+        return [
+            relevant: lastN,
+            other: [],
+            otherCount: 0,
+            scoped: false,
+            includedUnrelated: true
+        ]
+    }
+    def anchorTs = anchor.entry.timestamp as Long
+    def windowStart = anchorTs - windowMs
+    def windowEnd = anchorTs + windowMs
+    def matchesContext = { entry ->
+        if (args.failingTool && entry.details?.tool == args.failingTool) return true
+        if (args.ruleId && entry.ruleId?.toString() == args.ruleId?.toString()) return true
+        if (args.nativeAppId && entry.details?.appId?.toString() == args.nativeAppId?.toString()) return true
+        return false
+    }
+    def relevant = []
+    def other = []
+    entries.each { entry ->
+        def ts = entry.timestamp as Long
+        if (ts >= windowStart && ts <= windowEnd && matchesContext(entry)) {
+            relevant << entry
+        } else {
+            other << entry
         }
     }
+    return [
+        relevant: relevant.takeRight(20),
+        other: other.takeRight(20),
+        otherCount: other.size(),
+        scoped: true,
+        includedUnrelated: (args.includeUnrelatedRecentLogs == true)
+    ]
+}
 
-    // Get device count
-    def deviceCount = selectedDevices?.size() ?: 0
-    def ruleCount = getChildApps()?.size() ?: 0
+private Map _bugReportEnvironmentSummary(args, String privacyMode) {
+    def hubName = "Unknown"
+    def hubModel = "Unknown"
+    def hubFirmware = "Unknown"
+    def timeZone = "Unknown"
+    try {
+        hubName = location.hub?.name?.toString() ?: "Unknown"
+        hubModel = location.hub?.hardwareID?.toString() ?: location.hub?.type?.toString() ?: "Unknown"
+        hubFirmware = location.hub?.firmwareVersionString?.toString() ?: "Unknown"
+        timeZone = location.timeZone?.ID?.toString() ?: "Unknown"
+    } catch (Throwable ignored) {}
+    return [
+        version: currentVersion(),
+        hubName: privacyMode == "public" ? "<hub-name>" : hubName,
+        hubModel: hubModel,
+        hubFirmware: hubFirmware,
+        timeZone: timeZone,
+        logLevel: getConfiguredLogLevel(),
+        customMcpRuleCount: getChildApps()?.size() ?: 0,
+        nativeRmRuleCount: _bugReportNativeRmCount(),
+        deviceCount: selectedDevices?.size() ?: 0,
+        llmClient: args.llmClient?.toString() ?: "Not provided"
+    ]
+}
 
-    // Build the formatted report
-    def report = """# Bug Report: ${args.title}
+private Integer _bugReportNativeRmCount() {
+    def ids = [] as Set
+    try {
+        def v4 = hubitat.helper.RMUtils.getRuleList() ?: []
+        v4.each { r -> if (r?.id != null) ids << r.id.toString() }
+    } catch (Throwable ignored) {}
+    try {
+        def v5 = hubitat.helper.RMUtils.getRuleList("5.0") ?: []
+        v5.each { r -> if (r?.id != null) ids << r.id.toString() }
+    } catch (Throwable ignored) {}
+    return ids.size()
+}
 
-**Generated:** ${timestamp}
-**MCP Server Version:** ${version}
+private Map _bugReportRuleInfo(args) {
+    if (!args.ruleId) return null
+    try {
+        def childApp = getChildAppById(args.ruleId)
+        if (!childApp) return null
+        def ruleData = childApp.getRuleData()
+        return [
+            id: args.ruleId,
+            name: ruleData.name,
+            enabled: ruleData.enabled,
+            triggerCount: ruleData.triggers?.size() ?: 0,
+            conditionCount: ruleData.conditions?.size() ?: 0,
+            actionCount: ruleData.actions?.size() ?: 0,
+            lastTriggered: ruleData.lastTriggered ? formatTimestamp(ruleData.lastTriggered) : "Never",
+            executionCount: ruleData.executionCount ?: 0
+        ]
+    } catch (Throwable e) {
+        return [id: args.ruleId, error: "Could not retrieve rule info: ${e.message}"]
+    }
+}
 
-## Environment
-- **Hub Firmware:** ${hubInfo.hubModel ?: 'Unknown'}
-- **Time Zone:** ${hubInfo.timeZone ?: 'Unknown'}
-- **Devices Exposed to MCP:** ${deviceCount}
-- **Total Rules:** ${ruleCount}
-- **Current Log Level:** ${getConfiguredLogLevel()}
+private String _bugReportSuggestedTitle(args, String issueType) {
+    def prefix = ["bug": "[bug]", "enhancement": "[feature]", "agent_behavior": "[agent-behavior]"][issueType]
+    def toolCtx = args.failingTool?.toString()?.trim()
+    def userTitle = args.title?.toString()?.trim() ?: "Issue report"
+    def body = toolCtx ? "${toolCtx}: ${userTitle}" : userTitle
+    def full = "${prefix} ${body}"
+    return full.length() > 140 ? (full.take(137) + "...") : full
+}
 
-## Bug Description
+private String _bugReportSubmitUrl(String issueType, String suggestedTitle) {
+    def template = ["bug": "bug_report.yml", "enhancement": "enhancement.yml", "agent_behavior": "agent_behavior.yml"][issueType]
+    def base = "https://github.com/kingpanther13/Hubitat-local-MCP-server/issues/new"
+    def encodedTitle = URLEncoder.encode(suggestedTitle ?: "", "UTF-8")
+    return "${base}?template=${template}&title=${encodedTitle}"
+}
 
-### Expected Behavior
-${args.expected}
+private String _bugReportFormatLogEntry(entry) {
+    def ts = formatTimestamp(entry.timestamp)
+    def lvl = entry.level?.toString()?.toUpperCase()
+    def tool = entry.details?.tool ? " [tool=${entry.details.tool}]" : ""
+    def ruleRef = entry.ruleId ? " (Rule: ${entry.ruleId})" : ""
+    return "[${ts}] ${lvl}${tool}: ${entry.message}${ruleRef}"
+}
 
-### Actual Behavior
-${args.actual}
-
-${args.stepsToReproduce ? """### Steps to Reproduce
-${args.stepsToReproduce}
-""" : ""}
-${ruleInfo ? """## Related Rule Info
+private String _bugReportBuildMarkdown(Map params) {
+    def args = params.args
+    def issueType = params.issueType
+    def privacyMode = params.privacyMode
+    def includeRawLogs = params.includeRawLogs
+    def env = params.env
+    def ruleInfo = params.ruleInfo
+    def scopedLogs = params.scopedLogs
+    def heading = ["bug": "Bug Report", "enhancement": "Feature Request", "agent_behavior": "Agent-Behavior Report"][issueType]
+    def expectedActualHeader = issueType == "enhancement" ? "## Request" : (issueType == "agent_behavior" ? "## Agent Behavior" : "## Bug Description")
+    def relevantLines = scopedLogs.relevant.collect { _bugReportFormatLogEntry(it) }
+    def otherLines = scopedLogs.includedUnrelated ? scopedLogs.other.collect { _bugReportFormatLogEntry(it) } : []
+    def failingToolLine = args.failingTool ? "- **Failing tool:** ${args.failingTool}\n" : ""
+    def nativeAppLine = args.nativeAppId ? "- **Native RM app id:** ${args.nativeAppId}\n" : ""
+    def reproSection = args.stepsToReproduce ? "\n### Steps to Reproduce\n${args.stepsToReproduce}\n" : ""
+    def ruleSection = ruleInfo ? """
+## Related Custom MCP Rule
 - **Rule ID:** ${ruleInfo.id}
 - **Rule Name:** ${ruleInfo.name ?: 'Unknown'}
 - **Enabled:** ${ruleInfo.enabled}
@@ -7665,32 +7806,55 @@ ${ruleInfo ? """## Related Rule Info
 - **Actions:** ${ruleInfo.actionCount}
 - **Last Triggered:** ${ruleInfo.lastTriggered}
 - **Execution Count:** ${ruleInfo.executionCount}
-""" : ""}
-## Recent Error/Warning Logs
-${recentErrors.size() > 0 ? "```\n" + recentErrors.join("\n") + "\n```" : "_No recent errors logged_"}
+""" : ""
+    def logSection
+    if (!includeRawLogs) {
+        def n = relevantLines.size()
+        def stand = n > 0 ?
+            "_${n} relevant entr${n == 1 ? 'y' : 'ies'} (raw text omitted in public mode — re-run with privacyMode='private' or pass includeRawLogs=true to see them)._" :
+            "_No relevant errors logged (raw text omitted in public mode)._"
+        logSection = "## Recent Error/Warning Logs\n${stand}"
+    } else {
+        def relevantBlock = relevantLines ? "```\n" + relevantLines.join("\n") + "\n```" : "_No relevant errors logged_"
+        logSection = "## Recent Error/Warning Logs\n${relevantBlock}"
+        if (otherLines) {
+            logSection += "\n\n### Other Recent Logs\n```\n" + otherLines.join("\n") + "\n```"
+        } else if (scopedLogs.scoped && scopedLogs.otherCount > 0) {
+            logSection += "\n\n_${scopedLogs.otherCount} other recent log entr${scopedLogs.otherCount == 1 ? 'y' : 'ies'} omitted — pass includeUnrelatedRecentLogs=true to include them._"
+        }
+    }
+
+    return """# ${heading}: ${args.title}
+
+**Generated:** ${formatTimestamp(now())}
+**MCP Server Version:** ${env.version}
+**Issue type:** ${issueType}
+**Privacy mode:** ${privacyMode}
+
+## Environment
+- **Hub name:** ${env.hubName}
+- **Hub model:** ${env.hubModel}
+- **Hub firmware:** ${env.hubFirmware}
+- **Time zone:** ${env.timeZone}
+- **MCP log level:** ${env.logLevel}
+- **Custom MCP rules:** ${env.customMcpRuleCount}
+- **Native Rule Machine rules:** ${env.nativeRmRuleCount}
+- **Devices exposed to MCP:** ${env.deviceCount}
+- **LLM / client:** ${env.llmClient}
+${failingToolLine}${nativeAppLine}
+${expectedActualHeader}
+
+### Expected
+${args.expected}
+
+### Actual
+${args.actual}
+${reproSection}${ruleSection}
+${logSection}
 
 ## Additional Context
-_Add any other context about the problem here._
-
----
-**To submit this bug report:**
-1. Go to: https://github.com/kingpanther13/Hubitat-local-MCP-server/issues/new
-2. Copy this entire report into the issue description
-3. Add any additional details or screenshots
-4. Submit the issue
-
-Thank you for helping improve the MCP Rule Server!"""
-
-    def result = [
-        success: true,
-        report: report,
-        submitUrl: "https://github.com/kingpanther13/Hubitat-local-MCP-server/issues/new",
-        instructions: "Copy the 'report' field content and paste it into a new GitHub issue at the submitUrl. Add any additional context or screenshots that might help diagnose the issue."
-    ]
-    if (state.updateCheck?.updateAvailable) {
-        result.updateAvailable = state.updateCheck.latestVersion
-    }
-    return result
+_Add any other context, screenshots, or transcripts when filing._
+"""
 }
 
 // ==================== HUB ADMIN READ TOOL IMPLEMENTATIONS ====================

--- a/src/test/groovy/server/ToolGenerateBugReportSpec.groovy
+++ b/src/test/groovy/server/ToolGenerateBugReportSpec.groovy
@@ -1,0 +1,251 @@
+package server
+
+import spock.lang.Shared
+import support.TestHub
+import support.TestLocation
+import support.ToolSpecBase
+
+/**
+ * Spec for the reworked generate_bug_report tool (#171).
+ *
+ * Covers:
+ *   - default invocation returns the expected result shape (bug + private mode)
+ *   - split environment counts (custom MCP / native RM / devices)
+ *   - issueType=bug | enhancement | agent_behavior route to the right title prefix + template
+ *   - submitUrl URL-encodes the suggested title
+ *   - log scoping kicks in ONLY when failingTool/ruleId/nativeAppId is passed
+ *   - includeUnrelatedRecentLogs folds omitted entries back into the report
+ *   - privacyMode=public substitutes <hub-name>, suppresses raw log text,
+ *     and the instructions field carries both an LLM-directed sanitization
+ *     ask and a user-directed review warning
+ *   - includeRawLogs=true in public mode shows raw lines but still hides hub name
+ *
+ * Log entries follow the shape produced by mcpLog(): a Map with timestamp,
+ * level, component, message, and an optional details Map carrying tool / appId
+ * context (see mcpLog at hubitat-mcp-server.groovy:5740 in main).
+ */
+class ToolGenerateBugReportSpec extends ToolSpecBase {
+
+    @Shared private TestLocation sharedLocation = new TestLocation()
+
+    def setupSpec() {
+        appExecutor.getLocation() >> sharedLocation
+    }
+
+    def cleanup() {
+        sharedLocation.hub = null
+    }
+
+    // ---------- helpers ----------
+
+    private void seedLogs(List entries) {
+        stateMap.debugLogs = [entries: entries, config: [logLevel: 'error', maxEntries: 100]]
+    }
+
+    private Map baseArgs(Map overrides = [:]) {
+        return [
+            title    : 'Trigger schema rejected my native rule',
+            expected : 'Trigger was created',
+            actual   : 'addTrigger errored',
+        ] + overrides
+    }
+
+    private Map logEntry(Map fields) {
+        Map entry = [
+            timestamp: fields.timestamp ?: 1_700_000_000_000L,
+            level    : fields.level ?: 'error',
+            component: fields.component ?: 'server',
+            message  : fields.message ?: 'boom',
+            details  : fields.details ?: [:],
+        ]
+        if (fields.ruleId) entry.ruleId = fields.ruleId
+        return entry
+    }
+
+    // ---------- default invocation ----------
+
+    def "default invocation returns success with split env counts and a [bug] title"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs())
+
+        then:
+        result.success == true
+        result.issueType == 'bug'
+        result.privacyMode == 'private'
+        result.suggestedTitle.startsWith('[bug] ')
+        result.submitUrl.contains('?template=bug_report.yml')
+        result.submitUrl.contains('&title=')
+        result.report.contains('## Environment')
+        result.report.contains('Custom MCP rules:')
+        result.report.contains('Native Rule Machine rules:')
+        result.report.contains('Devices exposed to MCP:')
+        result.logs.scoped == false
+        result.logs.relevantCount == 0
+        result.logs.otherRecentLogCount == 0
+        result.logs.hint == null
+    }
+
+    // ---------- issueType routing ----------
+
+    def "issueType=enhancement uses [feature] prefix and enhancement.yml template"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([issueType: 'enhancement']))
+
+        then:
+        result.issueType == 'enhancement'
+        result.suggestedTitle.startsWith('[feature] ')
+        result.submitUrl.contains('?template=enhancement.yml')
+    }
+
+    def "issueType=agent_behavior uses [agent-behavior] prefix and agent_behavior.yml template"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([issueType: 'agent_behavior']))
+
+        then:
+        result.issueType == 'agent_behavior'
+        result.suggestedTitle.startsWith('[agent-behavior] ')
+        result.submitUrl.contains('?template=agent_behavior.yml')
+    }
+
+    // ---------- URL encoding ----------
+
+    def "submitUrl URL-encodes the suggested title (no raw spaces or ampersands)"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([title: 'spaces & ampersands need encoding']))
+
+        then:
+        result.submitUrl.contains('&title=')
+        def titleQuery = result.submitUrl.substring(result.submitUrl.indexOf('&title=') + '&title='.length())
+        !titleQuery.contains(' ')
+        !titleQuery.contains('&')
+    }
+
+    // ---------- log scoping ----------
+
+    def "log scoping with failingTool keeps matching entries and exposes hint for omitted ones"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        long anchor = 1_700_000_000_000L
+        seedLogs([
+            logEntry(timestamp: anchor - 500_000, level: 'error', details: [tool: 'other_tool'],                       message: 'unrelated_old_log'),
+            logEntry(timestamp: anchor,           level: 'error', details: [tool: 'manage_native_rules_and_apps'],     message: 'the_real_failure'),
+            logEntry(timestamp: anchor + 5_000,   level: 'warn',  details: [tool: 'manage_native_rules_and_apps'],     message: 'followup_warn'),
+            logEntry(timestamp: anchor + 10_000,  level: 'error', details: [tool: 'different_tool'],                   message: 'noise_after'),
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([failingTool: 'manage_native_rules_and_apps']))
+
+        then:
+        result.logs.scoped == true
+        result.logs.relevantCount == 2
+        result.logs.otherRecentLogCount == 2
+        result.logs.hint != null
+        result.logs.hint.contains('includeUnrelatedRecentLogs=true')
+        result.report.contains('the_real_failure')
+        result.report.contains('followup_warn')
+        !result.report.contains('unrelated_old_log')
+        !result.report.contains('noise_after')
+    }
+
+    def "no failingTool / ruleId / nativeAppId means no scoping (all entries returned)"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        long anchor = 1_700_000_000_000L
+        seedLogs([
+            logEntry(timestamp: anchor,        level: 'error', details: [tool: 'tool_a'], message: 'aaa'),
+            logEntry(timestamp: anchor + 1000, level: 'warn',  details: [tool: 'tool_b'], message: 'bbb'),
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs())
+
+        then:
+        result.logs.scoped == false
+        result.logs.otherRecentLogCount == 0
+        result.logs.hint == null
+        result.report.contains('aaa')
+        result.report.contains('bbb')
+    }
+
+    def "includeUnrelatedRecentLogs=true folds the omitted entries into the report and drops the hint"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        long anchor = 1_700_000_000_000L
+        seedLogs([
+            logEntry(timestamp: anchor,         level: 'error', details: [tool: 'manage_native_rules_and_apps'], message: 'real_failure'),
+            logEntry(timestamp: anchor + 5_000, level: 'error', details: [tool: 'different_tool'],               message: 'noise_after_real'),
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([
+            failingTool                : 'manage_native_rules_and_apps',
+            includeUnrelatedRecentLogs : true,
+        ]))
+
+        then:
+        result.report.contains('real_failure')
+        result.report.contains('noise_after_real')
+        result.logs.hint == null
+    }
+
+    // ---------- privacy / public-safe mode ----------
+
+    def "privacyMode=public suppresses raw log text, placeholders hub name, and instructs LLM + user"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([
+            logEntry(timestamp: 1_700_000_000_000L, level: 'error', details: [tool: 'manage_native_rules_and_apps'], message: 'secret_message_in_log'),
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([
+            failingTool : 'manage_native_rules_and_apps',
+            privacyMode : 'public',
+        ]))
+
+        then:
+        result.privacyMode == 'public'
+        result.sanitizationApplied == true
+        result.report.contains('<hub-name>')
+        !result.report.contains('secret_message_in_log')
+        result.report.contains('raw text omitted in public mode')
+        result.instructions.toLowerCase().contains('if you are an llm')
+        result.instructions.toLowerCase().contains('review')
+    }
+
+    def "includeRawLogs=true in public mode still hides hub name but shows raw log text"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([
+            logEntry(timestamp: 1_700_000_000_000L, level: 'error', details: [tool: 'manage_native_rules_and_apps'], message: 'shown_anyway_in_public_mode'),
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([
+            failingTool    : 'manage_native_rules_and_apps',
+            privacyMode    : 'public',
+            includeRawLogs : true,
+        ]))
+
+        then:
+        result.report.contains('<hub-name>')
+        result.report.contains('shown_anyway_in_public_mode')
+    }
+}

--- a/src/test/groovy/server/ToolGenerateBugReportSpec.groovy
+++ b/src/test/groovy/server/ToolGenerateBugReportSpec.groovy
@@ -1,29 +1,13 @@
 package server
 
 import spock.lang.Shared
+import spock.lang.Unroll
+import support.RMUtilsMock
+import support.TestChildApp
 import support.TestHub
 import support.TestLocation
 import support.ToolSpecBase
 
-/**
- * Spec for the reworked generate_bug_report tool (#171).
- *
- * Covers:
- *   - default invocation returns the expected result shape (bug + private mode)
- *   - split environment counts (custom MCP / native RM / devices)
- *   - issueType=bug | enhancement | agent_behavior route to the right title prefix + template
- *   - submitUrl URL-encodes the suggested title
- *   - log scoping kicks in ONLY when failingTool/ruleId/nativeAppId is passed
- *   - includeUnrelatedRecentLogs folds omitted entries back into the report
- *   - privacyMode=public substitutes <hub-name>, suppresses raw log text,
- *     and the instructions field carries both an LLM-directed sanitization
- *     ask and a user-directed review warning
- *   - includeRawLogs=true in public mode shows raw lines but still hides hub name
- *
- * Log entries follow the shape produced by mcpLog(): a Map with timestamp,
- * level, component, message, and an optional details Map carrying tool / appId
- * context (see mcpLog at hubitat-mcp-server.groovy:5740 in main).
- */
 class ToolGenerateBugReportSpec extends ToolSpecBase {
 
     @Shared private TestLocation sharedLocation = new TestLocation()
@@ -51,12 +35,13 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
     }
 
     private Map logEntry(Map fields) {
+        Map details = (fields.details ?: [:]) + (fields.nativeAppId ? [appId: fields.nativeAppId] : [:])
         Map entry = [
             timestamp: fields.timestamp ?: 1_700_000_000_000L,
             level    : fields.level ?: 'error',
             component: fields.component ?: 'server',
             message  : fields.message ?: 'boom',
-            details  : fields.details ?: [:],
+            details  : details,
         ]
         if (fields.ruleId) entry.ruleId = fields.ruleId
         return entry
@@ -80,13 +65,105 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         result.submitUrl.contains('?template=bug_report.yml')
         result.submitUrl.contains('&title=')
         result.report.contains('## Environment')
-        result.report.contains('Custom MCP rules:')
-        result.report.contains('Native Rule Machine rules:')
-        result.report.contains('Devices exposed to MCP:')
+        result.report.contains('**Rules in legacy custom rule engine:** 0')
+        result.report.contains('**Native Rule Machine rules:** 0')
+        result.report.contains('**Devices exposed to MCP:** 0')
         result.logs.scoped == false
         result.logs.relevantCount == 0
         result.logs.otherRecentLogCount == 0
         result.logs.hint == null
+    }
+
+    def "env summary uses 'Rules in legacy custom rule engine' (not 'Custom MCP rules') so users don't read it as 'MCP can't see my RM rules'"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs())
+
+        then: 'the label clarifies this is the legacy custom rule engine, not the full MCP-visible rule set'
+        result.report.contains('**Rules in legacy custom rule engine:**')
+        !result.report.contains('**Custom MCP rules:**')
+    }
+
+    def "env summary shows non-zero customMcpRuleCount when child apps are present"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        childAppsList << new TestChildApp(id: 1L, label: 'Rule A')
+        childAppsList << new TestChildApp(id: 2L, label: 'Rule B')
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs())
+
+        then:
+        result.report.contains('**Rules in legacy custom rule engine:** 2')
+    }
+
+    // ---------- native RM status (F1/F4 — installed vs not, count distinction) ----------
+
+    def "env summary renders 'Native Rule Machine: not installed' when RMUtils throws the class-missing absence pattern"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+        def rmMock = new RMUtilsMock(
+            throwOnGetRuleList4: new NoClassDefFoundError('hubitat.helper.RMUtils'),
+            throwOnGetRuleList5: new NoClassDefFoundError('hubitat.helper.RMUtils'),
+        )
+        rmMock.install()
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs())
+
+        then:
+        result.report.contains('**Native Rule Machine:** not installed')
+        !result.report.contains('**Native Rule Machine rules:** 0')
+
+        cleanup:
+        rmMock.uninstall()
+    }
+
+    def "env summary renders 'Native Rule Machine rules: N' when RMUtils returns N rules"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+        def rmMock = new RMUtilsMock(
+            stubRuleList4: [[id: 101], [id: 102], [id: 103]],
+            stubRuleList5: [],
+        )
+        rmMock.install()
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs())
+
+        then:
+        result.report.contains('**Native Rule Machine rules:** 3')
+        !result.report.contains('not installed')
+
+        cleanup:
+        rmMock.uninstall()
+    }
+
+    def "env summary marks partial failure when one RMUtils version throws a non-absence error"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+        def rmMock = new RMUtilsMock(
+            stubRuleList4: [[id: 1]],
+            throwOnGetRuleList5: new RuntimeException('RMUtils v5 internal error'),
+        )
+        rmMock.install()
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs())
+
+        then: 'count from the surviving version is still surfaced, but the report flags partial failure'
+        result.report.contains('**Native Rule Machine rules:** 1')
+        result.report.contains('RMUtils partial failure')
+
+        cleanup:
+        rmMock.uninstall()
     }
 
     // ---------- issueType routing ----------
@@ -119,6 +196,31 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         result.submitUrl.contains('?template=agent_behavior.yml')
     }
 
+    @Unroll
+    def "issueType '#raw' normalizes to '#expected' (template=#template)"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([issueType: raw]))
+
+        then:
+        result.issueType == expected
+        result.submitUrl.contains("?template=${template}")
+
+        where:
+        raw                 || expected         | template
+        'feature'           || 'enhancement'    | 'enhancement.yml'
+        'feat'              || 'enhancement'    | 'enhancement.yml'
+        'feature_request'   || 'enhancement'    | 'enhancement.yml'
+        'agent-behavior'    || 'agent_behavior' | 'agent_behavior.yml'
+        'tool_description'  || 'agent_behavior' | 'agent_behavior.yml'
+        'BUG'               || 'bug'            | 'bug_report.yml'
+        'garbage'           || 'bug'            | 'bug_report.yml'
+        null                || 'bug'            | 'bug_report.yml'
+    }
+
     // ---------- URL encoding ----------
 
     def "submitUrl URL-encodes the suggested title (no raw spaces or ampersands)"() {
@@ -134,6 +236,39 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         def titleQuery = result.submitUrl.substring(result.submitUrl.indexOf('&title=') + '&title='.length())
         !titleQuery.contains(' ')
         !titleQuery.contains('&')
+    }
+
+    // ---------- title truncation ----------
+
+    def "suggested title truncates to 140 chars with ellipsis when prefix+tool+title overflows"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+        def longTitle = 'x' * 200
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([
+            title       : longTitle,
+            failingTool : 'manage_native_rules_and_apps',
+        ]))
+
+        then:
+        result.suggestedTitle.length() == 140
+        result.suggestedTitle.endsWith('...')
+        result.suggestedTitle.startsWith('[bug] manage_native_rules_and_apps:')
+    }
+
+    def "suggested title left untouched when under 140 chars"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([title: 'short title']))
+
+        then:
+        result.suggestedTitle == '[bug] short title'
+        !result.suggestedTitle.endsWith('...')
     }
 
     // ---------- log scoping ----------
@@ -164,6 +299,69 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         !result.report.contains('noise_after')
     }
 
+    def "log scoping anchored on ruleId keeps entries whose ruleId matches"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        long anchor = 1_700_000_000_000L
+        seedLogs([
+            logEntry(timestamp: anchor,         level: 'error', ruleId: '42',     message: 'rule_42_failure'),
+            logEntry(timestamp: anchor + 1_000, level: 'warn',  ruleId: '42',     message: 'rule_42_warn'),
+            logEntry(timestamp: anchor + 5_000, level: 'error', ruleId: '999',    message: 'unrelated_rule_999'),
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([ruleId: '42']))
+
+        then:
+        result.logs.scoped == true
+        result.logs.relevantCount == 2
+        result.report.contains('rule_42_failure')
+        result.report.contains('rule_42_warn')
+        !result.report.contains('unrelated_rule_999')
+    }
+
+    def "log scoping anchored on nativeAppId keeps entries whose details.appId matches"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        long anchor = 1_700_000_000_000L
+        seedLogs([
+            logEntry(timestamp: anchor,         level: 'error', nativeAppId: '1234', message: 'native_app_1234_failure'),
+            logEntry(timestamp: anchor + 1_000, level: 'warn',  nativeAppId: '1234', message: 'native_app_1234_warn'),
+            logEntry(timestamp: anchor + 5_000, level: 'error', nativeAppId: '5678', message: 'unrelated_app_5678'),
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([nativeAppId: '1234']))
+
+        then:
+        result.logs.scoped == true
+        result.logs.relevantCount == 2
+        result.report.contains('native_app_1234_failure')
+        result.report.contains('native_app_1234_warn')
+        !result.report.contains('unrelated_app_5678')
+    }
+
+    def "failingTool with no matching log entries falls through to unscoped (lastN) output"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        long anchor = 1_700_000_000_000L
+        seedLogs([
+            logEntry(timestamp: anchor,         level: 'error', details: [tool: 'tool_a'], message: 'unrelated_a'),
+            logEntry(timestamp: anchor + 1_000, level: 'warn',  details: [tool: 'tool_b'], message: 'unrelated_b'),
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([failingTool: 'tool_that_never_logged']))
+
+        then: 'no anchor → unscoped path; both lastN entries returned, no hint'
+        result.logs.scoped == false
+        result.logs.relevantCount == 2
+        result.logs.otherRecentLogCount == 0
+        result.logs.hint == null
+        result.report.contains('unrelated_a')
+        result.report.contains('unrelated_b')
+    }
+
     def "no failingTool / ruleId / nativeAppId means no scoping (all entries returned)"() {
         given:
         sharedLocation.hub = new TestHub()
@@ -182,6 +380,22 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         result.logs.hint == null
         result.report.contains('aaa')
         result.report.contains('bbb')
+    }
+
+    def "empty log buffer with scoping requested returns scoped=false, no crash"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([failingTool: 'manage_native_rules_and_apps']))
+
+        then: 'anchor is null (empty buffer), so fallback path is the unscoped lastN (which is also empty)'
+        result.success == true
+        result.logs.scoped == false
+        result.logs.relevantCount == 0
+        result.logs.otherRecentLogCount == 0
+        result.logs.hint == null
     }
 
     def "includeUnrelatedRecentLogs=true folds the omitted entries into the report and drops the hint"() {
@@ -205,6 +419,109 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         result.logs.hint == null
     }
 
+    def "logWindowSeconds window boundary — entries at the edge are in, just past are out"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        long anchor = 1_700_000_000_000L
+        // The most-recent matching entry becomes the anchor (resolveAnchor returns the first
+        // hit from the reversed list). With anchor = the latest entry, the window extends
+        // backwards ±logWindowSeconds. windowStart = anchor - 30s, windowEnd = anchor + 30s.
+        seedLogs([
+            logEntry(timestamp: anchor - 30_001, level: 'warn',  details: [tool: 'X'], message: 'just_before'),  // out of window
+            logEntry(timestamp: anchor - 30_000, level: 'warn',  details: [tool: 'X'], message: 'edge_in'),       // exactly at window start
+            logEntry(timestamp: anchor,           level: 'error', details: [tool: 'X'], message: 'anchor_entry'), // anchor itself
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([failingTool: 'X', logWindowSeconds: 30]))
+
+        then:
+        result.logs.scoped == true
+        result.logs.relevantCount == 2
+        result.report.contains('anchor_entry')
+        result.report.contains('edge_in')
+        !result.report.contains('just_before')
+    }
+
+    def "hint singular grammar fires when exactly one unrelated entry is omitted"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        long anchor = 1_700_000_000_000L
+        seedLogs([
+            logEntry(timestamp: anchor,         level: 'error', details: [tool: 'X'], message: 'matched'),
+            logEntry(timestamp: anchor + 1_000, level: 'error', details: [tool: 'Y'], message: 'unrelated_single'),
+        ])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([failingTool: 'X']))
+
+        then:
+        result.logs.otherRecentLogCount == 1
+        result.logs.hint.endsWith('entry.')
+        !result.logs.hint.endsWith('entries.')
+    }
+
+    // ---------- ruleId rule-info section ----------
+
+    def "ruleId pointing at a real custom MCP rule renders the related-rule section"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+        def child = new TestChildApp(id: 42L, label: 'My Test Rule')
+        child.ruleData = [
+            name: 'My Test Rule', enabled: true,
+            triggers: [[type: 'time']], conditions: [], actions: [[type: 'on']],
+            lastTriggered: 1_700_000_000_000L, executionCount: 7,
+        ]
+        childAppsList << child
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([ruleId: '42']))
+
+        then:
+        result.report.contains('## Related Custom MCP Rule')
+        result.report.contains('**Rule ID:** 42')
+        result.report.contains('**Rule Name:** My Test Rule')
+        result.report.contains('**Enabled:** true')
+        result.report.contains('**Triggers:** 1')
+        result.report.contains('**Actions:** 1')
+        result.report.contains('**Execution Count:** 7')
+        !result.report.contains('**Last Triggered:** Never')
+    }
+
+    def "ruleId with no matching child app omits the related-rule section entirely"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([ruleId: '999']))
+
+        then:
+        !result.report.contains('## Related Custom MCP Rule')
+        !result.report.contains('## Related Rule (lookup failed)')
+        result.success == true
+    }
+
+    def "ruleId matching a child whose getRuleData throws renders a 'lookup failed' section instead of nulls"() {
+        given:
+        sharedLocation.hub = new TestHub()
+        seedLogs([])
+        def child = new TestChildApp(id: 77L, label: 'Native-RM-style child')
+        child.metaClass.getRuleData = { throw new MissingMethodException('getRuleData', child.getClass(), [] as Object[]) }
+        childAppsList << child
+
+        when:
+        def result = script.toolGenerateBugReport(baseArgs([ruleId: '77']))
+
+        then:
+        result.report.contains('## Related Rule (lookup failed)')
+        result.report.contains('**Rule ID:** 77')
+        result.report.contains('**Lookup error:**')
+        result.report.contains('pass it as `nativeAppId` instead')
+        !result.report.contains('**Rule Name:** Unknown')
+    }
+
     // ---------- privacy / public-safe mode ----------
 
     def "privacyMode=public suppresses raw log text, placeholders hub name, and instructs LLM + user"() {
@@ -222,10 +539,9 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
 
         then:
         result.privacyMode == 'public'
-        result.sanitizationApplied == true
         result.report.contains('<hub-name>')
         !result.report.contains('secret_message_in_log')
-        result.report.contains('raw text omitted in public mode')
+        result.report.contains('public mode')
         result.instructions.toLowerCase().contains('if you are an llm')
         result.instructions.toLowerCase().contains('review')
     }
@@ -248,4 +564,5 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         result.report.contains('<hub-name>')
         result.report.contains('shown_anyway_in_public_mode')
     }
+
 }


### PR DESCRIPTION
## Summary

- Reworks `generate_bug_report` to file bug / enhancement / agent-behavior issues with a prefilled GitHub issue link (template + URL-encoded title).
- Recent error/warning logs are scoped to the failure when `failingTool` / `ruleId` / `nativeAppId` is provided; otherwise behavior matches today's tool (no auto-magic anchor).
- Public-safe privacy mode: placeholders the hub name, suppresses raw log text, and instructs the LLM/user to sanitize and review before posting — no regex scrubbing (matches the #176 thread caveat).

Closes #171. Folds in #175 (env summary split), #176 (privacy mode), #177 (log scoping).

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- New optional params: `issueType` (`bug` | `enhancement` | `agent_behavior`), `failingTool`, `nativeAppId`, `llmClient`, `privacyMode`, `includeRawLogs`, `includeUnrelatedRecentLogs`, `logWindowSeconds`. Existing `title` / `expected` / `actual` / `stepsToReproduce` / `ruleId` unchanged.
- Environment summary splits into `Custom MCP rules`, `Native Rule Machine rules` (via `RMUtils.getRuleList()` v4+v5 deduped), `Devices exposed to MCP`, plus hub model, firmware, time zone, and LLM client.
- `submitUrl` is now `…/issues/new?template=<form>.yml&title=<url-encoded>` — title only, no body prefill (the user types the narrative in one form field and pastes the report into another).
- Public-safe mode: hub name replaced with `<hub-name>`, raw log text suppressed unless `includeRawLogs=true`. The returned `instructions` field asks the LLM to attempt sanitization and warns the user to review before posting.
- Three new GitHub issue forms in `.github/ISSUE_TEMPLATE/` (`bug_report.yml`, `enhancement.yml`, `agent_behavior.yml`) plus a `config.yml` that disables blank issues and routes questions to Discussions.
- New Spock spec `ToolGenerateBugReportSpec` — 9 cases covering default behavior, all three `issueType` values, URL encoding, log scoping with/without context, `includeUnrelatedRecentLogs`, public mode, and `includeRawLogs` override.

## Release Notes

- `generate_bug_report` now files bug, enhancement, or agent-behavior issues — pass `issueType` to choose.
- The returned `submitUrl` is a prefilled GitHub issue link with the title already filled in. Paste the report content into the form's "Agent report output" field.
- Recent error logs are scoped to the failure when you pass `failingTool` / `ruleId` / `nativeAppId`; `includeUnrelatedRecentLogs=true` keeps the broader log dump.
- New `privacyMode: "public"` produces a public-safe report (hub name placeholder, raw logs suppressed). Always review before posting — tool-side sanitization is a best-effort assist, not a guarantee.
- Three new GitHub issue forms make it easier to file structured bug / enhancement / agent-behavior reports.

## Testing

- `./gradlew test` — full suite green locally (1350 tests).
- `python tests/sandbox_lint.py` — clean.
- New spec `ToolGenerateBugReportSpec` — 9/9 pass.
- The regression test `HandleMcpRequestDispatchSpec.tools/list with useGateways=false` still passes — verified the trimmed registration leaves the flat catalog under the hub's 124KB cap. (Catalog headroom is thin; see #181 for the broader trim follow-up.)

## Checklist

- [x] Unit tests added for the rewritten tool (`ToolGenerateBugReportSpec`).
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`.
- [x] `./gradlew test` passes locally.
- [ ] Live-hub BAT tests updated if tool behaviour changed — not required (info-only tool, no destructive side effects).
- [ ] Documentation updated if user-facing behaviour or tool surface changed — Release Notes above carries the user-visible changes; no `TOOL_GUIDE.md` / `README.md` change needed in this PR.