### PR TITLE
feat: fold location event history into get_device_history

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Source code is automatically backed up before any modify/delete operation.
 | Tool | Description |
 |------|-------------|
 | `get_hub_logs` | Hub log entries (most recent first) with level/source/regex filters, multi-pattern AND/OR, time-window (since/until, max 30d relative -- throws if exceeded; use ISO-8601 for longer ranges), and server-side deviceId/appId scoping. `pattern` matches the message field only; pathological regex like `(.*)*` may hang the matcher. |
-| `get_device_history` | Up to 7 days of device event history |
+| `get_device_history` | Up to 7 days of device or location event history (omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent history) |
 | `get_performance_stats` | Device/app performance stats (count, % busy, total ms, state size, events, large-state flag) |
 | `get_hub_jobs` | Scheduled jobs, running jobs, and hub actions |
 | `get_debug_logs` | Retrieve MCP debug log entries |

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -380,6 +380,7 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 **get_device_history:**
 - Up to 7 days of history
 - Use attribute filter to reduce data volume
+- **Location-scope mode**: omit `deviceId` to return location events instead of device events. Returns mode changes (`name: 'mode'`), HSM status/alerts (`'hsmStatus'`, `'hsmAlert'`), hub variable changes (name = the variable's name), and any `sendLocationEvent(...)` emissions from rules/apps. `attribute` filter applies to event name in the same way. Response includes `source: 'location'` and omits `device`/`deviceId`.
 
 **get_app_config:**
 - Reads any legacy SmartApp's configuration page: RM rules, Room Lighting instances, Basic Rules, HPM, Mode Manager, Button Controllers, third-party community apps

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -891,7 +891,7 @@ def getGatewayConfig() {
             tools: ["get_hub_logs", "get_device_history", "get_performance_stats", "get_hub_jobs", "get_debug_logs", "clear_debug_logs", "set_log_level", "get_logging_status"],
             summaries: [
                 get_hub_logs: "Get Hubitat system logs, most recent first. Args: level (debug/info/warn/error), source (substring), pattern (regex), patterns + patternMode (multi-regex AND/OR), since/until (ISO-8601 or '30m'/'2h'/'1d'), deviceId or appId (server-side scope), limit",
-                get_device_history: "Get device event history (up to 7 days). Args: deviceId, hours, attribute",
+                get_device_history: "Get device or location event history (up to 7 days). Omit deviceId for location events. Args: deviceId (optional), hoursBack, attribute, limit",
                 get_performance_stats: "Get device/app performance stats (count, % busy, total ms, state size, events, large state flag). Args: type (device/app/both), sortBy (pct/count/stateSize/totalMs/name), limit",
                 get_hub_jobs: "Get scheduled jobs, running jobs, and hub actions",
                 get_debug_logs: "Get MCP internal debug logs. Args: level, limit",
@@ -901,7 +901,7 @@ def getGatewayConfig() {
             ],
             searchHints: [
                 get_hub_logs: "errors warnings messages trace syslog output print recent latest newest device app scope regex pattern filter time window since until last hour minute",
-                get_device_history: "events timeline past activity what happened sensor",
+                get_device_history: "events timeline past activity what happened sensor mode hsm location hub variable",
                 get_performance_stats: "slow cpu busy resource usage hog bottleneck",
                 get_hub_jobs: "scheduled cron timer recurring what is running next automation",
                 get_debug_logs: "mcp internal troubleshoot trace",
@@ -1765,16 +1765,15 @@ Verify rule after creation.""",
         ],
         [
             name: "get_device_history",
-            description: "Get device event history over a time range (up to 7 days). Supports attribute filtering.",
+            description: "Get device or location event history (up to 7 days). Omit deviceId for location events (mode/HSM/hub variable/sendLocationEvent). Supports attribute filtering.",
             inputSchema: [
                 type: "object",
                 properties: [
-                    deviceId: [type: "string", description: "Device ID"],
+                    deviceId: [type: "string", description: "Device ID. Omit for location-level events."],
                     hoursBack: [type: "integer", description: "How many hours of history to retrieve. Default: 24, max: 168 (7 days).", default: 24],
-                    attribute: [type: "string", description: "Filter to a specific attribute name (e.g., 'temperature', 'switch')"],
+                    attribute: [type: "string", description: "Event name filter. Device: an attribute (e.g. 'switch'). Location: 'mode', 'hsmStatus', 'hsmAlert', or hub-variable name."],
                     limit: [type: "integer", description: "Max events to return. Default: 100, max: 500.", default: 100]
-                ],
-                required: ["deviceId"]
+                ]
             ]
         ],
         [
@@ -8704,16 +8703,54 @@ def toolGetHubLogs(args) {
 }
 
 def toolGetDeviceHistory(args) {
-    if (!args.deviceId) throw new IllegalArgumentException("deviceId is required")
-    def device = findDevice(args.deviceId)
-    if (!device) throw new IllegalArgumentException("Device not found: ${args.deviceId}. Device must be selected in MCP Rule Server app settings.")
-
     def hoursBack = Math.min(args.hoursBack ?: 24, 168)
     def limit = Math.min(args.limit ?: 100, 500)
     def attributeFilter = args.attribute
+    def sinceDate = new Date(now() - (hoursBack * 3600000L))
+
+    // Location-scope branch: when deviceId is omitted, fold in
+    // Hubitat's getLocationEventsSince(Date) so callers can pull
+    // mode/HSM/hub-variable/sendLocationEvent history alongside
+    // device history through one tool.
+    if (!args.deviceId) {
+        def locEvents
+        try {
+            locEvents = location.eventsSince(sinceDate, [max: limit])
+        } catch (Exception e) {
+            mcpLog("warn", "monitoring", "location.eventsSince failed: ${e.message}")
+            return [error: "location.eventsSince not supported or failed: ${e.message}", source: "location"]
+        }
+
+        def locResults = locEvents?.collect { evt ->
+            [
+                name: evt.name,
+                value: evt.value,
+                unit: evt.unit,
+                description: evt.descriptionText,
+                date: evt.date?.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
+                isStateChange: evt.isStateChange
+            ]
+        } ?: []
+
+        if (attributeFilter) {
+            locResults = locResults.findAll { it.name == attributeFilter }
+        }
+
+        mcpLog("info", "monitoring", "Retrieved ${locResults.size()} location history events (${hoursBack}h back)")
+        return [
+            source: "location",
+            hoursBack: hoursBack,
+            attributeFilter: attributeFilter,
+            events: locResults,
+            count: locResults.size(),
+            sinceTimestamp: sinceDate.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+        ]
+    }
+
+    def device = findDevice(args.deviceId)
+    if (!device) throw new IllegalArgumentException("Device not found: ${args.deviceId}. Device must be selected in MCP Rule Server app settings.")
 
     def deviceLabel = device.label ?: device.name ?: "Device ${args.deviceId}"
-    def sinceDate = new Date(now() - (hoursBack * 3600000L))
 
     def events
     try {
@@ -8734,13 +8771,13 @@ def toolGetDeviceHistory(args) {
         ]
     } ?: []
 
-    // Apply attribute filter post-query
     if (attributeFilter) {
         results = results.findAll { it.name == attributeFilter }
     }
 
     mcpLog("info", "monitoring", "Retrieved ${results.size()} history events for ${deviceLabel} (${hoursBack}h back)")
     return [
+        source: "device",
         device: deviceLabel,
         deviceId: args.deviceId,
         hoursBack: hoursBack,

--- a/src/test/groovy/server/ToolManageLogsSpec.groovy
+++ b/src/test/groovy/server/ToolManageLogsSpec.groovy
@@ -4,6 +4,7 @@ import groovy.json.JsonOutput
 import spock.lang.Shared
 import support.TestChildApp
 import support.TestDevice
+import support.TestLocation
 import support.ToolSpecBase
 
 /**
@@ -36,6 +37,7 @@ import support.ToolSpecBase
 class ToolManageLogsSpec extends ToolSpecBase {
 
     @Shared private TestChildApp sharedAppStub = new TestChildApp(id: 1L, label: 'MCP')
+    @Shared private TestLocation sharedLocation = new TestLocation()
 
     def setupSpec() {
         // HarnessSpec.setupSpec runs first (Spock auto-invokes superclass
@@ -44,6 +46,9 @@ class ToolManageLogsSpec extends ToolSpecBase {
         // call a non-null target. Same additive-stub pattern that
         // ToolRoomsSpec uses for appExecutor.httpPost(_, _).
         appExecutor.getApp() >> sharedAppStub
+        // toolGetDeviceHistory's location-scope branch reads location.eventsSince(...);
+        // wire it through appExecutor so the server's `location` reference resolves.
+        appExecutor.getLocation() >> sharedLocation
     }
 
     def cleanup() {
@@ -203,13 +208,82 @@ class ToolManageLogsSpec extends ToolSpecBase {
 
     // -------- toolGetDeviceHistory --------
 
-    def "get_device_history throws when deviceId is missing"() {
+    def "get_device_history returns location events when deviceId is omitted"() {
+        given: 'location.eventsSince stubbed to return mode + HSM + hub-variable events'
+        def fixedDate = new Date(1234567880000L)
+        def capturedSince = null
+        def capturedOpts = null
+        sharedLocation.metaClass.eventsSince = { Date since, Map opts ->
+            capturedSince = since
+            capturedOpts = opts
+            [
+                [name: 'mode',        value: 'Night',  unit: null, descriptionText: 'Mode changed to Night', date: fixedDate, isStateChange: true],
+                [name: 'hsmStatus',   value: 'armedAway', unit: null, descriptionText: 'HSM armed away',     date: fixedDate, isStateChange: true],
+                [name: 'guestCount',  value: '3',     unit: null, descriptionText: 'hub variable updated',   date: fixedDate, isStateChange: true]
+            ]
+        }
+
         when:
-        script.toolGetDeviceHistory([:])
+        def result = script.toolGetDeviceHistory([hoursBack: 6, limit: 25])
+
+        then: 'location.eventsSince receives the hoursBack-derived sinceDate and opts.max'
+        capturedSince != null
+        capturedSince.time == 1234567890000L - (6 * 3600000L)
+        capturedOpts == [max: 25]
+
+        and:
+        result.source == 'location'
+        !result.containsKey('device')
+        !result.containsKey('deviceId')
+        result.hoursBack == 6
+        result.count == 3
+        result.events*.name == ['mode', 'hsmStatus', 'guestCount']
+        result.events[0].value == 'Night'
+
+        cleanup:
+        sharedLocation.metaClass = null
+    }
+
+    def "get_device_history applies attribute filter to location events"() {
+        given:
+        def fixedDate = new Date(1234567880000L)
+        sharedLocation.metaClass.eventsSince = { Date since, Map opts ->
+            [
+                [name: 'mode',      value: 'Night',  date: fixedDate, isStateChange: true],
+                [name: 'hsmStatus', value: 'armedAway', date: fixedDate, isStateChange: true],
+                [name: 'mode',      value: 'Day',   date: fixedDate, isStateChange: true]
+            ]
+        }
+
+        when:
+        def result = script.toolGetDeviceHistory([attribute: 'mode'])
 
         then:
-        def ex = thrown(IllegalArgumentException)
-        ex.message.contains('deviceId is required')
+        result.source == 'location'
+        result.attributeFilter == 'mode'
+        result.count == 2
+        result.events.every { it.name == 'mode' }
+
+        cleanup:
+        sharedLocation.metaClass = null
+    }
+
+    def "get_device_history returns an error map when location.eventsSince throws"() {
+        given:
+        sharedLocation.metaClass.eventsSince = { Date since, Map opts ->
+            throw new RuntimeException('location event store unavailable')
+        }
+
+        when:
+        def result = script.toolGetDeviceHistory([:])
+
+        then:
+        result.source == 'location'
+        result.error.contains('failed')
+        result.error.contains('location event store unavailable')
+
+        cleanup:
+        sharedLocation.metaClass = null
     }
 
     def "get_device_history throws when device is not found"() {


### PR DESCRIPTION
## Summary

- Make `deviceId` optional on `get_device_history`. When omitted, the tool returns location-scope events via `location.eventsSince(Date)` — mode changes, HSM status/alerts, hub-variable changes, and `sendLocationEvent` emissions — in the same response shape as the device branch.
- Single tool surface for "what changed on this device" and "what changed at the location level", as raised in issue #97 item 2 — no new tool added, no LLM tool-selection surface widened.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- `hubitat-mcp-server.groovy` — `get_device_history` schema: `deviceId` removed from `required`, description + `deviceId`/`attribute` property descriptions extended (kept tight to stay clear of the 124KB tools/list per-response cap). `toolGetDeviceHistory` gains a location-scope branch that calls `location.eventsSince(sinceDate, [max: limit])` when `deviceId` is absent and returns `source: 'location'`. Device branch unchanged except for the added `source: 'device'` field. `manage_logs` gateway summary + `searchHints` updated.
- `src/test/groovy/server/ToolManageLogsSpec.groovy` — wires `appExecutor.getLocation() >> sharedLocation`; replaces the obsolete "throws when deviceId is missing" test with three new cases (returns location events, attribute filter on location events, error path when `location.eventsSince` throws).
- `TOOL_GUIDE.md`, `README.md` — note the location-scope mode.

Part of #97.

## Release Notes

- `get_device_history` now also returns location events (mode changes, HSM status/alerts, hub-variable changes, `sendLocationEvent` emissions) — just omit `deviceId`. `attribute` filter scopes location results too (e.g. `'mode'`, `'hsmStatus'`, `'hsmAlert'`, or a hub-variable name).
- Response includes a `source: 'device' | 'location'` field; existing fields are unchanged.

## Testing

- `./gradlew test --tests "server.ToolManageLogsSpec"` — all green, including the three new location-branch tests.
- `./gradlew test --tests "server.HandleMcpRequestDispatchSpec"` — all green; flat-mode `tools/list` pagination still iterates cleanly, no page hits the 124KB cap.
- `python tests/sandbox_lint.py` — clean.

## Checklist

- [x] **Unit tests added for any new MCP tools** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
- [x] Documentation updated if user-facing behaviour or tool surface changed