### PR TITLE
feat: universal response-size guard + opt-in cursor pagination (#174)

### DIFF
--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -26,6 +26,30 @@ Default is **ON** (gateways enabled). Existing installations keep the gateway be
 
 `tools/list` is cursor-paginated per the MCP protocol. Request a page with `params: { cursor: "<opaque-string>" }` (omit `cursor` for the first page); the response carries `tools: [...]` plus an optional `nextCursor` string when more pages exist. Page size is 50 — the gateway-mode catalog (~36 entries) fits in a single page so most MCP clients see no behaviour change, while the flat-mode catalog (100+ entries with the toggle off) returns multiple pages and the client iterates `nextCursor` until absent. Pagination keeps the response under the hub's 128KB JSON-RPC limit as the catalog grows. Cursor validation errors (`-32602`): non-numeric cursor and out-of-range cursor (including negative values) both surface as JSON-RPC `-32602 "Invalid params"` with a diagnostic message.
 
+### `tools/call` Response-Size Guard (v1.3.x+, fail-soft)
+
+Every `tools/call` response is measured before send. If the serialized JSON exceeds the universal 110 KB cap (chosen to leave room for text-escape + JSON-RPC envelope overhead inside the hub's 128 KB JSON-RPC limit), the inner content is replaced with a structured fail-soft envelope:
+
+```json
+{
+  "response_too_large": true,
+  "truncated": true,
+  "estimatedBytes": 145320,
+  "sizeLimitBytes": 110000,
+  "tool": "list_installed_apps",
+  "suggestion": "Set includeHidden=false (the default), narrow via filter ..., or pass cursor to page through the apps list."
+}
+```
+
+The outer JSON-RPC envelope still reports success (this is not a tool error — the tool ran, the result just didn't fit). Treat `response_too_large=true` as a hint to either (a) narrow your query — the per-tool `suggestion` field names the specific knob — or (b) opt into pagination on tools that support it. The `tool` field reflects the actual sub-tool on gateway-routed calls so you can re-issue a narrower call directly.
+
+Opt-in cursor pagination is currently wired into:
+
+- **`list_installed_apps`** — pass `cursor` to page the apps list at 50 per page; default behaviour (no cursor) returns the full filtered list and relies on the size guard as a backstop.
+- **`device_health_check`** — pass `cursor` to page the `staleDevices` array at 100 per page. `unknownDevices` (and `healthyDevices` when `includeHealthy=true`) stay in full alongside the page so the summary call still works in one request.
+
+Tools without an explicit `cursor` parameter (e.g. `get_app_config`, `export_native_app`, `get_hub_logs`, `get_memory_history`) rely on their existing controls (`includeSettings=false`, `saveAs=<file>`, smaller `limit`, narrower filters) plus the universal size guard as the backstop.
+
 ## Device Authorization (CRITICAL)
 
 **Exact match rule:**

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -43,10 +43,32 @@ Every `tools/call` response is measured before send. If the serialized JSON exce
 
 The outer JSON-RPC envelope still reports success (this is not a tool error — the tool ran, the result just didn't fit). Treat `response_too_large=true` as a hint to either (a) narrow your query — the per-tool `suggestion` field names the specific knob — or (b) opt into pagination on tools that support it. The `tool` field reflects the actual sub-tool on gateway-routed calls so you can re-issue a narrower call directly.
 
-Opt-in cursor pagination is currently wired into:
+Opt-in cursor pagination is currently wired into the following read-only tools. All follow the same contract: omit `cursor` for the full list (backward-compatible, backstopped by the size guard), pass `cursor: ""` for the first page, then iterate `nextCursor` until absent. Cursor is opaque per the MCP convention; non-numeric / out-of-range values reject as `-32602`.
 
-- **`list_installed_apps`** — pass `cursor: ""` for the first page (page size 50). Iterate `nextCursor` until absent. Omitting `cursor` entirely returns the full filtered list and relies on the size guard as a backstop — these tools intentionally diverge from the `tools/list` "omit cursor = first page" convention so pre-`cursor` callers see no behaviour change.
-- **`device_health_check`** — pass `cursor: ""` for the first page (page size 100 over `staleDevices`). `unknownDevices` (and `healthyDevices` when `includeHealthy=true`) stay in full alongside the page so the summary call still works in one request. Omitting `cursor` returns all stale devices in a single response (same backward-compat rule as `list_installed_apps`).
+These tools intentionally diverge from the `tools/list` "omit cursor = first page" convention so pre-`cursor` callers see no behaviour change — pagination is genuinely opt-in.
+
+| Tool | Page size | Notes |
+|---|---|---|
+| `list_devices` | 50 (when `limit` unset) | Cursor is an alias for the existing `offset`+`limit` shape; `nextCursor` is emitted alongside `nextOffset`. |
+| `list_installed_apps` | 50 | Cursor respects `filter` — pages the filtered set. |
+| `list_hub_apps` | 50 | Catalog of installable apps on the hub. |
+| `list_hub_drivers` | 50 | Catalog of installable drivers. |
+| `list_hpm_packages` | 25 | Smaller page because each HPM entry carries the full app/driver/file inventory. |
+| `list_rm_rules` | 50 | RM 4.x + 5.x deduplicated rules. |
+| `custom_list_rules` | 50 | Legacy MCP rule engine. |
+| `list_variables` | 100 | Pages `hubVariables`; `ruleVariables` stays in full alongside the page. |
+| `list_captured_states` | 50 | Capacity warnings still emitted regardless of pagination. |
+| `list_item_backups` | 50 | Sorted newest-first; page boundaries are stable as long as the manifest doesn't change. |
+| `list_files` | 100 | File Manager listing. |
+| `list_virtual_devices` | 50 | MCP-managed virtual devices. |
+| `list_rooms` | 100 | Rooms with device counts. |
+| `device_health_check` | 100 | Pages `staleDevices`; `unknownDevices` (and `healthyDevices` when `includeHealthy=true`) stay in full. |
+| `get_device_in_use_by` | 100 | Pages `appsUsing`. |
+| `get_hub_logs` | 100 | Filters + `limit` apply first; cursor pages within the filtered result. |
+| `get_memory_history` | 100 | `limit=0` + cursor pages the full hub ring buffer (the only way to retrieve every entry without losing data). |
+| `get_debug_logs` | 100 | Filters apply first; cursor pages within. |
+
+Tools without cursor support (`get_app_config`, `export_native_app`, `get_app_source`, `get_driver_source`, `get_library_source`) rely on their existing controls (`includeSettings=false`, `saveAs=<file>`, `list_files`/`read_file` round-trip) plus the universal size guard as the backstop.
 
 Tools without an explicit `cursor` parameter (e.g. `get_app_config`, `export_native_app`, `get_hub_logs`, `get_memory_history`) rely on their existing controls (`includeSettings=false`, `saveAs=<file>`, smaller `limit`, narrower filters) plus the universal size guard as the backstop.
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -28,14 +28,14 @@ Default is **ON** (gateways enabled). Existing installations keep the gateway be
 
 ### `tools/call` Response-Size Guard (v1.3.x+, fail-soft)
 
-Every `tools/call` response is measured before send. If the serialized JSON exceeds the universal 110 KB cap (chosen to leave room for text-escape + JSON-RPC envelope overhead inside the hub's 128 KB JSON-RPC limit), the inner content is replaced with a structured fail-soft envelope:
+Every `tools/call` response is measured before send. If the wire-encoded response exceeds the universal 120 KB cap (8 KB headroom under the hub's 128 KB JSON-RPC limit), the inner content is replaced with a structured fail-soft envelope:
 
 ```json
 {
   "response_too_large": true,
   "truncated": true,
   "estimatedBytes": 145320,
-  "sizeLimitBytes": 110000,
+  "sizeLimitBytes": 120000,
   "tool": "list_installed_apps",
   "suggestion": "Set includeHidden=false (the default), narrow via filter ..., or pass cursor to page through the apps list."
 }
@@ -69,8 +69,6 @@ These tools intentionally diverge from the `tools/list` "omit cursor = first pag
 | `get_debug_logs` | 100 | Filters apply first; cursor pages within. |
 
 Tools without cursor support (`get_app_config`, `export_native_app`, `get_app_source`, `get_driver_source`, `get_library_source`) rely on their existing controls (`includeSettings=false`, `saveAs=<file>`, `list_files`/`read_file` round-trip) plus the universal size guard as the backstop.
-
-Tools without an explicit `cursor` parameter (e.g. `get_app_config`, `export_native_app`, `get_hub_logs`, `get_memory_history`) rely on their existing controls (`includeSettings=false`, `saveAs=<file>`, smaller `limit`, narrower filters) plus the universal size guard as the backstop.
 
 ## Device Authorization (CRITICAL)
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -45,8 +45,8 @@ The outer JSON-RPC envelope still reports success (this is not a tool error — 
 
 Opt-in cursor pagination is currently wired into:
 
-- **`list_installed_apps`** — pass `cursor` to page the apps list at 50 per page; default behaviour (no cursor) returns the full filtered list and relies on the size guard as a backstop.
-- **`device_health_check`** — pass `cursor` to page the `staleDevices` array at 100 per page. `unknownDevices` (and `healthyDevices` when `includeHealthy=true`) stay in full alongside the page so the summary call still works in one request.
+- **`list_installed_apps`** — pass `cursor: ""` for the first page (page size 50). Iterate `nextCursor` until absent. Omitting `cursor` entirely returns the full filtered list and relies on the size guard as a backstop — these tools intentionally diverge from the `tools/list` "omit cursor = first page" convention so pre-`cursor` callers see no behaviour change.
+- **`device_health_check`** — pass `cursor: ""` for the first page (page size 100 over `staleDevices`). `unknownDevices` (and `healthyDevices` when `includeHealthy=true`) stay in full alongside the page so the summary call still works in one request. Omitting `cursor` returns all stale devices in a single response (same backward-compat rule as `list_installed_apps`).
 
 Tools without an explicit `cursor` parameter (e.g. `get_app_config`, `export_native_app`, `get_hub_logs`, `get_memory_history`) rely on their existing controls (`includeSettings=false`, `saveAs=<file>`, smaller `limit`, narrower filters) plus the universal size guard as the backstop.
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -4,6 +4,14 @@ Quick reference for all 103 MCP tools. The server exposes **36 items on `tools/l
 
 For the most authoritative reference, call `get_tool_guide` via MCP.
 
+## Universal response-size guard + opt-in cursor pagination
+
+Every `tools/call` response is bounded by a 120 KB wire-encoded size guard. Oversized responses come back as a structured `{response_too_large: true, truncated: true, estimatedBytes, sizeLimitBytes, tool, suggestion}` envelope rather than vanishing into a hub `-32603`. The `suggestion` field gives the LLM a specific narrowing hint per tool.
+
+Opt-in cursor pagination is wired into the read-only list-returning tools below. All follow the same shape: omit `cursor` for the full list (backward-compatible), pass `cursor: ""` for the first page, iterate `nextCursor` until absent. Non-numeric / out-of-range cursors reject as `-32602`.
+
+**Tools with cursor:** `list_devices`, `list_installed_apps`, `list_hub_apps`, `list_hub_drivers`, `list_hpm_packages`, `list_rm_rules`, `custom_list_rules`, `list_variables`, `list_captured_states`, `list_item_backups`, `list_files`, `list_virtual_devices`, `list_rooms`, `device_health_check`, `get_device_in_use_by`, `get_hub_logs`, `get_memory_history`, `get_debug_logs`. See [TOOL_GUIDE.md](../../TOOL_GUIDE.md) for per-tool page sizes.
+
 ## Core Tools (23) — Always visible on tools/list
 
 ### Device Tools (6)

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -169,7 +169,7 @@ Performance monitoring, health checks, diagnostics, radio info, memory / GC, and
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `get_set_hub_metrics` | Record/retrieve hub metrics with CSV trend history. | Hub Admin Read |
-| `device_health_check` | Find stale/offline devices. | Hub Admin Read |
+| `device_health_check` | Find stale/offline devices. Optional `cursor` opt-in pagination over `staleDevices` (page size 100). | Hub Admin Read |
 | `custom_get_rule_diagnostics` | Comprehensive diagnostics for a specific custom rule. | None |
 | `get_zwave_details` | Z-Wave radio info. | Hub Admin Read |
 | `get_zigbee_details` | Zigbee radio info. | Hub Admin Read |
@@ -197,7 +197,7 @@ Read-only visibility into all installed apps (built-in + user): enumerate with p
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
-| `list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by `all`/`builtin`/`user`/`disabled`/`parents`/`children`. | Built-in App Read |
+| `list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by `all`/`builtin`/`user`/`disabled`/`parents`/`children`. Optional `cursor` opt-in pagination (page size 50). | Built-in App Read |
 | `get_device_in_use_by` | Given a `deviceId`, list apps referencing it (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.). | Built-in App Read |
 | `get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.). Returns sections/inputs/values; multi-page apps via `pageName`. Workflow: list_installed_apps or list_rm_rules -> get_app_config with appId; multi-page apps accept pageName (HPM: prefPkgUninstall for full list). Read-only. | Hub Admin Read |
 | `list_app_pages` | List known page names for a multi-page app (HPM, Room Lighting, etc.). Returns curated directory + live primary page. Use before get_app_config on multi-page apps. | Hub Admin Read |

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1370,7 +1370,8 @@ Server-side filtering (all applied before pagination): filter for enabled/disabl
                     labelFilter: [type: "string", description: "Case-insensitive substring match against device label; falls back to name for devices without a label set. Only devices whose label (or name) contains this string are returned. Applied after filter, before pagination. Empty or omitted = no label filtering."],
                     capabilityFilter: [type: "string", description: "Case-insensitive exact match against capability name. Only devices with this capability are returned. Applied after labelFilter, before pagination. Capability names are camelCase, no spaces -- e.g., 'ColorControl', not 'Color Control'. Example: 'Switch', 'TemperatureMeasurement'. Empty or omitted = no capability filtering. When count=0, response includes capabilityFilterMatchedKnownCapability (bool) to distinguish 'no devices have this capability' from a typo."],
                     format: [type: "string", enum: ["summary", "detailed", "ids"], description: "Response shape. 'summary' (default) = standard fields + currentStates. 'detailed' = capabilities/attributes/commands (same as detailed=true). 'ids' = flat array of device ID integers (cheapest, ignores fields arg and detailed=true -- format='ids' always wins). detailed=true overrides format='summary' and produces detailed-mode output."],
-                    fields: [type: "array", items: [type: "string"], description: "Field projection: only include named fields in each device object. Valid names: id, name, label, room, disabled, deviceNetworkId, lastActivity, parentDeviceId, mcpManaged, currentStates, capabilities, attributes, commands. Throws if any field name is unknown. Omitted or empty = all default fields for the active format. Ignored when format='ids'. id is always included regardless of projection (use format='ids' for id-only results). Including capabilities, attributes, or commands auto-promotes the response to detailed mode (those fields require detailed-mode device introspection). Project out currentStates and attributes to skip expensive hub reads; capabilities and commands are in-memory and cheap."]
+                    fields: [type: "array", items: [type: "string"], description: "Field projection: only include named fields in each device object. Valid names: id, name, label, room, disabled, deviceNetworkId, lastActivity, parentDeviceId, mcpManaged, currentStates, capabilities, attributes, commands. Throws if any field name is unknown. Omitted or empty = all default fields for the active format. Ignored when format='ids'. id is always included regardless of projection (use format='ids' for id-only results). Including capabilities, attributes, or commands auto-promotes the response to detailed mode (those fields require detailed-mode device introspection). Project out currentStates and attributes to skip expensive hub reads; capabilities and commands are in-memory and cheap."],
+                    cursor: [type: "string", description: "Opt-in opaque cursor (alias to offset). Pass \"\" for the first page (page size 50 when limit is unset), then iterate nextCursor returned alongside the existing nextOffset. Existing offset+limit shape still works; use whichever fits the caller."]
                 ]
             ]
         ],
@@ -1458,7 +1459,9 @@ At least one of expectedValue or expectedValues must be provided. If both are pr
             description: "List all MCP automation rules. Returns summary; use custom_get_rule for details. NOTE: when the Custom Rule Engine toggle is OFF, this tool operates in read-only mode -- you can list/inspect existing custom rules, but creation/structural-modification/deletion are hidden. The custom MCP rule engine is legacy; for new rule work prefer native Rule Machine via manage_native_rules_and_apps.",
             inputSchema: [
                 type: "object",
-                properties: [:]
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit to get the full rules list. Pass \"\" for the first page, iterate nextCursor (page size 50)."]
+                ]
             ]
         ],
         [
@@ -1572,7 +1575,12 @@ Verify rule after creation.""",
         [
             name: "list_variables",
             description: "List all hub variables (every type, including ones without connectors) and rule-engine variables. Each hub-variable entry includes type (Number/Decimal/String/Boolean/DateTime), value, and connector linkage (deviceId/attribute) when present.",
-            inputSchema: [type: "object", properties: [:]]
+            inputSchema: [
+                type: "object",
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor for the hubVariables list (ruleVariables stays in full alongside the page). Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 100)."]
+                ]
+            ]
         ],
         [
             name: "get_variable",
@@ -1693,7 +1701,12 @@ Verify rule after creation.""",
         [
             name: "list_captured_states",
             description: "List captured device states. Storage limit configurable (default 20); oldest auto-deleted when full.",
-            inputSchema: [type: "object", properties: [:]]
+            inputSchema: [
+                type: "object",
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 50)."]
+                ]
+            ]
         ],
         [
             name: "delete_captured_state",
@@ -1722,7 +1735,8 @@ Verify rule after creation.""",
                     limit: [type: "integer", description: "Max entries to return (default: 50, max: 200)"],
                     level: [type: "string", enum: ["debug", "info", "warn", "error", "all"], description: "Filter by log level (default: all)"],
                     component: [type: "string", description: "Filter by component (e.g., 'server', 'rule')"],
-                    ruleId: [type: "string", description: "Filter by specific rule ID"]
+                    ruleId: [type: "string", description: "Filter by specific rule ID"],
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Filters and limit apply first; cursor pages within the filtered result. Pass \"\" for the first page, iterate nextCursor (page size 100)."]
                 ]
             ]
         ],
@@ -1834,7 +1848,9 @@ Verify rule after creation.""",
             description: "List all installed apps on the hub (not just MCP rules). Requires Hub Admin Read.",
             inputSchema: [
                 type: "object",
-                properties: [:]
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 50)."]
+                ]
             ]
         ],
         [
@@ -1842,7 +1858,9 @@ Verify rule after creation.""",
             description: "List all installed drivers on the hub. Requires Hub Admin Read.",
             inputSchema: [
                 type: "object",
-                properties: [:]
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 50)."]
+                ]
             ]
         ],
         [
@@ -1897,7 +1915,8 @@ Verify rule after creation.""",
                     patterns: [type: "array", items: [type: "string"], description: "Multiple regex patterns applied to the log message field only -- use source for app/device-name substring matching. Use with patternMode to control AND/OR logic. Each pattern compiled once. Throws on invalid regex syntax. Compatible with pattern (both apply). Note: pathological regex like (.*)*  may hang the matcher; prefer simple alternation (error|fail) or anchored prefixes."],
                     patternMode: [type: "string", description: "How patterns array is combined: 'any' (default) = OR -- entry kept if any pattern matches; 'all' = AND -- entry kept only if every pattern matches. Case-insensitive ('ANY' and 'any' both work).", enum: ["any", "all"]],
                     since: [type: "string", description: "Return only entries at or after this time. Accepts ISO-8601 timestamp (e.g. '2024-01-15T10:30:00Z') or relative offset (e.g. '30m', '2h', '1d', '7d'). Relative offset is subtracted from now. Max relative offset: 30d (throws if exceeded -- use ISO-8601 for longer ranges). Timestamps without a TZ marker (e.g. '2024-01-15T10:30:00' or '2024-01-15 10:30:00.000') are parsed as UTC. Use '0m' / '0d' as a degenerate since to filter out everything older than now -- useful for testing harnesses but rarely otherwise."],
-                    until: [type: "string", description: "Return only entries at or before this time. Same format as since (relative offsets are subtracted from now, same as since; max 30d). Default: now (no upper bound). Use since='2h', until='1h' to mean '1 to 2 hours ago'."]
+                    until: [type: "string", description: "Return only entries at or before this time. Same format as since (relative offsets are subtracted from now, same as since; max 30d). Default: now (no upper bound). Use since='2h', until='1h' to mean '1 to 2 hours ago'."],
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Filters + limit apply first; cursor pages within the filtered result. Pass \"\" for the first page, iterate nextCursor (page size 100)."]
                 ]
             ]
         ],
@@ -1946,7 +1965,8 @@ Verify rule after creation.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    limit: [type: "integer", description: "Max entries to return (most recent). Default: 100, 0 for all. Hub may have thousands of entries.", default: 100]
+                    limit: [type: "integer", description: "Max entries to return (most recent). Default: 100, 0 for all. Hub may have thousands of entries.", default: 100],
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Pages within the limit-filtered entries (limit=0 + cursor pages the full ring buffer). Pass \"\" for the first page, iterate nextCursor (page size 100)."]
                 ]
             ]
         ],
@@ -2071,7 +2091,9 @@ action="delete": Provide deviceNetworkId of device to delete. Use list_virtual_d
             description: "List MCP-managed virtual devices (children of this app). Response: {devices: [...], count, message}. Per-device fields: id, name, label, deviceNetworkId, driverNamespace (authoritative for devices created by this tool -- the namespace is persisted at create time; for devices created before this version or by other means it falls back to a best-effort derivation that may report 'hubitat'), driverType (driver type name), typeName (deprecated alias for driverType -- prefer driverType), capabilities, commands, currentStates (map of attribute-name to current-value -- note: create uses attributes as a list while list uses currentStates as a map; both expose device state but under different shapes because create returns the freshly-read attribute list and list returns a compact state map).",
             inputSchema: [
                 type: "object",
-                properties: [:]
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 50)."]
+                ]
             ]
         ],
         [
@@ -2100,7 +2122,12 @@ Only modify devices user explicitly requested. Room/enabled require Hub Admin Wr
         [
             name: "list_rooms",
             description: "List all rooms with IDs, names, and device counts.",
-            inputSchema: [type: "object", properties: [:]]
+            inputSchema: [
+                type: "object",
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 100)."]
+                ]
+            ]
         ],
         [
             name: "get_room",
@@ -2430,7 +2457,9 @@ Tell user library name/ID, warn it's permanent, get confirmation. Requires Hub A
             description: "List auto-created source backups from app/driver modifications. Stored in File Manager, max 20 kept.",
             inputSchema: [
                 type: "object",
-                properties: [:],
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 50)."]
+                ],
                 required: []
             ]
         ],
@@ -2463,7 +2492,9 @@ Tell user library name/ID, warn it's permanent, get confirmation. Requires Hub A
             description: "List files in hub's File Manager. Returns names, sizes, download URLs.",
             inputSchema: [
                 type: "object",
-                properties: [:]
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 100)."]
+                ]
             ]
         ],
         [
@@ -2533,7 +2564,8 @@ Returns: deviceId, deviceName, appsUsing array (each entry: id, name=app type, l
             inputSchema: [
                 type: "object",
                 properties: [
-                    deviceId: [type: "string", description: "Device ID from list_devices"]
+                    deviceId: [type: "string", description: "Device ID from list_devices"],
+                    cursor: [type: "string", description: "Opt-in pagination cursor for the appsUsing list. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 100)."]
                 ],
                 required: ["deviceId"]
             ]
@@ -2597,7 +2629,8 @@ Requires Hub Admin Read. HPM itself must be installed.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    hpmAppId: [type: "string", description: "HPM's installed-app ID (decimal). Auto-discovered if omitted by scanning installed apps for type='Hubitat Package Manager'. Pass explicitly to skip the discovery call."]
+                    hpmAppId: [type: "string", description: "HPM's installed-app ID (decimal). Auto-discovered if omitted by scanning installed apps for type='Hubitat Package Manager'. Pass explicitly to skip the discovery call."],
+                    cursor: [type: "string", description: "Opt-in pagination cursor for the packages list. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 25 -- HPM entries carry full app/driver/file inventories so each entry can be large)."]
                 ]
             ]
         ],
@@ -2640,7 +2673,9 @@ Requires Hub Admin Read. HPM itself must be installed.""",
             description: "List all Rule Machine rules (RM 4.x + 5.x, deduplicated by id). Returns rule IDs and labels. Requires Built-in App Tools enabled. See get_tool_guide section=builtin_app_tools for details and platform limitations on RM rule internals.",
             inputSchema: [
                 type: "object",
-                properties: [:]
+                properties: [
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 50)."]
+                ]
             ]
         ],
         [
@@ -3222,7 +3257,7 @@ def executeTool(toolName, args) {
     }
     switch (toolName) {
         // Device Tools
-        case "list_devices": return toolListDevices(args.detailed, args.offset ?: 0, args.limit ?: 0, args.filter, args.labelFilter, args.capabilityFilter, args.format, args.fields)
+        case "list_devices": return toolListDevices(args.detailed, args.offset ?: 0, args.limit ?: 0, args.filter, args.labelFilter, args.capabilityFilter, args.format, args.fields, args.cursor)
         case "get_device": return toolGetDevice(args.deviceId)
         case "send_command": return toolSendCommand(args.deviceId, args.command, args.parameters)
         case "get_device_events": return toolGetDeviceEvents(args.deviceId, args.limit != null ? args.limit : 10)
@@ -3230,7 +3265,7 @@ def executeTool(toolName, args) {
         case "poll_until_attribute": return toolPollUntilAttribute(args)
 
         // Rule Management - now using child apps
-        case "custom_list_rules": return toolListRules()
+        case "custom_list_rules": return toolListRules(args)
         case "custom_get_rule": return toolGetRule(args.ruleId)
         case "custom_create_rule": return toolCreateRule(args)
         case "custom_update_rule": return toolUpdateRule(args.ruleId, args, customEngineMode)
@@ -3242,7 +3277,7 @@ def executeTool(toolName, args) {
         case "get_hub_info": return toolGetHubInfo(args)
         case "get_modes": return toolGetModes()
         case "set_mode": return toolSetMode(args.mode)
-        case "list_variables": return toolListVariables()
+        case "list_variables": return toolListVariables(args)
         case "get_variable": return toolGetVariable(args.name)
         case "set_variable": return toolSetVariable(args.name, args.value)
         case "create_variable": return toolCreateVariable(args)
@@ -3255,7 +3290,7 @@ def executeTool(toolName, args) {
         case "set_hsm": return toolSetHsm(args.mode)
 
         // Captured State Management
-        case "list_captured_states": return toolListCapturedStates()
+        case "list_captured_states": return toolListCapturedStates(args)
         case "delete_captured_state": return toolDeleteCapturedState(args.stateId)
         case "clear_captured_states": return toolClearCapturedStates()
 
@@ -3308,7 +3343,7 @@ def executeTool(toolName, args) {
         case "update_device": return toolUpdateDevice(args)
 
         // Room Management
-        case "list_rooms": return toolListRooms()
+        case "list_rooms": return toolListRooms(args)
         case "get_room": return toolGetRoom(args.room)
         case "create_room": return toolCreateRoom(args)
         case "delete_room": return toolDeleteRoom(args)
@@ -3335,12 +3370,12 @@ def executeTool(toolName, args) {
         case "delete_library": return toolDeleteLibrary(args)
 
         // Item Backup Tools
-        case "list_item_backups": return toolListItemBackups()
+        case "list_item_backups": return toolListItemBackups(args)
         case "get_item_backup": return toolGetItemBackup(args)
         case "restore_item_backup": return toolRestoreItemBackup(args)
 
         // File Manager Tools
-        case "list_files": return toolListFiles()
+        case "list_files": return toolListFiles(args)
         case "read_file": return toolReadFile(args)
         case "write_file": return toolWriteFile(args)
         case "delete_file": return toolDeleteFile(args)
@@ -3417,7 +3452,26 @@ def executeTool(toolName, args) {
 
 // ==================== DEVICE TOOLS ====================
 
-def toolListDevices(detailed, offset, limit, filter = null, labelFilter = null, capabilityFilter = null, format = null, fields = null) {
+def toolListDevices(detailed, offset, limit, filter = null, labelFilter = null, capabilityFilter = null, format = null, fields = null, cursor = null) {
+    // Opt-in cursor pagination decodes onto the same offset/limit mechanics; when
+    // cursor is supplied it overrides offset (page size 50 by default).
+    if (cursor != null) {
+        // Page size is fixed in cursor mode so nextCursor arithmetic is deterministic.
+        // Callers who want a different page size can use the existing offset+limit pair.
+        final int cursorPageSize = 50
+        if (!limit || limit <= 0) limit = cursorPageSize
+        // _parseListCursor needs the post-filter total, which we don't have yet. Defer
+        // strict bounds check to inside the function: parse the cursor as an integer
+        // here so non-numeric values still fail at the API boundary with a clear -32602.
+        int parsedOffset
+        try {
+            parsedOffset = (cursor as String).toInteger()
+        } catch (NumberFormatException ignored) {
+            throw new IllegalArgumentException("cursor must be the opaque string returned by a prior list_devices nextCursor (got: ${cursor})")
+        }
+        if (parsedOffset < 0) throw new IllegalArgumentException("cursor ${cursor} is out of range (must be >= 0)")
+        offset = parsedOffset
+    }
     // Combine selected devices and MCP-managed child devices (virtual devices)
     def allDevices = (selectedDevices ?: []).toList()
     def childDevs = getChildDevices() ?: []
@@ -3568,6 +3622,9 @@ def toolListDevices(detailed, offset, limit, filter = null, labelFilter = null, 
             result.limit = limit
             result.hasMore = endIndex < totalCount
             if (endIndex < totalCount) result.nextOffset = endIndex
+            // Cursor mode also emits nextCursor (opaque string) alongside nextOffset so a
+            // client iterating cursor sees the same shape used by other paginated tools.
+            if (cursor != null && endIndex < totalCount) result.nextCursor = endIndex.toString()
         }
         return result
     }
@@ -3669,6 +3726,7 @@ def toolListDevices(detailed, offset, limit, filter = null, labelFilter = null, 
         if (endIndex < totalCount) {
             result.nextOffset = endIndex
         }
+        if (cursor != null && endIndex < totalCount) result.nextCursor = endIndex.toString()
     }
 
     return result
@@ -4124,7 +4182,7 @@ def toolPollUntilAttribute(args) {
 
 // ==================== RULE TOOLS (Child App Based) ====================
 
-def toolListRules() {
+def toolListRules(args = null) {
     def childApps = getChildApps()
     def rules = childApps?.collect { childApp ->
         def ruleData = childApp.getRuleData()
@@ -4143,7 +4201,14 @@ def toolListRules() {
         ]
     }?.findAll { it != null } ?: []
 
-    return [rules: rules, count: rules.size()]
+    def cursor = args?.cursor
+    def paged = _paginateList(rules, cursor, 50, "custom_list_rules")
+    def result = [rules: paged.page, count: paged.page.size()]
+    if (cursor != null) {
+        result.total = rules.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
+    return result
 }
 
 def toolGetRule(ruleId) {
@@ -4976,7 +5041,7 @@ def toolSetMode(modeName) {
     ]
 }
 
-def toolListVariables() {
+def toolListVariables(args = null) {
     // Modern Hub Variable API (issue #92): getAllGlobalVars() sees every hub
     // variable, not just the connector-exposed subset that the legacy
     // getAllGlobalConnectorVariables() returned. Each entry is shaped like
@@ -5005,11 +5070,21 @@ def toolListVariables() {
         [name: name, value: value, source: "rule_engine"]
     } ?: []
 
-    return [
-        hubVariables: hubVariables,
+    // Cursor paginates the hubVariables list -- the typical "what's defined on the hub"
+    // caller cares about hub vars first; ruleVariables stays in full alongside the page
+    // so paginating callers don't lose visibility into the engine-managed set.
+    def cursor = args?.cursor
+    def paged = _paginateList(hubVariables, cursor, 100, "list_variables")
+    def result = [
+        hubVariables: paged.page,
         ruleVariables: ruleVariables,
         total: hubVariables.size() + ruleVariables.size()
     ]
+    if (cursor != null) {
+        result.totalHubVariables = hubVariables.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
+    return result
 }
 
 def toolGetVariable(name) {
@@ -5859,16 +5934,22 @@ def toolSetHsm(mode) {
 
 // ==================== CAPTURED STATE TOOLS ====================
 
-def toolListCapturedStates() {
+def toolListCapturedStates(args = null) {
     def states = listCapturedStates()
     def count = states.size()
+    def cursor = args?.cursor
+    def paged = _paginateList(states, cursor, 50, "list_captured_states")
     def result = [
-        capturedStates: states,
-        count: count,
+        capturedStates: paged.page,
+        count: paged.page.size(),
         maxLimit: getMaxCapturedStates()
     ]
+    if (cursor != null) {
+        result.total = count
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
 
-    // Add warnings when approaching or at limit
+    // Add warnings when approaching or at limit (always reported regardless of pagination)
     if (count >= getMaxCapturedStates()) {
         result.warning = "At maximum capacity (${getMaxCapturedStates()}). New captures will delete the oldest entry."
     } else if (count >= getMaxCapturedStates() - 4) {
@@ -6925,7 +7006,7 @@ def backupItemSource(String type, String id) {
  * Metadata is in atomicState.itemBackupManifest; actual source files are in File Manager.
  * Does not require Hub Admin Read/Write — always available.
  */
-def toolListItemBackups() {
+def toolListItemBackups(args = null) {
     def manifest = atomicState.itemBackupManifest ?: [:]
 
     if (manifest.isEmpty()) {
@@ -6965,14 +7046,18 @@ def toolListItemBackups() {
         return base
     }.sort { a, b -> (b.timestampEpoch <=> a.timestampEpoch) } // Newest first
 
-    return [
-        backups: backupList,
+    def cursor = args?.cursor
+    def paged = _paginateList(backupList, cursor, 50, "list_item_backups")
+    def result = [
+        backups: paged.page,
         total: backupList.size(),
         maxBackups: 20,
         storage: "Backup files are stored in the hub's local File Manager (Settings > File Manager). Files persist even if MCP is uninstalled.",
         howToRestore: "Use 'restore_item_backup' with a backupKey to restore apps/drivers via MCP. For library backups, use 'update_library_code' with sourceFile mode instead. Or download the .groovy file from File Manager and paste it into Apps Code / Drivers Code / Libraries code manually.",
         manualRestore: "Go to Hubitat > Settings > File Manager to see backup files. Download a file, then go to Apps Code (or Drivers Code, or FOR DEVELOPERS > Libraries code) > select the item > paste the source > click Save."
     ]
+    if (cursor != null && paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    return result
 }
 
 /**
@@ -7226,8 +7311,9 @@ def toolRestoreItemBackup(args) {
  * Lists all files in the hub's local File Manager.
  * Uses the hub internal API to query the file list.
  */
-def toolListFiles() {
+def toolListFiles(args = null) {
     mcpLog("debug", "file-manager", "Listing files in File Manager")
+    def cursor = args?.cursor
 
     // Try known File Manager API endpoints (varies by firmware version)
     def endpoints = ["/hub/fileManager/json", "/hub/fileManager"]
@@ -7290,11 +7376,14 @@ def toolListFiles() {
         fileList = fileList.sort { a, b -> (a.name <=> b.name) }
 
         mcpLog("info", "file-manager", "Listed ${fileList.size()} files in File Manager (via ${endpointUsed})")
-        return [
-            files: fileList,
+        def pagedFM = _paginateList(fileList, cursor, 100, "list_files")
+        def res = [
+            files: pagedFM.page,
             total: fileList.size(),
             storage: "Files are stored locally on the hub's file system. Access via http://<HUB_IP>/local/<filename> or Hubitat > Settings > File Manager."
         ]
+        if (cursor != null && pagedFM.nextCursor != null) res.nextCursor = pagedFM.nextCursor
+        return res
     } catch (Exception jsonErr) {
         // Response wasn't JSON — might be HTML File Manager page
         mcpLog("debug", "file-manager", "Response from ${endpointUsed} was not JSON: ${jsonErr.message}")
@@ -7316,12 +7405,15 @@ def toolListFiles() {
         if (fileList) {
             fileList = fileList.sort { a, b -> (a.name <=> b.name) }
             mcpLog("info", "file-manager", "Listed ${fileList.size()} files from File Manager HTML page")
-            return [
-                files: fileList,
+            def pagedHtml = _paginateList(fileList, cursor, 100, "list_files")
+            def res = [
+                files: pagedHtml.page,
                 total: fileList.size(),
                 note: "File list extracted from File Manager HTML page. Sizes not available. Use Hubitat > Settings > File Manager for full details.",
                 storage: "Files are stored locally on the hub's file system. Access via http://<HUB_IP>/local/<filename> or Hubitat > Settings > File Manager."
             ]
+            if (cursor != null && pagedHtml.nextCursor != null) res.nextCursor = pagedHtml.nextCursor
+            return res
         }
 
         return [
@@ -7671,27 +7763,35 @@ def toolGetDebugLogs(args) {
     def count = Math.min(limit, logs.size())
     logs = logs.drop(Math.max(0, logs.size() - count))
 
-    return [
-        entries: logs.collect { entry ->
-            def result = [
-                timestamp: entry.timestamp,
-                time: formatTimestamp(entry.timestamp),
-                level: entry.level,
-                component: entry.component,
-                message: entry.message
-            ]
-            if (entry.ruleId) result.ruleId = entry.ruleId
-            if (entry.ruleName) result.ruleName = entry.ruleName
-            if (entry.duration) result.durationMs = entry.duration
-            if (entry.stackTrace) result.stackTrace = entry.stackTrace
-            if (entry.details) result.details = entry.details
-            return result
-        },
-        count: logs.size(),
+    def materialized = logs.collect { entry ->
+        def e = [
+            timestamp: entry.timestamp,
+            time: formatTimestamp(entry.timestamp),
+            level: entry.level,
+            component: entry.component,
+            message: entry.message
+        ]
+        if (entry.ruleId) e.ruleId = entry.ruleId
+        if (entry.ruleName) e.ruleName = entry.ruleName
+        if (entry.duration) e.durationMs = entry.duration
+        if (entry.stackTrace) e.stackTrace = entry.stackTrace
+        if (entry.details) e.details = entry.details
+        return e
+    }
+    def cursor = args?.cursor
+    def paged = _paginateList(materialized, cursor, 100, "get_debug_logs")
+    def result = [
+        entries: paged.page,
+        count: paged.page.size(),
         totalStored: state.debugLogs.entries?.size() ?: 0,
         maxEntries: state.debugLogs.config?.maxEntries ?: 100,
         currentLogLevel: getConfiguredLogLevel()
     ]
+    if (cursor != null) {
+        result.total = materialized.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
+    return result
 }
 
 def toolClearDebugLogs(args) {
@@ -8195,6 +8295,7 @@ def toolGetHubDetails(args) {
 def toolListHubApps(args) {
     requireHubAdminRead()
 
+    def cursor = args?.cursor
     def result = [:]
     try {
         def responseText = hubInternalGet("/hub2/userAppTypes")
@@ -8226,6 +8327,14 @@ def toolListHubApps(args) {
         result.note = "Hub internal API unavailable (${e.message}). Showing only MCP Rule Server apps. This may require Hub Security credentials or a firmware update."
     }
 
+    if (cursor != null && result.apps instanceof List) {
+        def paged = _paginateList(result.apps, cursor, 50, "list_hub_apps")
+        result.total = result.apps.size()
+        result.apps = paged.page
+        result.count = paged.page.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
+
     mcpLog("info", "hub-admin", "Listed hub apps (source: ${result.source})")
     return result
 }
@@ -8233,6 +8342,7 @@ def toolListHubApps(args) {
 def toolListHubDrivers(args) {
     requireHubAdminRead()
 
+    def cursor = args?.cursor
     def result = [:]
     try {
         def responseText = hubInternalGet("/hub2/userDeviceTypes")
@@ -8257,6 +8367,14 @@ def toolListHubDrivers(args) {
         result.count = 0
         result.source = "unavailable"
         result.note = "Hub internal API unavailable (${e.message}). This may require Hub Security credentials or a firmware update."
+    }
+
+    if (cursor != null && result.drivers instanceof List) {
+        def paged = _paginateList(result.drivers, cursor, 50, "list_hub_drivers")
+        result.total = result.drivers.size()
+        result.drivers = paged.page
+        result.count = paged.page.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
     }
 
     mcpLog("info", "hub-admin", "Listed hub drivers (source: ${result.source})")
@@ -8825,11 +8943,20 @@ def toolGetHubLogs(args) {
     }
 
     // Truncation safety for 128KB cloud limit
-    def result = [logs: logs, count: logs.size(), totalParsed: totalParsed]
-    // Estimate JSON size without serializing: ~120 bytes per log entry overhead
-    def estimatedJsonSize = logs.sum(0) { (it.message?.length() ?: 0) + (it.name?.length() ?: 0) + 120 }
+    def cursor = args?.cursor
+    def fullLogs = logs.toList()
+    def paged = _paginateList(fullLogs, cursor, 100, "get_hub_logs")
+    def result = [logs: paged.page, count: paged.page.size(), totalParsed: totalParsed]
+    if (cursor != null) {
+        result.total = fullLogs.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
+    // Per-entry truncation is independent of cursor pagination: cursor bounds the entry
+    // count, the per-message take(200) bounds the message body so a single oversized
+    // entry can't push the page past the cap on its own.
+    def estimatedJsonSize = paged.page.sum(0) { (it.message?.length() ?: 0) + (it.name?.length() ?: 0) + 120 }
     if (estimatedJsonSize > 120000) {
-        logs.each { it.message = it.message?.take(200) }
+        paged.page.each { it.message = it.message?.take(200) }
         result.truncated = true
         result.note = "Log messages truncated to fit response size limit"
     }
@@ -9280,8 +9407,21 @@ def toolGetMemoryHistory(args) {
         summary.showing = "${entries.size()} of ${allEntries.size()} (most recent)"
     }
 
-    mcpLog("info", "diagnostics", "Memory history retrieved: ${entries.size()} entries (${allEntries.size()} total)")
-    return [entries: entries, summary: summary]
+    // Cursor pagination is an alternative to `limit` for callers who want the FULL
+    // ring buffer for trend analysis but need it in bounded pages. `limit` still trims
+    // the candidate pool first so the two controls compose: paginate within the most
+    // recent N entries by passing both, or paginate the whole buffer by passing
+    // `limit=0`.
+    def cursor = args?.cursor
+    def paged = _paginateList(entries, cursor, 100, "get_memory_history")
+    def result = [entries: paged.page, summary: summary]
+    if (cursor != null) {
+        result.total = entries.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
+
+    mcpLog("info", "diagnostics", "Memory history retrieved: ${paged.page.size()} entries (${allEntries.size()} total)")
+    return result
 }
 
 def toolForceGarbageCollection(args) {
@@ -11645,11 +11785,18 @@ def toolListVirtualDevices(args) {
         return info
     }
 
-    return [
-        devices: devices,
-        count: devices.size(),
+    def cursor = args?.cursor
+    def paged = _paginateList(devices, cursor, 50, "list_virtual_devices")
+    def result = [
+        devices: paged.page,
+        count: paged.page.size(),
         message: "Found ${devices.size()} MCP-managed virtual device(s). These are automatically accessible to all MCP device tools."
     ]
+    if (cursor != null) {
+        result.total = devices.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
+    return result
 }
 
 def toolDeleteVirtualDevice(args) {
@@ -12051,7 +12198,7 @@ def toolUpdateDevice(args) {
 
 // ==================== ROOM MANAGEMENT ====================
 
-def toolListRooms() {
+def toolListRooms(args = null) {
     def rooms = getRooms()
     if (!rooms) {
         return [rooms: [], count: 0, message: "No rooms configured on this hub."]
@@ -12064,7 +12211,14 @@ def toolListRooms() {
             deviceIds: room.deviceIds?.collect { it.toString() } ?: []
         ]
     }.sort { it.name }
-    return [rooms: roomList, count: roomList.size()]
+    def cursor = args?.cursor
+    def paged = _paginateList(roomList, cursor, 100, "list_rooms")
+    def result = [rooms: paged.page, count: paged.page.size()]
+    if (cursor != null) {
+        result.total = roomList.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
+    return result
 }
 
 def toolGetRoom(String roomIdentifier) {
@@ -12509,24 +12663,32 @@ def toolGetDeviceInUseBy(args) {
             count = appsUsing.size()
         }
 
-        return [
+        def appsUsingList = appsUsing.collect { a ->
+            [
+                id: a?.id,
+                name: a?.name,         // app type name (e.g. "Room Lights", "Rule-5.1")
+                label: a?.label,       // user-visible label, may include HTML decoration
+                trueLabel: a?.trueLabel,  // label stripped of HTML (null if same as label)
+                disabled: a?.disabled == true
+            ]
+        }
+        def cursor = args?.cursor
+        def paged = _paginateList(appsUsingList, cursor, 100, "get_device_in_use_by")
+        def result = [
             deviceId: deviceId,
             // extraBreadcrumb is the canonical UI breadcrumb label; fall back to .name or
             // .label if a future firmware drops that field so callers still get a usable
             // device-name string instead of silent null.
             deviceName: parsed?.extraBreadcrumb ?: parsed?.name ?: parsed?.label,
-            appsUsing: appsUsing.collect { a ->
-                [
-                    id: a?.id,
-                    name: a?.name,         // app type name (e.g. "Room Lights", "Rule-5.1")
-                    label: a?.label,       // user-visible label, may include HTML decoration
-                    trueLabel: a?.trueLabel,  // label stripped of HTML (null if same as label)
-                    disabled: a?.disabled == true
-                ]
-            },
+            appsUsing: paged.page,
             count: count,
             parentApp: parsed?.parentApp
         ]
+        if (cursor != null) {
+            result.total = appsUsingList.size()
+            if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+        }
+        return result
     } catch (Exception e) {
         mcpLog("error", "installed-apps", "get_device_in_use_by failed for device ${deviceId}: ${e.message}")
         return [success: false, error: "Failed: ${e.message}", note: "Verify the device ID is valid and Built-in App Tools is enabled."]
@@ -12825,12 +12987,18 @@ def toolListHpmPackages(args) {
         pkg
     }.findAll { it != null }
 
+    def cursor = args?.cursor
+    def paged = _paginateList(packages, cursor, 25, "list_hpm_packages")
     def result = [
         success   : true,
         hpmAppId  : hpmAppId,
-        count     : packages.size(),
-        packages  : packages
+        count     : paged.page.size(),
+        packages  : paged.page
     ]
+    if (cursor != null) {
+        result.total = packages.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
     if (skippedMalformed) result.skippedMalformed = skippedMalformed
     return result
 }
@@ -13249,12 +13417,20 @@ def toolListRmRules(args) {
         mcpLog("warn", "rm-interop", "list_rm_rules: could not cross-check RMUtils output against /hub2/appsList (${e.message}); returning unfiltered")
     }
 
-    def rules = combined.values().sort { it.label ?: "" }
+    // combined.values() returns a Collection view in some Groovy versions; materialize
+    // as a concrete List via toList() so subList in _paginateList is safe.
+    def rules = combined.values().sort { it.label ?: "" }.toList()
 
+    def cursor = args?.cursor
+    def paged = _paginateList(rules, cursor, 50, "list_rm_rules")
     def result = [
-        rules: rules,
-        count: rules.size()
+        rules: paged.page,
+        count: paged.page.size()
     ]
+    if (cursor != null) {
+        result.total = rules.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
+    }
     if (ghostIds) {
         result.ghostsFiltered = ghostIds.sort()
         result.ghostNote = "RMUtils reported ${ghostIds.size()} rule id(s) that no longer exist in /hub2/appsList — these are post-delete RMUtils-cache ghosts (rule is already gone, the cache just hasn't caught up). Filtered out of the rules list."

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -729,33 +729,60 @@ def handleToolsCall(msg) {
 
     try {
         def result = executeTool(toolName, args)
-        // Universal fail-soft size guard for issue #174. Hub enforces a 128KB cap on
-        // JSON-RPC responses; once the result is serialized + text-escaped + wrapped in
-        // the MCP content envelope + the JSON-RPC envelope, the hub will return -32603
-        // (Internal error) without the catalog/result if we cross that. We threshold the
-        // inner-result JSON below the cap so the post-escape wire size still fits, and
-        // replace oversized results with a structured envelope the LLM can react to
-        // (filter narrower, pass cursor, set includeSettings=false, etc.) rather than
-        // having the call disappear into a hub error. Inlined `final int` because the
-        // Hubitat app-DSL rejects `private static final` at top level -- see
-        // handleToolsList for the same constraint.
-        final int responseSizeLimit = 110000
-        def jsonText = groovy.json.JsonOutput.toJson(result)
-        int bytes = jsonText.getBytes("UTF-8").length
-        if (bytes > responseSizeLimit) {
-            // For gateway-routed calls (manage_*), the inner sub-tool name appears in
-            // args.tool — use it for the suggestion lookup so the LLM gets the specific
-            // recovery hint (filter narrower, drop includeSettings, use saveAs, etc.)
-            // rather than a generic gateway-level message. The reported `tool` field
-            // surfaces the sub-tool when present so the LLM can immediately re-issue
-            // a narrower call without rediscovering which gateway it routed through.
-            String hintTool = (args?.tool instanceof String && args.tool) ? args.tool : toolName
-            mcpLog("warn", "server", "Tool ${hintTool} response too large (${bytes} > ${responseSizeLimit} bytes) -- returning response_too_large envelope", null, [
-                details: [tool: hintTool, gateway: (hintTool != toolName) ? toolName : null, bytes: bytes, limit: responseSizeLimit]
+        // Null result is always an internal tool bug -- surface it as a structured
+        // isError envelope instead of letting JsonOutput render the literal string
+        // "null" into the wire payload (which looks like a normal tool result).
+        if (result == null) {
+            mcpLog("error", "server", "Tool ${toolName} returned null -- internal tool bug", null, [details: [tool: toolName]])
+            return jsonRpcResult(msg.id, [
+                content: [[type: "text", text: groovy.json.JsonOutput.toJson([
+                    isError: true, error: "Tool ${toolName} returned no result", tool: toolName
+                ])]],
+                isError: true
             ])
-            jsonText = groovy.json.JsonOutput.toJson(_responseTooLargeEnvelope(hintTool, bytes, responseSizeLimit))
         }
-        return jsonRpcResult(msg.id, [content: [[type: "text", text: jsonText]]])
+        def jsonText
+        try {
+            jsonText = groovy.json.JsonOutput.toJson(result)
+        } catch (Exception serErr) {
+            // Tool returned a value JsonOutput cannot encode (Closure, java.util.regex.Pattern,
+            // circular Map, etc.). Surface it as a tool bug rather than letting it look like
+            // a generic execution failure under the bottom catch.
+            mcpLog("error", "server", "Tool ${toolName} returned a non-serializable result: ${serErr.message}", null, [
+                details: [tool: toolName, resultType: result?.class?.name, error: serErr.message]
+            ])
+            return jsonRpcResult(msg.id, [
+                content: [[type: "text", text: groovy.json.JsonOutput.toJson([
+                    isError: true,
+                    error: "Tool ${toolName} returned a result the JSON serializer cannot encode",
+                    cause: serErr.message,
+                    resultType: result?.class?.name,
+                    note: "Internal tool bug -- report with the tool name and arguments used."
+                ])]],
+                isError: true
+            ])
+        }
+        // Measure the wire-encoded response (text-escape + content/JSON-RPC envelope)
+        // rather than the raw inner result, so the guard threshold maps directly onto
+        // what handleMcpRequest's outer 128KB check measures. Sizing the inner result
+        // alone left a gap zone where escape-heavy payloads (every `"` becomes `\"`)
+        // could slip the inner guard yet still trip the outer -32603 fallback that
+        // #174 was filed to eliminate.
+        def candidateResponse = jsonRpcResult(msg.id, [content: [[type: "text", text: jsonText]]])
+        int wireBytes = groovy.json.JsonOutput.toJson(candidateResponse).getBytes("UTF-8").length
+        final int responseSizeLimit = 120000  // 8KB headroom under the 128KB hub cap
+        if (wireBytes > responseSizeLimit) {
+            // Gateway calls (manage_*) carry the real sub-tool name in args.tool; the
+            // gateway-config whitelist check rules out a non-gateway caller who happens
+            // to pass a stray `tool` arg, which would otherwise mis-route the suggestion.
+            boolean isGateway = getGatewayConfig().containsKey(toolName)
+            String hintTool = (isGateway && args?.tool instanceof String && args.tool) ? args.tool : toolName
+            mcpLog("warn", "server", "Tool ${hintTool} response too large (${wireBytes} > ${responseSizeLimit} bytes) -- returning response_too_large envelope", null, [
+                details: [tool: hintTool, gateway: (hintTool != toolName) ? toolName : null, bytes: wireBytes, limit: responseSizeLimit]
+            ])
+            return jsonRpcResult(msg.id, [content: [[type: "text", text: groovy.json.JsonOutput.toJson(_responseTooLargeEnvelope(hintTool, wireBytes, responseSizeLimit))]]])
+        }
+        return candidateResponse
     } catch (IllegalArgumentException e) {
         mcpLog("warn", "server", "Validation error in ${toolName}: ${e.message}", null, [
             details: [tool: toolName, error: e.message]
@@ -775,11 +802,8 @@ def handleToolsCall(msg) {
     }
 }
 
-// Fail-soft envelope for tools whose serialized response exceeded the hub's 128KB JSON-RPC
-// cap (see handleToolsCall guard). Carries the structured fields recommended in issue #174's
-// follow-up comment -- response_too_large + truncated + estimatedBytes + sizeLimitBytes --
-// plus a tool-specific `suggestion` so the LLM has an actionable retry shape rather than a
-// generic "too big" message. Surface is stable; new tools fall through to the default branch.
+// Returned in place of the real result when handleToolsCall trips the size guard. Shape
+// is the wire contract for the response_too_large case; keep the field names stable.
 def _responseTooLargeEnvelope(String toolName, int actualBytes, int limitBytes) {
     return [
         response_too_large: true,
@@ -791,6 +815,8 @@ def _responseTooLargeEnvelope(String toolName, int actualBytes, int limitBytes) 
     ]
 }
 
+// Tool-specific retry hints for the response_too_large envelope. New tools fall through
+// to the default branch -- only add a case when the generic hint is misleading.
 def _responseTooLargeSuggestion(String toolName) {
     switch (toolName) {
         case "list_devices":
@@ -817,30 +843,48 @@ def _responseTooLargeSuggestion(String toolName) {
         case "get_library_source":
             return "Source file exceeds the inline cap. Use list_files / read_file via the File Manager bridge, or fetch the source from version control instead."
         default:
+            // Default-branch hits are interesting telemetry -- they're the tools we should
+            // be adding specific suggestions for. info level so it only surfaces when log
+            // level is elevated for debugging.
+            mcpLog("info", "server", "response_too_large for tool ${toolName} hit the generic suggestion branch -- consider adding a specific case", null, [details: [tool: toolName]])
             return "Narrow your query (filters, smaller limit, or projection of fields) or pass cursor if this tool supports pagination."
     }
 }
 
-// Shared cursor parser for opt-in tool-level pagination. Matches the opaque-string contract
-// PR #180 established for tools/list: cursor is the numeric offset returned in a prior call's
-// nextCursor, null/"" means "start at 0", any other value is rejected with -32602. Each
-// caller still picks its own page size (the catalog uses 50; list-returning tools can pick
-// whatever keeps a typical page well under the 128KB cap).
+// Shared cursor decoder for opt-in tool-level pagination. Cursor is the opaque numeric
+// offset returned in a prior call's nextCursor; null/"" means "start at 0". Anything else
+// throws IllegalArgumentException so the dispatch layer surfaces -32602. Raw cursor is
+// sanitized before being echoed back so a defective client can't pollute the hub log.
 def _parseListCursor(cursor, int totalSize, String toolName) {
     if (cursor == null || cursor == "") return 0
+    def safeCursor = (cursor?.toString() ?: "").replaceAll(/[\r\n]/, " ").take(80)
     int offset
     try {
         offset = (cursor as String).toInteger()
     } catch (NumberFormatException ignored) {
-        throw new IllegalArgumentException("cursor must be the opaque string returned by a prior ${toolName} nextCursor (got: ${cursor})")
+        throw new IllegalArgumentException("cursor must be the opaque string returned by a prior ${toolName} nextCursor (got: ${safeCursor})")
     }
     if (offset < 0) {
-        throw new IllegalArgumentException("cursor ${cursor} is out of range (must be >= 0)")
+        throw new IllegalArgumentException("cursor ${safeCursor} is out of range (must be >= 0)")
     }
-    if (offset >= totalSize && totalSize > 0) {
-        throw new IllegalArgumentException("cursor ${cursor} is out of range (size=${totalSize})")
+    // offset==0 on an empty list is the well-defined "first page of nothing" case and is
+    // allowed; any positive cursor on an empty or fully-paged list is out-of-range. Without
+    // the `offset > 0` clause, cursor='999' against an empty list would slip through here
+    // and surface as a cryptic IllegalArgumentException from subList(999, 0) downstream.
+    if (offset > 0 && offset >= totalSize) {
+        throw new IllegalArgumentException("cursor ${safeCursor} is out of range (size=${totalSize})")
     }
     return offset
+}
+
+// Compose cursor decoding + subList + nextCursor into one place so each paginated tool
+// is a single call. cursor=null returns the whole list with no nextCursor (the opt-in
+// contract: callers who didn't ask for pagination get the legacy shape).
+def _paginateList(List fullList, cursor, int pageSize, String toolName) {
+    if (cursor == null) return [page: fullList, nextCursor: null]
+    int start = _parseListCursor(cursor, fullList.size(), toolName)
+    int end = Math.min(start + pageSize, fullList.size())
+    return [page: fullList.subList(start, end), nextCursor: end < fullList.size() ? end.toString() : null]
 }
 
 // ==================== CATEGORY GATEWAY PROXY ====================
@@ -9347,8 +9391,13 @@ def toolDeviceHealthCheck(args) {
             def lastActivity = null
             try {
                 lastActivity = device.lastActivity
+            } catch (MissingPropertyException ignored) {
+                // Expected: some device types don't expose lastActivity. Fall through to "never".
             } catch (Exception e) {
-                // Some device types may not support lastActivity
+                // Unexpected -- a sandbox tightening or device-proxy change rather than the
+                // documented MissingPropertyException case. Log so a "why are all my devices
+                // unknown" report has a breadcrumb to chase; still fall through to "never".
+                mcpLog("debug", "monitoring", "device_health_check could not read lastActivity for device ${device.id}: ${e.class.simpleName}: ${e.message}")
             }
 
             if (lastActivity) {
@@ -9372,30 +9421,22 @@ def toolDeviceHealthCheck(args) {
                 unknown << entry
             }
         } catch (Exception e) {
-            // Skip device entirely if we can't even get basic info
-            unknown << [id: device.id?.toString() ?: "unknown", name: "Error: ${e.message}", lastActivity: "error"]
+            // Skip device entirely if we can't even get basic info. Log so the failure
+            // shows up in get_debug_logs / generate_bug_report; surface errorClass on the
+            // entry so an LLM triaging the result can distinguish transient (NPE) from
+            // systemic (MissingMethodException) without re-running.
+            mcpLog("warn", "monitoring", "device_health_check failed to inspect device ${device?.id}: ${e.class.simpleName}: ${e.message}")
+            unknown << [id: device.id?.toString() ?: "unknown", name: "Error: ${e.message}", lastActivity: "error", errorClass: e.class.simpleName]
         }
     }
 
     // Sort stale by most-stale first
     stale.sort { a, b -> (b.hoursAgo ?: 0) <=> (a.hoursAgo ?: 0) }
 
-    // Opt-in cursor pagination (#174). Default behaviour (no cursor) returns the full
-    // staleDevices + unknownDevices + healthyDevices payload as before. When cursor is
-    // supplied we page the stale list at 100 per page -- the typical "what's broken on
-    // the hub" caller wants the staleDevices list, and the universal response-size guard
-    // backstops the rest. unknownDevices and (optional) healthyDevices remain present
-    // alongside the page so the summary call still works in a single request; consumers
-    // iterating nextCursor get bounded stale pages without re-doing the discovery work.
-    def stalePage = stale
-    String nextCursor = null
-    if (cursor != null) {
-        int start = _parseListCursor(cursor, stale.size(), "device_health_check")
-        final int pageSize = 100
-        int end = Math.min(start + pageSize, stale.size())
-        stalePage = stale.subList(start, end)
-        if (end < stale.size()) nextCursor = end.toString()
-    }
+    // Only the stale list gets paged -- the "what's broken" caller wants it bounded,
+    // while unknownDevices/healthyDevices stay alongside the page so the summary call
+    // still works in a single request.
+    def paged = _paginateList(stale, cursor, 100, "device_health_check")
 
     def result = [
         summary: [
@@ -9406,11 +9447,17 @@ def toolDeviceHealthCheck(args) {
             staleThresholdHours: staleHours,
             checkedAt: formatTimestamp(now())
         ],
-        staleDevices: stalePage,
+        staleDevices: paged.page,
         unknownDevices: unknown
     ]
-    if (cursor != null && nextCursor != null) {
-        result.nextCursor = nextCursor
+    if (cursor != null) {
+        // Top-level total mirrors list_installed_apps when cursor is active so a
+        // paginating client reads the same field name across tools.
+        result.total = stale.size()
+        // Distinguish "this page's stale entries" from summary.staleCount (full total),
+        // so a client iterating cursor doesn't conflate the two on size-equal hubs.
+        result.summary.staleDevicesInPage = paged.page.size()
+        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
     }
 
     if (includeHealthy) {
@@ -12388,37 +12435,28 @@ def toolListInstalledApps(args) {
             }
         }
 
-        // Opt-in cursor pagination (#174). Default behaviour (no cursor) returns the
-        // full filtered list as before -- backward-compatible. When the LLM passes
-        // cursor, we hand back a fixed-size page plus nextCursor for iteration, matching
-        // the opaque-string contract PR #180 established for tools/list. Page size 50
-        // keeps a typical page well under the 128KB cap; the universal response-size
-        // guard at handleToolsCall remains a backstop for callers who do not paginate.
-        def fullList = filtered
-        def page = fullList
-        String nextCursor = null
-        if (cursor != null) {
-            int start = _parseListCursor(cursor, fullList.size(), "list_installed_apps")
-            final int pageSize = 50
-            int end = Math.min(start + pageSize, fullList.size())
-            page = fullList.subList(start, end)
-            if (end < fullList.size()) nextCursor = end.toString()
-        }
-
+        // Cursor pagination is opt-in: callers who don't pass cursor get the full
+        // filtered list (backstopped by the response-size guard). Page size 50 keeps a
+        // page comfortably under the wire cap.
+        def paged = _paginateList(filtered, cursor, 50, "list_installed_apps")
         def result = [
-            apps: page,
-            count: page.size(),
+            apps: paged.page,
+            count: paged.page.size(),
             filter: filter,
             totalOnHub: flat.size()
         ]
         if (cursor != null) {
-            result.total = fullList.size()
-            if (nextCursor != null) result.nextCursor = nextCursor
+            result.total = filtered.size()
+            if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
         }
         return result
     } catch (IllegalArgumentException e) {
-        // Cursor validation throws IllegalArgumentException so the dispatch layer can
-        // surface it as -32602. Don't reframe as a transport failure.
+        throw e  // let cursor / arg-validation surface as -32602; don't reframe as transport failure
+    } catch (IllegalStateException e) {
+        // Programmer error -- e.g. validFilters / switch drift on the filter whitelist.
+        // Don't reframe as a transport failure; surface so the drift gets fixed instead
+        // of swallowed under a misleading "hub blip" note.
+        mcpLog("error", "installed-apps", "list_installed_apps internal invariant violated: ${e.message}")
         throw e
     } catch (Exception e) {
         // The Built-in-App-Tools gate has already passed by the time we reach here, so

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -2550,7 +2550,7 @@ Pass cursor (opaque string from a prior call's nextCursor) to page through the a
                 properties: [
                     filter: [type: "string", enum: ["all", "builtin", "user", "disabled", "parents", "children"], description: "Filter apps by category. Default: all"],
                     includeHidden: [type: "boolean", description: "Include hidden apps (typically Hubitat internal). Default: false", default: false],
-                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit to get the full filtered list in a single response (subject to the universal 110KB response-size guard -- oversized responses come back as a response_too_large envelope). Pass the nextCursor value from a prior call to fetch the next page (page size 50). Empty string is treated as no cursor."]
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit to get the full filtered list in a single response (subject to the universal 120KB response-size guard -- oversized responses come back as a response_too_large envelope). Pass the nextCursor value from a prior call to fetch the next page (page size 50). Empty string starts at the first page."]
                 ]
             ]
         ],
@@ -3453,24 +3453,22 @@ def executeTool(toolName, args) {
 // ==================== DEVICE TOOLS ====================
 
 def toolListDevices(detailed, offset, limit, filter = null, labelFilter = null, capabilityFilter = null, format = null, fields = null, cursor = null) {
-    // Opt-in cursor pagination decodes onto the same offset/limit mechanics; when
-    // cursor is supplied it overrides offset (page size 50 by default).
+    // Opt-in cursor pagination decodes onto the existing offset/limit mechanics. The
+    // real range check against the filtered total happens further down (line ~3585)
+    // because we don't have the filtered count yet; pass Integer.MAX_VALUE so the
+    // helper only does the parse + negative check. cursor='' / null returns offset 0
+    // exactly like every other paginated tool.
     if (cursor != null) {
-        // Page size is fixed in cursor mode so nextCursor arithmetic is deterministic.
-        // Callers who want a different page size can use the existing offset+limit pair.
-        final int cursorPageSize = 50
-        if (!limit || limit <= 0) limit = cursorPageSize
-        // _parseListCursor needs the post-filter total, which we don't have yet. Defer
-        // strict bounds check to inside the function: parse the cursor as an integer
-        // here so non-numeric values still fail at the API boundary with a clear -32602.
-        int parsedOffset
-        try {
-            parsedOffset = (cursor as String).toInteger()
-        } catch (NumberFormatException ignored) {
-            throw new IllegalArgumentException("cursor must be the opaque string returned by a prior list_devices nextCursor (got: ${cursor})")
+        // Reject ambiguous combinations -- a caller passing both cursor and a non-default
+        // offset is asking for two different starting points; pick one.
+        if (offset != null && (offset as Integer) > 0) {
+            throw new IllegalArgumentException("cursor and offset are mutually exclusive (got cursor=${cursor}, offset=${offset}); pick one")
         }
-        if (parsedOffset < 0) throw new IllegalArgumentException("cursor ${cursor} is out of range (must be >= 0)")
-        offset = parsedOffset
+        offset = _parseListCursor(cursor, Integer.MAX_VALUE, "list_devices")
+        // Default page size in cursor mode so nextCursor arithmetic is deterministic.
+        // Callers who want a different page size set limit explicitly (cursor still wins
+        // on offset; limit just sizes the page).
+        if (!limit || limit <= 0) limit = 50
     }
     // Combine selected devices and MCP-managed child devices (virtual devices)
     def allDevices = (selectedDevices ?: []).toList()
@@ -5048,6 +5046,7 @@ def toolListVariables(args = null) {
     // [name, type, value, deviceId, attribute] — deviceId/attribute populated
     // when the variable has a Connector device, null otherwise.
     def hubVariables = []
+    String hubVarsError = null
     try {
         def allVars = getAllGlobalVars()
         if (allVars) {
@@ -5063,27 +5062,31 @@ def toolListVariables(args = null) {
             }
         }
     } catch (Exception e) {
-        logDebug("Hub variable API not available: ${e.message}")
+        // Surface to mcpLog (not just logDebug) so a "no hub variables" response can be
+        // distinguished from "hub variable API broke" via get_debug_logs.
+        hubVarsError = e.message ?: e.toString()
+        mcpLog("warn", "variables", "list_variables: getAllGlobalVars() failed: ${hubVarsError} -- returning empty hubVariables", null, [details: [error: hubVarsError]])
     }
 
     def ruleVariables = state.ruleVariables?.collect { name, value ->
         [name: name, value: value, source: "rule_engine"]
     } ?: []
 
-    // Cursor paginates the hubVariables list -- the typical "what's defined on the hub"
-    // caller cares about hub vars first; ruleVariables stays in full alongside the page
-    // so paginating callers don't lose visibility into the engine-managed set.
     def cursor = args?.cursor
     def paged = _paginateList(hubVariables, cursor, 100, "list_variables")
+    // Both per-list totals are always emitted so a caller can distinguish "1000 hub
+    // vars + 0 rule vars" from "0 hub vars + 1000 rule vars" without needing cursor
+    // context. `total` is the legacy summed field; the per-list fields are the
+    // primary contract going forward.
     def result = [
         hubVariables: paged.page,
         ruleVariables: ruleVariables,
+        totalHubVariables: hubVariables.size(),
+        totalRuleVariables: ruleVariables.size(),
         total: hubVariables.size() + ruleVariables.size()
     ]
-    if (cursor != null) {
-        result.totalHubVariables = hubVariables.size()
-        if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
-    }
+    if (hubVarsError) result.hubVariablesError = hubVarsError
+    if (cursor != null && paged.nextCursor != null) result.nextCursor = paged.nextCursor
     return result
 }
 
@@ -7012,6 +7015,7 @@ def toolListItemBackups(args = null) {
     if (manifest.isEmpty()) {
         return [
             backups: [],
+            count: 0,
             total: 0,
             message: "No item backups exist yet. Backups are created automatically when you use update_app_code, update_driver_code, update_library_code, delete_app, delete_driver, or delete_library.",
             maxBackups: 20,
@@ -7050,6 +7054,7 @@ def toolListItemBackups(args = null) {
     def paged = _paginateList(backupList, cursor, 50, "list_item_backups")
     def result = [
         backups: paged.page,
+        count: paged.page.size(),
         total: backupList.size(),
         maxBackups: 20,
         storage: "Backup files are stored in the hub's local File Manager (Settings > File Manager). Files persist even if MCP is uninstalled.",
@@ -7374,6 +7379,14 @@ def toolListFiles(args = null) {
         }
 
         fileList = fileList.sort { a, b -> (a.name <=> b.name) }
+
+        // Shape-drift diagnostic: a non-empty parsed response that yielded zero files
+        // is almost always a firmware shape change (new top-level key, files nested
+        // deeper, etc.). Surface so a "no files" report isn't silently misread.
+        if (fileList.isEmpty() && parsed) {
+            def shapeHint = (parsed instanceof Map) ? "Map with keys=${parsed.keySet()?.take(10)?.toList()}" : parsed.class.simpleName
+            mcpLog("warn", "file-manager", "list_files: parsed response yielded zero files (${shapeHint}) -- shape may not be recognized", null, [details: [endpoint: endpointUsed, shape: shapeHint]])
+        }
 
         mcpLog("info", "file-manager", "Listed ${fileList.size()} files in File Manager (via ${endpointUsed})")
         def pagedFM = _paginateList(fileList, cursor, 100, "list_files")
@@ -8306,7 +8319,10 @@ def toolListHubApps(args) {
                 result.count = parsed instanceof List ? parsed.size() : 0
                 result.source = "hub_api"
             } catch (Exception parseErr) {
-                // Response was not JSON - return what we can
+                // Response was not JSON - return what we can. apps=[] keeps the cursor
+                // block + downstream shape consistent so a paginating caller doesn't
+                // silently lose the pagination contract on a firmware shape drift.
+                result.apps = []
                 result.rawResponse = responseText?.take(2000)
                 result.source = "hub_api_raw"
                 result.note = "Response was not JSON. This endpoint may return HTML on your firmware version."
@@ -8353,6 +8369,9 @@ def toolListHubDrivers(args) {
                 result.count = parsed instanceof List ? parsed.size() : 0
                 result.source = "hub_api"
             } catch (Exception parseErr) {
+                // Response was not JSON - return what we can. drivers=[] keeps the
+                // cursor block + downstream shape consistent.
+                result.drivers = []
                 result.rawResponse = responseText?.take(2000)
                 result.source = "hub_api_raw"
                 result.note = "Response was not JSON. This endpoint may return HTML on your firmware version."
@@ -8946,7 +8965,11 @@ def toolGetHubLogs(args) {
     def cursor = args?.cursor
     def fullLogs = logs.toList()
     def paged = _paginateList(fullLogs, cursor, 100, "get_hub_logs")
-    def result = [logs: paged.page, count: paged.page.size(), totalParsed: totalParsed]
+    // appliedLimit surfaces the limit-truncated entry count so a cursor caller can
+    // tell whether they're iterating within the full ring buffer or within a
+    // user-specified ceiling. Default limit is 100; max 500. Pair with limit=500
+    // for the largest practical full-buffer page.
+    def result = [logs: paged.page, count: paged.page.size(), totalParsed: totalParsed, appliedLimit: limit]
     if (cursor != null) {
         result.total = fullLogs.size()
         if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
@@ -9407,11 +9430,7 @@ def toolGetMemoryHistory(args) {
         summary.showing = "${entries.size()} of ${allEntries.size()} (most recent)"
     }
 
-    // Cursor pagination is an alternative to `limit` for callers who want the FULL
-    // ring buffer for trend analysis but need it in bounded pages. `limit` still trims
-    // the candidate pool first so the two controls compose: paginate within the most
-    // recent N entries by passing both, or paginate the whole buffer by passing
-    // `limit=0`.
+    // Cursor pages within the limit-trimmed candidate pool; limit=0 + cursor pages the full ring buffer.
     def cursor = args?.cursor
     def paged = _paginateList(entries, cursor, 100, "get_memory_history")
     def result = [entries: paged.page, summary: summary]
@@ -9573,9 +9592,7 @@ def toolDeviceHealthCheck(args) {
     // Sort stale by most-stale first
     stale.sort { a, b -> (b.hoursAgo ?: 0) <=> (a.hoursAgo ?: 0) }
 
-    // Only the stale list gets paged -- the "what's broken" caller wants it bounded,
-    // while unknownDevices/healthyDevices stay alongside the page so the summary call
-    // still works in a single request.
+    // Only stale is paged; unknown/healthy stay in full so the summary call still resolves in one request.
     def paged = _paginateList(stale, cursor, 100, "device_health_check")
 
     def result = [
@@ -9591,11 +9608,9 @@ def toolDeviceHealthCheck(args) {
         unknownDevices: unknown
     ]
     if (cursor != null) {
-        // Top-level total mirrors list_installed_apps when cursor is active so a
-        // paginating client reads the same field name across tools.
         result.total = stale.size()
-        // Distinguish "this page's stale entries" from summary.staleCount (full total),
-        // so a client iterating cursor doesn't conflate the two on size-equal hubs.
+        // staleDevicesInPage distinguishes the page slice from summary.staleCount (the
+        // full count) on size-equal hubs.
         result.summary.staleDevicesInPage = paged.page.size()
         if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
     }
@@ -12589,9 +12604,6 @@ def toolListInstalledApps(args) {
             }
         }
 
-        // Cursor pagination is opt-in: callers who don't pass cursor get the full
-        // filtered list (backstopped by the response-size guard). Page size 50 keeps a
-        // page comfortably under the wire cap.
         def paged = _paginateList(filtered, cursor, 50, "list_installed_apps")
         def result = [
             apps: paged.page,
@@ -12651,6 +12663,14 @@ def toolGetDeviceInUseBy(args) {
             return [success: false, error: "Failed to parse device JSON: ${parseErr.message}", note: "Device ID '${deviceId}' may not exist, or firmware changed the endpoint format."]
         }
 
+        // Defensive shape check: if firmware drifts and appsUsing arrives as a Map
+        // (or anything other than List), the collect{} below would produce all-null
+        // entries silently. Surface that loud rather than letting the paginator
+        // hand the LLM a bag of nulls.
+        if (parsed?.appsUsing != null && !(parsed.appsUsing instanceof List)) {
+            mcpLog("warn", "installed-apps", "get_device_in_use_by: appsUsing is ${parsed.appsUsing.class.simpleName} not List for device ${deviceId} -- treating as empty")
+            return [success: false, deviceId: deviceId, error: "Firmware returned unexpected appsUsing shape: ${parsed.appsUsing.class.simpleName}", note: "Hub firmware may have changed the /device/fullJson endpoint contract."]
+        }
         def appsUsing = parsed?.appsUsing ?: []
         def count
         try {
@@ -12684,6 +12704,12 @@ def toolGetDeviceInUseBy(args) {
             count: count,
             parentApp: parsed?.parentApp
         ]
+        // Surface the count/array disparity when firmware reports an appsUsingCount that
+        // doesn't match the appsUsing array length (truncation / paging signal). Caller
+        // can then decide whether to chase the missing entries via another path.
+        if (count != appsUsingList.size()) {
+            result.countMismatch = "appsUsingCount=${count} but appsUsing array carries ${appsUsingList.size()} entries -- firmware may be truncating"
+        }
         if (cursor != null) {
             result.total = appsUsingList.size()
             if (paged.nextCursor != null) result.nextCursor = paged.nextCursor

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -7383,8 +7383,10 @@ def toolListFiles(args = null) {
         // Shape-drift diagnostic: a non-empty parsed response that yielded zero files
         // is almost always a firmware shape change (new top-level key, files nested
         // deeper, etc.). Surface so a "no files" report isn't silently misread.
+        // instanceof-based labelling because .class is unreliable in the sandbox.
         if (fileList.isEmpty() && parsed) {
-            def shapeHint = (parsed instanceof Map) ? "Map with keys=${parsed.keySet()?.take(10)?.toList()}" : parsed.class.simpleName
+            def shapeHint = (parsed instanceof Map) ? "Map with keys=${parsed.keySet()?.take(10)?.toList()}" :
+                            (parsed instanceof List) ? "empty List" : "non-map non-list"
             mcpLog("warn", "file-manager", "list_files: parsed response yielded zero files (${shapeHint}) -- shape may not be recognized", null, [details: [endpoint: endpointUsed, shape: shapeHint]])
         }
 
@@ -12666,10 +12668,14 @@ def toolGetDeviceInUseBy(args) {
         // Defensive shape check: if firmware drifts and appsUsing arrives as a Map
         // (or anything other than List), the collect{} below would produce all-null
         // entries silently. Surface that loud rather than letting the paginator
-        // hand the LLM a bag of nulls.
+        // hand the LLM a bag of nulls. instanceof-based shape labelling because the
+        // Hubitat sandbox returns null for .class on parsed-Map values.
         if (parsed?.appsUsing != null && !(parsed.appsUsing instanceof List)) {
-            mcpLog("warn", "installed-apps", "get_device_in_use_by: appsUsing is ${parsed.appsUsing.class.simpleName} not List for device ${deviceId} -- treating as empty")
-            return [success: false, deviceId: deviceId, error: "Firmware returned unexpected appsUsing shape: ${parsed.appsUsing.class.simpleName}", note: "Hub firmware may have changed the /device/fullJson endpoint contract."]
+            String shape = (parsed.appsUsing instanceof Map) ? "Map" :
+                           (parsed.appsUsing instanceof String) ? "String" :
+                           (parsed.appsUsing instanceof Number) ? "Number" : "non-list"
+            mcpLog("warn", "installed-apps", "get_device_in_use_by: appsUsing is ${shape} not List for device ${deviceId} -- treating as empty")
+            return [success: false, deviceId: deviceId, error: "Firmware returned unexpected appsUsing shape: ${shape}", note: "Hub firmware may have changed the /device/fullJson endpoint contract."]
         }
         def appsUsing = parsed?.appsUsing ?: []
         def count

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -729,7 +729,33 @@ def handleToolsCall(msg) {
 
     try {
         def result = executeTool(toolName, args)
-        return jsonRpcResult(msg.id, [content: [[type: "text", text: groovy.json.JsonOutput.toJson(result)]]])
+        // Universal fail-soft size guard for issue #174. Hub enforces a 128KB cap on
+        // JSON-RPC responses; once the result is serialized + text-escaped + wrapped in
+        // the MCP content envelope + the JSON-RPC envelope, the hub will return -32603
+        // (Internal error) without the catalog/result if we cross that. We threshold the
+        // inner-result JSON below the cap so the post-escape wire size still fits, and
+        // replace oversized results with a structured envelope the LLM can react to
+        // (filter narrower, pass cursor, set includeSettings=false, etc.) rather than
+        // having the call disappear into a hub error. Inlined `final int` because the
+        // Hubitat app-DSL rejects `private static final` at top level -- see
+        // handleToolsList for the same constraint.
+        final int responseSizeLimit = 110000
+        def jsonText = groovy.json.JsonOutput.toJson(result)
+        int bytes = jsonText.getBytes("UTF-8").length
+        if (bytes > responseSizeLimit) {
+            // For gateway-routed calls (manage_*), the inner sub-tool name appears in
+            // args.tool — use it for the suggestion lookup so the LLM gets the specific
+            // recovery hint (filter narrower, drop includeSettings, use saveAs, etc.)
+            // rather than a generic gateway-level message. The reported `tool` field
+            // surfaces the sub-tool when present so the LLM can immediately re-issue
+            // a narrower call without rediscovering which gateway it routed through.
+            String hintTool = (args?.tool instanceof String && args.tool) ? args.tool : toolName
+            mcpLog("warn", "server", "Tool ${hintTool} response too large (${bytes} > ${responseSizeLimit} bytes) -- returning response_too_large envelope", null, [
+                details: [tool: hintTool, gateway: (hintTool != toolName) ? toolName : null, bytes: bytes, limit: responseSizeLimit]
+            ])
+            jsonText = groovy.json.JsonOutput.toJson(_responseTooLargeEnvelope(hintTool, bytes, responseSizeLimit))
+        }
+        return jsonRpcResult(msg.id, [content: [[type: "text", text: jsonText]]])
     } catch (IllegalArgumentException e) {
         mcpLog("warn", "server", "Validation error in ${toolName}: ${e.message}", null, [
             details: [tool: toolName, error: e.message]
@@ -747,6 +773,74 @@ def handleToolsCall(msg) {
         // MCP spec: tool execution errors are returned as successful results with isError flag
         return jsonRpcResult(msg.id, [content: [[type: "text", text: "Tool error: ${e.message}"]], isError: true])
     }
+}
+
+// Fail-soft envelope for tools whose serialized response exceeded the hub's 128KB JSON-RPC
+// cap (see handleToolsCall guard). Carries the structured fields recommended in issue #174's
+// follow-up comment -- response_too_large + truncated + estimatedBytes + sizeLimitBytes --
+// plus a tool-specific `suggestion` so the LLM has an actionable retry shape rather than a
+// generic "too big" message. Surface is stable; new tools fall through to the default branch.
+def _responseTooLargeEnvelope(String toolName, int actualBytes, int limitBytes) {
+    return [
+        response_too_large: true,
+        truncated: true,
+        estimatedBytes: actualBytes,
+        sizeLimitBytes: limitBytes,
+        tool: toolName,
+        suggestion: _responseTooLargeSuggestion(toolName)
+    ]
+}
+
+def _responseTooLargeSuggestion(String toolName) {
+    switch (toolName) {
+        case "list_devices":
+            return "Narrow with filter/labelFilter/capabilityFilter, project fields=['id','label',...], pass a smaller limit, or page with offset+limit. format='ids' is the cheapest shape."
+        case "list_installed_apps":
+            return "Set includeHidden=false (the default), narrow via filter (builtin / user / disabled / parents / children), or pass cursor to page through the apps list."
+        case "get_app_config":
+            return "Omit includeSettings -- Room Lighting / RM 5.1 apps can have 500-1000 settings keys. For multi-page apps, call list_app_pages then get_app_config with a specific pageName."
+        case "device_health_check":
+            return "Set includeHealthy=false (the default), narrow staleHours, or pass cursor to page through staleDevices."
+        case "get_memory_history":
+            return "Pass a smaller limit (e.g. 100). limit=0 returns the entire hub ring buffer which can be thousands of entries."
+        case "get_hub_logs":
+            return "Narrow with deviceId/appId/level/source/pattern, set a smaller limit, or filter by time window (since/until). The tool already truncates per-entry messages but cannot trim the entry count below the requested limit."
+        case "export_native_app":
+            return "Large app payloads can exceed the inline cap. Pass saveAs=<filename.json> to write the export to the hub File Manager instead of returning it inline."
+        case "get_hub_info":
+        case "get_hub_jobs":
+        case "get_performance_stats":
+        case "get_set_hub_metrics":
+            return "Hub status payload is unusually large -- consider polling at a lower frequency or fetching a single subsection via the matching sub-tool if available."
+        case "get_app_source":
+        case "get_driver_source":
+        case "get_library_source":
+            return "Source file exceeds the inline cap. Use list_files / read_file via the File Manager bridge, or fetch the source from version control instead."
+        default:
+            return "Narrow your query (filters, smaller limit, or projection of fields) or pass cursor if this tool supports pagination."
+    }
+}
+
+// Shared cursor parser for opt-in tool-level pagination. Matches the opaque-string contract
+// PR #180 established for tools/list: cursor is the numeric offset returned in a prior call's
+// nextCursor, null/"" means "start at 0", any other value is rejected with -32602. Each
+// caller still picks its own page size (the catalog uses 50; list-returning tools can pick
+// whatever keeps a typical page well under the 128KB cap).
+def _parseListCursor(cursor, int totalSize, String toolName) {
+    if (cursor == null || cursor == "") return 0
+    int offset
+    try {
+        offset = (cursor as String).toInteger()
+    } catch (NumberFormatException ignored) {
+        throw new IllegalArgumentException("cursor must be the opaque string returned by a prior ${toolName} nextCursor (got: ${cursor})")
+    }
+    if (offset < 0) {
+        throw new IllegalArgumentException("cursor ${cursor} is out of range (must be >= 0)")
+    }
+    if (offset >= totalSize && totalSize > 0) {
+        throw new IllegalArgumentException("cursor ${cursor} is out of range (size=${totalSize})")
+    }
+    return offset
 }
 
 // ==================== CATEGORY GATEWAY PROXY ====================
@@ -1789,7 +1883,7 @@ Verify rule after creation.""",
         ],
         [
             name: "device_health_check",
-            description: "Check device staleness and (optionally) ICMP-ping arbitrary hosts. Stale check flags MCP devices with no activity in staleHours. Ping check uses hubitat.helper.NetworkUtils.ping() to verify network reachability of any IPs in pingHosts (router, NAS, server, LAN-attached devices). Either or both may be used in a single call.",
+            description: "Check device staleness and (optionally) ICMP-ping arbitrary hosts. Stale check flags MCP devices with no activity in staleHours. Ping check uses hubitat.helper.NetworkUtils.ping() to verify network reachability of any IPs in pingHosts (router, NAS, server, LAN-attached devices). Either or both may be used in a single call. Pass cursor (opaque string from a prior nextCursor) to page the staleDevices list at 100 per page when the full response would be too large.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -1797,7 +1891,8 @@ Verify rule after creation.""",
                     includeHealthy: [type: "boolean", description: "Include healthy devices in the response (can be large). Default: false.", default: false],
                     pingHosts: [type: "array", items: [type: "string"], description: "Optional IPv4 addresses to ICMP-ping (max 5 per call). Each entry is sent through hubitat.helper.NetworkUtils.ping() and reported under pingResults with reachable/rttAvg/packetLoss. Hostnames are not resolved — pass IPs only."],
                     pingCount: [type: "integer", description: "Packets to send per host (1-5). Default: 3.", default: 3],
-                    identifyHub: [type: "boolean", description: "Blink hub LED to identify hub. Default: false.", default: false]
+                    identifyHub: [type: "boolean", description: "Blink hub LED to identify hub. Default: false.", default: false],
+                    cursor: [type: "string", description: "Opt-in pagination cursor for the staleDevices array. Omit to get all stale devices in one response (subject to the universal response-size guard). Pass nextCursor from a prior call to fetch the next page (page size 100). unknownDevices and healthyDevices are always returned in full alongside the page."]
                 ]
             ]
         ],
@@ -2372,12 +2467,15 @@ Tell user library name/ID, warn it's permanent, get confirmation. Requires Hub A
 
 Each app entry returns: id, name, type, disabled, user (true=user-installed Groovy app, false=built-in), hidden, parentId (null for top-level), hasChildren, childCount.
 
-Use filter to narrow results: 'all' (default), 'builtin' (Hubitat native apps), 'user' (custom Groovy apps), 'disabled' (paused/disabled), 'parents' (apps with children like Rule Machine, Room Lighting, Groups and Scenes), 'children' (individual rules, scenes, etc.).""",
+Use filter to narrow results: 'all' (default), 'builtin' (Hubitat native apps), 'user' (custom Groovy apps), 'disabled' (paused/disabled), 'parents' (apps with children like Rule Machine, Room Lighting, Groups and Scenes), 'children' (individual rules, scenes, etc.).
+
+Pass cursor (opaque string from a prior call's nextCursor) to page through the apps list at 50 per page when the full response would exceed the hub's 128KB JSON-RPC cap.""",
             inputSchema: [
                 type: "object",
                 properties: [
                     filter: [type: "string", enum: ["all", "builtin", "user", "disabled", "parents", "children"], description: "Filter apps by category. Default: all"],
-                    includeHidden: [type: "boolean", description: "Include hidden apps (typically Hubitat internal). Default: false", default: false]
+                    includeHidden: [type: "boolean", description: "Include hidden apps (typically Hubitat internal). Default: false", default: false],
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit to get the full filtered list in a single response (subject to the universal 110KB response-size guard -- oversized responses come back as a response_too_large envelope). Pass the nextCursor value from a prior call to fetch the next page (page size 50). Empty string is treated as no cursor."]
                 ]
             ]
         ],
@@ -9188,6 +9286,7 @@ def toolForceGarbageCollection(args) {
 def toolDeviceHealthCheck(args) {
     def staleHours = args.staleHours ?: 24
     def includeHealthy = args.includeHealthy ?: false
+    def cursor = args.cursor
     def pingHosts = (args.pingHosts ?: []) as List
     // ?: treats explicit 0 as absent, so distinguish null from 0 here. Accept Number to keep
     // the friendly "between 1 and 5" message for non-numeric input instead of a cast exception.
@@ -9281,6 +9380,23 @@ def toolDeviceHealthCheck(args) {
     // Sort stale by most-stale first
     stale.sort { a, b -> (b.hoursAgo ?: 0) <=> (a.hoursAgo ?: 0) }
 
+    // Opt-in cursor pagination (#174). Default behaviour (no cursor) returns the full
+    // staleDevices + unknownDevices + healthyDevices payload as before. When cursor is
+    // supplied we page the stale list at 100 per page -- the typical "what's broken on
+    // the hub" caller wants the staleDevices list, and the universal response-size guard
+    // backstops the rest. unknownDevices and (optional) healthyDevices remain present
+    // alongside the page so the summary call still works in a single request; consumers
+    // iterating nextCursor get bounded stale pages without re-doing the discovery work.
+    def stalePage = stale
+    String nextCursor = null
+    if (cursor != null) {
+        int start = _parseListCursor(cursor, stale.size(), "device_health_check")
+        final int pageSize = 100
+        int end = Math.min(start + pageSize, stale.size())
+        stalePage = stale.subList(start, end)
+        if (end < stale.size()) nextCursor = end.toString()
+    }
+
     def result = [
         summary: [
             totalDevices: settings.selectedDevices.size(),
@@ -9290,9 +9406,12 @@ def toolDeviceHealthCheck(args) {
             staleThresholdHours: staleHours,
             checkedAt: formatTimestamp(now())
         ],
-        staleDevices: stale,
+        staleDevices: stalePage,
         unknownDevices: unknown
     ]
+    if (cursor != null && nextCursor != null) {
+        result.nextCursor = nextCursor
+    }
 
     if (includeHealthy) {
         result.healthyDevices = healthy
@@ -12203,6 +12322,7 @@ def toolListInstalledApps(args) {
     requireBuiltinApp()
     def filter = args?.filter ?: "all"
     def includeHidden = args?.includeHidden == true
+    def cursor = args?.cursor
 
     def validFilters = ["all", "builtin", "user", "disabled", "parents", "children"]
     if (!validFilters.contains(filter)) {
@@ -12268,12 +12388,38 @@ def toolListInstalledApps(args) {
             }
         }
 
-        return [
-            apps: filtered,
-            count: filtered.size(),
+        // Opt-in cursor pagination (#174). Default behaviour (no cursor) returns the
+        // full filtered list as before -- backward-compatible. When the LLM passes
+        // cursor, we hand back a fixed-size page plus nextCursor for iteration, matching
+        // the opaque-string contract PR #180 established for tools/list. Page size 50
+        // keeps a typical page well under the 128KB cap; the universal response-size
+        // guard at handleToolsCall remains a backstop for callers who do not paginate.
+        def fullList = filtered
+        def page = fullList
+        String nextCursor = null
+        if (cursor != null) {
+            int start = _parseListCursor(cursor, fullList.size(), "list_installed_apps")
+            final int pageSize = 50
+            int end = Math.min(start + pageSize, fullList.size())
+            page = fullList.subList(start, end)
+            if (end < fullList.size()) nextCursor = end.toString()
+        }
+
+        def result = [
+            apps: page,
+            count: page.size(),
             filter: filter,
             totalOnHub: flat.size()
         ]
+        if (cursor != null) {
+            result.total = fullList.size()
+            if (nextCursor != null) result.nextCursor = nextCursor
+        }
+        return result
+    } catch (IllegalArgumentException e) {
+        // Cursor validation throws IllegalArgumentException so the dispatch layer can
+        // surface it as -32602. Don't reframe as a transport failure.
+        throw e
     } catch (Exception e) {
         // The Built-in-App-Tools gate has already passed by the time we reach here, so
         // do not blame it in the note. Failures at this point come from the hub transport

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -218,6 +218,68 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         response.result.tools.size() > 0
     }
 
+    def "tools/call returns response_too_large envelope when serialized result exceeds the 110KB cap (#174)"() {
+        given: 'a tool whose serialized result will exceed the 110KB universal-guard threshold'
+        // Each room serializes to roughly 80-100 bytes once name + deviceCount + deviceIds
+        // overhead is counted; 2000 such rooms with a padded name push the toolListRooms
+        // result well past 110KB so the guard kicks in.
+        def padding = 'x' * 80
+        def bigRooms = (0..<2000).collect { i ->
+            [id: i as Long, name: "Room-${i}-${padding}"]
+        }
+        script.metaClass.getRooms = { -> bigRooms }
+        mcpDriver.pushBody([
+            jsonrpc: '2.0', id: 100, method: 'tools/call',
+            params: [name: 'list_rooms', arguments: [:]]
+        ])
+
+        when:
+        script.handleMcpRequest()
+
+        then: 'JSON-RPC success envelope — fail-soft is NOT a JSON-RPC error'
+        def response = mcpDriver.parseResponseJson()
+        response.jsonrpc == '2.0'
+        response.id == 100
+        response.error == null
+
+        and: 'inner content carries the structured response_too_large envelope (not isError)'
+        // isError is reserved for tool execution failure per the MCP spec; response-too-large
+        // is a soft outcome (the tool ran, the result just doesnt fit), and clients should
+        // be able to react to it programmatically rather than treating it as a hard failure.
+        response.result.isError != true
+        def inner = new groovy.json.JsonSlurper().parseText(response.result.content[0].text)
+        inner.response_too_large == true
+        inner.truncated == true
+        inner.tool == 'list_rooms'
+        inner.sizeLimitBytes == 110000
+        inner.estimatedBytes instanceof Number
+        inner.estimatedBytes > inner.sizeLimitBytes
+        inner.suggestion instanceof String
+        !inner.suggestion.isEmpty()
+
+        and: 'no rooms leak through the envelope (the whole point of fail-soft)'
+        inner.rooms == null
+    }
+
+    def "tools/call passes small results through unchanged (size guard does not perturb normal traffic)"() {
+        given: 'a tiny rooms list well under the cap'
+        script.metaClass.getRooms = { -> [[id: 1L, name: 'Den']] }
+        mcpDriver.pushBody([
+            jsonrpc: '2.0', id: 101, method: 'tools/call',
+            params: [name: 'list_rooms', arguments: [:]]
+        ])
+
+        when:
+        script.handleMcpRequest()
+
+        then: 'the inner content is the real tool result, not the fail-soft envelope'
+        def response = mcpDriver.parseResponseJson()
+        response.error == null
+        def inner = new groovy.json.JsonSlurper().parseText(response.result.content[0].text)
+        inner.response_too_large == null
+        inner.rooms*.name == ['Den']
+    }
+
     def "tools/call list_rooms flows through render with an MCP content envelope"() {
         given: 'a stubbed getRooms returning a deterministic list'
         script.metaClass.getRooms = { ->

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -1,5 +1,6 @@
 package server
 
+import support.TestDevice
 import support.ToolSpecBase
 
 /**
@@ -222,15 +223,17 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         response.result.tools.size() > 0
     }
 
-    def "tools/call returns response_too_large envelope when serialized result exceeds the 110KB cap (#174)"() {
-        given: 'a tool whose serialized result will exceed the 110KB universal-guard threshold'
-        // Each room serializes to roughly 80-100 bytes once name + deviceCount + deviceIds
-        // overhead is counted; 2000 such rooms with a padded name push the toolListRooms
-        // result well past 110KB so the guard kicks in.
+    def "tools/call returns response_too_large envelope when wire-encoded response exceeds the universal-guard threshold"() {
+        given: 'a tool whose wire-encoded response will exceed the 120KB universal-guard threshold'
+        // 2000 padded rooms ~> >120KB once wire-serialized.
         def padding = 'x' * 80
         def bigRooms = (0..<2000).collect { i ->
             [id: i as Long, name: "Room-${i}-${padding}"]
         }
+        // Defensive: if anyone retunes the threshold or trims the room shape, fail loud
+        // here instead of letting the test silently slide into the pass-through branch.
+        def roomList = bigRooms.collect { [id: it.id?.toString(), name: it.name, deviceCount: 0, deviceIds: []] }
+        assert groovy.json.JsonOutput.toJson([rooms: roomList, count: roomList.size()]).getBytes("UTF-8").length > 120000
         script.metaClass.getRooms = { -> bigRooms }
         mcpDriver.pushBody([
             jsonrpc: '2.0', id: 100, method: 'tools/call',
@@ -240,22 +243,19 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         when:
         script.handleMcpRequest()
 
-        then: 'JSON-RPC success envelope — fail-soft is NOT a JSON-RPC error'
+        then: 'JSON-RPC success envelope -- fail-soft is not a JSON-RPC error'
         def response = mcpDriver.parseResponseJson()
         response.jsonrpc == '2.0'
         response.id == 100
         response.error == null
 
-        and: 'inner content carries the structured response_too_large envelope (not isError)'
-        // isError is reserved for tool execution failure per the MCP spec; response-too-large
-        // is a soft outcome (the tool ran, the result just doesnt fit), and clients should
-        // be able to react to it programmatically rather than treating it as a hard failure.
+        and: 'inner content carries the structured envelope (no isError -- fail-soft is not a tool error)'
         response.result.isError != true
         def inner = new groovy.json.JsonSlurper().parseText(response.result.content[0].text)
         inner.response_too_large == true
         inner.truncated == true
         inner.tool == 'list_rooms'
-        inner.sizeLimitBytes == 110000
+        inner.sizeLimitBytes == 120000
         inner.estimatedBytes instanceof Number
         inner.estimatedBytes > inner.sizeLimitBytes
         inner.suggestion instanceof String
@@ -263,6 +263,95 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
 
         and: 'no rooms leak through the envelope (the whole point of fail-soft)'
         inner.rooms == null
+    }
+
+    def "size-guard mcpLog entry carries the warn level + structured details map a debug-log consumer can read"() {
+        given: 'oversize result so the guard fires + debug-log scaffolding wired (mcpLog otherwise no-ops at default log level)'
+        stateMap.debugLogs = [
+            entries: [],
+            config: [logLevel: 'debug', maxEntries: 1000]
+        ]
+        settingsMap.mcpLogLevel = 'debug'
+        def padding = 'x' * 80
+        script.metaClass.getRooms = { -> (0..<2000).collect { i -> [id: i as Long, name: "Room-${i}-${padding}"] } }
+        mcpDriver.pushBody([jsonrpc: '2.0', id: 110, method: 'tools/call', params: [name: 'list_rooms', arguments: [:]]])
+
+        when:
+        script.handleMcpRequest()
+
+        then:
+        def warn = (stateMap.debugLogs?.entries ?: []).find { it.message?.contains('response too large') }
+        warn != null
+        warn.level == 'warn'
+        warn.details.tool == 'list_rooms'
+        warn.details.gateway == null  // direct call, not gateway-routed
+        warn.details.bytes > 120000
+        warn.details.limit == 120000
+    }
+
+    def "size guard surfaces the inner sub-tool name + gateway hint when called through a manage_* gateway (#174)"() {
+        given: 'a stubbed sub-tool (get_app_config) that returns a huge config'
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableHubAdminRead = true
+        // Build a get_app_config response large enough to trip the wire-byte guard once
+        // wrapped + escaped + envelope-encoded.
+        def bigSettings = (0..<3000).collectEntries { i -> ["k${i}".toString(), ("v" * 50)] }
+        script.metaClass.toolGetAppConfig = { Map args -> [success: true, app: [id: 99, label: 'X'], settings: bigSettings] }
+        stateMap.debugLogs = [
+            entries: [],
+            config: [logLevel: 'debug', maxEntries: 1000]
+        ]
+        settingsMap.mcpLogLevel = 'debug'
+        // Gateway-routed call: name=manage_installed_apps, args carries tool+args.
+        mcpDriver.pushBody([
+            jsonrpc: '2.0', id: 200, method: 'tools/call',
+            params: [name: 'manage_installed_apps', arguments: [tool: 'get_app_config', args: [appId: '99', includeSettings: true]]]
+        ])
+
+        when:
+        script.handleMcpRequest()
+
+        then: 'envelope reports the SUB-tool, not the gateway, so the LLMs retry hint matches the call it issued'
+        def response = mcpDriver.parseResponseJson()
+        response.error == null
+        def inner = new groovy.json.JsonSlurper().parseText(response.result.content[0].text)
+        inner.response_too_large == true
+        inner.tool == 'get_app_config'
+        inner.suggestion.contains('includeSettings')
+
+        and: 'debug-log details surface the gateway/sub-tool split for an operator running get_debug_logs'
+        def warn = (stateMap.debugLogs?.entries ?: []).find { it.message?.contains('response too large') }
+        warn.details.tool == 'get_app_config'
+        warn.details.gateway == 'manage_installed_apps'
+    }
+
+    def "non-gateway caller passing a stray `tool` arg does NOT route the suggestion to the wrong tool"() {
+        // Defends against the would-be bug where a direct (non-gateway) caller with a
+        // stray args.tool='export_native_app' on list_devices would get an export_native_app
+        // suggestion ("use saveAs=..."), nonsensical for list_devices.
+        given:
+        // Force list_devices to blow the cap by stubbing a giant selected-device list.
+        def padding = 'x' * 80
+        def bigDevices = (0..<2000).collect { i ->
+            def d = new TestDevice(id: i, name: "D${i}", label: "Device-${i}-${padding}")
+            d.metaClass.getLastActivity = { -> null }
+            d
+        }
+        settingsMap.selectedDevices = bigDevices
+        mcpDriver.pushBody([
+            jsonrpc: '2.0', id: 201, method: 'tools/call',
+            params: [name: 'list_devices', arguments: [tool: 'export_native_app']]
+        ])
+
+        when:
+        script.handleMcpRequest()
+
+        then:
+        def inner = new groovy.json.JsonSlurper().parseText(mcpDriver.parseResponseJson().result.content[0].text)
+        inner.response_too_large == true
+        inner.tool == 'list_devices'                       // NOT export_native_app
+        inner.suggestion.contains('filter')                // list_devices guidance
+        !inner.suggestion.contains('saveAs')               // not export_native_app guidance
     }
 
     def "tools/call passes small results through unchanged (size guard does not perturb normal traffic)"() {
@@ -282,6 +371,70 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         def inner = new groovy.json.JsonSlurper().parseText(response.result.content[0].text)
         inner.response_too_large == null
         inner.rooms*.name == ['Den']
+    }
+
+    def "tools/call surfaces a structured isError envelope when the tool implementation returns null"() {
+        // Defends against a future tool whose last expression evaluates to null -- without
+        // the explicit null guard, the wire payload becomes text: "null" which looks like
+        // a normal tool result to an LLM.
+        given:
+        script.metaClass.toolListRooms = { -> null }
+        mcpDriver.pushBody([jsonrpc: '2.0', id: 102, method: 'tools/call', params: [name: 'list_rooms', arguments: [:]]])
+
+        when:
+        script.handleMcpRequest()
+
+        then:
+        def response = mcpDriver.parseResponseJson()
+        response.error == null
+        response.result.isError == true
+        def inner = new groovy.json.JsonSlurper().parseText(response.result.content[0].text)
+        inner.isError == true
+        inner.error.contains('list_rooms')
+        inner.tool == 'list_rooms'
+    }
+
+    def "tools/call surfaces a structured isError envelope when the tool returns a non-JSON-serializable result"() {
+        // A Closure is one of JsonOutput's documented unserializable types; stubbing the
+        // tool to return one verifies the size-guard's serialization-failure branch fires
+        // a structured isError instead of an opaque "Tool error: ..." string.
+        given:
+        script.metaClass.toolListRooms = { -> [bad: { -> "closure" }] }
+        mcpDriver.pushBody([jsonrpc: '2.0', id: 103, method: 'tools/call', params: [name: 'list_rooms', arguments: [:]]])
+
+        when:
+        script.handleMcpRequest()
+
+        then:
+        def response = mcpDriver.parseResponseJson()
+        response.error == null
+        response.result.isError == true
+        def inner = new groovy.json.JsonSlurper().parseText(response.result.content[0].text)
+        inner.isError == true
+        inner.error.contains('cannot encode')
+        inner.cause != null
+    }
+
+    @spock.lang.Unroll
+    def "_responseTooLargeSuggestion returns tool-specific guidance for #toolName"() {
+        expect:
+        def suggestion = script._responseTooLargeSuggestion(toolName)
+        suggestion instanceof String
+        !suggestion.isEmpty()
+        suggestion.toLowerCase().contains(expectedFragment.toLowerCase())
+
+        where:
+        toolName              | expectedFragment
+        'list_devices'        | 'filter'
+        'list_installed_apps' | 'cursor'
+        'get_app_config'      | 'includeSettings'
+        'device_health_check' | 'includeHealthy'
+        'get_memory_history'  | 'limit'
+        'get_hub_logs'        | 'pattern'
+        'export_native_app'   | 'saveAs'
+        'get_hub_info'        | 'subsection'
+        'get_app_source'      | 'File Manager'
+        'unknown_tool_xyz'    | 'narrow your query'
     }
 
     def "tools/call list_rooms flows through render with an MCP content envelope"() {

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -377,8 +377,10 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         // Defends against a future tool whose last expression evaluates to null -- without
         // the explicit null guard, the wire payload becomes text: "null" which looks like
         // a normal tool result to an LLM.
+        // Signature mirrors def toolListRooms(args = null) so the metaClass override
+        // intercepts the dispatch call regardless of whether args is passed.
         given:
-        script.metaClass.toolListRooms = { -> null }
+        script.metaClass.toolListRooms = { Object[] ignored -> null }
         mcpDriver.pushBody([jsonrpc: '2.0', id: 102, method: 'tools/call', params: [name: 'list_rooms', arguments: [:]]])
 
         when:

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -394,26 +394,11 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         inner.tool == 'list_rooms'
     }
 
-    def "tools/call surfaces a structured isError envelope when the tool returns a non-JSON-serializable result"() {
-        // A Closure is one of JsonOutput's documented unserializable types; stubbing the
-        // tool to return one verifies the size-guard's serialization-failure branch fires
-        // a structured isError instead of an opaque "Tool error: ..." string.
-        given:
-        script.metaClass.toolListRooms = { -> [bad: { -> "closure" }] }
-        mcpDriver.pushBody([jsonrpc: '2.0', id: 103, method: 'tools/call', params: [name: 'list_rooms', arguments: [:]]])
-
-        when:
-        script.handleMcpRequest()
-
-        then:
-        def response = mcpDriver.parseResponseJson()
-        response.error == null
-        response.result.isError == true
-        def inner = new groovy.json.JsonSlurper().parseText(response.result.content[0].text)
-        inner.isError == true
-        inner.error.contains('cannot encode')
-        inner.cause != null
-    }
+    // The non-serializable-result branch in handleToolsCall is defensive: groovy.json.JsonOutput
+    // silently coerces most "weird" types (Closure -> {}, Pattern -> {pattern, flags}, etc.) so
+    // there is no portable way to deterministically trigger the catch from a Spock spec.
+    // The branch is exercised by code review + the production path it protects (a future tool
+    // returning something genuinely unserializable). Kept here as documentation of the gap.
 
     @spock.lang.Unroll
     def "_responseTooLargeSuggestion returns tool-specific guidance for #toolName"() {

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -377,10 +377,10 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         // Defends against a future tool whose last expression evaluates to null -- without
         // the explicit null guard, the wire payload becomes text: "null" which looks like
         // a normal tool result to an LLM.
-        // Signature mirrors def toolListRooms(args = null) so the metaClass override
-        // intercepts the dispatch call regardless of whether args is passed.
+        // Dispatch always calls toolListRooms(args) so a 1-arg metaClass override
+        // intercepts cleanly.
         given:
-        script.metaClass.toolListRooms = { Object[] ignored -> null }
+        script.metaClass.toolListRooms = { ignored -> null }
         mcpDriver.pushBody([jsonrpc: '2.0', id: 102, method: 'tools/call', params: [name: 'list_rooms', arguments: [:]]])
 
         when:

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -16,7 +16,11 @@ import support.ToolSpecBase
  *   - {@code render(Map)} envelope (status, contentType, data)
  *   - JSON-RPC -32600 branches: empty batch, missing jsonrpc field,
  *     missing method
- *   - JSON-RPC -32601 (method-not-found) and -32603 (response-too-large)
+ *   - JSON-RPC -32601 (method-not-found); -32603 (response-too-large) is now
+ *     superseded for tools/call by the universal fail-soft size guard at
+ *     handleToolsCall (#174) -- tools/call returns a structured
+ *     response_too_large envelope on success, not a JSON-RPC error. The outer
+ *     handleMcpRequest guard remains as a backstop for other RPC methods.
  *   - Notification short-circuit (id-less request → 204 no-content)
  *   - Batch per-item error isolation (a failing item must not poison a
  *     later success)
@@ -484,31 +488,6 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
 
         and: 'id was echoed back — contract-locking per §5.1'
         response.id == 5
-    }
-
-    def "oversize tool response is replaced with -32603 Response-too-large"() {
-        given: 'a stubbed tool that returns more than the 124KB cap'
-        // Build a big label that after JSON-encoding + envelope wrapping
-        // blows past the 124000-byte threshold at hubitat-mcp-server.groovy:321.
-        String bigLabel = 'x' * 150_000
-        script.metaClass.getRooms = { ->
-            [[id: 1L, name: bigLabel]]
-        }
-        mcpDriver.pushBody([
-            jsonrpc: '2.0', id: 40, method: 'tools/call',
-            params: [name: 'list_rooms', arguments: [:]]
-        ])
-
-        when:
-        script.handleMcpRequest()
-
-        then: 'response is the -32603 error, not the oversize payload'
-        def response = mcpDriver.parseResponseJson()
-        response.jsonrpc == '2.0'
-        response.id == 40
-        response.error.code == -32603
-        response.error.message.contains('Response too large')
-        response.error.message.contains("exceeds hub's 128KB limit")
     }
 
     def "handleMcpGet returns 405 with the use-POST hint"() {

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -293,6 +293,9 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         given: 'a stubbed sub-tool (get_app_config) that returns a huge config'
         settingsMap.enableBuiltinApp = true
         settingsMap.enableHubAdminRead = true
+        // useGateways=true so manage_installed_apps actually dispatches (PR #187/#191's
+        // flat-mode matrix would otherwise short-circuit gateway calls with isError).
+        settingsMap.useGateways = true
         // Build a get_app_config response large enough to trip the wire-byte guard once
         // wrapped + escaped + envelope-encoded.
         def bigSettings = (0..<3000).collectEntries { i -> ["k${i}".toString(), ("v" * 50)] }

--- a/src/test/groovy/server/ToolGetDeviceInUseBySpec.groovy
+++ b/src/test/groovy/server/ToolGetDeviceInUseBySpec.groovy
@@ -286,6 +286,71 @@ class ToolGetDeviceInUseBySpec extends ToolSpecBase {
         useGateways << [true, false]
     }
 
+    def "cursor pagination over appsUsing returns bounded page + total (#174)"() {
+        given: 'a heavily-shared device with 150 apps referencing it'
+        settingsMap.enableBuiltinApp = true
+        def mockDevice = [id: '10', label: 'Switch', name: 'Switch']
+        childDevicesList << mockDevice
+        def apps = (0..<150).collect { i -> [id: i + 100, name: 'Rule Machine', label: "Rule ${i}", trueLabel: "Rule ${i}", disabled: false] }
+        def responseJson = JsonOutput.toJson([extraBreadcrumb: 'Switch', appsUsing: apps, appsUsingCount: 150])
+        hubGet.register('/device/fullJson/10') { params -> responseJson }
+
+        when: 'first page (cursor="")'
+        def page1 = script.toolGetDeviceInUseBy([deviceId: '10', cursor: ''])
+
+        then:
+        page1.appsUsing.size() == 100
+        page1.total == 150
+        page1.nextCursor == '100'
+        // count reports the firmware-reported full count, NOT the page size --
+        // a paginating client needs the full count to know when to stop
+        page1.count == 150
+
+        when: 'last page (cursor=100)'
+        def page2 = script.toolGetDeviceInUseBy([deviceId: '10', cursor: '100'])
+
+        then:
+        page2.appsUsing.size() == 50
+        !page2.containsKey('nextCursor')
+    }
+
+    def "count vs appsUsing.size() mismatch surfaces countMismatch field (firmware truncation signal)"() {
+        given:
+        settingsMap.enableBuiltinApp = true
+        def mockDevice = [id: '11', label: 'Switch', name: 'Switch']
+        childDevicesList << mockDevice
+        // firmware reports 42 but only 3 entries in the array (truncation case)
+        def responseJson = JsonOutput.toJson([extraBreadcrumb: 'Switch', appsUsing: [[id: 1], [id: 2], [id: 3]], appsUsingCount: 42])
+        hubGet.register('/device/fullJson/11') { params -> responseJson }
+
+        when:
+        def result = script.toolGetDeviceInUseBy([deviceId: '11'])
+
+        then:
+        result.count == 42
+        result.appsUsing.size() == 3
+        result.countMismatch != null
+        result.countMismatch.contains('42')
+        result.countMismatch.contains('3')
+    }
+
+    def "appsUsing arriving as a Map is rejected with a clear error instead of producing all-null entries"() {
+        given:
+        settingsMap.enableBuiltinApp = true
+        def mockDevice = [id: '12', label: 'Switch', name: 'Switch']
+        childDevicesList << mockDevice
+        // firmware shape drift -- appsUsing as a Map would silently produce all-null entries
+        def responseJson = JsonOutput.toJson([extraBreadcrumb: 'Switch', appsUsing: [foo: 'bar'], appsUsingCount: 1])
+        hubGet.register('/device/fullJson/12') { params -> responseJson }
+
+        when:
+        def result = script.toolGetDeviceInUseBy([deviceId: '12'])
+
+        then:
+        result.success == false
+        result.error.toLowerCase().contains('unexpected appsusing shape')
+    }
+
     def "gateway dispatch via handleGateway routes correctly"() {
         given:
         settingsMap.enableBuiltinApp = true

--- a/src/test/groovy/server/ToolGetHubLogsSpec.groovy
+++ b/src/test/groovy/server/ToolGetHubLogsSpec.groovy
@@ -1124,6 +1124,50 @@ class ToolGetHubLogsSpec extends ToolSpecBase {
         ex.message.toLowerCase().contains('patternmode')
     }
 
+    def "cursor pages within the limit-trimmed candidate pool (#174)"() {
+        // get_hub_logs composes three size controls: limit (trims candidate pool),
+        // cursor (pages within that), and per-entry message truncation. This spec
+        // pins the limit-trims-first-then-cursor-pages ordering so a regression
+        // that flipped the order surfaces.
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs((0..<300).collect { i -> "App ${i}\tinfo\tmsg ${i}\t2026-04-21 10:00:${String.format('%02d', i % 60)}.000\ttype" })
+
+        when: 'limit=150 + cursor="" -- candidates are first 150 entries, page size 100'
+        def page1 = script.toolGetHubLogs([limit: 150, cursor: ''])
+
+        then:
+        page1.logs.size() == 100
+        page1.total == 150               // post-limit candidate pool, NOT raw 300
+        page1.nextCursor == '100'
+        page1.appliedLimit == 150        // visibility into the limit ceiling
+
+        when: 'last page within the limit pool'
+        def page2 = script.toolGetHubLogs([limit: 150, cursor: '100'])
+
+        then:
+        page2.logs.size() == 50
+        !page2.containsKey('nextCursor')
+    }
+
+    def "no-cursor call still emits appliedLimit but no nextCursor/total leakage"() {
+        // Backward-compat shape guard for callers who don't paginate.
+        given:
+        settingsMap.enableHubAdminRead = true
+        registerLogs([
+            'App\tinfo\tmsg\t2026-04-21 10:00:00.000\ttype'
+        ])
+
+        when:
+        def result = script.toolGetHubLogs([:])
+
+        then:
+        result.logs.size() == 1
+        result.appliedLimit == 100       // default
+        !result.containsKey('nextCursor')
+        !result.containsKey('total')
+    }
+
     def "empty patterns list is accepted and applies no pattern filter"() {
         given:
         settingsMap.enableHubAdminRead = true

--- a/src/test/groovy/server/ToolHubVariablesSpec.groovy
+++ b/src/test/groovy/server/ToolHubVariablesSpec.groovy
@@ -95,6 +95,52 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         result.hubVariables == []
         result.ruleVariables == []
         result.total == 0
+        // unconditional per-list totals so a caller can distinguish "no hub vars"
+        // from "no rule vars" without cursor context
+        result.totalHubVariables == 0
+        result.totalRuleVariables == 0
+    }
+
+    def "list_variables cursor pages hubVariables while ruleVariables stays in full (#174)"() {
+        given: '150 hub vars + 5 rule vars'
+        def allVars = (0..<150).collectEntries { i -> ["var_${String.format('%03d', i)}".toString(), [name: "var_${i}".toString(), type: 'Number', value: i, deviceId: null, attribute: null]] }
+        script.metaClass.getAllGlobalVars = { -> allVars }
+        stateMap.ruleVariables = [a: 1, b: 2, c: 3, d: 4, e: 5]
+
+        when: 'first page (cursor="")'
+        def page1 = script.toolListVariables([cursor: ''])
+
+        then:
+        page1.hubVariables.size() == 100
+        page1.ruleVariables.size() == 5   // ruleVariables stays in full
+        page1.totalHubVariables == 150
+        page1.totalRuleVariables == 5
+        page1.total == 155                 // legacy combined total
+        page1.nextCursor == '100'
+
+        when: 'last page'
+        def page2 = script.toolListVariables([cursor: '100'])
+
+        then:
+        page2.hubVariables.size() == 50
+        page2.ruleVariables.size() == 5
+        !page2.containsKey('nextCursor')
+    }
+
+    def "list_variables surfaces a hubVariablesError field when getAllGlobalVars throws (not silent)"() {
+        // Pre-fix this exception was only logged via logDebug; a caller couldn't
+        // distinguish "no hub variables" from "hub API broke".
+        given:
+        script.metaClass.getAllGlobalVars = { -> throw new RuntimeException('sandbox tightened: getAllGlobalVars not available') }
+
+        when:
+        def result = script.toolListVariables()
+
+        then:
+        result.hubVariables == []
+        result.hubVariablesError != null
+        result.hubVariablesError.contains('sandbox tightened')
+        result.totalHubVariables == 0
     }
 
     // -------- toolGetVariable --------

--- a/src/test/groovy/server/ToolListDevicesSpec.groovy
+++ b/src/test/groovy/server/ToolListDevicesSpec.groovy
@@ -32,6 +32,84 @@ class ToolListDevicesSpec extends ToolSpecBase {
 
     // ---- labelFilter tests ----------------------------------------------
 
+    // ---- cursor pagination tests (#174) --------------------------------
+
+    def "cursor='' returns the first 50 devices + nextCursor (regression guard for the documented opt-in)"() {
+        // Pre-fix, the inline cursor parser called ''.toInteger() and threw -32602
+        // for the documented "pass '' for the first page" pattern.
+        given:
+        settingsMap.selectedDevices = (0..<120).collect { i -> makeDevice(id: i + 1, name: "D${i}", label: "Device-${String.format('%03d', i)}") }
+
+        when:
+        def result = script.toolListDevices(false, 0, 0, null, null, null, null, null, '')
+
+        then:
+        result.devices.size() == 50
+        result.nextCursor == '50'
+        result.total == 120
+    }
+
+    def "cursor iterates pages with no duplicates and last page omits nextCursor"() {
+        given:
+        settingsMap.selectedDevices = (0..<120).collect { i -> makeDevice(id: i + 1, name: "D${i}", label: "Device-${String.format('%03d', i)}") }
+
+        when:
+        def collected = []
+        String cursor = ''
+        int pages = 0
+        while (true) {
+            def page = script.toolListDevices(false, 0, 0, null, null, null, null, null, cursor)
+            collected.addAll(page.devices)
+            pages++
+            if (!page.nextCursor) break
+            cursor = page.nextCursor
+            assert pages < 10 : "pagination runaway"
+        }
+
+        then:
+        pages == 3
+        collected.size() == 120
+        (collected*.id as Set).size() == 120
+    }
+
+    def "cursor + non-zero offset is rejected (mutually exclusive)"() {
+        // Defends against silent cursor-override-offset surprise.
+        given:
+        settingsMap.selectedDevices = [makeDevice(id: 1, name: 'D1')]
+
+        when:
+        script.toolListDevices(false, 50, 0, null, null, null, null, null, '0')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('mutually exclusive')
+    }
+
+    def "non-numeric cursor throws with the list_devices-specific error message"() {
+        given:
+        settingsMap.selectedDevices = [makeDevice(id: 1, name: 'D1')]
+
+        when:
+        script.toolListDevices(false, 0, 0, null, null, null, null, null, 'banana')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('cursor')
+        ex.message.contains('list_devices')
+    }
+
+    def "cursor + format='ids' emits nextCursor in the ids branch too"() {
+        given:
+        settingsMap.selectedDevices = (0..<120).collect { i -> makeDevice(id: i + 1, name: "D${i}", label: "Device-${String.format('%03d', i)}") }
+
+        when:
+        def result = script.toolListDevices(false, 0, 0, null, null, null, 'ids', null, '')
+
+        then:
+        result.deviceIds.size() == 50
+        result.nextCursor == '50'
+    }
+
     def "labelFilter: returns only devices whose label contains the substring"() {
         given:
         def kitchen = makeDevice(id: 1, label: 'Kitchen Light')

--- a/src/test/groovy/server/ToolListInstalledAppsSpec.groovy
+++ b/src/test/groovy/server/ToolListInstalledAppsSpec.groovy
@@ -661,6 +661,163 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         useGateways << [true, false]
     }
 
+    def "cursor=null returns the full filtered list (backward compatible)"() {
+        // No cursor means full list, no nextCursor field, no total field --
+        // pre-#174 callers see no change. The universal size guard is the only
+        // safety net active in this mode.
+        given:
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { params ->
+            JsonOutput.toJson([apps: (0..<10).collect {
+                [data: [id: it, name: "App-${it}", type: 'X', user: false, disabled: false, hidden: false], children: []]
+            }])
+        }
+
+        when:
+        def result = script.toolListInstalledApps([:])
+
+        then:
+        result.apps.size() == 10
+        result.count == 10
+        result.containsKey('nextCursor') == false
+        result.containsKey('total') == false
+    }
+
+    def "cursor='' starts at page 1 of 50 and emits nextCursor when more pages remain (#174)"() {
+        given:
+        settingsMap.enableBuiltinApp = true
+        // 120 apps -> 3 pages of 50 (50 + 50 + 20)
+        hubGet.register('/hub2/appsList') { params ->
+            JsonOutput.toJson([apps: (0..<120).collect {
+                [data: [id: it, name: "App-${it}", type: 'X', user: false, disabled: false, hidden: false], children: []]
+            }])
+        }
+
+        when:
+        def result = script.toolListInstalledApps([cursor: ''])
+
+        then:
+        result.apps.size() == 50
+        result.count == 50
+        result.total == 120
+        result.nextCursor == '50'
+        result.apps[0].id == 0
+        result.apps[49].id == 49
+    }
+
+    def "iterating cursor across pages returns each app exactly once and the last page omits nextCursor"() {
+        given:
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { params ->
+            JsonOutput.toJson([apps: (0..<120).collect {
+                [data: [id: it, name: "App-${it}", type: 'X', user: false, disabled: false, hidden: false], children: []]
+            }])
+        }
+
+        when: 'iterate every page'
+        def collected = []
+        String cursor = ''
+        int pages = 0
+        while (true) {
+            def page = script.toolListInstalledApps([cursor: cursor])
+            collected.addAll(page.apps)
+            pages++
+            if (!page.nextCursor) break
+            cursor = page.nextCursor
+            assert pages < 10 : "pagination runaway"
+        }
+
+        then: 'exactly 3 pages, no duplicates, every app surfaced exactly once'
+        pages == 3
+        collected.size() == 120
+        (collected*.id as Set).size() == 120
+
+        and: 'last page omits nextCursor'
+        def lastPage = script.toolListInstalledApps([cursor: '100'])
+        lastPage.apps.size() == 20
+        !lastPage.containsKey('nextCursor')
+    }
+
+    def "cursor='not-a-number' throws IllegalArgumentException so dispatch surfaces -32602"() {
+        given:
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { params ->
+            JsonOutput.toJson([apps: [[data: [id: 1, name: 'App', type: 'X', user: false, disabled: false, hidden: false], children: []]]])
+        }
+
+        when:
+        script.toolListInstalledApps([cursor: 'banana'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('cursor')
+        ex.message.contains('list_installed_apps')
+    }
+
+    def "negative cursor is rejected as out of range (matches PR #180 contract)"() {
+        given:
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { params ->
+            JsonOutput.toJson([apps: [[data: [id: 1, name: 'App', type: 'X', user: false, disabled: false, hidden: false], children: []]]])
+        }
+
+        when:
+        script.toolListInstalledApps([cursor: '-1'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('out of range')
+    }
+
+    def "cursor past the end of a non-empty list is rejected as out of range"() {
+        given:
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { params ->
+            JsonOutput.toJson([apps: (0..<5).collect {
+                [data: [id: it, name: "App-${it}", type: 'X', user: false, disabled: false, hidden: false], children: []]
+            }])
+        }
+
+        when:
+        script.toolListInstalledApps([cursor: '999'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('out of range')
+    }
+
+    def "cursor pagination respects filter (paginates the filtered set, not the raw catalog)"() {
+        given:
+        settingsMap.enableBuiltinApp = true
+        // 60 builtin + 60 user apps -> filter=user should paginate 60 apps (not 120)
+        hubGet.register('/hub2/appsList') { params ->
+            JsonOutput.toJson([apps:
+                (0..<60).collect {
+                    [data: [id: it, name: "Builtin-${it}", type: 'X', user: false, disabled: false, hidden: false], children: []]
+                } +
+                (100..<160).collect {
+                    [data: [id: it, name: "User-${it}", type: 'X', user: true, disabled: false, hidden: false], children: []]
+                }
+            ])
+        }
+
+        when:
+        def page1 = script.toolListInstalledApps([filter: 'user', cursor: ''])
+
+        then: 'page is 50 user apps, total is 60 (filtered set), nextCursor=50'
+        page1.apps.size() == 50
+        page1.total == 60
+        page1.nextCursor == '50'
+        page1.apps.every { it.id >= 100 }
+
+        when:
+        def page2 = script.toolListInstalledApps([filter: 'user', cursor: '50'])
+
+        then: 'remaining 10 user apps, no nextCursor'
+        page2.apps.size() == 10
+        !page2.containsKey('nextCursor')
+    }
+
     def "gateway dispatch via handleGateway also returns apps list"() {
         given:
         settingsMap.enableBuiltinApp = true

--- a/src/test/groovy/server/ToolListInstalledAppsSpec.groovy
+++ b/src/test/groovy/server/ToolListInstalledAppsSpec.groovy
@@ -786,6 +786,42 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         ex.message.toLowerCase().contains('out of range')
     }
 
+    def "cursor='0' on an empty filtered list returns an empty page with no nextCursor (no IOOBE)"() {
+        // Regression guard: a too-loose empty-list check would let cursor>0 through, then
+        // subList(N, 0) would throw IndexOutOfBoundsException with a gibberish message.
+        given:
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { params -> JsonOutput.toJson([apps: []]) }
+
+        when:
+        def result = script.toolListInstalledApps([cursor: '0'])
+
+        then:
+        result.apps == []
+        result.total == 0
+        !result.containsKey('nextCursor')
+    }
+
+    def "cursor='1' on an empty filtered list throws IllegalArgumentException with the friendly out-of-range message"() {
+        // The would-be bug: without the offset>0 clause, the empty-list short-circuit lets
+        // cursor=1 through, then subList(1, 0) throws java.lang.IllegalArgumentException
+        // "fromIndex(1) > toIndex(0)" -- which surfaces to the LLM as "Invalid params:
+        // fromIndex(1) > toIndex(0)" with no clue the real cause was a stale cursor.
+        given:
+        settingsMap.enableBuiltinApp = true
+        hubGet.register('/hub2/appsList') { params -> JsonOutput.toJson([apps: []]) }
+
+        when:
+        script.toolListInstalledApps([cursor: '1'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('out of range')
+        ex.message.contains('size=0')
+        // Should NOT be the gibberish JVM message
+        !ex.message.contains('fromIndex')
+    }
+
     def "cursor pagination respects filter (paginates the filtered set, not the raw catalog)"() {
         given:
         settingsMap.enableBuiltinApp = true

--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -488,6 +488,63 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         result.healthyDevices[0].name == 'Fresh Sensor'
     }
 
+    def "device_health_check cursor paginates staleDevices and emits nextCursor (#174)"() {
+        given: '150 stale devices -> 2 pages of 100 + 50'
+        def nowMs = 1234567890000L
+        def staleDevs = (0..<150).collect { i ->
+            def d = new TestDevice(id: 1000 + i, name: "S${i}", label: "Stale Sensor ${i}")
+            d.metaClass.getLastActivity = { -> new Date(nowMs - (48 * 3600000L)) }
+            d
+        }
+        settingsMap.selectedDevices = staleDevs
+
+        when: 'first page (cursor="")'
+        def page1 = script.toolDeviceHealthCheck([staleHours: 24, cursor: ''])
+
+        then: 'page is bounded but the summary still reflects the full stale count'
+        page1.summary.staleCount == 150
+        page1.staleDevices.size() == 100
+        page1.nextCursor == '100'
+
+        when: 'second page (cursor=100)'
+        def page2 = script.toolDeviceHealthCheck([staleHours: 24, cursor: '100'])
+
+        then: 'remaining 50 stale devices, no nextCursor'
+        page2.staleDevices.size() == 50
+        !page2.containsKey('nextCursor')
+    }
+
+    def "device_health_check without cursor returns the full staleDevices list (backward compatible)"() {
+        given:
+        def nowMs = 1234567890000L
+        def stale = new TestDevice(id: 1, name: 'S', label: 'Stale')
+        stale.metaClass.getLastActivity = { -> new Date(nowMs - (48 * 3600000L)) }
+        settingsMap.selectedDevices = [stale]
+
+        when:
+        def result = script.toolDeviceHealthCheck([staleHours: 24])
+
+        then: 'no cursor=null leaks pagination fields'
+        result.staleDevices.size() == 1
+        result.containsKey('nextCursor') == false
+    }
+
+    def "device_health_check cursor rejects non-numeric values"() {
+        given:
+        def nowMs = 1234567890000L
+        def stale = new TestDevice(id: 1, name: 'S', label: 'Stale')
+        stale.metaClass.getLastActivity = { -> new Date(nowMs - (48 * 3600000L)) }
+        settingsMap.selectedDevices = [stale]
+
+        when:
+        script.toolDeviceHealthCheck([cursor: 'banana'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('cursor')
+        ex.message.contains('device_health_check')
+    }
+
     def "device_health_check pingHosts: happy + failure paths populate pingResults"() {
         given:
         def network = new NetworkUtilsMock()

--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -506,11 +506,15 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         page1.staleDevices.size() == 100
         page1.nextCursor == '100'
 
+        and: 'top-level total mirrors list_installed_apps so paginating clients read the same shape across tools'
+        page1.total == 150
+
         when: 'second page (cursor=100)'
         def page2 = script.toolDeviceHealthCheck([staleHours: 24, cursor: '100'])
 
         then: 'remaining 50 stale devices, no nextCursor'
         page2.staleDevices.size() == 50
+        page2.total == 150
         !page2.containsKey('nextCursor')
     }
 
@@ -527,6 +531,45 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         then: 'no cursor=null leaks pagination fields'
         result.staleDevices.size() == 1
         result.containsKey('nextCursor') == false
+    }
+
+    def "device_health_check cursor='0' on an empty stale list returns an empty page (no IOOBE)"() {
+        // Selected device exists (so we don't take the "No devices selected" early-return)
+        // but it's healthy -- stale list is therefore empty when cursor is supplied.
+        given:
+        def nowMs = 1234567890000L
+        def fresh = new TestDevice(id: 1, name: 'F', label: 'Fresh')
+        fresh.metaClass.getLastActivity = { -> new Date(nowMs - 600000L) }
+        settingsMap.selectedDevices = [fresh]
+
+        when:
+        def result = script.toolDeviceHealthCheck([staleHours: 24, cursor: '0'])
+
+        then:
+        result.staleDevices == []
+        result.total == 0
+        !result.containsKey('nextCursor')
+    }
+
+    def "device_health_check cursor='5' on an empty stale list throws IllegalArgumentException with the friendly out-of-range message"() {
+        // Regression guard for the empty-list edge case -- without the offset>0 clause in
+        // _parseListCursor, subList(5, 0) would throw a JVM gibberish IAE that the dispatch
+        // layer surfaces as "Invalid params: fromIndex(5) > toIndex(0)" with no actionable
+        // hint that the real cause is a stale cursor against a now-empty list.
+        given:
+        def nowMs = 1234567890000L
+        def fresh = new TestDevice(id: 1, name: 'F', label: 'Fresh')
+        fresh.metaClass.getLastActivity = { -> new Date(nowMs - 600000L) }
+        settingsMap.selectedDevices = [fresh]
+
+        when:
+        script.toolDeviceHealthCheck([staleHours: 24, cursor: '5'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('out of range')
+        ex.message.contains('size=0')
+        !ex.message.contains('fromIndex')
     }
 
     def "device_health_check cursor rejects non-numeric values"() {

--- a/src/test/groovy/server/ToolRoomsSpec.groovy
+++ b/src/test/groovy/server/ToolRoomsSpec.groovy
@@ -206,6 +206,50 @@ class ToolRoomsSpec extends ToolSpecBase {
         useGateways << [true, false]
     }
 
+    def "list_rooms cursor pagination opt-in (#174)"() {
+        // Representative spec for the cursor-helper rollout: every tool that wires
+        // _paginateList behaves identically -- no cursor returns the full list, cursor=''
+        // emits a bounded page with total + nextCursor, last page omits nextCursor,
+        // non-numeric/out-of-range cursors throw IllegalArgumentException so dispatch
+        // surfaces -32602. The per-tool spec is exercised exhaustively for list_rooms
+        // here; the other paginated tools rely on the shared _paginateList contract
+        // pinned by ToolListInstalledAppsSpec.
+        given: '150 rooms -> 2 pages of 100 + 50'
+        installGetRoomsStub((0..<150).collect { i -> [id: i + 1, name: "Room-${String.format('%03d', i)}", deviceIds: []] })
+
+        when: 'no cursor: backward-compatible full list'
+        def all = script.toolListRooms()
+
+        then:
+        all.rooms.size() == 150
+        !all.containsKey('nextCursor')
+        !all.containsKey('total')
+
+        when: 'first page (cursor="")'
+        def page1 = script.toolListRooms([cursor: ''])
+
+        then:
+        page1.rooms.size() == 100
+        page1.total == 150
+        page1.nextCursor == '100'
+
+        when: 'last page'
+        def page2 = script.toolListRooms([cursor: '100'])
+
+        then:
+        page2.rooms.size() == 50
+        page2.total == 150
+        !page2.containsKey('nextCursor')
+
+        when: 'non-numeric cursor'
+        script.toolListRooms([cursor: 'banana'])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains('cursor')
+        ex.message.contains('list_rooms')
+    }
+
     // -------- toolGetRoom --------
 
     def "get_room returns room details when located by name (case-insensitive)"() {


### PR DESCRIPTION
## Summary

- **Universal fail-soft size guard** at `handleToolsCall` — every `tools/call` response is measured against an 110000-byte threshold; oversized results return a structured `response_too_large` envelope (estimatedBytes / sizeLimitBytes / tool / suggestion) instead of vanishing into the hub's silent -32603 for crossing the 128KB JSON-RPC cap.
- **Opt-in cursor pagination** added to `list_installed_apps` (page size 50) and `device_health_check` (page size 100 over `staleDevices`), matching the opaque-string contract PR #180 established for `tools/list`. Default behaviour (no `cursor`) is unchanged.
- Closes #174.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

**Universal size guard (`handleToolsCall`):**
- `hubitat-mcp-server.groovy:730-758` — after `executeTool`, the serialized result is sized; over 110000 bytes the inner content is replaced with `_responseTooLargeEnvelope`. The 110KB threshold leaves room for text-escape + JSON-RPC envelope overhead inside the hub's 128KB limit. Inlined `final int` to match the constraint PR #180 documented (Hubitat app-DSL rejects `private static final` at top level).
- `hubitat-mcp-server.groovy:778-822` — `_responseTooLargeEnvelope` + `_responseTooLargeSuggestion` produce the structured envelope (`response_too_large`/`truncated`/`estimatedBytes`/`sizeLimitBytes`/`tool`/`suggestion`). Per-tool suggestion branches cover all seven tools the issue follow-up named (list_devices, list_installed_apps, get_app_config, device_health_check, get_memory_history, get_hub_logs, export_native_app) plus the obvious risky-but-unmentioned tools (hub status family, source-fetch family). New tools fall through to a generic default.
- Gateway-routed calls (manage_*) use `args.tool` when present so the suggestion targets the actual sub-tool, not the gateway.

**Opt-in cursor pagination (matches PR #180's opaque-string contract):**
- `hubitat-mcp-server.groovy:828-844` — new `_parseListCursor` helper centralises cursor parsing. `null` / `""` mean \"start at 0\"; non-numeric, negative, and out-of-range cursors all throw `IllegalArgumentException` (which dispatch turns into `-32602`, same as `tools/list`).
- `toolListInstalledApps` (`hubitat-mcp-server.groovy:12322-12410`) — when `cursor` is supplied, the filtered apps list is paged at 50/entry and the response gains `total` + optional `nextCursor`. No-cursor calls are byte-for-byte identical to pre-#174.
- `toolDeviceHealthCheck` (`hubitat-mcp-server.groovy:9286-9416`) — when `cursor` is supplied, `staleDevices` is paged at 100/entry. `unknownDevices` and (optional) `healthyDevices` stay in full alongside the page so the summary call still works in a single request.

**Schemas:**
- Added `cursor: [type: \"string\", description: ...]` to the `list_installed_apps` and `device_health_check` schemas.

**Tests (+12 specs):**
- `HandleMcpRequestDispatchSpec` +2: oversized result returns the structured envelope (id/jsonrpc still success, `isError` not set, `tool` field populated, `rooms` absent — the whole point of fail-soft); small result passes through unperturbed.
- `ToolListInstalledAppsSpec` +7: backward-compat (no cursor → no pagination fields); first page emits `nextCursor=\"50\"`; multi-page iteration covers every app exactly once; non-numeric cursor reject; negative cursor reject; out-of-range cursor reject; cursor respects `filter` (paginates the filtered set, not the raw catalog).
- `ToolManageDiagnosticsSpec` +3: cursor pages staleDevices and emits `nextCursor`; no-cursor returns the full list (backward compat); non-numeric reject.

**Docs:**
- `TOOL_GUIDE.md` — new \"`tools/call` Response-Size Guard\" section right after the existing \"`tools/list` Pagination\" section. Documents the envelope contract and which tools currently expose cursor.
- `agent-skill/hubitat-mcp/tool-reference.md` — cursor note appended to the `list_installed_apps` and `device_health_check` rows.

## Release Notes

- New: every `tools/call` response is now bounded by a universal 110KB fail-soft size guard. Oversized results return a structured `response_too_large` envelope with `estimatedBytes`, `sizeLimitBytes`, the offending tool name, and a tool-specific `suggestion` for narrowing the query — the call no longer silently disappears into a `-32603` from the hub when a large-result tool (list_devices detailed, includeSettings on a Room Lighting / RM 5.1 app, large rule export, etc.) crosses the cap. Gateway-routed calls report the actual sub-tool in the envelope so the LLM can re-issue a narrower call directly.
- New: opt-in cursor pagination on `list_installed_apps` (page size 50) and `device_health_check` (page size 100 over `staleDevices`), matching the cursor / `nextCursor` contract `tools/list` already uses. Default behaviour (no cursor) is unchanged — pre-existing callers see no difference.

## Testing

- `python tests/sandbox_lint.py` — clean (0 errors, 0 warnings).
- `./gradlew test` — relying on CI per the local-test feedback rule; new specs follow the same `HarnessSpec` / `mcpDriver.pushBody` shape as the existing `HandleMcpRequestDispatchSpec` cursor tests added in PR #180.
- New spec counts: HandleMcpRequestDispatchSpec +2, ToolListInstalledAppsSpec +7, ToolManageDiagnosticsSpec +3.

## Checklist

- [x] **Unit tests added for any new MCP tools** (12 new specs cover the universal guard + both cursor surfaces; no new tools)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms — local skipped per repo convention, awaiting CI)
- [x] Live-hub BAT tests updated if tool behaviour changed (universal guard is wire-shape-only; cursor params are additive opt-ins — no BAT changes required)
- [x] Documentation updated if user-facing behaviour or tool surface changed