### PR TITLE
ci(hub-e2e): deploy PR source to test hub before running tests

### DIFF
--- a/.github/scripts/mcp_deploy_source.sh
+++ b/.github/scripts/mcp_deploy_source.sh
@@ -36,11 +36,21 @@ set -euo pipefail
 SOURCE_FILE="${1:-hubitat-mcp-server.groovy}"
 PRE_SOURCE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source.groovy"
 CLASS_ID_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_class_id"
+PRE_LEN_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_charlen"
 
 # Pulled from the parent app's definition() block — keep these in sync if
 # the parent ever changes its namespace/name (it shouldn't; HPM tracks it).
 APP_NAMESPACE="mcp"
 APP_NAME="MCP Rule Server"
+
+# How long we wait for the hub-side recompile to finish AFTER cloud
+# returns 504. Cloud's gateway window is ~10s; the hub's actual recompile
+# of a 1.2MB Groovy app on a real Hubitat C-7/C-8 is ~10-25s; we poll
+# get_app_source until totalLength changes from PRE_LEN (proving the
+# write landed) or we time out.
+POST_DEPLOY_VERIFY_SLEEP=20
+POST_DEPLOY_VERIFY_TIMEOUT=90
+POST_DEPLOY_VERIFY_INTERVAL=8
 
 if [ ! -f "$SOURCE_FILE" ]; then
   echo "::error::Source file not found: $SOURCE_FILE"
@@ -104,6 +114,7 @@ printf '%s' "$CLASS_ID" > "$CLASS_ID_FILE"
 
 echo "Snapshotting current class $CLASS_ID source to $PRE_SOURCE_FILE..."
 : > "$PRE_SOURCE_FILE"
+: > "$PRE_LEN_FILE"
 OFFSET=0
 CHUNK_LEN=64000
 while :; do
@@ -126,7 +137,9 @@ while :; do
     exit 1
   fi
   if [ "$OFFSET" -eq 0 ]; then
-    echo "DEBUG first-chunk meta: totalLength=$(echo "$TEXT" | jq -r '.totalLength // null') chunkLength=$(echo "$TEXT" | jq -r '.chunkLength // null') hasMore=$(echo "$TEXT" | jq -r '.hasMore // null')"
+    PRE_LEN=$(echo "$TEXT" | jq -r '.totalLength // 0')
+    echo "DEBUG first-chunk meta: totalLength=$PRE_LEN chunkLength=$(echo "$TEXT" | jq -r '.chunkLength // null') hasMore=$(echo "$TEXT" | jq -r '.hasMore // null')"
+    printf '%s' "$PRE_LEN" > "$PRE_LEN_FILE"
   fi
   # jq -j (join output, no trailing newline) -- chunks must concatenate
   # byte-for-byte; jq -r would inject a separator newline at every 64KB
@@ -162,6 +175,34 @@ jq -nc \
   '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}' \
   > "$DEPLOY_RPC_FILE"
 
+# Poll get_app_source until totalLength differs from a known baseline,
+# proving the write landed even when cloud bailed mid-recompile with a
+# 504. Caller passes the baseline charlen we want to see change away
+# from (PRE_LEN for deploy verification, NEW_LEN-ish for restore).
+verify_source_changed_from() {
+  local baseline="$1"
+  local what="$2"   # "deploy" or "restore" -- for logs
+  local elapsed=0
+  local rpc resp text current_len ok
+  while [ $elapsed -lt $POST_DEPLOY_VERIFY_TIMEOUT ]; do
+    rpc=$(jq -nc --arg id "$CLASS_ID" \
+      '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"get_app_source",arguments:{appId:$id,offset:0,length:1}}}')
+    resp=$(mcp_call "$rpc")
+    text=$(echo "$resp" | jq -r '.result.content[0].text // empty')
+    ok=$(echo "$text" | jq -r '.success // false')
+    current_len=$(echo "$text" | jq -r '.totalLength // 0')
+    if [ "$ok" = "true" ] && [ -n "$current_len" ] && [ "$current_len" != "$baseline" ] && [ "$current_len" != "0" ]; then
+      echo "$what verified: hub source totalLength=$current_len differs from baseline=$baseline."
+      return 0
+    fi
+    echo "Polling ($what)... current totalLength=$current_len, baseline=$baseline, elapsed=${elapsed}s/${POST_DEPLOY_VERIFY_TIMEOUT}s"
+    sleep $POST_DEPLOY_VERIFY_INTERVAL
+    elapsed=$((elapsed + POST_DEPLOY_VERIFY_INTERVAL))
+  done
+  echo "::error::$what verification timed out after ${POST_DEPLOY_VERIFY_TIMEOUT}s; hub totalLength still $current_len (baseline was $baseline)"
+  return 1
+}
+
 DEPLOY_RESP_FILE="${RUNNER_TEMP:-/tmp}/mcp_deploy_resp.txt"
 mcp_call_stdin < "$DEPLOY_RPC_FILE" > "$DEPLOY_RESP_FILE" || true
 rm -f "$DEPLOY_RPC_FILE"
@@ -171,33 +212,42 @@ HTTP_CODE=$(tail -n1 "$DEPLOY_RESP_FILE")
 # Strip the last line (status) to leave just the body.
 DEPLOY_BODY=$(head -c -$((${#HTTP_CODE} + 1)) "$DEPLOY_RESP_FILE")
 echo "Hub responded HTTP $HTTP_CODE; body length=$(printf '%s' "$DEPLOY_BODY" | wc -c)"
-
-if [ "$HTTP_CODE" != "200" ]; then
-  echo "::error::update_app_code got HTTP $HTTP_CODE"
-  echo "Body head: $(printf '%s' "$DEPLOY_BODY" | head -c 1000)"
-  rm -f "$DEPLOY_RESP_FILE"
-  exit 1
-fi
-
-# Try MCP-envelope parse. If parse fails, the hub returned 200 with a
-# non-JSON body (HTML error page, plain-text, etc.) -- log it raw so we
-# can see what came back.
-DEPLOY_TEXT=$(printf '%s' "$DEPLOY_BODY" | jq -r '.result.content[0].text // empty' 2>/dev/null || true)
-if [ -z "$DEPLOY_TEXT" ]; then
-  echo "::error::update_app_code returned 200 but body was not parseable MCP JSON"
-  echo "Body head (first 1500 bytes):"
-  printf '%s' "$DEPLOY_BODY" | head -c 1500
-  rm -f "$DEPLOY_RESP_FILE"
-  exit 1
-fi
 rm -f "$DEPLOY_RESP_FILE"
 
-DEPLOY_OK=$(echo "$DEPLOY_TEXT" | jq -r '.success // false')
-if [ "$DEPLOY_OK" != "true" ]; then
-  echo "::error::update_app_code failed: $(echo "$DEPLOY_TEXT" | jq -r '.error // .message // empty')"
-  echo "Tool response: $DEPLOY_TEXT" | head -c 2000
+if [ "$HTTP_CODE" = "200" ]; then
+  # Happy path: parse the MCP envelope and accept the hub's own success report.
+  DEPLOY_TEXT=$(printf '%s' "$DEPLOY_BODY" | jq -r '.result.content[0].text // empty' 2>/dev/null || true)
+  if [ -z "$DEPLOY_TEXT" ]; then
+    echo "::error::update_app_code returned 200 but body was not parseable MCP JSON"
+    echo "Body head (first 1500 bytes):"
+    printf '%s' "$DEPLOY_BODY" | head -c 1500
+    exit 1
+  fi
+  DEPLOY_OK=$(echo "$DEPLOY_TEXT" | jq -r '.success // false')
+  if [ "$DEPLOY_OK" != "true" ]; then
+    echo "::error::update_app_code failed: $(echo "$DEPLOY_TEXT" | jq -r '.error // .message // empty')"
+    echo "Tool response: $DEPLOY_TEXT" | head -c 2000
+    exit 1
+  fi
+  echo "Deploy succeeded (200/JSON). PR source ($NEW_BYTES bytes) is now live on the hub at class $CLASS_ID."
+elif [ "$HTTP_CODE" = "504" ] || [ "$HTTP_CODE" = "502" ] || [ "$HTTP_CODE" = "503" ]; then
+  # Cloud gateway gave up waiting (the hub-side recompile of a ~1.2MB
+  # Groovy app takes longer than cloud's ~10s response budget). The hub
+  # usually keeps working and completes the save -- verify by polling
+  # get_app_source totalLength until it changes from the pre-deploy
+  # snapshot.
+  echo "::notice::Hub returned HTTP $HTTP_CODE (cloud gateway timeout). Sleeping ${POST_DEPLOY_VERIFY_SLEEP}s for the hub-side recompile, then polling get_app_source to verify..."
+  sleep $POST_DEPLOY_VERIFY_SLEEP
+  if verify_source_changed_from "$PRE_LEN" "deploy"; then
+    echo "Deploy verified despite HTTP $HTTP_CODE. PR source is on the hub."
+  else
+    echo "::error::Deploy not verified -- hub source did not converge away from pre-deploy length."
+    exit 1
+  fi
+else
+  echo "::error::update_app_code got unexpected HTTP $HTTP_CODE"
+  echo "Body head: $(printf '%s' "$DEPLOY_BODY" | head -c 1000)"
   exit 1
 fi
 
-echo "Deploy succeeded. PR source ($NEW_BYTES bytes) is now live on the hub at class $CLASS_ID."
 echo "Pre-image preserved at $PRE_SOURCE_FILE for cleanup-time restore."

--- a/.github/scripts/mcp_deploy_source.sh
+++ b/.github/scripts/mcp_deploy_source.sh
@@ -57,6 +57,9 @@ while :; do
     --argjson off "$OFFSET" \
     --argjson len "$CHUNK_LEN" \
     '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"get_app_source",arguments:{appId:$id,offset:$off,length:$len}}}')
+  if [ "$OFFSET" -eq 0 ]; then
+    echo "DEBUG first-chunk request: $RPC"
+  fi
   RESP=$(mcp_call "$RPC")
   TEXT=$(echo "$RESP" | jq -r '.result.content[0].text // empty')
   if [ -z "$TEXT" ]; then
@@ -69,6 +72,13 @@ while :; do
     echo "::error::get_app_source failed: $(echo "$TEXT" | jq -r '.error // empty')"
     rm -f "$PRE_SOURCE_FILE"
     exit 1
+  fi
+  # Debug: log shape on the first iteration so we can diagnose unexpected
+  # response envelopes (e.g. after #174's response-size guard rollout).
+  if [ "$OFFSET" -eq 0 ]; then
+    echo "DEBUG first-chunk envelope keys: $(echo "$TEXT" | jq -r 'keys | join(",")')"
+    echo "DEBUG first-chunk meta: success=$(echo "$TEXT" | jq -r '.success // null') totalLength=$(echo "$TEXT" | jq -r '.totalLength // null') chunkLength=$(echo "$TEXT" | jq -r '.chunkLength // null') hasMore=$(echo "$TEXT" | jq -r '.hasMore // null') sourceLen=$(echo "$TEXT" | jq -r '.source // "" | length')"
+    echo "DEBUG first-chunk full text head: $(echo "$TEXT" | head -c 600)"
   fi
   # jq -j (join output, no trailing newline) -- chunks must concatenate
   # byte-for-byte; jq -r would inject a separator newline at every 64KB

--- a/.github/scripts/mcp_deploy_source.sh
+++ b/.github/scripts/mcp_deploy_source.sh
@@ -57,9 +57,13 @@ mcp_call() {
 
 mcp_call_stdin() {
   # Caller pipes the RPC body to stdin. --data-binary @- streams the body
-  # without shell-arg or newline mangling.
+  # without shell-arg or newline mangling. -w '\n%{http_code}' appends the
+  # HTTP status code on a new line so callers can distinguish "hub returned
+  # 200 with non-JSON body" from "hub returned 504/413/etc." -- both fail
+  # the JSON parse but for very different reasons.
   curl -sS --max-time 120 -X POST "$MCP_URL" \
     -H "Content-Type: application/json" \
+    -w '\n%{http_code}' \
     --data-binary @-
 }
 
@@ -158,16 +162,35 @@ jq -nc \
   '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}' \
   > "$DEPLOY_RPC_FILE"
 
-DEPLOY_RESP=$(mcp_call_stdin < "$DEPLOY_RPC_FILE")
+DEPLOY_RESP_FILE="${RUNNER_TEMP:-/tmp}/mcp_deploy_resp.txt"
+mcp_call_stdin < "$DEPLOY_RPC_FILE" > "$DEPLOY_RESP_FILE" || true
 rm -f "$DEPLOY_RPC_FILE"
 
-DEPLOY_TEXT=$(echo "$DEPLOY_RESP" | jq -r '.result.content[0].text // empty')
+# Body and HTTP status are separated by the trailing `\n<code>` from curl -w.
+HTTP_CODE=$(tail -n1 "$DEPLOY_RESP_FILE")
+# Strip the last line (status) to leave just the body.
+DEPLOY_BODY=$(head -c -$((${#HTTP_CODE} + 1)) "$DEPLOY_RESP_FILE")
+echo "Hub responded HTTP $HTTP_CODE; body length=$(printf '%s' "$DEPLOY_BODY" | wc -c)"
 
-if [ -z "$DEPLOY_TEXT" ]; then
-  echo "::error::update_app_code returned empty MCP content"
-  echo "Full response head: $(echo "$DEPLOY_RESP" | head -c 1000)"
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "::error::update_app_code got HTTP $HTTP_CODE"
+  echo "Body head: $(printf '%s' "$DEPLOY_BODY" | head -c 1000)"
+  rm -f "$DEPLOY_RESP_FILE"
   exit 1
 fi
+
+# Try MCP-envelope parse. If parse fails, the hub returned 200 with a
+# non-JSON body (HTML error page, plain-text, etc.) -- log it raw so we
+# can see what came back.
+DEPLOY_TEXT=$(printf '%s' "$DEPLOY_BODY" | jq -r '.result.content[0].text // empty' 2>/dev/null || true)
+if [ -z "$DEPLOY_TEXT" ]; then
+  echo "::error::update_app_code returned 200 but body was not parseable MCP JSON"
+  echo "Body head (first 1500 bytes):"
+  printf '%s' "$DEPLOY_BODY" | head -c 1500
+  rm -f "$DEPLOY_RESP_FILE"
+  exit 1
+fi
+rm -f "$DEPLOY_RESP_FILE"
 
 DEPLOY_OK=$(echo "$DEPLOY_TEXT" | jq -r '.success // false')
 if [ "$DEPLOY_OK" != "true" ]; then

--- a/.github/scripts/mcp_deploy_source.sh
+++ b/.github/scripts/mcp_deploy_source.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Deploy the PR's parent-app source to the donated test hub so E2E
+# actually exercises the code under review (rather than whatever was
+# last deployed manually). Snapshots the hub's current source to
+# RUNNER_TEMP first so mcp_restore_source.sh can put it back on
+# cleanup -- if the snapshot fails, the deploy is skipped, so the
+# hub is only ever in the PR-code state while we hold a verified
+# pre-image.
+#
+# Usage:  mcp_deploy_source.sh [path/to/hubitat-mcp-server.groovy]
+# Env:    MCP_URL              -- full cloud OAuth URL with access_token
+#         HUBITAT_APP_ID       -- parent-app ID parsed from MCP_URL
+#         RUNNER_TEMP          -- GHA-provided temp dir; falls back to /tmp
+#
+# Preconditions enforced by update_app_code in the hub:
+#   - Developer Mode ON (otherwise the self-update guard refuses)
+#   - enableHubAdminWrite ON (already set up by manual hub config)
+#   - Hub backup <24h (best-effort create_hub_backup attempted here;
+#     gateway timeouts are tolerated since the gate counts the cached
+#     state.lastBackupTimestamp written by any previous successful
+#     run, and CI runs keep that window populated)
+
+set -euo pipefail
+
+: "${MCP_URL:?MCP_URL env var required (full cloud OAuth URL with access_token)}"
+: "${HUBITAT_APP_ID:?HUBITAT_APP_ID env var required (parent-app numeric ID)}"
+
+SOURCE_FILE="${1:-hubitat-mcp-server.groovy}"
+PRE_SOURCE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source.groovy"
+
+if [ ! -f "$SOURCE_FILE" ]; then
+  echo "::error::Source file not found: $SOURCE_FILE"
+  exit 1
+fi
+
+mcp_call() {
+  # --max-time 120 -- update_app_code uploads ~1.2MB of Groovy and
+  # the hub recompiles inline; 30s (the read/write default elsewhere
+  # in CI) is too tight for the round-trip.
+  curl -sS --max-time 120 -X POST "$MCP_URL" \
+    -H "Content-Type: application/json" \
+    -d "$1"
+}
+
+echo "Triggering hub backup (best-effort; tolerated if it 504s -- the <24h gate is timestamp-cached)..."
+BACKUP_RPC='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_hub_backup","arguments":{"confirm":true}}}'
+mcp_call "$BACKUP_RPC" >/dev/null 2>&1 || \
+  echo "::warning::create_hub_backup call failed/timed out; relying on cached <24h backup timestamp"
+
+echo "Snapshotting current app $HUBITAT_APP_ID source to $PRE_SOURCE_FILE..."
+: > "$PRE_SOURCE_FILE"
+OFFSET=0
+CHUNK_LEN=64000
+while :; do
+  RPC=$(jq -nc \
+    --arg id "$HUBITAT_APP_ID" \
+    --argjson off "$OFFSET" \
+    --argjson len "$CHUNK_LEN" \
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"get_app_source",arguments:{appId:$id,offset:$off,length:$len}}}')
+  RESP=$(mcp_call "$RPC")
+  TEXT=$(echo "$RESP" | jq -r '.result.content[0].text // empty')
+  if [ -z "$TEXT" ]; then
+    echo "::error::get_app_source returned empty MCP content (resp head: $(echo "$RESP" | head -c 500))"
+    rm -f "$PRE_SOURCE_FILE"
+    exit 1
+  fi
+  OK=$(echo "$TEXT" | jq -r '.success // false')
+  if [ "$OK" != "true" ]; then
+    echo "::error::get_app_source failed: $(echo "$TEXT" | jq -r '.error // empty')"
+    rm -f "$PRE_SOURCE_FILE"
+    exit 1
+  fi
+  # jq -j (join output, no trailing newline) -- chunks must concatenate
+  # byte-for-byte; jq -r would inject a separator newline at every 64KB
+  # boundary, corrupting the snapshot for the restore step.
+  echo "$TEXT" | jq -j '.source // ""' >> "$PRE_SOURCE_FILE"
+  HAS_MORE=$(echo "$TEXT" | jq -r '.hasMore // false')
+  NEXT=$(echo "$TEXT" | jq -r '.nextOffset // empty')
+  if [ "$HAS_MORE" != "true" ] || [ -z "$NEXT" ]; then
+    break
+  fi
+  OFFSET="$NEXT"
+done
+
+PRE_BYTES=$(wc -c < "$PRE_SOURCE_FILE")
+echo "Snapshotted $PRE_BYTES bytes."
+
+if [ "$PRE_BYTES" -lt 1000 ]; then
+  echo "::error::Pre-deploy snapshot is suspiciously small ($PRE_BYTES bytes); refusing to deploy"
+  rm -f "$PRE_SOURCE_FILE"
+  exit 1
+fi
+
+NEW_BYTES=$(wc -c < "$SOURCE_FILE")
+echo "Pushing $SOURCE_FILE ($NEW_BYTES bytes) to app $HUBITAT_APP_ID..."
+
+DEPLOY_RPC=$(jq -nc \
+  --arg id "$HUBITAT_APP_ID" \
+  --rawfile src "$SOURCE_FILE" \
+  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}')
+
+DEPLOY_RESP=$(mcp_call "$DEPLOY_RPC")
+DEPLOY_TEXT=$(echo "$DEPLOY_RESP" | jq -r '.result.content[0].text // empty')
+
+if [ -z "$DEPLOY_TEXT" ]; then
+  echo "::error::update_app_code returned empty MCP content"
+  echo "Full response head: $(echo "$DEPLOY_RESP" | head -c 1000)"
+  exit 1
+fi
+
+DEPLOY_OK=$(echo "$DEPLOY_TEXT" | jq -r '.success // false')
+if [ "$DEPLOY_OK" != "true" ]; then
+  echo "::error::update_app_code failed: $(echo "$DEPLOY_TEXT" | jq -r '.error // .message // empty')"
+  echo "Tool response: $DEPLOY_TEXT" | head -c 2000
+  exit 1
+fi
+
+echo "Deploy succeeded. PR source ($NEW_BYTES bytes) is now live on the hub."
+echo "Pre-image preserved at $PRE_SOURCE_FILE for cleanup-time restore."

--- a/.github/scripts/mcp_deploy_source.sh
+++ b/.github/scripts/mcp_deploy_source.sh
@@ -9,7 +9,12 @@
 #
 # Usage:  mcp_deploy_source.sh [path/to/hubitat-mcp-server.groovy]
 # Env:    MCP_URL              -- full cloud OAuth URL with access_token
-#         HUBITAT_APP_ID       -- parent-app ID parsed from MCP_URL
+#         HUBITAT_APP_ID       -- installed-instance ID parsed from MCP_URL.
+#                                 NOT used for source operations -- the
+#                                 source-bearing Apps Code entry lives at a
+#                                 different ID in a separate namespace, so
+#                                 we look it up via list_hub_apps + match by
+#                                 (namespace, name) from definition().
 #         RUNNER_TEMP          -- GHA-provided temp dir; falls back to /tmp
 #
 # Preconditions enforced by update_app_code in the hub:
@@ -19,47 +24,90 @@
 #     gateway timeouts are tolerated since the gate counts the cached
 #     state.lastBackupTimestamp written by any previous successful
 #     run, and CI runs keep that window populated)
+#
+# Large payloads (~1.2MB of Groovy) are streamed via stdin with
+# `--data-binary @-` so we never push the RPC envelope through a
+# command-line argument and hit Linux ARG_MAX.
 
 set -euo pipefail
 
 : "${MCP_URL:?MCP_URL env var required (full cloud OAuth URL with access_token)}"
-: "${HUBITAT_APP_ID:?HUBITAT_APP_ID env var required (parent-app numeric ID)}"
 
 SOURCE_FILE="${1:-hubitat-mcp-server.groovy}"
 PRE_SOURCE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source.groovy"
+CLASS_ID_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_class_id"
+
+# Pulled from the parent app's definition() block — keep these in sync if
+# the parent ever changes its namespace/name (it shouldn't; HPM tracks it).
+APP_NAMESPACE="mcp"
+APP_NAME="MCP Rule Server"
 
 if [ ! -f "$SOURCE_FILE" ]; then
   echo "::error::Source file not found: $SOURCE_FILE"
   exit 1
 fi
 
+# Two-arg call for small/in-process payloads; large payloads (the source
+# blob in update_app_code) pipe stdin via mcp_call_stdin to dodge ARG_MAX.
 mcp_call() {
-  # --max-time 120 -- update_app_code uploads ~1.2MB of Groovy and
-  # the hub recompiles inline; 30s (the read/write default elsewhere
-  # in CI) is too tight for the round-trip.
   curl -sS --max-time 120 -X POST "$MCP_URL" \
     -H "Content-Type: application/json" \
-    -d "$1"
+    --data-binary "$1"
+}
+
+mcp_call_stdin() {
+  # Caller pipes the RPC body to stdin. --data-binary @- streams the body
+  # without shell-arg or newline mangling.
+  curl -sS --max-time 120 -X POST "$MCP_URL" \
+    -H "Content-Type: application/json" \
+    --data-binary @-
 }
 
 echo "Triggering hub backup (best-effort; tolerated if it 504s -- the <24h gate is timestamp-cached)..."
 BACKUP_RPC='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_hub_backup","arguments":{"confirm":true}}}'
-mcp_call "$BACKUP_RPC" >/dev/null 2>&1 || \
+# `>/dev/null` (not `2>&1`) so genuine curl errors -- DNS, connection refused,
+# TLS handshake -- stay visible in the log even though the response body is
+# discarded.
+mcp_call "$BACKUP_RPC" >/dev/null || \
   echo "::warning::create_hub_backup call failed/timed out; relying on cached <24h backup timestamp"
 
-echo "Snapshotting current app $HUBITAT_APP_ID source to $PRE_SOURCE_FILE..."
+echo "Looking up Apps Code class ID for $APP_NAMESPACE:$APP_NAME via list_hub_apps..."
+LIST_RPC='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_hub_apps","arguments":{}}}'
+LIST_RESP=$(mcp_call "$LIST_RPC")
+LIST_TEXT=$(echo "$LIST_RESP" | jq -r '.result.content[0].text // empty')
+if [ -z "$LIST_TEXT" ]; then
+  echo "::error::list_hub_apps returned empty MCP content (resp head: $(echo "$LIST_RESP" | head -c 500))"
+  exit 1
+fi
+
+# /hub2/userAppTypes returns an array of {id, name, namespace, ...}. Match
+# both namespace AND name so we don't grab a fork that happens to reuse
+# either field. `select(...)` returns nothing on miss -- guard against that.
+CLASS_ID=$(echo "$LIST_TEXT" | jq -r \
+  --arg ns "$APP_NAMESPACE" \
+  --arg name "$APP_NAME" \
+  '.apps[]? | select(.namespace == $ns and .name == $name) | .id' | head -n1)
+
+if [ -z "$CLASS_ID" ] || [ "$CLASS_ID" = "null" ]; then
+  echo "::error::Apps Code class for $APP_NAMESPACE:$APP_NAME not found via list_hub_apps."
+  echo "DEBUG list_hub_apps envelope keys: $(echo "$LIST_TEXT" | jq -r 'keys | join(",")')"
+  echo "DEBUG first 5 entries: $(echo "$LIST_TEXT" | jq -c '.apps[0:5] // []')"
+  exit 1
+fi
+
+echo "Resolved class ID: $CLASS_ID (saving to $CLASS_ID_FILE for restore step)"
+printf '%s' "$CLASS_ID" > "$CLASS_ID_FILE"
+
+echo "Snapshotting current class $CLASS_ID source to $PRE_SOURCE_FILE..."
 : > "$PRE_SOURCE_FILE"
 OFFSET=0
 CHUNK_LEN=64000
 while :; do
   RPC=$(jq -nc \
-    --arg id "$HUBITAT_APP_ID" \
+    --arg id "$CLASS_ID" \
     --argjson off "$OFFSET" \
     --argjson len "$CHUNK_LEN" \
     '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"get_app_source",arguments:{appId:$id,offset:$off,length:$len}}}')
-  if [ "$OFFSET" -eq 0 ]; then
-    echo "DEBUG first-chunk request: $RPC"
-  fi
   RESP=$(mcp_call "$RPC")
   TEXT=$(echo "$RESP" | jq -r '.result.content[0].text // empty')
   if [ -z "$TEXT" ]; then
@@ -73,12 +121,8 @@ while :; do
     rm -f "$PRE_SOURCE_FILE"
     exit 1
   fi
-  # Debug: log shape on the first iteration so we can diagnose unexpected
-  # response envelopes (e.g. after #174's response-size guard rollout).
   if [ "$OFFSET" -eq 0 ]; then
-    echo "DEBUG first-chunk envelope keys: $(echo "$TEXT" | jq -r 'keys | join(",")')"
-    echo "DEBUG first-chunk meta: success=$(echo "$TEXT" | jq -r '.success // null') totalLength=$(echo "$TEXT" | jq -r '.totalLength // null') chunkLength=$(echo "$TEXT" | jq -r '.chunkLength // null') hasMore=$(echo "$TEXT" | jq -r '.hasMore // null') sourceLen=$(echo "$TEXT" | jq -r '.source // "" | length')"
-    echo "DEBUG first-chunk full text head: $(echo "$TEXT" | head -c 600)"
+    echo "DEBUG first-chunk meta: totalLength=$(echo "$TEXT" | jq -r '.totalLength // null') chunkLength=$(echo "$TEXT" | jq -r '.chunkLength // null') hasMore=$(echo "$TEXT" | jq -r '.hasMore // null')"
   fi
   # jq -j (join output, no trailing newline) -- chunks must concatenate
   # byte-for-byte; jq -r would inject a separator newline at every 64KB
@@ -97,19 +141,26 @@ echo "Snapshotted $PRE_BYTES bytes."
 
 if [ "$PRE_BYTES" -lt 1000 ]; then
   echo "::error::Pre-deploy snapshot is suspiciously small ($PRE_BYTES bytes); refusing to deploy"
-  rm -f "$PRE_SOURCE_FILE"
+  rm -f "$PRE_SOURCE_FILE" "$CLASS_ID_FILE"
   exit 1
 fi
 
 NEW_BYTES=$(wc -c < "$SOURCE_FILE")
-echo "Pushing $SOURCE_FILE ($NEW_BYTES bytes) to app $HUBITAT_APP_ID..."
+echo "Pushing $SOURCE_FILE ($NEW_BYTES bytes) to class $CLASS_ID..."
 
-DEPLOY_RPC=$(jq -nc \
-  --arg id "$HUBITAT_APP_ID" \
+# Build the RPC envelope as a file (jq --rawfile handles JSON-escaping the
+# 1.2MB source), then pipe to curl via stdin so we never put the body on
+# the command line. Same dodge for the restore script.
+DEPLOY_RPC_FILE="${RUNNER_TEMP:-/tmp}/mcp_deploy_rpc.json"
+jq -nc \
+  --arg id "$CLASS_ID" \
   --rawfile src "$SOURCE_FILE" \
-  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}')
+  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}' \
+  > "$DEPLOY_RPC_FILE"
 
-DEPLOY_RESP=$(mcp_call "$DEPLOY_RPC")
+DEPLOY_RESP=$(mcp_call_stdin < "$DEPLOY_RPC_FILE")
+rm -f "$DEPLOY_RPC_FILE"
+
 DEPLOY_TEXT=$(echo "$DEPLOY_RESP" | jq -r '.result.content[0].text // empty')
 
 if [ -z "$DEPLOY_TEXT" ]; then
@@ -125,5 +176,5 @@ if [ "$DEPLOY_OK" != "true" ]; then
   exit 1
 fi
 
-echo "Deploy succeeded. PR source ($NEW_BYTES bytes) is now live on the hub."
+echo "Deploy succeeded. PR source ($NEW_BYTES bytes) is now live on the hub at class $CLASS_ID."
 echo "Pre-image preserved at $PRE_SOURCE_FILE for cleanup-time restore."

--- a/.github/scripts/mcp_deploy_source.sh
+++ b/.github/scripts/mcp_deploy_source.sh
@@ -1,33 +1,24 @@
 #!/usr/bin/env bash
-# Deploy the PR's parent-app source to the donated test hub so E2E
-# actually exercises the code under review (rather than whatever was
-# last deployed manually). Snapshots the hub's current source to
-# RUNNER_TEMP first so mcp_restore_source.sh can put it back on
-# cleanup -- if the snapshot fails, the deploy is skipped, so the
-# hub is only ever in the PR-code state while we hold a verified
-# pre-image.
+# Snapshot the hub's current parent-app source, then attempt to push the
+# PR's source via update_app_code. On a verified write, drops a
+# "deploy landed" marker that mcp_restore_source.sh checks before
+# pushing anything back -- so a no-op deploy (e.g. blocked by cloud
+# body cap) doesn't trigger a wasted 1.2MB cleanup write.
 #
-# Usage:  mcp_deploy_source.sh [path/to/hubitat-mcp-server.groovy]
-# Env:    MCP_URL              -- full cloud OAuth URL with access_token
-#         HUBITAT_APP_ID       -- installed-instance ID parsed from MCP_URL.
-#                                 NOT used for source operations -- the
-#                                 source-bearing Apps Code entry lives at a
-#                                 different ID in a separate namespace, so
-#                                 we look it up via list_hub_apps + match by
-#                                 (namespace, name) from definition().
-#         RUNNER_TEMP          -- GHA-provided temp dir; falls back to /tmp
+# Usage: mcp_deploy_source.sh [path/to/hubitat-mcp-server.groovy]
+# Env:   MCP_URL     -- full cloud OAuth URL with access_token
+#        RUNNER_TEMP -- GHA temp dir; falls back to /tmp
 #
-# Preconditions enforced by update_app_code in the hub:
-#   - Developer Mode ON (otherwise the self-update guard refuses)
-#   - enableHubAdminWrite ON (already set up by manual hub config)
+# Preconditions (enforced hub-side by update_app_code):
+#   - Developer Mode ON (self-update guard)
+#   - enableHubAdminWrite ON
 #   - Hub backup <24h (best-effort create_hub_backup attempted here;
-#     gateway timeouts are tolerated since the gate counts the cached
-#     state.lastBackupTimestamp written by any previous successful
-#     run, and CI runs keep that window populated)
+#     gateway timeouts tolerated -- the gate is timestamp-cached and
+#     CI runs keep the window populated)
 #
-# Large payloads (~1.2MB of Groovy) are streamed via stdin with
-# `--data-binary @-` so we never push the RPC envelope through a
-# command-line argument and hit Linux ARG_MAX.
+# The MCP URL's app ID (e.g. 38) is the installed-instance ID, NOT the
+# source-bearing Apps Code class ID. We look up the class ID via
+# list_hub_apps and match by (namespace, name) from definition().
 
 set -euo pipefail
 
@@ -37,20 +28,25 @@ SOURCE_FILE="${1:-hubitat-mcp-server.groovy}"
 PRE_SOURCE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source.groovy"
 CLASS_ID_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_class_id"
 PRE_LEN_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_charlen"
+# Written only after the deploy is verified to have landed on the hub.
+# Restore step early-exits if this is absent: no marker = nothing to undo.
+DEPLOY_LANDED_FILE="${RUNNER_TEMP:-/tmp}/mcp_deploy_landed"
 
 # Pulled from the parent app's definition() block — keep these in sync if
 # the parent ever changes its namespace/name (it shouldn't; HPM tracks it).
 APP_NAMESPACE="mcp"
 APP_NAME="MCP Rule Server"
 
-# How long we wait for the hub-side recompile to finish AFTER cloud
-# returns 504. Cloud's gateway window is ~10s; the hub's actual recompile
-# of a 1.2MB Groovy app on a real Hubitat C-7/C-8 is ~10-25s; we poll
+# Cloud's gateway window is ~10s; a 1.2MB Groovy recompile on a real C-7/
+# C-8 hub takes ~10-25s. When cloud returns 5xx, we sleep, then poll
 # get_app_source until totalLength changes from PRE_LEN (proving the
-# write landed) or we time out.
+# write landed) or we hit the timeout.
 POST_DEPLOY_VERIFY_SLEEP=20
 POST_DEPLOY_VERIFY_TIMEOUT=90
 POST_DEPLOY_VERIFY_INTERVAL=8
+
+# Defensive: clear any stale marker from a previous run.
+rm -f "$DEPLOY_LANDED_FILE"
 
 if [ ! -f "$SOURCE_FILE" ]; then
   echo "::error::Source file not found: $SOURCE_FILE"
@@ -175,13 +171,13 @@ jq -nc \
   '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}' \
   > "$DEPLOY_RPC_FILE"
 
-# Poll get_app_source until totalLength differs from a known baseline,
-# proving the write landed even when cloud bailed mid-recompile with a
-# 504. Caller passes the baseline charlen we want to see change away
-# from (PRE_LEN for deploy verification, NEW_LEN-ish for restore).
-verify_source_changed_from() {
-  local baseline="$1"
-  local what="$2"   # "deploy" or "restore" -- for logs
+# Poll get_app_source until totalLength differs from PRE_LEN, proving the
+# write landed even when cloud bailed mid-recompile with a 5xx. Edge case:
+# if the PR source happens to have identical char length to the pre-image
+# (rare; whitespace-only or coincidentally length-matching diffs), this
+# returns a false negative and the deploy is declared failed even though
+# the write succeeded. Acceptable for an advisory continue-on-error step.
+verify_deploy_landed() {
   local elapsed=0
   local rpc resp text current_len ok
   while [ $elapsed -lt $POST_DEPLOY_VERIFY_TIMEOUT ]; do
@@ -191,32 +187,46 @@ verify_source_changed_from() {
     text=$(echo "$resp" | jq -r '.result.content[0].text // empty')
     ok=$(echo "$text" | jq -r '.success // false')
     current_len=$(echo "$text" | jq -r '.totalLength // 0')
-    if [ "$ok" = "true" ] && [ -n "$current_len" ] && [ "$current_len" != "$baseline" ] && [ "$current_len" != "0" ]; then
-      echo "$what verified: hub source totalLength=$current_len differs from baseline=$baseline."
+    if [ "$ok" = "true" ] && [ -n "$current_len" ] && [ "$current_len" != "$PRE_LEN" ] && [ "$current_len" != "0" ]; then
+      echo "Deploy verified: hub source totalLength=$current_len differs from baseline=$PRE_LEN."
       return 0
     fi
-    echo "Polling ($what)... current totalLength=$current_len, baseline=$baseline, elapsed=${elapsed}s/${POST_DEPLOY_VERIFY_TIMEOUT}s"
+    echo "Polling deploy... current totalLength=$current_len, baseline=$PRE_LEN, elapsed=${elapsed}s/${POST_DEPLOY_VERIFY_TIMEOUT}s"
     sleep $POST_DEPLOY_VERIFY_INTERVAL
     elapsed=$((elapsed + POST_DEPLOY_VERIFY_INTERVAL))
   done
-  echo "::error::$what verification timed out after ${POST_DEPLOY_VERIFY_TIMEOUT}s; hub totalLength still $current_len (baseline was $baseline)"
+  echo "::error::Deploy verification timed out after ${POST_DEPLOY_VERIFY_TIMEOUT}s; hub totalLength still $current_len (baseline was $PRE_LEN)"
   return 1
 }
 
 DEPLOY_RESP_FILE="${RUNNER_TEMP:-/tmp}/mcp_deploy_resp.txt"
-mcp_call_stdin < "$DEPLOY_RPC_FILE" > "$DEPLOY_RESP_FILE" || true
+# Don't || true here -- capture curl's exit code explicitly so DNS /
+# connection / TLS failures surface distinctly from HTTP-level errors.
+# set +e/-e around the call so curl's non-zero doesn't kill the script
+# before we can report it.
+set +e
+mcp_call_stdin < "$DEPLOY_RPC_FILE" > "$DEPLOY_RESP_FILE"
+CURL_RC=$?
+set -e
 rm -f "$DEPLOY_RPC_FILE"
 
-# Body and HTTP status are separated by the trailing `\n<code>` from curl -w.
+if [ $CURL_RC -ne 0 ]; then
+  echo "::error::curl exited $CURL_RC before HTTP exchange completed (DNS / connect / TLS / timeout)"
+  rm -f "$DEPLOY_RESP_FILE"
+  exit 1
+fi
+
+# Body and HTTP status are separated by curl -w's trailing `\n<code>`.
+# `sed '$d'` drops the last line (portable, unlike GNU `head -c -N`).
 HTTP_CODE=$(tail -n1 "$DEPLOY_RESP_FILE")
-# Strip the last line (status) to leave just the body.
-DEPLOY_BODY=$(head -c -$((${#HTTP_CODE} + 1)) "$DEPLOY_RESP_FILE")
+DEPLOY_BODY=$(sed '$d' "$DEPLOY_RESP_FILE")
 echo "Hub responded HTTP $HTTP_CODE; body length=$(printf '%s' "$DEPLOY_BODY" | wc -c)"
 rm -f "$DEPLOY_RESP_FILE"
 
 if [ "$HTTP_CODE" = "200" ]; then
   # Happy path: parse the MCP envelope and accept the hub's own success report.
-  DEPLOY_TEXT=$(printf '%s' "$DEPLOY_BODY" | jq -r '.result.content[0].text // empty' 2>/dev/null || true)
+  # jq stderr passes through so parse errors are visible in CI logs.
+  DEPLOY_TEXT=$(printf '%s' "$DEPLOY_BODY" | jq -r '.result.content[0].text // empty' || true)
   if [ -z "$DEPLOY_TEXT" ]; then
     echo "::error::update_app_code returned 200 but body was not parseable MCP JSON"
     echo "Body head (first 1500 bytes):"
@@ -230,16 +240,16 @@ if [ "$HTTP_CODE" = "200" ]; then
     exit 1
   fi
   echo "Deploy succeeded (200/JSON). PR source ($NEW_BYTES bytes) is now live on the hub at class $CLASS_ID."
+  printf 'verified-via=200-json bytes=%s\n' "$NEW_BYTES" > "$DEPLOY_LANDED_FILE"
 elif [ "$HTTP_CODE" = "504" ] || [ "$HTTP_CODE" = "502" ] || [ "$HTTP_CODE" = "503" ]; then
-  # Cloud gateway gave up waiting (the hub-side recompile of a ~1.2MB
-  # Groovy app takes longer than cloud's ~10s response budget). The hub
-  # usually keeps working and completes the save -- verify by polling
-  # get_app_source totalLength until it changes from the pre-deploy
-  # snapshot.
+  # Cloud bailed before the hub finished recompiling. The hub usually
+  # keeps working; poll get_app_source totalLength until it diverges
+  # from the pre-deploy snapshot.
   echo "::notice::Hub returned HTTP $HTTP_CODE (cloud gateway timeout). Sleeping ${POST_DEPLOY_VERIFY_SLEEP}s for the hub-side recompile, then polling get_app_source to verify..."
   sleep $POST_DEPLOY_VERIFY_SLEEP
-  if verify_source_changed_from "$PRE_LEN" "deploy"; then
+  if verify_deploy_landed; then
     echo "Deploy verified despite HTTP $HTTP_CODE. PR source is on the hub."
+    printf 'verified-via=5xx-poll bytes=%s\n' "$NEW_BYTES" > "$DEPLOY_LANDED_FILE"
   else
     echo "::error::Deploy not verified -- hub source did not converge away from pre-deploy length."
     exit 1
@@ -250,4 +260,4 @@ else
   exit 1
 fi
 
-echo "Pre-image preserved at $PRE_SOURCE_FILE for cleanup-time restore."
+echo "Pre-image preserved at $PRE_SOURCE_FILE, deploy-landed marker at $DEPLOY_LANDED_FILE."

--- a/.github/scripts/mcp_restore_source.sh
+++ b/.github/scripts/mcp_restore_source.sh
@@ -1,23 +1,15 @@
 #!/usr/bin/env bash
-# Push the pre-deploy parent-app source snapshot back to the test hub so
-# the hub is returned to whatever was live before this run mutated it.
-# Reads the Apps Code class ID + pre-deploy charlen that
-# mcp_deploy_source.sh wrote alongside the snapshot.
+# Push the pre-deploy source snapshot back to the test hub. Gated on the
+# deploy-landed marker that mcp_deploy_source.sh only writes after a
+# verified write -- no marker means deploy was a no-op and there's
+# nothing to undo.
 #
-# The 1.2MB recompile of the parent app reliably exceeds cloud.hubitat.com's
-# ~10s gateway timeout, so HTTP 504 from update_app_code is expected; we
-# verify the write landed by polling get_app_source for the source length
-# to match the pre-deploy baseline (PRE_LEN) -- which is the same charlen
-# we want the hub back at.
+# Runs in `if: always()` cleanup. Every error path falls through with a
+# warning and exit 0 so lease release + env restore still run.
 #
-# Tolerant of a missing pre-source file (early-exit no-op) so it can live
-# in an `if: always()` workflow step alongside the env restore + lease
-# release. Restore failure logs a warning but does not exit non-zero --
-# remaining cleanup (lease release, env restore) must still run.
-#
-# Usage:  mcp_restore_source.sh
-# Env:    MCP_URL              -- full cloud OAuth URL with access_token
-#         RUNNER_TEMP          -- GHA-provided temp dir; falls back to /tmp
+# Usage: mcp_restore_source.sh
+# Env:   MCP_URL     -- full cloud OAuth URL with access_token
+#        RUNNER_TEMP -- GHA temp dir; falls back to /tmp
 
 set -euo pipefail
 
@@ -26,13 +18,24 @@ set -euo pipefail
 PRE_SOURCE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source.groovy"
 CLASS_ID_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_class_id"
 PRE_LEN_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_charlen"
+DEPLOY_LANDED_FILE="${RUNNER_TEMP:-/tmp}/mcp_deploy_landed"
 
 POST_RESTORE_VERIFY_SLEEP=20
 POST_RESTORE_VERIFY_TIMEOUT=90
 POST_RESTORE_VERIFY_INTERVAL=8
 
+# Marker-gated: deploy writes this only after verifying the hub actually
+# took the write. Absent marker = deploy was a no-op = nothing to undo.
+# Saves a wasted 1.2MB cleanup push against the donated test hub on every
+# run while the cloud body cap blocks deploys.
+if [ ! -f "$DEPLOY_LANDED_FILE" ]; then
+  echo "No deploy-landed marker at $DEPLOY_LANDED_FILE -- deploy never mutated the hub. Skipping restore."
+  exit 0
+fi
+echo "Deploy-landed marker present: $(cat "$DEPLOY_LANDED_FILE")"
+
 if [ ! -f "$PRE_SOURCE_FILE" ]; then
-  echo "No pre-source snapshot at $PRE_SOURCE_FILE -- deploy step likely failed before capture. Skipping restore."
+  echo "::warning::Deploy-landed marker is present but no snapshot at $PRE_SOURCE_FILE -- can't restore. Hub may be on stale PR source."
   exit 0
 fi
 
@@ -74,16 +77,18 @@ curl -sS --max-time 120 -X POST "$MCP_URL" \
   --data-binary "@$RESTORE_RPC_FILE" > "$RESTORE_RESP_FILE" || true
 rm -f "$RESTORE_RPC_FILE"
 
+# `sed '$d'` to drop the trailing status line is portable; GNU's
+# `head -c -N` is not.
 HTTP_CODE=$(tail -n1 "$RESTORE_RESP_FILE")
-RESTORE_BODY=$(head -c -$((${#HTTP_CODE} + 1)) "$RESTORE_RESP_FILE")
+RESTORE_BODY=$(sed '$d' "$RESTORE_RESP_FILE")
 echo "Hub responded HTTP $HTTP_CODE; body length=$(printf '%s' "$RESTORE_BODY" | wc -c)"
 rm -f "$RESTORE_RESP_FILE"
 
 # Polls get_app_source until totalLength matches the pre-deploy charlen
-# (meaning the restore landed). Returns 0 on match, non-zero on timeout.
+# (meaning the restore landed).
 verify_restored_to_pre_len() {
   if [ -z "$PRE_LEN" ] || [ "$PRE_LEN" = "0" ]; then
-    echo "No PRE_LEN sidecar to verify against -- skipping length-match check."
+    echo "::warning::No PRE_LEN sidecar to verify against -- restore landed unverified."
     return 0
   fi
   local elapsed=0
@@ -113,7 +118,7 @@ verify_restored_to_pre_len() {
 # cleanup (lease release, env restore), so every error path falls through
 # with a warning and exit 0.
 if [ "$HTTP_CODE" = "200" ]; then
-  RESTORE_TEXT=$(printf '%s' "$RESTORE_BODY" | jq -r '.result.content[0].text // empty' 2>/dev/null || true)
+  RESTORE_TEXT=$(printf '%s' "$RESTORE_BODY" | jq -r '.result.content[0].text // empty' || true)
   if [ -n "$RESTORE_TEXT" ] && [ "$(echo "$RESTORE_TEXT" | jq -r '.success // false')" = "true" ]; then
     echo "Restore succeeded (200/JSON). Hub class $CLASS_ID source returned to pre-run state."
     exit 0

--- a/.github/scripts/mcp_restore_source.sh
+++ b/.github/scripts/mcp_restore_source.sh
@@ -50,20 +50,33 @@ jq -nc \
   '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}' \
   > "$RESTORE_RPC_FILE"
 
-RESTORE_RESP=$(curl -sS --max-time 120 -X POST "$MCP_URL" \
+RESTORE_RESP_FILE="${RUNNER_TEMP:-/tmp}/mcp_restore_resp.txt"
+curl -sS --max-time 120 -X POST "$MCP_URL" \
   -H "Content-Type: application/json" \
-  --data-binary "@$RESTORE_RPC_FILE")
+  -w '\n%{http_code}' \
+  --data-binary "@$RESTORE_RPC_FILE" > "$RESTORE_RESP_FILE" || true
 rm -f "$RESTORE_RPC_FILE"
 
-RESTORE_TEXT=$(echo "$RESTORE_RESP" | jq -r '.result.content[0].text // empty')
+HTTP_CODE=$(tail -n1 "$RESTORE_RESP_FILE")
+RESTORE_BODY=$(head -c -$((${#HTTP_CODE} + 1)) "$RESTORE_RESP_FILE")
+echo "Hub responded HTTP $HTTP_CODE; body length=$(printf '%s' "$RESTORE_BODY" | wc -c)"
+
+# Restore is in `if: always()` -- a failure here must not abort the
+# remaining cleanup (lease release, env restore), so all error paths
+# fall through with a warning and exit 0.
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "::warning::Restore got HTTP $HTTP_CODE -- hub source NOT returned to pre-run state"
+  echo "Body head: $(printf '%s' "$RESTORE_BODY" | head -c 800)"
+  rm -f "$RESTORE_RESP_FILE"
+  exit 0
+fi
+
+RESTORE_TEXT=$(printf '%s' "$RESTORE_BODY" | jq -r '.result.content[0].text // empty' 2>/dev/null || true)
+rm -f "$RESTORE_RESP_FILE"
 
 if [ -z "$RESTORE_TEXT" ]; then
-  # `if: always()` step -- log loudly but don't fail the workflow on
-  # restore failure, since lease release and env restore still need to run.
-  # Maintainer will see the warning in the run summary and can manually
-  # redeploy from .github/scripts/mcp_deploy_source.sh against main.
-  echo "::warning::Restore failed: update_app_code returned empty MCP content"
-  echo "Full response head: $(echo "$RESTORE_RESP" | head -c 1000)"
+  echo "::warning::Restore got 200 but body was not parseable MCP JSON -- hub source NOT returned to pre-run state"
+  echo "Body head: $(printf '%s' "$RESTORE_BODY" | head -c 800)"
   exit 0
 fi
 

--- a/.github/scripts/mcp_restore_source.sh
+++ b/.github/scripts/mcp_restore_source.sh
@@ -1,24 +1,37 @@
 #!/usr/bin/env bash
 # Push the pre-deploy parent-app source snapshot back to the test hub so
 # the hub is returned to whatever was live before this run mutated it.
-# Tolerant of a missing pre-source file (early-exit no-op) so it can live
-# in an `if: always()` workflow step alongside the env restore + lease
-# release.
+# Reads the Apps Code class ID that mcp_deploy_source.sh resolved (the
+# installed-instance ID from MCP_URL is NOT the same as the source-class
+# ID; they live in separate Hubitat namespaces) from the sibling file
+# alongside the snapshot. Tolerant of a missing pre-source file (early-
+# exit no-op) so it can live in an `if: always()` workflow step alongside
+# the env restore + lease release.
 #
 # Usage:  mcp_restore_source.sh
 # Env:    MCP_URL              -- full cloud OAuth URL with access_token
-#         HUBITAT_APP_ID       -- parent-app numeric ID
 #         RUNNER_TEMP          -- GHA-provided temp dir; falls back to /tmp
 
 set -euo pipefail
 
 : "${MCP_URL:?MCP_URL env var required (full cloud OAuth URL with access_token)}"
-: "${HUBITAT_APP_ID:?HUBITAT_APP_ID env var required (parent-app numeric ID)}"
 
 PRE_SOURCE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source.groovy"
+CLASS_ID_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_class_id"
 
 if [ ! -f "$PRE_SOURCE_FILE" ]; then
   echo "No pre-source snapshot at $PRE_SOURCE_FILE -- deploy step likely failed before capture. Skipping restore."
+  exit 0
+fi
+
+if [ ! -f "$CLASS_ID_FILE" ]; then
+  echo "::warning::No class-ID sidecar at $CLASS_ID_FILE -- can't target the right Apps Code entry. Skipping restore."
+  exit 0
+fi
+
+CLASS_ID=$(cat "$CLASS_ID_FILE")
+if [ -z "$CLASS_ID" ]; then
+  echo "::warning::Class-ID sidecar is empty. Skipping restore."
   exit 0
 fi
 
@@ -28,16 +41,19 @@ if [ "$PRE_BYTES" -lt 1000 ]; then
   exit 0
 fi
 
-echo "Restoring app $HUBITAT_APP_ID source from snapshot ($PRE_BYTES bytes)..."
+echo "Restoring class $CLASS_ID source from snapshot ($PRE_BYTES bytes)..."
 
-RESTORE_RPC=$(jq -nc \
-  --arg id "$HUBITAT_APP_ID" \
+RESTORE_RPC_FILE="${RUNNER_TEMP:-/tmp}/mcp_restore_rpc.json"
+jq -nc \
+  --arg id "$CLASS_ID" \
   --rawfile src "$PRE_SOURCE_FILE" \
-  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}')
+  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}' \
+  > "$RESTORE_RPC_FILE"
 
 RESTORE_RESP=$(curl -sS --max-time 120 -X POST "$MCP_URL" \
   -H "Content-Type: application/json" \
-  -d "$RESTORE_RPC")
+  --data-binary "@$RESTORE_RPC_FILE")
+rm -f "$RESTORE_RPC_FILE"
 
 RESTORE_TEXT=$(echo "$RESTORE_RESP" | jq -r '.result.content[0].text // empty')
 
@@ -58,4 +74,4 @@ if [ "$RESTORE_OK" != "true" ]; then
   exit 0
 fi
 
-echo "Restore succeeded. Hub source returned to pre-run state."
+echo "Restore succeeded. Hub class $CLASS_ID source returned to pre-run state."

--- a/.github/scripts/mcp_restore_source.sh
+++ b/.github/scripts/mcp_restore_source.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Push the pre-deploy parent-app source snapshot back to the test hub so
+# the hub is returned to whatever was live before this run mutated it.
+# Tolerant of a missing pre-source file (early-exit no-op) so it can live
+# in an `if: always()` workflow step alongside the env restore + lease
+# release.
+#
+# Usage:  mcp_restore_source.sh
+# Env:    MCP_URL              -- full cloud OAuth URL with access_token
+#         HUBITAT_APP_ID       -- parent-app numeric ID
+#         RUNNER_TEMP          -- GHA-provided temp dir; falls back to /tmp
+
+set -euo pipefail
+
+: "${MCP_URL:?MCP_URL env var required (full cloud OAuth URL with access_token)}"
+: "${HUBITAT_APP_ID:?HUBITAT_APP_ID env var required (parent-app numeric ID)}"
+
+PRE_SOURCE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source.groovy"
+
+if [ ! -f "$PRE_SOURCE_FILE" ]; then
+  echo "No pre-source snapshot at $PRE_SOURCE_FILE -- deploy step likely failed before capture. Skipping restore."
+  exit 0
+fi
+
+PRE_BYTES=$(wc -c < "$PRE_SOURCE_FILE")
+if [ "$PRE_BYTES" -lt 1000 ]; then
+  echo "::warning::Pre-source snapshot is suspiciously small ($PRE_BYTES bytes); refusing to push it back as the hub source"
+  exit 0
+fi
+
+echo "Restoring app $HUBITAT_APP_ID source from snapshot ($PRE_BYTES bytes)..."
+
+RESTORE_RPC=$(jq -nc \
+  --arg id "$HUBITAT_APP_ID" \
+  --rawfile src "$PRE_SOURCE_FILE" \
+  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}')
+
+RESTORE_RESP=$(curl -sS --max-time 120 -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -d "$RESTORE_RPC")
+
+RESTORE_TEXT=$(echo "$RESTORE_RESP" | jq -r '.result.content[0].text // empty')
+
+if [ -z "$RESTORE_TEXT" ]; then
+  # `if: always()` step -- log loudly but don't fail the workflow on
+  # restore failure, since lease release and env restore still need to run.
+  # Maintainer will see the warning in the run summary and can manually
+  # redeploy from .github/scripts/mcp_deploy_source.sh against main.
+  echo "::warning::Restore failed: update_app_code returned empty MCP content"
+  echo "Full response head: $(echo "$RESTORE_RESP" | head -c 1000)"
+  exit 0
+fi
+
+RESTORE_OK=$(echo "$RESTORE_TEXT" | jq -r '.success // false')
+if [ "$RESTORE_OK" != "true" ]; then
+  echo "::warning::Restore failed: $(echo "$RESTORE_TEXT" | jq -r '.error // .message // empty')"
+  echo "Tool response: $RESTORE_TEXT" | head -c 2000
+  exit 0
+fi
+
+echo "Restore succeeded. Hub source returned to pre-run state."

--- a/.github/scripts/mcp_restore_source.sh
+++ b/.github/scripts/mcp_restore_source.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 # Push the pre-deploy parent-app source snapshot back to the test hub so
 # the hub is returned to whatever was live before this run mutated it.
-# Reads the Apps Code class ID that mcp_deploy_source.sh resolved (the
-# installed-instance ID from MCP_URL is NOT the same as the source-class
-# ID; they live in separate Hubitat namespaces) from the sibling file
-# alongside the snapshot. Tolerant of a missing pre-source file (early-
-# exit no-op) so it can live in an `if: always()` workflow step alongside
-# the env restore + lease release.
+# Reads the Apps Code class ID + pre-deploy charlen that
+# mcp_deploy_source.sh wrote alongside the snapshot.
+#
+# The 1.2MB recompile of the parent app reliably exceeds cloud.hubitat.com's
+# ~10s gateway timeout, so HTTP 504 from update_app_code is expected; we
+# verify the write landed by polling get_app_source for the source length
+# to match the pre-deploy baseline (PRE_LEN) -- which is the same charlen
+# we want the hub back at.
+#
+# Tolerant of a missing pre-source file (early-exit no-op) so it can live
+# in an `if: always()` workflow step alongside the env restore + lease
+# release. Restore failure logs a warning but does not exit non-zero --
+# remaining cleanup (lease release, env restore) must still run.
 #
 # Usage:  mcp_restore_source.sh
 # Env:    MCP_URL              -- full cloud OAuth URL with access_token
@@ -18,6 +25,11 @@ set -euo pipefail
 
 PRE_SOURCE_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source.groovy"
 CLASS_ID_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_class_id"
+PRE_LEN_FILE="${RUNNER_TEMP:-/tmp}/mcp_pre_source_charlen"
+
+POST_RESTORE_VERIFY_SLEEP=20
+POST_RESTORE_VERIFY_TIMEOUT=90
+POST_RESTORE_VERIFY_INTERVAL=8
 
 if [ ! -f "$PRE_SOURCE_FILE" ]; then
   echo "No pre-source snapshot at $PRE_SOURCE_FILE -- deploy step likely failed before capture. Skipping restore."
@@ -35,13 +47,18 @@ if [ -z "$CLASS_ID" ]; then
   exit 0
 fi
 
+PRE_LEN=""
+if [ -f "$PRE_LEN_FILE" ]; then
+  PRE_LEN=$(cat "$PRE_LEN_FILE")
+fi
+
 PRE_BYTES=$(wc -c < "$PRE_SOURCE_FILE")
 if [ "$PRE_BYTES" -lt 1000 ]; then
   echo "::warning::Pre-source snapshot is suspiciously small ($PRE_BYTES bytes); refusing to push it back as the hub source"
   exit 0
 fi
 
-echo "Restoring class $CLASS_ID source from snapshot ($PRE_BYTES bytes)..."
+echo "Restoring class $CLASS_ID source from snapshot ($PRE_BYTES bytes, target charlen=$PRE_LEN)..."
 
 RESTORE_RPC_FILE="${RUNNER_TEMP:-/tmp}/mcp_restore_rpc.json"
 jq -nc \
@@ -60,31 +77,61 @@ rm -f "$RESTORE_RPC_FILE"
 HTTP_CODE=$(tail -n1 "$RESTORE_RESP_FILE")
 RESTORE_BODY=$(head -c -$((${#HTTP_CODE} + 1)) "$RESTORE_RESP_FILE")
 echo "Hub responded HTTP $HTTP_CODE; body length=$(printf '%s' "$RESTORE_BODY" | wc -c)"
-
-# Restore is in `if: always()` -- a failure here must not abort the
-# remaining cleanup (lease release, env restore), so all error paths
-# fall through with a warning and exit 0.
-if [ "$HTTP_CODE" != "200" ]; then
-  echo "::warning::Restore got HTTP $HTTP_CODE -- hub source NOT returned to pre-run state"
-  echo "Body head: $(printf '%s' "$RESTORE_BODY" | head -c 800)"
-  rm -f "$RESTORE_RESP_FILE"
-  exit 0
-fi
-
-RESTORE_TEXT=$(printf '%s' "$RESTORE_BODY" | jq -r '.result.content[0].text // empty' 2>/dev/null || true)
 rm -f "$RESTORE_RESP_FILE"
 
-if [ -z "$RESTORE_TEXT" ]; then
-  echo "::warning::Restore got 200 but body was not parseable MCP JSON -- hub source NOT returned to pre-run state"
+# Polls get_app_source until totalLength matches the pre-deploy charlen
+# (meaning the restore landed). Returns 0 on match, non-zero on timeout.
+verify_restored_to_pre_len() {
+  if [ -z "$PRE_LEN" ] || [ "$PRE_LEN" = "0" ]; then
+    echo "No PRE_LEN sidecar to verify against -- skipping length-match check."
+    return 0
+  fi
+  local elapsed=0
+  local rpc resp text current_len ok
+  while [ $elapsed -lt $POST_RESTORE_VERIFY_TIMEOUT ]; do
+    rpc=$(jq -nc --arg id "$CLASS_ID" \
+      '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"get_app_source",arguments:{appId:$id,offset:0,length:1}}}')
+    resp=$(curl -sS --max-time 30 -X POST "$MCP_URL" \
+      -H "Content-Type: application/json" \
+      --data-binary "$rpc" || true)
+    text=$(echo "$resp" | jq -r '.result.content[0].text // empty' 2>/dev/null || true)
+    ok=$(echo "$text" | jq -r '.success // false' 2>/dev/null || echo false)
+    current_len=$(echo "$text" | jq -r '.totalLength // 0' 2>/dev/null || echo 0)
+    if [ "$ok" = "true" ] && [ "$current_len" = "$PRE_LEN" ]; then
+      echo "Restore verified: hub source totalLength=$current_len matches pre-deploy baseline=$PRE_LEN."
+      return 0
+    fi
+    echo "Polling restore... current totalLength=$current_len, target=$PRE_LEN, elapsed=${elapsed}s/${POST_RESTORE_VERIFY_TIMEOUT}s"
+    sleep $POST_RESTORE_VERIFY_INTERVAL
+    elapsed=$((elapsed + POST_RESTORE_VERIFY_INTERVAL))
+  done
+  echo "::warning::Restore verification timed out after ${POST_RESTORE_VERIFY_TIMEOUT}s; hub totalLength=$current_len (target $PRE_LEN)"
+  return 1
+}
+
+# `if: always()` step -- a failure here must not abort the remaining
+# cleanup (lease release, env restore), so every error path falls through
+# with a warning and exit 0.
+if [ "$HTTP_CODE" = "200" ]; then
+  RESTORE_TEXT=$(printf '%s' "$RESTORE_BODY" | jq -r '.result.content[0].text // empty' 2>/dev/null || true)
+  if [ -n "$RESTORE_TEXT" ] && [ "$(echo "$RESTORE_TEXT" | jq -r '.success // false')" = "true" ]; then
+    echo "Restore succeeded (200/JSON). Hub class $CLASS_ID source returned to pre-run state."
+    exit 0
+  fi
+  echo "::warning::Restore got 200 but body didn't parse / tool reported failure"
+  echo "Body head: $(printf '%s' "$RESTORE_BODY" | head -c 800)"
+  exit 0
+elif [ "$HTTP_CODE" = "504" ] || [ "$HTTP_CODE" = "502" ] || [ "$HTTP_CODE" = "503" ]; then
+  echo "::notice::Restore returned HTTP $HTTP_CODE (cloud gateway timeout). Polling to verify hub-side completion..."
+  sleep $POST_RESTORE_VERIFY_SLEEP
+  if verify_restored_to_pre_len; then
+    echo "Restore verified despite HTTP $HTTP_CODE."
+    exit 0
+  fi
+  echo "::warning::Restore not verified -- hub source may NOT be back to pre-run state."
+  exit 0
+else
+  echo "::warning::Restore got HTTP $HTTP_CODE -- hub source likely NOT returned to pre-run state"
   echo "Body head: $(printf '%s' "$RESTORE_BODY" | head -c 800)"
   exit 0
 fi
-
-RESTORE_OK=$(echo "$RESTORE_TEXT" | jq -r '.success // false')
-if [ "$RESTORE_OK" != "true" ]; then
-  echo "::warning::Restore failed: $(echo "$RESTORE_TEXT" | jq -r '.error // .message // empty')"
-  echo "Tool response: $RESTORE_TEXT" | head -c 2000
-  exit 0
-fi
-
-echo "Restore succeeded. Hub class $CLASS_ID source returned to pre-run state."

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -133,21 +133,15 @@ jobs:
 
       - name: Deploy PR source to test hub
         if: steps.gate.outputs.available == 'true'
-        # Snapshots the hub's current parent-app source to
-        # $RUNNER_TEMP/mcp_pre_source.groovy, then attempts to push the PR's
-        # hubitat-mcp-server.groovy via update_app_code. Self-update is
-        # permitted because mcp_setup_env.sh already verified Developer Mode
-        # is on.
+        # Self-update is permitted because mcp_setup_env.sh already verified
+        # Developer Mode is on (the guard update_app_code checks for
+        # self-modification on the MCP server's own app row).
         #
-        # continue-on-error: this step is structurally blocked on the cloud
-        # gateway's request-body cap (~1 MB) -- a 1.18 MB inline source push
-        # reliably 504s before the hub receives it (confirmed by @level99 in
-        # #192). The unblock is a chunked manage_files write tool that
-        # doesn't yet exist; until it lands, treat deploy as advisory so the
-        # remaining E2E steps still run + report against whatever's
-        # currently deployed on the hub. The snapshot side of this script
-        # is unaffected (small reads), so the restore step at the end can
-        # still put the hub back if a future deploy ever does land.
+        # continue-on-error: a ~1.18 MB inline update_app_code(source=...)
+        # reliably 504s at the cloud gateway before the hub receives it.
+        # Until a chunked manage_files write tool exists, deploy is
+        # advisory — the snapshot reads (small) still work, so restore
+        # logic stays meaningful once a deploy ever lands.
         continue-on-error: true
         run: bash .github/scripts/mcp_deploy_source.sh hubitat-mcp-server.groovy
 

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -134,13 +134,21 @@ jobs:
       - name: Deploy PR source to test hub
         if: steps.gate.outputs.available == 'true'
         # Snapshots the hub's current parent-app source to
-        # $RUNNER_TEMP/mcp_pre_source.groovy, then pushes the PR's
-        # hubitat-mcp-server.groovy via update_app_code. Without this step
-        # the E2E suite tests whatever was last manually deployed on the
-        # hub — which is the bug that motivated this PR (test_tools_list
-        # asserts 36 tools but the hub returns 35 because @level99 hasn't
-        # re-uploaded since #167 merged). Self-update is permitted because
-        # mcp_setup_env.sh has already verified Developer Mode is on.
+        # $RUNNER_TEMP/mcp_pre_source.groovy, then attempts to push the PR's
+        # hubitat-mcp-server.groovy via update_app_code. Self-update is
+        # permitted because mcp_setup_env.sh already verified Developer Mode
+        # is on.
+        #
+        # continue-on-error: this step is structurally blocked on the cloud
+        # gateway's request-body cap (~1 MB) -- a 1.18 MB inline source push
+        # reliably 504s before the hub receives it (confirmed by @level99 in
+        # #192). The unblock is a chunked manage_files write tool that
+        # doesn't yet exist; until it lands, treat deploy as advisory so the
+        # remaining E2E steps still run + report against whatever's
+        # currently deployed on the hub. The snapshot side of this script
+        # is unaffected (small reads), so the restore step at the end can
+        # still put the hub back if a future deploy ever does land.
+        continue-on-error: true
         run: bash .github/scripts/mcp_deploy_source.sh hubitat-mcp-server.groovy
 
       - name: Run E2E tests

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -21,6 +21,8 @@ on:
       - '.github/scripts/lease_release.sh'
       - '.github/scripts/mcp_setup_env.sh'
       - '.github/scripts/mcp_restore_env.sh'
+      - '.github/scripts/mcp_deploy_source.sh'
+      - '.github/scripts/mcp_restore_source.sh'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -129,6 +131,18 @@ jobs:
         # itself is off (UI-only to enable).
         run: bash .github/scripts/mcp_setup_env.sh
 
+      - name: Deploy PR source to test hub
+        if: steps.gate.outputs.available == 'true'
+        # Snapshots the hub's current parent-app source to
+        # $RUNNER_TEMP/mcp_pre_source.groovy, then pushes the PR's
+        # hubitat-mcp-server.groovy via update_app_code. Without this step
+        # the E2E suite tests whatever was last manually deployed on the
+        # hub — which is the bug that motivated this PR (test_tools_list
+        # asserts 36 tools but the hub returns 35 because @level99 hasn't
+        # re-uploaded since #167 merged). Self-update is permitted because
+        # mcp_setup_env.sh has already verified Developer Mode is on.
+        run: bash .github/scripts/mcp_deploy_source.sh hubitat-mcp-server.groovy
+
       - name: Run E2E tests
         if: steps.gate.outputs.available == 'true'
         run: python tests/e2e_test.py
@@ -139,6 +153,15 @@ jobs:
         # but a crashed run can strand virtual devices / rules / variables
         # under the BAT_E2E_ prefix. This sweeps anything left over.
         run: python tests/e2e_test.py --cleanup-only
+
+      - name: Restore previous app source (push pre-deploy snapshot back)
+        if: always() && steps.gate.outputs.available == 'true'
+        # Pushes $RUNNER_TEMP/mcp_pre_source.groovy back to the hub so the
+        # next run (and any user inspecting the hub afterwards) sees the
+        # source that was live before this run mutated it. Tolerant of a
+        # missing snapshot file: if the deploy step never ran or never
+        # captured, this is a no-op.
+        run: bash .github/scripts/mcp_restore_source.sh
 
       - name: Restore test environment (settings back to pre-run state)
         if: always() && steps.gate.outputs.available == 'true'


### PR DESCRIPTION
## Summary

- **Status (2026-05-17):** the deploy path in this PR is structurally blocked on a cloud gateway request-body cap; @level99 has unblocked the immediate symptom by manually pushing current `main` to the test hub, and the durable fix is now a chunked `manage_files` write tool (not yet built). Deploy step is now `continue-on-error` so this PR stops contributing to E2E red Xs; the snapshot/restore/lease scripts stay in-repo as ready-to-use infrastructure for once the chunked-write tool exists.
- Original motivation: every PR for the last week+ failed `test_tools_list: Expected 36 tools, got 35` because the donated test hub had drifted behind `main` since #167 added `manage_hpm`. The plan was to have CI snapshot the hub's source, push the PR's `hubitat-mcp-server.groovy` via `update_app_code`, run E2E against that, then restore on cleanup.

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `ci` — CI/CD pipeline change

## Changes

- `mcp_deploy_source.sh` (new): snapshot the hub's current parent-app source to `$RUNNER_TEMP/mcp_pre_source.groovy` via chunked `get_app_source` (resolves the Apps Code class ID via `list_hub_apps` because the URL's `apps/<id>/mcp` is an installed-instance ID in a different namespace from the source-bearing entry), then attempt to push the PR source via `update_app_code` with inline `source` mode. Falls back to polling `get_app_source` totalLength to verify the write landed if cloud returns 502/503/504 (it always does on a 1.18 MB push — see Diagnosis).
- `mcp_restore_source.sh` (new): push the snapshot back via `update_app_code` on cleanup. Reads the class ID + pre-deploy charlen from sidecar files. Tolerant of missing inputs so it can live in an `if: always()` step.
- `hub-e2e.yml`: adds `Deploy PR source to test hub` (between env setup and the test run) and `Restore previous app source` (in the `if: always()` cleanup chain). Adds the two new scripts to the `paths` trigger. Deploy step is `continue-on-error: true` until the cloud cap is worked around — see Path Forward.

## Diagnosis

Cloud `https://cloud.hubitat.com/api/<UUID>/apps/<id>/mcp` reliably returns `HTTP 504` with a 20-byte `No response from hub` body about 11s into any `update_app_code` call carrying ~1.18 MB inline `source`. Polling `get_app_source` afterwards for 90s shows the hub's `totalLength` never moves off the pre-deploy baseline — so the request isn't being slow-compiled on the hub, it isn't reaching the hub at all. Reproduced across 4 deploy attempts on this branch (e.g. run [25974907344](https://github.com/kingpanther13/Hubitat-local-MCP-server/actions/runs/25974907344)).

@level99 confirmed (this PR's comment thread): this is a known platform limit, not tunable from our side. The `update_app_code` tool description's recommended workflow (`curl -F uploadFile=@./X.groovy http://<hub>/hub/fileManager/upload` followed by `update_app_code sourceFile`) only works for clients network-adjacent to the hub — that local upload endpoint isn't proxied through the cloud maker API. A cloud-only CI runner can't reach it.

## Path forward (folded in from level99's reply)

Per @level99's comment above, the durable fix is **chunked `manage_files` writes over the MCP endpoint** — each chunk under the cloud body cap — to stage the source in File Manager, then `update_app_code sourceFile` consumes it on-hub. Same shape as the manual recipe but CI-reachable, no LAN needed.

Gating story stays clean:
- Chunked `write_file` lives at the existing **Hub Admin Write** tier (no new privileged surface)
- **Developer Mode** stays the gate on the self-update step that consumes it (already enforced — that guard is what permitted level99's manual deploy)
- Preferred over a "hub `httpGet`s source from a GitHub raw URL" variant because that one is an RCE-by-design fetch-and-self-install surface and a heavier security story.

Once chunked `write_file` exists, `mcp_deploy_source.sh` swaps inline `update_app_code(source=...)` for two calls: `write_file` chunks staging the source in File Manager, then `update_app_code(sourceFile=...)` to compile it. The snapshot/restore/lease/polling logic in this PR stays unchanged. At that point the `continue-on-error: true` comes off the Deploy step.

@level99 mentioned he may take a look at the chunked-write tool tonight/tomorrow.

## Release Notes

- (no user-facing change — CI-only)

## Testing

- `bash -n` on both scripts.
- Snapshot phase verified on the test hub: chunked `get_app_source` pulls 1.08 MB cleanly across 17 chunks, class ID resolved via `list_hub_apps`.
- Push phase reliably 504s with current 1.18 MB source — confirmed cloud-side limit, not a tuning issue (see Diagnosis).
- With `continue-on-error: true`, the Deploy step's failure no longer fails the job; the E2E tests step still runs against the hub's deployed code (which is now fresh `main` after @level99's manual push).

## Checklist

- [x] **Unit tests added for any new MCP tools** — N/A (no Groovy changes)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py` — N/A (no Groovy changes)
- [x] `./gradlew test` passes locally (or CI confirms) — N/A (no Groovy changes)
- [ ] Live-hub BAT tests updated if tool behaviour changed — N/A (no tool changes)
- [ ] Documentation updated if user-facing behaviour or tool surface changed — N/A (no user-facing change)