### PR TITLE
fix: release-notes generator was picking issue refs instead of PR numbers

### DIFF
--- a/.github/scripts/release_bump.py
+++ b/.github/scripts/release_bump.py
@@ -107,6 +107,36 @@ def compute_next(current: str, label: str) -> str:
     raise ValueError(f"Unknown release label: {label!r}")
 
 
+_MERGE_COMMIT_RE = re.compile(r"^Merge pull request #(\d+)\b")
+_TRAILING_PR_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+
+def extract_pr_number(subject: str) -> int | None:
+    """Return the PR number referenced by a commit subject line, or None.
+
+    Two commit subject shapes are recognized:
+      * Merge-commit:  ``Merge pull request #NN from <branch>`` — number at start
+      * Squash-merge:  ``<title> (#NN)`` — number in trailing parenthesized ref
+
+    When a PR's title contains its own ``(#N)`` reference (e.g. linking an
+    issue), the squash commit subject ends up with multiple ``(#N)`` tokens:
+
+        fix: thing about issue (#100) (#150)
+
+    GitHub always appends the PR ref LAST, so this parser anchors the
+    squash pattern to end-of-line. Taking the first match would pick up the
+    in-title issue reference and the resulting ``gh pr view`` call would
+    fail, producing the ``- PR #NN`` placeholder bullet.
+    """
+    m = _MERGE_COMMIT_RE.match(subject)
+    if m:
+        return int(m.group(1))
+    m = _TRAILING_PR_RE.search(subject)
+    if m:
+        return int(m.group(1))
+    return None
+
+
 def merged_pr_numbers_since(tag: str | None) -> list[int]:
     """Return PR numbers referenced in commit subjects between `tag` (exclusive)
     and HEAD, in chronological order (oldest first). Handles both merge-commit
@@ -121,14 +151,11 @@ def merged_pr_numbers_since(tag: str | None) -> list[int]:
         return []
     numbers: list[int] = []
     seen: set[int] = set()
-    pr_re = re.compile(r"(?:Merge pull request #| \(#)(\d+)\b")
     for line in result.stdout.splitlines():
-        m = pr_re.search(line)
-        if m:
-            n = int(m.group(1))
-            if n not in seen:
-                seen.add(n)
-                numbers.append(n)
+        n = extract_pr_number(line)
+        if n is not None and n not in seen:
+            seen.add(n)
+            numbers.append(n)
     return list(reversed(numbers))
 
 

--- a/.github/scripts/release_bump.py
+++ b/.github/scripts/release_bump.py
@@ -108,32 +108,44 @@ def compute_next(current: str, label: str) -> str:
 
 
 _MERGE_COMMIT_RE = re.compile(r"^Merge pull request #(\d+)\b")
-_TRAILING_PR_RE = re.compile(r"\(#(\d+)\)\s*$")
+_PARENS_PR_RE = re.compile(r"\(#(\d+)\)")
 
 
 def extract_pr_number(subject: str) -> int | None:
     """Return the PR number referenced by a commit subject line, or None.
 
-    Two commit subject shapes are recognized:
+    Recognized shapes:
       * Merge-commit:  ``Merge pull request #NN from <branch>`` — number at start
-      * Squash-merge:  ``<title> (#NN)`` — number in trailing parenthesized ref
+      * Squash-merge:  ``<title> (#NN)`` — appended by GitHub at squash time
+      * Squash + trailing annotation:
+          ``<title> (#NN) (cherry picked from commit abc...)``
+          ``Revert "<orig> (#X)" (#NN)``
 
-    When a PR's title contains its own ``(#N)`` reference (e.g. linking an
+    When a PR's title contains its own ``(#X)`` reference (e.g. linking an
     issue), the squash commit subject ends up with multiple ``(#N)`` tokens:
 
         fix: thing about issue (#100) (#150)
 
-    GitHub always appends the PR ref LAST, so this parser anchors the
-    squash pattern to end-of-line. Taking the first match would pick up the
-    in-title issue reference and the resulting ``gh pr view`` call would
-    fail, producing the ``- PR #NN`` placeholder bullet.
+    GitHub always appends the PR ref LAST among the parenthesized tokens,
+    so the parser returns the LAST ``(#N)`` match rather than the first.
+    Taking the first match would pick up the in-title issue reference,
+    ``gh pr view <issue#>`` would fail, and the entry would fall back to
+    the ``- PR #NN`` placeholder bullet (the bug this helper was extracted
+    for). Anchoring to end-of-line — the simpler alternative — would drop
+    cherry-pick-annotated subjects, so the parser uses ``findall`` and
+    picks the last match instead.
+
+    Merge-commit format is checked first; it takes precedence over any
+    trailing ``(#N)`` in the same subject. GitHub itself never produces a
+    subject matching both shapes — the precedence only matters for hand-
+    crafted edge cases.
     """
     m = _MERGE_COMMIT_RE.match(subject)
     if m:
         return int(m.group(1))
-    m = _TRAILING_PR_RE.search(subject)
-    if m:
-        return int(m.group(1))
+    matches = _PARENS_PR_RE.findall(subject)
+    if matches:
+        return int(matches[-1])
     return None
 
 
@@ -142,6 +154,12 @@ def merged_pr_numbers_since(tag: str | None) -> list[int]:
     and HEAD, in chronological order (oldest first). Handles both merge-commit
     format ('Merge pull request #NN') and squash-merge format ('Title (#NN)').
     Deduplicates in case multiple commits reference the same PR.
+
+    A subject whose shape doesn't match either pattern emits a ``::warning::``
+    so the operator notices direct-push commits or hand-crafted subjects
+    being dropped from the release notes. Mirrors ``fetch_pr``'s anti-silent-
+    failure contract — a missing bullet is otherwise indistinguishable from
+    a success path in the rendered output.
     """
     if tag is None:
         return []
@@ -152,8 +170,18 @@ def merged_pr_numbers_since(tag: str | None) -> list[int]:
     numbers: list[int] = []
     seen: set[int] = set()
     for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
         n = extract_pr_number(line)
-        if n is not None and n not in seen:
+        if n is None:
+            print(
+                f"::warning::merged_pr_numbers_since: commit subject did not "
+                f"match either merge or squash PR-ref pattern; dropping from "
+                f"release notes: {line!r}",
+                file=sys.stderr,
+            )
+            continue
+        if n not in seen:
             seen.add(n)
             numbers.append(n)
     return list(reversed(numbers))

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "include": [".github/scripts", "scripts", "tests"],
+  "extraPaths": [".github/scripts"]
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,4 @@
 {
   "include": [".github/scripts", "scripts", "tests"],
-  "extraPaths": [".github/scripts"]
+  "extraPaths": [".github/scripts", "scripts"]
 }

--- a/tests/test_release_bump.py
+++ b/tests/test_release_bump.py
@@ -12,7 +12,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".github", "scripts"))
 
 import pytest
-import release_bump as rb  # pyright: ignore[reportMissingImports]
+import release_bump as rb
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_release_bump.py
+++ b/tests/test_release_bump.py
@@ -101,6 +101,62 @@ def test_parse_release_notes_orphan_indented_bullet_skipped():
 
 
 # ---------------------------------------------------------------------------
+# extract_pr_number — parses the PR number out of a commit subject line.
+# Squash merges produce subjects like "Title (#N)"; if the PR title itself
+# contained an issue reference like "Title about issue (#100)", the squash
+# commit becomes "Title about issue (#100) (#150)" — and the appended #150 is
+# the actual PR, not #100. GitHub always appends the PR ref LAST, so the
+# parser must take the trailing token, not the first.
+# ---------------------------------------------------------------------------
+
+def test_extract_pr_number_plain_squash():
+    """Standard squash-merge subject yields the trailing PR number."""
+    assert rb.extract_pr_number("docs: add CONTRIBUTING.md (#197)") == 197
+
+
+def test_extract_pr_number_title_with_issue_ref_baked_in():
+    """Regression: PR title containing `(#issue)` yields the LAST `(#N)`
+    (the GitHub-appended PR ref), not the in-title issue ref.
+
+    This is the bug behind v1.3.6/1.3.7/1.3.8 release notes showing
+    "- PR #181/#169/#187/#174" placeholders: `gh pr view <issue#>` failed
+    because the parser had returned the in-title issue number.
+    """
+    subj = "fix: addTrigger supports Hub Variable triggers + conditional A != B (#169) (#194)"
+    assert rb.extract_pr_number(subj) == 194
+
+
+def test_extract_pr_number_multiple_issue_refs_in_title():
+    """Title with multiple parenthesized issue refs still resolves to the
+    final GitHub-appended PR number."""
+    subj = "test: add dispatch-envelope coverage across all tool specs (#187, #121) (#191)"
+    assert rb.extract_pr_number(subj) == 191
+
+
+def test_extract_pr_number_bare_issue_hash_in_title():
+    """Bare `#N` references (no parentheses) in the title are ignored;
+    only the trailing `(#N)` PR ref is returned."""
+    subj = "test: close issue #141 Section A Spock coverage gaps (#193)"
+    assert rb.extract_pr_number(subj) == 193
+
+
+def test_extract_pr_number_merge_commit_format():
+    """Traditional merge-commit format ('Merge pull request #N from ...') yields N."""
+    assert rb.extract_pr_number("Merge pull request #50 from foo/bar") == 50
+
+
+def test_extract_pr_number_no_ref_returns_none():
+    """Subject with no PR reference returns None."""
+    assert rb.extract_pr_number("chore: tweak something") is None
+
+
+def test_extract_pr_number_revert_uses_new_pr():
+    """Revert commits get a new PR number; the trailing `(#N)` is the new one."""
+    subj = 'Revert "feat: thing (#100)" (#150)'
+    assert rb.extract_pr_number(subj) == 150
+
+
+# ---------------------------------------------------------------------------
 # split_release_blocks
 # ---------------------------------------------------------------------------
 

--- a/tests/test_release_bump.py
+++ b/tests/test_release_bump.py
@@ -115,13 +115,8 @@ def test_extract_pr_number_plain_squash():
 
 
 def test_extract_pr_number_title_with_issue_ref_baked_in():
-    """Regression: PR title containing `(#issue)` yields the LAST `(#N)`
-    (the GitHub-appended PR ref), not the in-title issue ref.
-
-    This is the bug behind v1.3.6/1.3.7/1.3.8 release notes showing
-    "- PR #181/#169/#187/#174" placeholders: `gh pr view <issue#>` failed
-    because the parser had returned the in-title issue number.
-    """
+    """Regression: in-title `(#issue)` references must not shadow the
+    GitHub-appended trailing `(#PR)` ref."""
     subj = "fix: addTrigger supports Hub Variable triggers + conditional A != B (#169) (#194)"
     assert rb.extract_pr_number(subj) == 194
 
@@ -154,6 +149,104 @@ def test_extract_pr_number_revert_uses_new_pr():
     """Revert commits get a new PR number; the trailing `(#N)` is the new one."""
     subj = 'Revert "feat: thing (#100)" (#150)'
     assert rb.extract_pr_number(subj) == 150
+
+
+def test_extract_pr_number_cherry_pick_annotation():
+    """`(cherry picked from commit ...)` follows the PR ref; findall+last
+    still returns the PR number, not None."""
+    subj = "feat: thing (#42) (cherry picked from commit abc1234)"
+    assert rb.extract_pr_number(subj) == 42
+
+
+def test_extract_pr_number_merge_format_takes_precedence_over_trailing_paren():
+    """Hand-crafted mixed shape: merge-commit format wins even if a trailing
+    `(#N)` is also present (GitHub never produces this; the precedence only
+    matters for manually-edited subjects)."""
+    subj = "Merge pull request #50 from foo/bar (#999)"
+    assert rb.extract_pr_number(subj) == 50
+
+
+# ---------------------------------------------------------------------------
+# merged_pr_numbers_since — integration around extract_pr_number. Covers
+# the wrapping behaviors: tag=None short-circuit, CalledProcessError recovery,
+# dedup, chronological reversal, and the ::warning:: on unrecognized subjects.
+# ---------------------------------------------------------------------------
+
+def test_merged_pr_numbers_since_none_tag_returns_empty():
+    """No prior tag (first release) → empty list, no `git log` call."""
+    assert rb.merged_pr_numbers_since(None) == []
+
+
+def test_merged_pr_numbers_since_git_log_error_returns_empty(monkeypatch):
+    """`git log` failure (e.g. corrupt repo) returns [] rather than crashing
+    the whole release."""
+    import subprocess as sp
+
+    def fake_run(*args, **kwargs):
+        del kwargs
+        raise sp.CalledProcessError(returncode=128, cmd=args)
+
+    monkeypatch.setattr(rb, "run", fake_run)
+    assert rb.merged_pr_numbers_since("v1.0.0") == []
+
+
+def _stub_git_log(monkeypatch, stdout: str) -> None:
+    """Install a fake `rb.run` that returns the given stdout from any call."""
+    from subprocess import CompletedProcess
+
+    def fake_run(*args, **kwargs):
+        del kwargs
+        return CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(rb, "run", fake_run)
+
+
+def test_merged_pr_numbers_since_reverses_to_chronological(monkeypatch):
+    """`git log` emits newest-first; output must be oldest-first so the
+    release entry reads in commit order."""
+    stdout = (
+        "feat: third (#30)\n"   # newest
+        "fix: second (#20)\n"
+        "docs: first (#10)\n"   # oldest
+    )
+    _stub_git_log(monkeypatch, stdout)
+    assert rb.merged_pr_numbers_since("v1.0.0") == [10, 20, 30]
+
+
+def test_merged_pr_numbers_since_dedups_repeated_refs(monkeypatch):
+    """Two commits both referencing the same PR (e.g. an `fixup!` squashed
+    in) produce one entry, not two."""
+    stdout = (
+        "fix: redo of #5 (#5)\n"
+        "fix: initial attempt (#5)\n"
+    )
+    _stub_git_log(monkeypatch, stdout)
+    assert rb.merged_pr_numbers_since("v1.0.0") == [5]
+
+
+def test_merged_pr_numbers_since_warns_on_unrecognized_subject(monkeypatch, capsys):
+    """A direct-push or hand-crafted subject with no PR ref is skipped AND
+    surfaces a ::warning:: so the operator sees it on the Actions run page —
+    mirrors fetch_pr's anti-silent-failure contract."""
+    stdout = (
+        "feat: legitimate squash (#42)\n"
+        "chore: direct push with no PR ref\n"
+        "feat: another (#43)\n"
+    )
+    _stub_git_log(monkeypatch, stdout)
+    result = rb.merged_pr_numbers_since("v1.0.0")
+    assert result == [43, 42]
+    captured = capsys.readouterr()
+    assert "::warning::merged_pr_numbers_since" in captured.err
+    assert "direct push with no PR ref" in captured.err
+
+
+def test_merged_pr_numbers_since_skips_blank_lines(monkeypatch):
+    """Blank lines in `git log` output (rare, but possible with custom
+    formatting) are skipped silently — not warned about."""
+    stdout = "feat: real (#10)\n\nfix: also real (#20)\n"
+    _stub_git_log(monkeypatch, stdout)
+    assert rb.merged_pr_numbers_since("v1.0.0") == [20, 10]
 
 
 # ---------------------------------------------------------------------------
@@ -601,7 +694,8 @@ def test_fetch_pr_handles_whitespace_only_stderr(monkeypatch, capsys):
     """
     import subprocess as sp
 
-    def fake_run(*args):
+    def fake_run(*args, **kwargs):
+        del kwargs  # rb.run accepts check= kwarg; preserve signature contract
         # Simulate gh CLI failing with whitespace-only stderr
         raise sp.CalledProcessError(
             returncode=1, cmd=args, output="", stderr="   \n  \n"
@@ -622,7 +716,8 @@ def test_build_bullets_warns_when_fetch_pr_fails(monkeypatch, capsys):
     executes its except path) rather than mocking fetch_pr away."""
     import subprocess as sp
 
-    def fake_run(*args):
+    def fake_run(*args, **kwargs):
+        del kwargs  # rb.run accepts check= kwarg; preserve signature contract
         raise sp.CalledProcessError(
             returncode=1, cmd=args, output="", stderr="not found"
         )

--- a/tests/test_release_bump.py
+++ b/tests/test_release_bump.py
@@ -12,7 +12,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".github", "scripts"))
 
 import pytest
-import release_bump as rb
+import release_bump as rb  # pyright: ignore[reportMissingImports]
 
 
 # ---------------------------------------------------------------------------
@@ -567,7 +567,7 @@ def test_build_bullets_warns_on_section_with_no_bullets(monkeypatch, capsys):
         "author": {"login": "alice"},
         "body": "## Release Notes\nThis fixes a thing but the author wrote prose.",
     }
-    monkeypatch.setattr(rb, "fetch_pr", lambda n: fake_pr)
+    monkeypatch.setattr(rb, "fetch_pr", lambda _: fake_pr)
     bullets = rb.build_bullets([42])
     # Title-only fallback shape
     assert len(bullets) == 1
@@ -589,7 +589,7 @@ def test_build_bullets_no_warning_when_section_absent(monkeypatch, capsys):
         "author": {"login": "alice"},
         "body": "## Summary\nNo release notes section at all.",
     }
-    monkeypatch.setattr(rb, "fetch_pr", lambda n: fake_pr)
+    monkeypatch.setattr(rb, "fetch_pr", lambda _: fake_pr)
     rb.build_bullets([42])
     captured = capsys.readouterr()
     assert "::warning::" not in captured.err
@@ -601,7 +601,7 @@ def test_fetch_pr_handles_whitespace_only_stderr(monkeypatch, capsys):
     """
     import subprocess as sp
 
-    def fake_run(*args, **kwargs):
+    def fake_run(*args):
         # Simulate gh CLI failing with whitespace-only stderr
         raise sp.CalledProcessError(
             returncode=1, cmd=args, output="", stderr="   \n  \n"
@@ -616,14 +616,23 @@ def test_fetch_pr_handles_whitespace_only_stderr(monkeypatch, capsys):
 
 
 def test_build_bullets_warns_when_fetch_pr_fails(monkeypatch, capsys):
-    """When fetch_pr returns None, build_bullets uses the placeholder bullet
-    AND fetch_pr itself emits the warning (verified here by checking that
-    the placeholder is in the output — fetch_pr's warning is exercised by
-    its own subprocess error path, which we can't easily mock without
-    overriding `run`)."""
-    monkeypatch.setattr(rb, "fetch_pr", lambda n: None)
+    """When gh pr view fails, build_bullets falls back to the `- PR #N`
+    placeholder AND fetch_pr emits a ::warning::. Both behaviours are
+    verified here by mocking the lower-level `rb.run` (so real fetch_pr
+    executes its except path) rather than mocking fetch_pr away."""
+    import subprocess as sp
+
+    def fake_run(*args):
+        raise sp.CalledProcessError(
+            returncode=1, cmd=args, output="", stderr="not found"
+        )
+
+    monkeypatch.setattr(rb, "run", fake_run)
     bullets = rb.build_bullets([99])
     assert bullets == ["- PR #99"]
+    captured = capsys.readouterr()
+    assert "::warning::fetch_pr" in captured.err
+    assert "#99" in captured.err
 
 
 def test_bump_manifest_legacy_blob_shrinkage_regression_anchor(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- `release_bump.merged_pr_numbers_since` used `re.search` on a regex that
  matched any ` (#NN)` token. When a squash-merged PR's title contained
  an issue reference like `Title (#100)`, the resulting commit subject was
  `Title (#100) (#150)` — the regex picked `#100` (an issue), `gh pr view`
  failed, and the entry fell back to the `- PR #NN` placeholder in
  CHANGELOG / packageManifest / README.
- Extracted parsing into `extract_pr_number(subject)`. Uses
  `re.findall` + last match (not EOL anchor), so trailing annotations
  like `(cherry picked from commit ...)` or `Revert "title (#X)" (#NN)`
  still resolve correctly. Merge-commit format checked first; takes
  precedence on hand-crafted mixed shapes.
- `merged_pr_numbers_since` now emits `::warning::` when a subject
  matches neither pattern. Mirrors `fetch_pr`'s anti-silent-failure
  contract — a dropped commit is otherwise invisible.
- Real-world commit subjects from v1.3.6–v1.3.8 that previously produced
  `- PR #181 / #169 / #187 / #174` placeholders now resolve to the
  correct PRs (198 / 194 / 191 / 190).

## Type of change

- [x] `fix` — bug fix

## Changes

- `.github/scripts/release_bump.py`: new `extract_pr_number()` helper;
  `merged_pr_numbers_since` delegates to it and warns on unrecognized
  subjects.
- `tests/test_release_bump.py`: 15 new tests (9 on the helper covering
  plain squash, in-title issue refs, multiple issue refs, bare `#N`,
  merge-commit format, no-ref, revert, cherry-pick annotation, and
  merge-vs-squash precedence; 6 on the caller covering tag=None,
  CalledProcessError, chronological reversal, dedup, warn-on-unknown,
  blank-line skip). Rewrote `test_build_bullets_warns_when_fetch_pr_fails`
  to actually exercise the warning path (was mocking `fetch_pr` away).
- `pyrightconfig.json` (new, static config — not wired into CI): sets
  `extraPaths` to `.github/scripts` and `scripts` so pyright resolves
  the `sys.path`-inserted imports in `tests/test_release_bump.py` and
  `tests/test_app_config_audit.py`. Active only when pyright runs locally
  or in an editor.

## Release Notes

- Fix release-notes generator dropping PR titles when squash-commit subjects
  embedded an issue reference like `(#NN)` in the title.
  - Affected entries in v1.3.6 – v1.3.8: the bare `- PR #181 / #169 / #187 / #174`
    placeholder lines were the symptom.
  - Future releases will show the correct PR title (and any author-supplied
    nested notes) for those PRs.

## Testing

- `python3.13 -m pytest tests/test_release_bump.py` — 71 passed
  (15 new + 56 existing)
- `python tests/sandbox_lint.py` — clean
- `pyright tests/test_release_bump.py` — 0 errors
- Spot-checked the new helper against the four real commit subjects
  from v1.3.6–v1.3.8 that produced placeholder bullets.

## Checklist

- [ ] Unit tests added for any new MCP tools (N/A — no MCP tool changes)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (deferred to CI — Groovy harness; this PR is Python-only)
- [ ] Live-hub BAT tests updated if tool behaviour changed (N/A)
- [ ] Documentation updated if user-facing behaviour or tool surface changed (N/A)