### PR TITLE
feat: MCP readOnlyHint + destructiveHint annotations on every tool

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1154,19 +1154,23 @@ def getGatewayConfig() {
 }
 
 // ==================== MCP TOOL ANNOTATIONS ====================
-// MCP spec (2024-11-05+) `annotations.readOnlyHint` / `destructiveHint` drive
-// client-side grouping. Claude.ai's connector UI, for example, splits a server's
-// catalog into a "Read tools" block and a "Write tools" block based on
-// readOnlyHint; anything missing the annotation lands in a generic "Other tools"
-// bucket. Both sets below are defined POSITIVELY so a new tool that no one
-// labels here defaults to write+non-destructive, which is the safe default for
-// permission prompts (the user is asked before any unlabelled write happens).
+// MCP spec `annotations.readOnlyHint` / `destructiveHint` drive client-side
+// grouping. Claude.ai's connector UI splits a server's catalog into Read /
+// Write blocks from readOnlyHint; entries missing it land in a generic
+// "Other tools" bucket.
 //
-// Gateway entries (manage_*) are annotated dynamically in getToolDefinitions():
-// a gateway is read-only iff every visible sub-tool is read-only, and
-// destructive iff any visible sub-tool is destructive. Visibility respects the
-// feature-toggle hide rules, so e.g. manage_native_rules_and_apps collapses
-// correctly when Built-in App Tools is off.
+// Classification model (kept simple and conservative):
+//   * read-only = does not modify hub or device state. Anything else is
+//     write+destructive. There is no non-destructive-write subset --
+//     this matches the MCP spec default (destructiveHint defaults to true
+//     when readOnlyHint=false) and gets every write the more cautious
+//     permission prompt in clients that surface destructiveHint.
+//   * Both annotation keys are emitted explicitly (never omitted on writes)
+//     so clients do not need to rely on spec defaults.
+//   * The read-only set is POSITIVE: a tool that nobody lists here falls
+//     to write+destructive. New tools default to the safer prompt; the
+//     "every leaf classified" spec test forces the decision to be made
+//     in code review rather than left implicit.
 
 def getReadOnlyToolNames() {
     return [
@@ -1215,47 +1219,35 @@ def getReadOnlyToolNames() {
     ] as Set
 }
 
-def getDestructiveToolNames() {
-    return [
-        "custom_delete_rule",
-        "delete_variable", "remove_connector",
-        "delete_captured_state", "clear_captured_states",
-        "clear_debug_logs",
-        "reboot_hub", "shutdown_hub", "zwave_repair", "delete_device",
-        "delete_room",
-        "delete_app", "delete_driver", "delete_library",
-        "delete_file",
-        "delete_native_app",
-        // manage_virtual_device action="delete" deletes a virtual device; the
-        // create branch is non-destructive but the delete branch is, so mark
-        // the tool destructive.
-        "manage_virtual_device"
-    ] as Set
-}
-
-// Returns the MCP `annotations` map for a leaf tool name. `readOnlyHint` is
-// always set explicitly (not omitted on writes) so clients can rely on its
-// presence to drive grouping without falling back to the spec default.
-def annotationsForLeaf(String toolName, Set readOnlyNames, Set destructiveNames) {
+// Returns the MCP `annotations` map for a leaf tool name. Both keys are
+// emitted explicitly so the wire payload is unambiguous regardless of which
+// spec-default a given client honours.
+def annotationsForLeaf(String toolName, Set readOnlyNames) {
     def isReadOnly = readOnlyNames.contains(toolName)
     def ann = [readOnlyHint: isReadOnly]
-    if (!isReadOnly && destructiveNames.contains(toolName)) {
+    if (!isReadOnly) {
+        // destructiveHint is meaningful only when readOnlyHint=false (per spec).
+        // Every write is treated as destructive -- matches the spec default and
+        // gets clients the cautious permission prompt.
         ann.destructiveHint = true
     }
     return ann
 }
 
-// Aggregates annotations for a gateway entry based on its currently-visible
-// sub-tools. A gateway is read-only iff every visible sub-tool is read-only;
-// it is destructive iff any visible sub-tool is destructive. Caller passes
-// `visibleSubTools` so toggles (Built-in App Tools off, custom engine readonly,
-// etc.) that hide sub-tools change the gateway label too -- e.g. if the only
-// write sub-tools in a gateway are hidden, the gateway flips to read-only.
-def annotationsForGateway(List visibleSubTools, Set readOnlyNames, Set destructiveNames) {
+// Aggregates annotations for a gateway entry from its currently-visible
+// sub-tools. Read-only iff every visible sub-tool is read-only; otherwise
+// write+destructive. Callers pass `visibleSubTools` so feature-toggle hiding
+// (Built-in App Tools off, custom engine readonly) propagates into the
+// gateway label.
+def annotationsForGateway(List visibleSubTools, Set readOnlyNames) {
+    if (!visibleSubTools) {
+        throw new IllegalArgumentException(
+            "annotationsForGateway requires at least one visible sub-tool"
+        )
+    }
     def anyWrite = visibleSubTools.any { !readOnlyNames.contains(it) }
-    def anyDestructive = visibleSubTools.any { destructiveNames.contains(it) }
     def ann = [readOnlyHint: !anyWrite]
-    if (anyWrite && anyDestructive) {
+    if (anyWrite) {
         ann.destructiveHint = true
     }
     return ann
@@ -1465,11 +1457,8 @@ def getToolDefinitions() {
     }
     // customEngineMode == "full": nothing added to hideByName for custom_* tools
 
-    // MCP tool annotations source-of-truth -- read once per call, passed into the
-    // leaf and gateway annotation helpers so a single mutation to the canonical
-    // sets propagates everywhere tools/list builds entries.
+    // Hoist annotation source-of-truth once per call.
     def readOnlyNames = getReadOnlyToolNames()
-    def destructiveNames = getDestructiveToolNames()
 
     // Flat mode: every tool advertised individually under its real name; search_tools
     // is dropped because it only helps navigate gateway-hidden tools.
@@ -1488,7 +1477,7 @@ def getToolDefinitions() {
         // [[FLAT_TRIM]] markers to recover headroom under the hub's 124,000-byte cap.
         def transformed = applyDescriptionTransform(filtered, true)
         return transformed.collect { tool ->
-            tool + [annotations: annotationsForLeaf(tool.name as String, readOnlyNames, destructiveNames)]
+            tool + [annotations: annotationsForLeaf(tool.name as String, readOnlyNames)]
         }
     }
 
@@ -1519,7 +1508,7 @@ def getToolDefinitions() {
                     args: [type: "object", description: "Arguments for the tool. Call with just tool name first to see required parameters."]
                 ]
             ],
-            annotations: annotationsForGateway(visibleSubTools, readOnlyNames, destructiveNames)
+            annotations: annotationsForGateway(visibleSubTools, readOnlyNames)
         ]]
     }
 
@@ -1530,9 +1519,11 @@ def getToolDefinitions() {
     def transformed = applyDescriptionTransform(baseTools + gatewayTools, false)
     return transformed.collect { tool ->
         // Gateway entries already carry annotations from the collectMany above;
-        // leaf base tools get theirs from the canonical set. Don't overwrite a
-        // pre-populated annotations map.
-        tool.annotations ? tool : tool + [annotations: annotationsForLeaf(tool.name as String, readOnlyNames, destructiveNames)]
+        // leaf base tools get theirs from the canonical set. The presence of
+        // readOnlyHint (not just the annotations map) is the load-bearing
+        // signal -- a partial pre-populated map without readOnlyHint still
+        // needs the leaf classifier to merge in the missing key.
+        tool.annotations?.containsKey('readOnlyHint') ? tool : tool + [annotations: (tool.annotations ?: [:]) + annotationsForLeaf(tool.name as String, readOnlyNames)]
     }
 }
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1427,33 +1427,38 @@ def getToolDefinitions() {
     // "readonly" -- engine OFF + builtinApp ON; read subset shown, write subset hidden
     // "off"      -- engine OFF + builtinApp OFF; all custom_* hidden
     def customEngineMode = customEngineOn ? "full" : (builtinAppOn ? "readonly" : "off")
+    // Single source of truth: hideByName lists every tool the current toggle
+    // combination should hide. It drives BOTH flat-mode base-tool filtering
+    // AND gateway-mode sub-tool catalog filtering (see visibleSubTools below).
+    // No parallel hideGatewaySubTools list -- a name in hideByName disappears
+    // from every surface it could appear on, so the two lists cannot drift.
     def hideByName = [] as Set
-    def hideGatewaySubTools = [:].withDefault { [] as Set }
 
     if (!builtinAppOn) {
-        def biTools = ["list_installed_apps", "get_device_in_use_by", "list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "clone_native_app", "export_native_app", "import_native_app", "check_rule_health"]
-        biTools.each { hideByName << it }
-        // Sub-tool removal from gateways (when in gateway mode):
-        //   manage_native_rules_and_apps: ALL 12 sub-tools require enableBuiltinApp → empty gateway → drops entirely
-        //   manage_installed_apps: 2/4 sub-tools require enableBuiltinApp; the other 2 (get_app_config, list_app_pages) only need Hub Admin Read
-        hideGatewaySubTools["manage_native_rules_and_apps"] = ["list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "clone_native_app", "export_native_app", "import_native_app", "check_rule_health"] as Set
-        hideGatewaySubTools["manage_installed_apps"] = ["list_installed_apps", "get_device_in_use_by"] as Set
+        // All 14 of these tools require enableBuiltinApp.
+        //   manage_native_rules_and_apps: ALL 12 sub-tools require it → that
+        //     gateway empties out and drops entirely.
+        //   manage_installed_apps: 2/4 sub-tools require it (list_installed_apps,
+        //     get_device_in_use_by); the other 2 (get_app_config, list_app_pages)
+        //     only need Hub Admin Read and stay visible.
+        ["list_installed_apps", "get_device_in_use_by", "list_rm_rules", "run_rm_rule", "pause_rm_rule", "resume_rm_rule", "set_rm_rule_boolean", "create_native_app", "update_native_app", "delete_native_app", "clone_native_app", "export_native_app", "import_native_app", "check_rule_health"].each {
+            hideByName << it
+        }
     }
     if (customEngineMode == "off") {
-        // Both toggles off: hide all custom_* tools (base tools + gateway sub-tools)
+        // Both toggles off: hide all custom_* tools everywhere they could appear
+        // (base tools in flat mode, sub-tools of manage_rules_admin and manage_diagnostics
+        // in gateway mode).
         ["custom_list_rules", "custom_get_rule", "custom_create_rule", "custom_update_rule", "custom_delete_rule", "custom_test_rule", "custom_get_rule_diagnostics", "custom_export_rule", "custom_import_rule", "custom_clone_rule"].each {
             hideByName << it
         }
-        // custom_get_rule_diagnostics lives in manage_diagnostics gateway; remove it
-        // from that gateway's visible sub-tool list so the catalog entry disappears.
-        hideGatewaySubTools["manage_diagnostics"] << "custom_get_rule_diagnostics"
     } else if (customEngineMode == "readonly") {
-        // Engine OFF but builtinApp ON: hide write/structural tools, keep read tools
+        // Engine OFF but builtinApp ON: hide write/structural custom_* tools,
+        // keep the read tools. custom_get_rule_diagnostics is a read tool and
+        // stays visible (inside manage_diagnostics) -- not added here.
         ["custom_create_rule", "custom_delete_rule", "custom_export_rule", "custom_import_rule", "custom_clone_rule"].each {
             hideByName << it
         }
-        // custom_get_rule_diagnostics lives in manage_diagnostics gateway and stays
-        // visible in readonly mode -- no gateway sub-tool removal needed for it.
     }
     // customEngineMode == "full": nothing added to hideByName for custom_* tools
 
@@ -1489,11 +1494,13 @@ def getToolDefinitions() {
         !proxiedNames.contains(it.name) && !hideByName.contains(it.name)
     }
 
-    // Gateway tools: one tool per gateway, with sub-tool list filtered. If a gateway
+    // Gateway tools: one tool per gateway, with sub-tool list filtered through
+    // the same hideByName the base-tool path uses. Sharing the filter means a
+    // toggle that hides a tool hides it on every surface (base + gateway sub-tool
+    // + flat-mode entry) with no chance of the two lists drifting. If a gateway
     // ends up with zero remaining sub-tools, drop the gateway entry entirely.
     def gatewayTools = gatewayConfig.collectMany { gwName, config ->
-        def hiddenInGw = hideGatewaySubTools[gwName] ?: ([] as Set)
-        def visibleSubTools = config.tools.findAll { !hiddenInGw.contains(it) }
+        def visibleSubTools = config.tools.findAll { !hideByName.contains(it) }
         if (!visibleSubTools) return []
         def catalog = visibleSubTools.collect { toolName ->
             "- ${toolName}: ${config.summaries[toolName]}"

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1153,6 +1153,114 @@ def getGatewayConfig() {
     ]
 }
 
+// ==================== MCP TOOL ANNOTATIONS ====================
+// MCP spec (2024-11-05+) `annotations.readOnlyHint` / `destructiveHint` drive
+// client-side grouping. Claude.ai's connector UI, for example, splits a server's
+// catalog into a "Read tools" block and a "Write tools" block based on
+// readOnlyHint; anything missing the annotation lands in a generic "Other tools"
+// bucket. Both sets below are defined POSITIVELY so a new tool that no one
+// labels here defaults to write+non-destructive, which is the safe default for
+// permission prompts (the user is asked before any unlabelled write happens).
+//
+// Gateway entries (manage_*) are annotated dynamically in getToolDefinitions():
+// a gateway is read-only iff every visible sub-tool is read-only, and
+// destructive iff any visible sub-tool is destructive. Visibility respects the
+// feature-toggle hide rules, so e.g. manage_native_rules_and_apps collapses
+// correctly when Built-in App Tools is off.
+
+def getReadOnlyToolNames() {
+    return [
+        // Device introspection
+        "list_devices", "get_device", "get_attribute", "get_device_events",
+        "poll_until_attribute",
+        // Custom rule reads (legacy MCP engine) -- test_rule is dry-run, no
+        // actions fire; export is a serialization read.
+        "custom_list_rules", "custom_get_rule", "custom_test_rule",
+        "custom_get_rule_diagnostics", "custom_export_rule",
+        // Hub state reads
+        "get_hub_info", "get_modes", "get_hsm_status", "check_for_update",
+        // Variables (reads)
+        "list_variables", "get_variable", "get_variable_history",
+        // Captured states (read)
+        "list_captured_states",
+        // Diagnostics + logs (read)
+        "get_debug_logs", "get_logging_status", "generate_bug_report",
+        "get_hub_logs", "get_device_history", "get_performance_stats",
+        "get_hub_jobs", "get_memory_history",
+        "get_zwave_details", "get_zigbee_details",
+        // device_health_check has an optional identifyHub LED blink, but its
+        // primary mode is staleness + ICMP-ping observation; treating as read
+        // matches user expectation for a "health check" tool.
+        "device_health_check",
+        // Apps/drivers (read)
+        "list_hub_apps", "list_hub_drivers",
+        "get_app_source", "get_driver_source", "get_library_source",
+        "list_item_backups", "get_item_backup",
+        // Virtual devices (read)
+        "list_virtual_devices",
+        // Rooms (read)
+        "list_rooms", "get_room",
+        // Files (read)
+        "list_files", "read_file",
+        // Installed apps (read)
+        "list_installed_apps", "get_device_in_use_by", "get_app_config",
+        "list_app_pages",
+        // HPM (read)
+        "list_hpm_packages", "get_hpm_drift",
+        // Native rules (read) -- export is appCloner serialization; check_rule_health
+        // inspects only.
+        "list_rm_rules", "export_native_app", "check_rule_health",
+        // Meta
+        "get_tool_guide", "search_tools"
+    ] as Set
+}
+
+def getDestructiveToolNames() {
+    return [
+        "custom_delete_rule",
+        "delete_variable", "remove_connector",
+        "delete_captured_state", "clear_captured_states",
+        "clear_debug_logs",
+        "reboot_hub", "shutdown_hub", "zwave_repair", "delete_device",
+        "delete_room",
+        "delete_app", "delete_driver", "delete_library",
+        "delete_file",
+        "delete_native_app",
+        // manage_virtual_device action="delete" deletes a virtual device; the
+        // create branch is non-destructive but the delete branch is, so mark
+        // the tool destructive.
+        "manage_virtual_device"
+    ] as Set
+}
+
+// Returns the MCP `annotations` map for a leaf tool name. `readOnlyHint` is
+// always set explicitly (not omitted on writes) so clients can rely on its
+// presence to drive grouping without falling back to the spec default.
+def annotationsForLeaf(String toolName, Set readOnlyNames, Set destructiveNames) {
+    def isReadOnly = readOnlyNames.contains(toolName)
+    def ann = [readOnlyHint: isReadOnly]
+    if (!isReadOnly && destructiveNames.contains(toolName)) {
+        ann.destructiveHint = true
+    }
+    return ann
+}
+
+// Aggregates annotations for a gateway entry based on its currently-visible
+// sub-tools. A gateway is read-only iff every visible sub-tool is read-only;
+// it is destructive iff any visible sub-tool is destructive. Caller passes
+// `visibleSubTools` so toggles (Built-in App Tools off, custom engine readonly,
+// etc.) that hide sub-tools change the gateway label too -- e.g. if the only
+// write sub-tools in a gateway are hidden, the gateway flips to read-only.
+def annotationsForGateway(List visibleSubTools, Set readOnlyNames, Set destructiveNames) {
+    def anyWrite = visibleSubTools.any { !readOnlyNames.contains(it) }
+    def anyDestructive = visibleSubTools.any { destructiveNames.contains(it) }
+    def ann = [readOnlyHint: !anyWrite]
+    if (anyWrite && anyDestructive) {
+        ann.destructiveHint = true
+    }
+    return ann
+}
+
 def handleGateway(gatewayName, toolName, toolArgs) {
     def config = getGatewayConfig()[gatewayName]
     if (!config) {
@@ -1357,6 +1465,12 @@ def getToolDefinitions() {
     }
     // customEngineMode == "full": nothing added to hideByName for custom_* tools
 
+    // MCP tool annotations source-of-truth -- read once per call, passed into the
+    // leaf and gateway annotation helpers so a single mutation to the canonical
+    // sets propagates everywhere tools/list builds entries.
+    def readOnlyNames = getReadOnlyToolNames()
+    def destructiveNames = getDestructiveToolNames()
+
     // Flat mode: every tool advertised individually under its real name; search_tools
     // is dropped because it only helps navigate gateway-hidden tools.
     if (settings.useGateways == false) {
@@ -1372,7 +1486,10 @@ def getToolDefinitions() {
         }
         // Flat-mode tools/list is the size-constrained path -- drop content inside
         // [[FLAT_TRIM]] markers to recover headroom under the hub's 124,000-byte cap.
-        return applyDescriptionTransform(filtered, true)
+        def transformed = applyDescriptionTransform(filtered, true)
+        return transformed.collect { tool ->
+            tool + [annotations: annotationsForLeaf(tool.name as String, readOnlyNames, destructiveNames)]
+        }
     }
 
     def gatewayConfig = getGatewayConfig()
@@ -1401,7 +1518,8 @@ def getToolDefinitions() {
                     tool: [type: "string", description: "Tool to execute. Omit to see full schemas for all tools in this group.", enum: visibleSubTools],
                     args: [type: "object", description: "Arguments for the tool. Call with just tool name first to see required parameters."]
                 ]
-            ]
+            ],
+            annotations: annotationsForGateway(visibleSubTools, readOnlyNames, destructiveNames)
         ]]
     }
 
@@ -1409,7 +1527,13 @@ def getToolDefinitions() {
     // summaries) plus any base tools. None of those descriptions currently carry
     // [[FLAT_TRIM]] markers, but strip-tokens-only is cheap and keeps us honest
     // if a future author adds one to a base-tool description.
-    return applyDescriptionTransform(baseTools + gatewayTools, false)
+    def transformed = applyDescriptionTransform(baseTools + gatewayTools, false)
+    return transformed.collect { tool ->
+        // Gateway entries already carry annotations from the collectMany above;
+        // leaf base tools get theirs from the canonical set. Don't overwrite a
+        // pre-populated annotations map.
+        tool.annotations ? tool : tool + [annotations: annotationsForLeaf(tool.name as String, readOnlyNames, destructiveNames)]
+    }
 }
 
 // Returns ALL tool definitions (used internally by gateway catalog and executeTool dispatch)

--- a/src/test/groovy/server/GatewayToggleSpec.groovy
+++ b/src/test/groovy/server/GatewayToggleSpec.groovy
@@ -243,6 +243,42 @@ class GatewayToggleSpec extends ToolSpecBase {
         names.contains('custom_get_rule_diagnostics')
     }
 
+    def "useGateways=true + enableCustomRuleEngine=false (readonly): gateway sub-tool catalogs shrink to read-only tools"() {
+        // Pins the unified-hideByName invariant: a name in hideByName must be filtered
+        // out of every gateway sub-tool catalog AND the input-schema enum, not just
+        // out of flat-mode base-tool placement. Previously two parallel lists
+        // (hideByName + hideGatewaySubTools) could drift; now hideByName is the single
+        // source of truth. Regression guard against a future refactor splitting them
+        // back apart and silently advertising sub-tools that fail at executeTool.
+        given:
+        settingsMap.useGateways = true
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = false  // customEngineMode = readonly
+
+        when:
+        def tools = script.getToolDefinitions()
+        def rulesAdmin = tools.find { it.name == 'manage_rules_admin' }
+
+        then: 'gateway entry still appears (custom_test_rule remains visible)'
+        rulesAdmin != null
+
+        and: 'write/structural sub-tools are removed from the catalog prose'
+        !rulesAdmin.description.contains('custom_delete_rule')
+        !rulesAdmin.description.contains('custom_export_rule')
+        !rulesAdmin.description.contains('custom_import_rule')
+        !rulesAdmin.description.contains('custom_clone_rule')
+
+        and: 'and from the input-schema tool enum (clients should not be offered them)'
+        def toolEnum = rulesAdmin.inputSchema.properties.tool.enum as Set
+        !toolEnum.contains('custom_delete_rule')
+        !toolEnum.contains('custom_export_rule')
+        !toolEnum.contains('custom_import_rule')
+        !toolEnum.contains('custom_clone_rule')
+
+        and: 'the surviving read sub-tool is still offered'
+        toolEnum.contains('custom_test_rule')
+    }
+
     def "useGateways=false + builtin/custom both off: gateway-name hint omits hidden sub-tools"() {
         // The flat-mode guard's hint must filter through hideByName — telling a stale
         // client to call list_rm_rules when it's also disabled by enableBuiltinApp=false

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -89,6 +89,20 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
             it.description instanceof String && !it.description.isEmpty() &&
             it.inputSchema instanceof Map
         }
+
+        and: 'MCP annotations survive serialization through jsonRpcResult → render'
+        // McpToolAnnotationsSpec pins the in-process map shape; this `and:`
+        // pins that the annotation keys actually land in the wire envelope
+        // (Claude.ai's catalog grouping only cares about what gets serialized).
+        // A regression in applyDescriptionTransform / JsonOutput that stripped
+        // the `annotations` key would silently undo the Read/Write split.
+        response.result.tools.every { it.annotations?.readOnlyHint instanceof Boolean }
+        def listDevices = response.result.tools.find { it.name == 'list_devices' }
+        listDevices.annotations.readOnlyHint == true
+        listDevices.annotations.containsKey('destructiveHint') == false
+        def manageDestructive = response.result.tools.find { it.name == 'manage_destructive_hub_ops' }
+        manageDestructive.annotations.readOnlyHint == false
+        manageDestructive.annotations.destructiveHint == true
     }
 
     def "tools/list with useGateways=false returns the full flat catalog in a single response (no pagination)"() {
@@ -136,6 +150,15 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
 
         and: 'no duplicate tool names in the response'
         response.result.tools.size() == names.size()
+
+        and: 'flat-mode wire envelope also carries readOnlyHint per leaf tool'
+        response.result.tools.every { it.annotations?.readOnlyHint instanceof Boolean }
+        def listRooms = response.result.tools.find { it.name == 'list_rooms' }
+        listRooms.annotations.readOnlyHint == true
+        listRooms.annotations.containsKey('destructiveHint') == false
+        def deleteRoom = response.result.tools.find { it.name == 'delete_room' }
+        deleteRoom.annotations.readOnlyHint == false
+        deleteRoom.annotations.destructiveHint == true
     }
 
     def "tools/list gateway-mode catalog also returns in a single response with no nextCursor"() {

--- a/src/test/groovy/server/McpToolAnnotationsSpec.groovy
+++ b/src/test/groovy/server/McpToolAnnotationsSpec.groovy
@@ -1,0 +1,327 @@
+package server
+
+import spock.lang.Unroll
+import support.ToolSpecBase
+
+/**
+ * Pins the MCP `annotations.readOnlyHint` / `destructiveHint` contract emitted
+ * by getToolDefinitions(). Claude.ai's connector UI groups a server's catalog
+ * into Read tools vs Write tools blocks based on readOnlyHint; tools missing
+ * the annotation fall into a generic "Other tools" bucket. Pre-2026 this
+ * server emitted no annotations, so every entry on tools/list — over 100
+ * tools — was lumped into "Other tools". This spec ensures every entry
+ * (base tools, gateway entries, and flat-mode entries) carries a
+ * readOnlyHint, that the value matches the source-of-truth set in
+ * getReadOnlyToolNames(), and that gateway aggregation rolls the leaf
+ * labels up correctly (any write sub-tool → gateway is write; any
+ * destructive sub-tool → gateway is destructive).
+ */
+class McpToolAnnotationsSpec extends ToolSpecBase {
+
+    def "every gateway-mode entry carries an MCP annotations.readOnlyHint boolean"() {
+        given:
+        settingsMap.remove('useGateways')
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def tools = script.getToolDefinitions()
+
+        then:
+        tools.every {
+            it.annotations instanceof Map &&
+            it.annotations.readOnlyHint instanceof Boolean
+        }
+    }
+
+    def "every flat-mode entry carries an MCP annotations.readOnlyHint boolean"() {
+        given:
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def tools = script.getToolDefinitions()
+
+        then:
+        tools.every {
+            it.annotations instanceof Map &&
+            it.annotations.readOnlyHint instanceof Boolean
+        }
+    }
+
+    @Unroll
+    def "flat mode: read-only tool '#name' is annotated readOnlyHint=true"() {
+        given:
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def tools = script.getToolDefinitions()
+        def tool = tools.find { it.name == name }
+
+        then:
+        tool != null
+        tool.annotations.readOnlyHint == true
+        tool.annotations.destructiveHint != true  // destructiveHint is only meaningful on writes
+
+        where:
+        // Sample from each category in getReadOnlyToolNames() — full set lives in source.
+        name << [
+            'list_devices', 'get_device', 'get_attribute', 'poll_until_attribute',
+            'custom_list_rules', 'custom_test_rule', 'custom_export_rule',
+            'get_hub_info', 'get_modes', 'get_hsm_status',
+            'list_variables', 'get_variable', 'get_variable_history',
+            'list_captured_states',
+            'get_debug_logs', 'get_logging_status', 'generate_bug_report',
+            'get_hub_logs', 'get_device_history', 'get_performance_stats',
+            'get_zwave_details', 'get_zigbee_details', 'device_health_check',
+            'list_hub_apps', 'get_app_source', 'list_item_backups',
+            'list_virtual_devices',
+            'list_rooms', 'get_room',
+            'list_files', 'read_file',
+            'list_installed_apps', 'get_app_config',
+            'list_hpm_packages', 'get_hpm_drift',
+            'list_rm_rules', 'export_native_app', 'check_rule_health',
+            'get_tool_guide'
+        ]
+    }
+
+    @Unroll
+    def "flat mode: write tool '#name' is annotated readOnlyHint=false"() {
+        given:
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def tools = script.getToolDefinitions()
+        def tool = tools.find { it.name == name }
+
+        then:
+        tool != null
+        tool.annotations.readOnlyHint == false
+
+        where:
+        name << [
+            'send_command',
+            'custom_create_rule', 'custom_update_rule', 'custom_import_rule', 'custom_clone_rule',
+            'set_mode',
+            'set_variable', 'create_variable', 'create_connector',
+            'set_hsm', 'set_log_level',
+            'update_mcp_settings',
+            'create_hub_backup', 'force_garbage_collection', 'get_set_hub_metrics',
+            'update_device',
+            'create_room', 'rename_room',
+            'install_app', 'install_driver', 'update_app_code', 'update_driver_code',
+            'install_library', 'update_library_code', 'restore_item_backup',
+            'write_file',
+            'run_rm_rule', 'pause_rm_rule', 'resume_rm_rule', 'set_rm_rule_boolean',
+            'create_native_app', 'update_native_app', 'clone_native_app', 'import_native_app'
+        ]
+    }
+
+    @Unroll
+    def "flat mode: destructive tool '#name' is annotated destructiveHint=true and readOnlyHint=false"() {
+        given:
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def tools = script.getToolDefinitions()
+        def tool = tools.find { it.name == name }
+
+        then:
+        tool != null
+        tool.annotations.readOnlyHint == false
+        tool.annotations.destructiveHint == true
+
+        where:
+        name << [
+            'custom_delete_rule',
+            'delete_variable', 'remove_connector',
+            'delete_captured_state', 'clear_captured_states',
+            'clear_debug_logs',
+            'reboot_hub', 'shutdown_hub', 'zwave_repair', 'delete_device',
+            'delete_room',
+            'delete_app', 'delete_driver', 'delete_library',
+            'delete_file',
+            'delete_native_app',
+            'manage_virtual_device'
+        ]
+    }
+
+    def "gateway entries: all-read-only sub-tools roll up to readOnlyHint=true"() {
+        given:
+        settingsMap.remove('useGateways')
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def tools = script.getToolDefinitions()
+
+        then: 'gateways whose every sub-tool is in getReadOnlyToolNames()'
+        // manage_apps_drivers, manage_installed_apps, and manage_hpm are pure-read
+        // gateways per their getGatewayConfig() entries; surface them as such.
+        tools.find { it.name == 'manage_apps_drivers' }.annotations.readOnlyHint == true
+        tools.find { it.name == 'manage_installed_apps' }.annotations.readOnlyHint == true
+        tools.find { it.name == 'manage_hpm' }.annotations.readOnlyHint == true
+    }
+
+    def "gateway entries: any write sub-tool flips the whole gateway to write"() {
+        given:
+        settingsMap.remove('useGateways')
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def tools = script.getToolDefinitions()
+
+        then: 'gateways with mixed read/write sub-tools surface as writes'
+        // manage_hub_variables mixes list_variables (read) with set_variable / delete_variable (write+destructive).
+        // manage_rooms mixes list_rooms (read) with create_room / delete_room (write+destructive).
+        // manage_logs mixes get_hub_logs (read) with clear_debug_logs / set_log_level (write).
+        // manage_files mixes list_files / read_file (read) with write_file / delete_file (write+destructive).
+        // manage_native_rules_and_apps mixes list_rm_rules / check_rule_health (read) with create_native_app etc (write).
+        // manage_rules_admin mixes custom_test_rule / custom_export_rule (read) with custom_delete_rule etc (write).
+        tools.find { it.name == 'manage_hub_variables' }.annotations.readOnlyHint == false
+        tools.find { it.name == 'manage_rooms' }.annotations.readOnlyHint == false
+        tools.find { it.name == 'manage_logs' }.annotations.readOnlyHint == false
+        tools.find { it.name == 'manage_files' }.annotations.readOnlyHint == false
+        tools.find { it.name == 'manage_native_rules_and_apps' }.annotations.readOnlyHint == false
+        tools.find { it.name == 'manage_rules_admin' }.annotations.readOnlyHint == false
+
+        and: 'all-write gateways are also writes'
+        tools.find { it.name == 'manage_destructive_hub_ops' }.annotations.readOnlyHint == false
+        tools.find { it.name == 'manage_app_driver_code' }.annotations.readOnlyHint == false
+        tools.find { it.name == 'manage_mcp_self' }.annotations.readOnlyHint == false
+    }
+
+    def "gateway entries: any destructive sub-tool surfaces destructiveHint=true"() {
+        given:
+        settingsMap.remove('useGateways')
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def tools = script.getToolDefinitions()
+
+        then:
+        tools.find { it.name == 'manage_destructive_hub_ops' }.annotations.destructiveHint == true
+        tools.find { it.name == 'manage_hub_variables' }.annotations.destructiveHint == true
+        tools.find { it.name == 'manage_rooms' }.annotations.destructiveHint == true
+        tools.find { it.name == 'manage_files' }.annotations.destructiveHint == true
+        tools.find { it.name == 'manage_app_driver_code' }.annotations.destructiveHint == true
+        tools.find { it.name == 'manage_native_rules_and_apps' }.annotations.destructiveHint == true
+        tools.find { it.name == 'manage_rules_admin' }.annotations.destructiveHint == true
+        tools.find { it.name == 'manage_diagnostics' }.annotations.destructiveHint == true
+
+        and: 'pure-read gateways do not carry destructiveHint'
+        tools.find { it.name == 'manage_apps_drivers' }.annotations.containsKey('destructiveHint') == false
+        tools.find { it.name == 'manage_installed_apps' }.annotations.containsKey('destructiveHint') == false
+        tools.find { it.name == 'manage_hpm' }.annotations.containsKey('destructiveHint') == false
+
+        and: 'write-but-not-destructive gateways do not carry destructiveHint'
+        // manage_logs has clear_debug_logs (destructive) -- so this gateway IS destructive.
+        // manage_mcp_self contains only update_mcp_settings (write, non-destructive).
+        tools.find { it.name == 'manage_mcp_self' }.annotations.containsKey('destructiveHint') == false
+    }
+
+    def "gateway aggregation survives sub-tool hiding without crashing or mis-classifying"() {
+        // customEngineMode=off ANDs both toggles to false; that path adds
+        // custom_get_rule_diagnostics to hideGatewaySubTools["manage_diagnostics"],
+        // so the aggregator runs over a strictly smaller visibleSubTools list than
+        // the static gateway config. Smoke-tests that the aggregator survives the
+        // narrower list -- manage_diagnostics still contains zwave_repair /
+        // clear_captured_states so the label stays write+destructive.
+        given:
+        settingsMap.remove('useGateways')
+        settingsMap.enableBuiltinApp = false
+        settingsMap.enableCustomRuleEngine = false  // customEngineMode = off
+
+        when:
+        def tools = script.getToolDefinitions()
+        def diag = tools.find { it.name == 'manage_diagnostics' }
+
+        then:
+        diag != null
+        diag.annotations.readOnlyHint == false
+        diag.annotations.destructiveHint == true
+    }
+
+    def "readOnlyToolNames and destructiveToolNames are disjoint -- a tool cannot be both"() {
+        when:
+        def readOnly = script.getReadOnlyToolNames()
+        def destructive = script.getDestructiveToolNames()
+
+        then:
+        (readOnly.intersect(destructive)) == [] as Set
+    }
+
+    def "every name in readOnlyToolNames and destructiveToolNames exists in getAllToolDefinitions"() {
+        // Guards against typos that silently classify a non-existent tool — and against
+        // stale entries that linger after a tool is renamed or removed.
+        when:
+        def allNames = script.getAllToolDefinitions()*.name as Set
+        def readOnly = script.getReadOnlyToolNames()
+        def destructive = script.getDestructiveToolNames()
+
+        then:
+        (readOnly - allNames) == [] as Set
+        (destructive - allNames) == [] as Set
+    }
+
+    def "every leaf tool (flat mode) is classified — none fall through to default-write-without-listing"() {
+        // The annotation layer treats unlisted tools as write+non-destructive (safe default),
+        // but a tool that genuinely should be read-only would silently land in the write
+        // group. This spec forces explicit classification: every tool in the flat catalog
+        // must appear in EITHER getReadOnlyToolNames() OR the implicit-write set (which we
+        // derive here as `allNames - readOnly`). The intent: catch new tools added without
+        // an explicit annotation decision.
+        given:
+        settingsMap.useGateways = false
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+
+        when:
+        def allNames = script.getToolDefinitions()*.name as Set
+        def readOnly = script.getReadOnlyToolNames()
+        def destructive = script.getDestructiveToolNames()
+        def classifiedAsWrite = (allNames - readOnly)
+
+        then: 'every classified-as-write entry is intentional (i.e., appears here as a sanity check on the count).'
+        // Adjust this list when intentionally adding/removing write tools. The point is
+        // to make any change to the write surface visible in code review.
+        def expectedWrites = [
+            'send_command',
+            'custom_create_rule', 'custom_update_rule', 'custom_delete_rule',
+            'custom_import_rule', 'custom_clone_rule',
+            'set_mode',
+            'set_variable', 'create_variable', 'delete_variable',
+            'create_connector', 'remove_connector',
+            'update_mcp_settings',
+            'set_hsm',
+            'delete_captured_state', 'clear_captured_states',
+            'clear_debug_logs', 'set_log_level',
+            'create_hub_backup',
+            'reboot_hub', 'shutdown_hub', 'zwave_repair', 'delete_device',
+            'force_garbage_collection', 'get_set_hub_metrics',
+            'manage_virtual_device', 'update_device',
+            'create_room', 'delete_room', 'rename_room',
+            'install_app', 'install_driver', 'update_app_code', 'update_driver_code',
+            'delete_app', 'delete_driver',
+            'install_library', 'update_library_code', 'delete_library',
+            'restore_item_backup',
+            'write_file', 'delete_file',
+            'run_rm_rule', 'pause_rm_rule', 'resume_rm_rule', 'set_rm_rule_boolean',
+            'create_native_app', 'update_native_app', 'clone_native_app',
+            'import_native_app', 'delete_native_app'
+        ] as Set
+        classifiedAsWrite == expectedWrites
+
+        and: 'destructive is a subset of write'
+        (destructive - classifiedAsWrite) == [] as Set
+    }
+}

--- a/src/test/groovy/server/McpToolAnnotationsSpec.groovy
+++ b/src/test/groovy/server/McpToolAnnotationsSpec.groovy
@@ -256,11 +256,11 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
     }
 
     def "gateway aggregation survives toggle-driven sub-tool hiding"() {
-        // Smoke-tests the end-to-end path: customEngineMode=off pushes
-        // custom_get_rule_diagnostics into hideGatewaySubTools["manage_diagnostics"],
-        // so the aggregator runs on a strictly narrower visibleSubTools list.
-        // manage_diagnostics still contains write sub-tools (zwave_repair etc.) so
-        // the label stays write+destructive.
+        // Smoke-tests the end-to-end path: customEngineMode=off adds
+        // custom_get_rule_diagnostics to hideByName, which now also filters
+        // gateway sub-tools, so manage_diagnostics's visibleSubTools is one
+        // shorter than its config. The remaining sub-tools still include
+        // writes (zwave_repair etc.), so the label stays write+destructive.
         given:
         settingsMap.remove('useGateways')
         settingsMap.enableBuiltinApp = false

--- a/src/test/groovy/server/McpToolAnnotationsSpec.groovy
+++ b/src/test/groovy/server/McpToolAnnotationsSpec.groovy
@@ -6,15 +6,13 @@ import support.ToolSpecBase
 /**
  * Pins the MCP `annotations.readOnlyHint` / `destructiveHint` contract emitted
  * by getToolDefinitions(). Claude.ai's connector UI groups a server's catalog
- * into Read tools vs Write tools blocks based on readOnlyHint; tools missing
- * the annotation fall into a generic "Other tools" bucket. Pre-2026 this
- * server emitted no annotations, so every entry on tools/list — over 100
- * tools — was lumped into "Other tools". This spec ensures every entry
- * (base tools, gateway entries, and flat-mode entries) carries a
- * readOnlyHint, that the value matches the source-of-truth set in
- * getReadOnlyToolNames(), and that gateway aggregation rolls the leaf
- * labels up correctly (any write sub-tool → gateway is write; any
- * destructive sub-tool → gateway is destructive).
+ * into Read vs Write blocks from readOnlyHint; entries missing the annotation
+ * fall into a generic "Other tools" bucket. This spec ensures every entry
+ * (base tools, gateway entries, flat-mode and gateway-mode) carries
+ * readOnlyHint, that writes also carry destructiveHint=true (matching the
+ * MCP spec default and the project's "writes are destructive" policy), and
+ * that gateway aggregation rolls leaf labels up correctly (any write sub-tool
+ * flips the gateway to write+destructive).
  */
 class McpToolAnnotationsSpec extends ToolSpecBase {
 
@@ -28,6 +26,8 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         def tools = script.getToolDefinitions()
 
         then:
+        // Asserting non-empty defends against `every {}` returning true vacuously.
+        !tools.isEmpty()
         tools.every {
             it.annotations instanceof Map &&
             it.annotations.readOnlyHint instanceof Boolean
@@ -44,6 +44,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         def tools = script.getToolDefinitions()
 
         then:
+        !tools.isEmpty()
         tools.every {
             it.annotations instanceof Map &&
             it.annotations.readOnlyHint instanceof Boolean
@@ -51,7 +52,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
     }
 
     @Unroll
-    def "flat mode: read-only tool '#name' is annotated readOnlyHint=true"() {
+    def "flat mode: read-only tool '#name' has readOnlyHint=true and omits destructiveHint"() {
         given:
         settingsMap.useGateways = false
         settingsMap.enableBuiltinApp = true
@@ -64,10 +65,12 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         then:
         tool != null
         tool.annotations.readOnlyHint == true
-        tool.annotations.destructiveHint != true  // destructiveHint is only meaningful on writes
+        // destructiveHint is only meaningful when readOnlyHint=false -- read-only
+        // tools omit the key entirely, not just set it to false.
+        tool.annotations.containsKey('destructiveHint') == false
 
         where:
-        // Sample from each category in getReadOnlyToolNames() — full set lives in source.
+        // Sample from each category in getReadOnlyToolNames() -- full set lives in source.
         name << [
             'list_devices', 'get_device', 'get_attribute', 'poll_until_attribute',
             'custom_list_rules', 'custom_test_rule', 'custom_export_rule',
@@ -89,41 +92,11 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
     }
 
     @Unroll
-    def "flat mode: write tool '#name' is annotated readOnlyHint=false"() {
-        given:
-        settingsMap.useGateways = false
-        settingsMap.enableBuiltinApp = true
-        settingsMap.enableCustomRuleEngine = true
-
-        when:
-        def tools = script.getToolDefinitions()
-        def tool = tools.find { it.name == name }
-
-        then:
-        tool != null
-        tool.annotations.readOnlyHint == false
-
-        where:
-        name << [
-            'send_command',
-            'custom_create_rule', 'custom_update_rule', 'custom_import_rule', 'custom_clone_rule',
-            'set_mode',
-            'set_variable', 'create_variable', 'create_connector',
-            'set_hsm', 'set_log_level',
-            'update_mcp_settings',
-            'create_hub_backup', 'force_garbage_collection', 'get_set_hub_metrics',
-            'update_device',
-            'create_room', 'rename_room',
-            'install_app', 'install_driver', 'update_app_code', 'update_driver_code',
-            'install_library', 'update_library_code', 'restore_item_backup',
-            'write_file',
-            'run_rm_rule', 'pause_rm_rule', 'resume_rm_rule', 'set_rm_rule_boolean',
-            'create_native_app', 'update_native_app', 'clone_native_app', 'import_native_app'
-        ]
-    }
-
-    @Unroll
-    def "flat mode: destructive tool '#name' is annotated destructiveHint=true and readOnlyHint=false"() {
+    def "flat mode: write tool '#name' is annotated readOnlyHint=false AND destructiveHint=true"() {
+        // Project policy: every write is destructive. The explicit destructiveHint=true
+        // matches the MCP spec default (destructiveHint defaults to true on writes) and
+        // makes the wire payload unambiguous for clients that don't fall back to the
+        // spec default.
         given:
         settingsMap.useGateways = false
         settingsMap.enableBuiltinApp = true
@@ -140,20 +113,32 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
 
         where:
         name << [
-            'custom_delete_rule',
-            'delete_variable', 'remove_connector',
+            'send_command',
+            'custom_create_rule', 'custom_update_rule', 'custom_delete_rule',
+            'custom_import_rule', 'custom_clone_rule',
+            'set_mode',
+            'set_variable', 'create_variable', 'delete_variable',
+            'create_connector', 'remove_connector',
+            'set_hsm', 'set_log_level',
+            'update_mcp_settings',
             'delete_captured_state', 'clear_captured_states',
             'clear_debug_logs',
+            'create_hub_backup', 'force_garbage_collection', 'get_set_hub_metrics',
             'reboot_hub', 'shutdown_hub', 'zwave_repair', 'delete_device',
-            'delete_room',
-            'delete_app', 'delete_driver', 'delete_library',
-            'delete_file',
-            'delete_native_app',
-            'manage_virtual_device'
+            'manage_virtual_device', 'update_device',
+            'create_room', 'delete_room', 'rename_room',
+            'install_app', 'install_driver', 'update_app_code', 'update_driver_code',
+            'delete_app', 'delete_driver',
+            'install_library', 'update_library_code', 'delete_library',
+            'restore_item_backup',
+            'write_file', 'delete_file',
+            'run_rm_rule', 'pause_rm_rule', 'resume_rm_rule', 'set_rm_rule_boolean',
+            'create_native_app', 'update_native_app', 'clone_native_app',
+            'import_native_app', 'delete_native_app'
         ]
     }
 
-    def "gateway entries: all-read-only sub-tools roll up to readOnlyHint=true"() {
+    def "gateway entries: all-read-only sub-tools roll up to readOnlyHint=true and omit destructiveHint"() {
         given:
         settingsMap.remove('useGateways')
         settingsMap.enableBuiltinApp = true
@@ -163,14 +148,15 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         def tools = script.getToolDefinitions()
 
         then: 'gateways whose every sub-tool is in getReadOnlyToolNames()'
-        // manage_apps_drivers, manage_installed_apps, and manage_hpm are pure-read
-        // gateways per their getGatewayConfig() entries; surface them as such.
-        tools.find { it.name == 'manage_apps_drivers' }.annotations.readOnlyHint == true
-        tools.find { it.name == 'manage_installed_apps' }.annotations.readOnlyHint == true
-        tools.find { it.name == 'manage_hpm' }.annotations.readOnlyHint == true
+        ['manage_apps_drivers', 'manage_installed_apps', 'manage_hpm'].each { gwName ->
+            def gw = tools.find { it.name == gwName }
+            assert gw != null : "${gwName} missing from gateway-mode catalog"
+            assert gw.annotations.readOnlyHint == true : "${gwName} should be read-only"
+            assert gw.annotations.containsKey('destructiveHint') == false : "${gwName} should omit destructiveHint"
+        }
     }
 
-    def "gateway entries: any write sub-tool flips the whole gateway to write"() {
+    def "gateway entries: any write sub-tool flips the whole gateway to write+destructive"() {
         given:
         settingsMap.remove('useGateways')
         settingsMap.enableBuiltinApp = true
@@ -179,63 +165,102 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         when:
         def tools = script.getToolDefinitions()
 
-        then: 'gateways with mixed read/write sub-tools surface as writes'
-        // manage_hub_variables mixes list_variables (read) with set_variable / delete_variable (write+destructive).
-        // manage_rooms mixes list_rooms (read) with create_room / delete_room (write+destructive).
-        // manage_logs mixes get_hub_logs (read) with clear_debug_logs / set_log_level (write).
-        // manage_files mixes list_files / read_file (read) with write_file / delete_file (write+destructive).
-        // manage_native_rules_and_apps mixes list_rm_rules / check_rule_health (read) with create_native_app etc (write).
-        // manage_rules_admin mixes custom_test_rule / custom_export_rule (read) with custom_delete_rule etc (write).
-        tools.find { it.name == 'manage_hub_variables' }.annotations.readOnlyHint == false
-        tools.find { it.name == 'manage_rooms' }.annotations.readOnlyHint == false
-        tools.find { it.name == 'manage_logs' }.annotations.readOnlyHint == false
-        tools.find { it.name == 'manage_files' }.annotations.readOnlyHint == false
-        tools.find { it.name == 'manage_native_rules_and_apps' }.annotations.readOnlyHint == false
-        tools.find { it.name == 'manage_rules_admin' }.annotations.readOnlyHint == false
-
-        and: 'all-write gateways are also writes'
-        tools.find { it.name == 'manage_destructive_hub_ops' }.annotations.readOnlyHint == false
-        tools.find { it.name == 'manage_app_driver_code' }.annotations.readOnlyHint == false
-        tools.find { it.name == 'manage_mcp_self' }.annotations.readOnlyHint == false
+        then: 'every gateway with at least one write sub-tool is write+destructive'
+        def writeGateways = [
+            'manage_rules_admin',        // custom_delete_rule + others
+            'manage_hub_variables',      // set/create/delete + others
+            'manage_rooms',              // create/delete/rename + others
+            'manage_destructive_hub_ops',// reboot/shutdown/delete_device
+            'manage_app_driver_code',    // install/update/delete code
+            'manage_logs',               // clear_debug_logs, set_log_level
+            'manage_diagnostics',        // zwave_repair, clear_captured_states
+            'manage_files',              // write_file, delete_file
+            'manage_native_rules_and_apps', // create/update/delete/run native rules
+            'manage_mcp_self'            // update_mcp_settings
+        ]
+        writeGateways.each { gwName ->
+            def gw = tools.find { it.name == gwName }
+            assert gw != null : "${gwName} missing from gateway-mode catalog"
+            assert gw.annotations.readOnlyHint == false : "${gwName} should be write"
+            assert gw.annotations.destructiveHint == true : "${gwName} should be destructive (any write sub-tool flips destructive)"
+        }
     }
 
-    def "gateway entries: any destructive sub-tool surfaces destructiveHint=true"() {
-        given:
-        settingsMap.remove('useGateways')
-        settingsMap.enableBuiltinApp = true
-        settingsMap.enableCustomRuleEngine = true
-
+    def "annotationsForLeaf: read-only name returns readOnlyHint=true and no destructiveHint key"() {
+        // Direct unit test of the helper -- catches regressions independently of
+        // the larger getToolDefinitions() integration path.
         when:
-        def tools = script.getToolDefinitions()
+        def readOnly = ['list_rooms', 'get_room'] as Set
+        def ann = script.annotationsForLeaf('list_rooms', readOnly)
 
         then:
-        tools.find { it.name == 'manage_destructive_hub_ops' }.annotations.destructiveHint == true
-        tools.find { it.name == 'manage_hub_variables' }.annotations.destructiveHint == true
-        tools.find { it.name == 'manage_rooms' }.annotations.destructiveHint == true
-        tools.find { it.name == 'manage_files' }.annotations.destructiveHint == true
-        tools.find { it.name == 'manage_app_driver_code' }.annotations.destructiveHint == true
-        tools.find { it.name == 'manage_native_rules_and_apps' }.annotations.destructiveHint == true
-        tools.find { it.name == 'manage_rules_admin' }.annotations.destructiveHint == true
-        tools.find { it.name == 'manage_diagnostics' }.annotations.destructiveHint == true
-
-        and: 'pure-read gateways do not carry destructiveHint'
-        tools.find { it.name == 'manage_apps_drivers' }.annotations.containsKey('destructiveHint') == false
-        tools.find { it.name == 'manage_installed_apps' }.annotations.containsKey('destructiveHint') == false
-        tools.find { it.name == 'manage_hpm' }.annotations.containsKey('destructiveHint') == false
-
-        and: 'write-but-not-destructive gateways do not carry destructiveHint'
-        // manage_logs has clear_debug_logs (destructive) -- so this gateway IS destructive.
-        // manage_mcp_self contains only update_mcp_settings (write, non-destructive).
-        tools.find { it.name == 'manage_mcp_self' }.annotations.containsKey('destructiveHint') == false
+        ann.readOnlyHint == true
+        ann.containsKey('destructiveHint') == false
     }
 
-    def "gateway aggregation survives sub-tool hiding without crashing or mis-classifying"() {
-        // customEngineMode=off ANDs both toggles to false; that path adds
-        // custom_get_rule_diagnostics to hideGatewaySubTools["manage_diagnostics"],
-        // so the aggregator runs over a strictly smaller visibleSubTools list than
-        // the static gateway config. Smoke-tests that the aggregator survives the
-        // narrower list -- manage_diagnostics still contains zwave_repair /
-        // clear_captured_states so the label stays write+destructive.
+    def "annotationsForLeaf: write name returns readOnlyHint=false and destructiveHint=true"() {
+        when:
+        def readOnly = ['list_rooms'] as Set
+        def ann = script.annotationsForLeaf('delete_room', readOnly)
+
+        then:
+        ann.readOnlyHint == false
+        ann.destructiveHint == true
+    }
+
+    def "annotationsForGateway: all-read sub-tools roll up to read-only, no destructiveHint"() {
+        when:
+        def readOnly = ['list_rooms', 'get_room', 'list_devices'] as Set
+        def ann = script.annotationsForGateway(['list_rooms', 'get_room'], readOnly)
+
+        then:
+        ann.readOnlyHint == true
+        ann.containsKey('destructiveHint') == false
+    }
+
+    def "annotationsForGateway: any write sub-tool flips gateway to write+destructive"() {
+        when:
+        def readOnly = ['list_rooms', 'get_room'] as Set
+        def ann = script.annotationsForGateway(['list_rooms', 'delete_room'], readOnly)
+
+        then:
+        ann.readOnlyHint == false
+        ann.destructiveHint == true
+    }
+
+    def "annotationsForGateway: empty visibleSubTools throws (precondition guard)"() {
+        when:
+        script.annotationsForGateway([], ['list_rooms'] as Set)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "annotationsForGateway: hidden sub-tool drops out of the aggregation, flipping a mixed gateway to read-only"() {
+        // Pins the load-bearing claim in the header comment: visibleSubTools drives
+        // the label, so if a feature toggle hides every write sub-tool, the remaining
+        // read-only sub-tools relabel the gateway to read-only. No current toggle
+        // exercises this end-to-end (it requires a gateway whose writes are all
+        // toggle-hidden while at least one read sub-tool stays visible), so this
+        // unit-level test pins the helper contract directly.
+        when:
+        def readOnly = ['list_rooms', 'get_room', 'list_devices'] as Set
+        def withWrites = script.annotationsForGateway(['list_rooms', 'delete_room'], readOnly)
+        def writesHidden = script.annotationsForGateway(['list_rooms', 'get_room'], readOnly)
+
+        then:
+        withWrites.readOnlyHint == false
+        withWrites.destructiveHint == true
+        writesHidden.readOnlyHint == true
+        writesHidden.containsKey('destructiveHint') == false
+    }
+
+    def "gateway aggregation survives toggle-driven sub-tool hiding"() {
+        // Smoke-tests the end-to-end path: customEngineMode=off pushes
+        // custom_get_rule_diagnostics into hideGatewaySubTools["manage_diagnostics"],
+        // so the aggregator runs on a strictly narrower visibleSubTools list.
+        // manage_diagnostics still contains write sub-tools (zwave_repair etc.) so
+        // the label stays write+destructive.
         given:
         settingsMap.remove('useGateways')
         settingsMap.enableBuiltinApp = false
@@ -251,35 +276,24 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         diag.annotations.destructiveHint == true
     }
 
-    def "readOnlyToolNames and destructiveToolNames are disjoint -- a tool cannot be both"() {
-        when:
-        def readOnly = script.getReadOnlyToolNames()
-        def destructive = script.getDestructiveToolNames()
-
-        then:
-        (readOnly.intersect(destructive)) == [] as Set
-    }
-
-    def "every name in readOnlyToolNames and destructiveToolNames exists in getAllToolDefinitions"() {
-        // Guards against typos that silently classify a non-existent tool — and against
-        // stale entries that linger after a tool is renamed or removed.
+    def "every name in getReadOnlyToolNames() resolves to a real tool in getAllToolDefinitions()"() {
+        // Guards against typos and stale entries after a tool is renamed or removed.
         when:
         def allNames = script.getAllToolDefinitions()*.name as Set
         def readOnly = script.getReadOnlyToolNames()
-        def destructive = script.getDestructiveToolNames()
 
         then:
         (readOnly - allNames) == [] as Set
-        (destructive - allNames) == [] as Set
     }
 
-    def "every leaf tool (flat mode) is classified — none fall through to default-write-without-listing"() {
-        // The annotation layer treats unlisted tools as write+non-destructive (safe default),
+    def "every leaf tool in the flat catalog is explicitly classified read or write"() {
+        // The annotation helper treats unlisted names as write+destructive (safe default),
         // but a tool that genuinely should be read-only would silently land in the write
-        // group. This spec forces explicit classification: every tool in the flat catalog
-        // must appear in EITHER getReadOnlyToolNames() OR the implicit-write set (which we
-        // derive here as `allNames - readOnly`). The intent: catch new tools added without
-        // an explicit annotation decision.
+        // group, surfacing surprise permission prompts. This spec forces explicit
+        // classification: every flat-catalog entry must appear in either the read-only
+        // set or the enumerated write set below. Adjust the snapshots when intentionally
+        // adding/removing tools -- the point is to make any change to the read/write
+        // surface visible in code review.
         given:
         settingsMap.useGateways = false
         settingsMap.enableBuiltinApp = true
@@ -288,12 +302,35 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         when:
         def allNames = script.getToolDefinitions()*.name as Set
         def readOnly = script.getReadOnlyToolNames()
-        def destructive = script.getDestructiveToolNames()
+        def classifiedAsRead = allNames.intersect(readOnly)
         def classifiedAsWrite = (allNames - readOnly)
 
-        then: 'every classified-as-write entry is intentional (i.e., appears here as a sanity check on the count).'
-        // Adjust this list when intentionally adding/removing write tools. The point is
-        // to make any change to the write surface visible in code review.
+        def expectedReadOnly = [
+            'list_devices', 'get_device', 'get_attribute', 'get_device_events',
+            'poll_until_attribute',
+            'custom_list_rules', 'custom_get_rule', 'custom_test_rule',
+            'custom_get_rule_diagnostics', 'custom_export_rule',
+            'get_hub_info', 'get_modes', 'get_hsm_status', 'check_for_update',
+            'list_variables', 'get_variable', 'get_variable_history',
+            'list_captured_states',
+            'get_debug_logs', 'get_logging_status', 'generate_bug_report',
+            'get_hub_logs', 'get_device_history', 'get_performance_stats',
+            'get_hub_jobs', 'get_memory_history',
+            'get_zwave_details', 'get_zigbee_details', 'device_health_check',
+            'list_hub_apps', 'list_hub_drivers',
+            'get_app_source', 'get_driver_source', 'get_library_source',
+            'list_item_backups', 'get_item_backup',
+            'list_virtual_devices',
+            'list_rooms', 'get_room',
+            'list_files', 'read_file',
+            'list_installed_apps', 'get_device_in_use_by', 'get_app_config',
+            'list_app_pages',
+            'list_hpm_packages', 'get_hpm_drift',
+            'list_rm_rules', 'export_native_app', 'check_rule_health',
+            'get_tool_guide'
+            // search_tools is in getReadOnlyToolNames() but suppressed in flat mode.
+        ] as Set
+
         def expectedWrites = [
             'send_command',
             'custom_create_rule', 'custom_update_rule', 'custom_delete_rule',
@@ -319,9 +356,13 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
             'create_native_app', 'update_native_app', 'clone_native_app',
             'import_native_app', 'delete_native_app'
         ] as Set
-        classifiedAsWrite == expectedWrites
 
-        and: 'destructive is a subset of write'
-        (destructive - classifiedAsWrite) == [] as Set
+        then:
+        // Symmetric snapshots: a regression in either direction surfaces with a clear
+        // failure message ("expected reads matches actual reads" vs "expected writes
+        // matches actual writes") instead of forcing the author to reverse-engineer
+        // which side moved.
+        classifiedAsRead == expectedReadOnly
+        classifiedAsWrite == expectedWrites
     }
 }

--- a/src/test/groovy/server/UpdateNativeAppSchemaTrimSpec.groovy
+++ b/src/test/groovy/server/UpdateNativeAppSchemaTrimSpec.groovy
@@ -21,15 +21,15 @@ import support.ToolSpecBase
  */
 class UpdateNativeAppSchemaTrimSpec extends ToolSpecBase {
 
-    // 118,000 = ~6 KB headroom under the hub's 124,000-byte JSON-RPC response cap
-    // and ~3 KB tripwire above today's ~115 KB post-trim catalog. Issue #181 named
-    // a strict ≤120,000 target; we beat it after extending the trim to the top-4
-    // heaviest tools (update_native_app, get_hpm_drift, create_native_app,
-    // list_devices). The lower bound (FLAT_CATALOG_BYTE_FLOOR) guards against an
-    // accidental over-trim regression where someone drops content unconditionally
-    // -- if the catalog ever falls below ~100 KB on a flat-mode run, something
-    // important is missing.
-    private static final int FLAT_CATALOG_BYTE_BUDGET = 118_000
+    // 122,000 = ~2 KB headroom under the hub's 124,000-byte JSON-RPC response cap.
+    // The earlier 118,000 budget had ~6 KB headroom but no MCP `annotations.readOnlyHint`
+    // / `destructiveHint` keys -- adding those for client-side Read/Write grouping
+    // costs ~5 KB across the ~100-tool flat catalog. The 2 KB residual headroom
+    // is still wider than any single description's variance. The lower bound
+    // (FLAT_CATALOG_BYTE_FLOOR) guards against an accidental over-trim regression
+    // where someone drops content unconditionally -- if the catalog ever falls
+    // below ~100 KB on a flat-mode run, something important is missing.
+    private static final int FLAT_CATALOG_BYTE_BUDGET = 122_000
     private static final int FLAT_CATALOG_BYTE_FLOOR = 100_000
     private static final String OPEN_MARKER = '[[FLAT_TRIM]]'
     private static final String CLOSE_MARKER = '[[/FLAT_TRIM]]'


### PR DESCRIPTION
## Summary

- Every entry on `tools/list` now carries MCP `annotations.readOnlyHint`, and every write also carries `annotations.destructiveHint=true`. Claude.ai's connector UI groups the Hubitat catalog into Read vs Write blocks instead of dumping all 100+ tools into "Other tools".
- Classification model: a tool either lives in `getReadOnlyToolNames()` (read-only) or it's a write — every write is destructive. No non-destructive-write subset. Matches the MCP spec default (`destructiveHint` defaults to `true` when `readOnlyHint=false`) and gets every write the cautious permission prompt.
- Gateway entries (`manage_*`) aggregate from currently-visible sub-tools: read-only iff every visible sub-tool is read-only, otherwise write+destructive. Pure-read gateways (`manage_apps_drivers`, `manage_installed_apps`, `manage_hpm`) surface as Read tools.
- Side fix: `hideByName` is now the single source of truth for toggle-driven tool hiding — drove out the parallel `hideGatewaySubTools` map that maintained the same names by hand and risked drift. A name in `hideByName` now disappears from every surface (flat catalog, gateway sub-tool prose, input-schema enum). Visible consequence: under `customEngineMode=readonly` with gateway mode on, `manage_rules_admin`'s catalog and tool-enum now correctly omit the 4 write sub-tools instead of advertising calls that would fail at `executeTool`.

## Type of change

- [x] `feat` — new feature or capability

## Changes

- `hubitat-mcp-server.groovy`:
  - New `getReadOnlyToolNames()` canonical set + `annotationsForLeaf` / `annotationsForGateway` helpers (both emit annotation keys explicitly; precondition on the gateway helper for empty sub-tool lists).
  - `getToolDefinitions()` injects the annotation map onto every flat-mode and gateway-mode entry. Gateway-mode merge uses `containsKey('readOnlyHint')` as the predicate (not map-truthiness), so a partial pre-populated `annotations` map merges instead of silently bypassing the classifier.
  - Unified `hideByName` as single source of truth; `hideGatewaySubTools` removed; gateway sub-tool filter shares the same set.
- `src/test/groovy/server/McpToolAnnotationsSpec.groovy`: pins per-leaf labels (read tools omit `destructiveHint`, writes carry `destructiveHint=true`), gateway aggregation, the disjointness/membership invariants on the canonical set, the precondition guard, and symmetric snapshots of expected reads + expected writes so a regression in either direction surfaces with a clear failure message.
- `src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy`: wire-level assertions that annotations survive `jsonRpcResult → render` to land in `response.result.tools[*].annotations` (covers both flat and gateway mode).
- `src/test/groovy/server/GatewayToggleSpec.groovy`: regression test that gateway sub-tool catalogs and input-schema enums shrink to match `hideByName` (pins the unified-list invariant).
- `src/test/groovy/server/UpdateNativeAppSchemaTrimSpec.groovy`: tripwire bumped 118,000 → 122,000 to absorb the ~5 KB the annotations add across the flat catalog (still 2 KB under the hub's 124,000-byte JSON-RPC cap; response-size guard at `handleMcpRequest` still backstops with -32603).

## Release Notes

- Tools are now grouped as Read vs Write in MCP clients that surface that distinction (e.g. Claude.ai connectors), instead of all landing in a generic "Other tools" bucket. Every write also flags `destructiveHint=true`, so clients show the cautious permission prompt for writes.
- Under "Custom Rule Engine readonly" + gateway mode, `manage_rules_admin` no longer advertises the 4 write-side `custom_*` sub-tools that would fail when called. The gateway catalog reflects the live executable surface.

## Testing

- `python tests/sandbox_lint.py` — pass.
- `./gradlew test` — pass (all 4 CI matrix variants: normal/strict × flat/gateway).
- e2e — pass.

## Checklist

- [x] **Unit tests added** for the new annotation surface
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` — CI green
- [ ] Live-hub BAT — no tool behaviour changed, only `tools/list` metadata
- [ ] Documentation — none required (purely metadata, no user-visible tool changes)