### PR TITLE
fix: drop top-level anyOf from import_native_app input_schema (Haiku 4.5 compat)

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3371,13 +3371,12 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
                     newName: [type: "string", description: "Label for the imported app. If omitted, the cloner default ('<original-label> import') is kept."],
                     confirm: [type: "boolean", description: "Must be true."]
                 ],
-                required: ["parentHintAppId", "confirm"],
-                // anyOf (not oneOf) — the impl accepts either field and prefers
-                // jsonContent if both are present; oneOf would reject that.
-                anyOf: [
-                    [required: ["jsonContent"]],
-                    [required: ["fromFile"]]
-                ]
+                required: ["parentHintAppId", "confirm"]
+                // "jsonContent OR fromFile" is enforced at runtime in
+                // toolImportNativeApp (throws IllegalArgumentException). A
+                // top-level anyOf used to encode this here, but Haiku 4.5's
+                // input_schema validator rejects top-level anyOf/oneOf/allOf
+                // with HTTP 400, breaking every Hubitat tools/list dispatch.
             ]
         ],
         [

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3371,12 +3371,15 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
                     newName: [type: "string", description: "Label for the imported app. If omitted, the cloner default ('<original-label> import') is kept."],
                     confirm: [type: "boolean", description: "Must be true."]
                 ],
-                required: ["parentHintAppId", "confirm"]
                 // "jsonContent OR fromFile" is enforced at runtime in
-                // toolImportNativeApp (throws IllegalArgumentException). A
-                // top-level anyOf used to encode this here, but Haiku 4.5's
-                // input_schema validator rejects top-level anyOf/oneOf/allOf
-                // with HTTP 400, breaking every Hubitat tools/list dispatch.
+                // toolImportNativeApp (throws IllegalArgumentException) rather
+                // than via a schema-level anyOf: Anthropic's MCP input_schema
+                // validator rejects top-level anyOf/oneOf/allOf with HTTP 400
+                // (first surfaced via Haiku 4.5; Sonnet/Opus accept the same
+                // shape, but the constraint applies to every model going
+                // forward). Tool + property descriptions document the OR for
+                // LLM tool-selection.
+                required: ["parentHintAppId", "confirm"]
             ]
         ],
         [
@@ -21583,15 +21586,25 @@ def toolCloneNativeApp(args) {
 
     Integer newAppId = _appClonerDiscoverNewChild(parentAppId, preIds, sourceLabel, newName)
 
-    return [
+    String note = newAppId
+        ? "Cloned source ${sourceAppId} -> new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
+        : "Clone fired but no new child appeared under parent ${parentAppId}. Re-check via list_installed_apps shortly."
+    def result = [
         success: newAppId != null,
         sourceAppId: sourceAppId,
         clonerAppId: clonerAppId,
         newAppId: newAppId,
-        note: newAppId
-            ? "Cloned source ${sourceAppId} -> new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
-            : "Clone fired but no new child appeared under parent ${parentAppId}. Re-check via list_installed_apps shortly."
+        note: note
     ]
+    if (newAppId == null) {
+        // Cloner fired but child discovery returned no match. Surface the
+        // structured isError/error fields callers branching on the
+        // file-wide error contract expect (handleToolsCall flags isError
+        // on the JSON-RPC envelope; LLM clients use it to route retries).
+        result.isError = true
+        result.error = note
+    }
+    return result
 }
 
 /**
@@ -21824,17 +21837,25 @@ def toolImportNativeApp(args) {
 
     Integer newAppId = _appClonerDiscoverNewChild(parentAppId, preIds, originalLabel, newName)
 
-    return [
+    String note = newAppId
+        ? "Imported '${originalLabel ?: 'app'}' as new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
+        : "Import fired but no new child appeared under parent ${parentAppId}. Re-check via list_installed_apps shortly."
+    def result = [
         success: newAppId != null,
         clonerAppId: clonerAppId,
         newAppId: newAppId,
         originalSourceId: originalSourceId,
         originalLabel: originalLabel,
         contentLength: jsonContent.length(),
-        note: newAppId
-            ? "Imported '${originalLabel ?: 'app'}' as new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use update_native_app to further customize."
-            : "Import fired but no new child appeared under parent ${parentAppId}. Re-check via list_installed_apps shortly."
+        note: note
     ]
+    if (newAppId == null) {
+        // Wizard fired but child discovery returned no match. Same shape as
+        // toolCloneNativeApp on the soft-failure path — see comment there.
+        result.isError = true
+        result.error = note
+    }
+    return result
 }
 
 /**

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -90,6 +90,20 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
             it.inputSchema instanceof Map
         }
 
+        and: 'no inputSchema carries a top-level anyOf/oneOf/allOf (issue #204 regression guard — Anthropic input_schema validator HTTP-400s on these; first surfaced via Haiku 4.5)'
+        // Iterates the full catalog so this guard catches a new tool added
+        // anywhere in getToolDefinitions(), not just the one that originally
+        // tripped it (import_native_app). Both modes carry this assertion
+        // because the flat catalog is what Anthropic-validator clients
+        // actually see (gateway-mode hides sub-tool schemas under the
+        // gateway entry's catalog payload, but the catch-all here still
+        // pins the gateway entries themselves).
+        response.result.tools.every { tool ->
+            !tool.inputSchema.containsKey('anyOf') &&
+            !tool.inputSchema.containsKey('oneOf') &&
+            !tool.inputSchema.containsKey('allOf')
+        }
+
         and: 'MCP annotations survive serialization through jsonRpcResult → render'
         // McpToolAnnotationsSpec pins the in-process map shape; this `and:`
         // pins that the annotation keys actually land in the wire envelope
@@ -150,6 +164,18 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
 
         and: 'no duplicate tool names in the response'
         response.result.tools.size() == names.size()
+
+        and: 'no flat-mode inputSchema carries a top-level anyOf/oneOf/allOf (issue #204 regression guard)'
+        // Flat mode is the catalog Anthropic-validator clients (Claude.ai
+        // connector, Claude Code haiku subagent) actually walk. Top-level
+        // anyOf/oneOf/allOf in any tool here HTTP-400s the entire tools/list
+        // dispatch, so this guard catches a regression in any of the
+        // ~80 flat-catalog tools, not just the one being patched.
+        response.result.tools.every { tool ->
+            !tool.inputSchema.containsKey('anyOf') &&
+            !tool.inputSchema.containsKey('oneOf') &&
+            !tool.inputSchema.containsKey('allOf')
+        }
 
         and: 'flat-mode wire envelope also carries readOnlyHint per leaf tool'
         response.result.tools.every { it.annotations?.readOnlyHint instanceof Boolean }

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -2587,6 +2587,43 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         navPost != null
     }
 
+    def "clone_native_app surfaces isError + error when child discovery returns null (soft-failure shape)"() {
+        // Cloner fires but _appClonerDiscoverNewChild can't find the new
+        // child (race, parent re-fetch lag, etc.). Pre-fix the return was
+        // {success: false, newAppId: null, note: "..."} with no isError/error
+        // — divergent from the rest of the file's error contract and
+        // invisible to LLM callers that branch on isError.
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Source Rule", [], 21) }
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context page</html>' }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> clonerPageStateWithIdx("importRule", 0) }
+        // Parent NEVER acquires the new child — simulates discovery failure.
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentConfigJson(21, [[id: 100, label: "Source Rule"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolCloneNativeApp([sourceAppId: 100, confirm: true])
+
+        then: "soft-failure carries the isError + error envelope, not just success: false + note"
+        result.success == false
+        result.newAppId == null
+        result.isError == true
+        result.error instanceof String
+        result.error.toLowerCase().contains("no new child appeared")
+        result.note == result.error
+    }
+
     def "clone_native_app rename writes settings[newName<sourceId>] before importNow"() {
         given:
         enableHubAdminWrite()
@@ -2729,6 +2766,22 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         ex.message.toLowerCase().contains("appreplacements")
     }
 
+    def "import_native_app throws when neither jsonContent nor fromFile is provided"() {
+        // Pre-issue-#204, a top-level anyOf in the inputSchema rejected the
+        // no-payload call at the MCP boundary. The anyOf was removed because
+        // Anthropic's input_schema validator HTTP-400s on top-level
+        // anyOf/oneOf/allOf (first surfaced via Haiku 4.5), so the runtime
+        // throw in toolImportNativeApp is now the sole guard for this case.
+        given: enableHubAdminWrite()
+
+        when:
+        script.toolImportNativeApp([parentHintAppId: 100, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.toLowerCase().contains("jsoncontent or fromfile")
+    }
+
     def "import_native_app drives the cloner with settings[ruleUpload]= and finds the new appId"() {
         given:
         enableHubAdminWrite()
@@ -2789,6 +2842,44 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         importRulePosts.any { it.body?.containsKey("settings[newName42]") }
         importRulePosts.every { it.body?["settings[newName42]"] == "" }
         !importRulePosts.any { it.body?.containsKey("settings[newName100]") }
+    }
+
+    def "import_native_app surfaces isError + error when child discovery returns null (soft-failure shape)"() {
+        // Wizard fires but _appClonerDiscoverNewChild can't diff a new child
+        // under the parent. Pre-fix this returned {success: false, newAppId:
+        // null, note: "..."} with no isError/error fields. LLM callers that
+        // branch on isError saw nothing actionable. Mirrors the clone test
+        // immediately above — same contract, same enforcement.
+        given:
+        enableHubAdminWrite()
+        def importJson = '{"deviceReplacements":{},"appReplacements":{"42":{"appLabel":"Source Rule","appTypeName":"Rule-5.1"}}}'
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "ExistingRule", [], 21) }
+        hubGet.register('/apps/api/4242/app/100') { params -> '<html>source-context</html>' }
+        hubGet.register('/installedapp/configure/json/4242/main') { params -> clonerPageStateWithIdx("importRule", 55) }
+        // Parent NEVER acquires the new child — simulates discovery failure.
+        hubGet.register('/installedapp/configure/json/21') { params ->
+            parentConfigJson(21, [[id: 100, label: "ExistingRule"]])
+        }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/apps/api/4242/app/100", data: ""]
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.hubInternalPostFormRaw = { String path, String encodedBody, Integer t = 420 ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def result = script.toolImportNativeApp([jsonContent: importJson, parentHintAppId: 100, confirm: true])
+
+        then: "soft-failure carries the isError + error envelope, not just success: false + note"
+        result.success == false
+        result.newAppId == null
+        result.isError == true
+        result.error instanceof String
+        result.error.toLowerCase().contains("no new child appeared")
+        result.note == result.error
     }
 
     def "import_native_app preserves backslash-escapes in settings[ruleUpload] (HTTPBuilder Map encoder mangles them)"() {


### PR DESCRIPTION
## Summary

- Haiku 4.5's stricter `input_schema` validator HTTP-400s on any top-level `anyOf`/`oneOf`/`allOf`, so any Claude Code session with Hubitat MCP connected that dispatches a `haiku` subagent fails with `tools.<N>.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level` before the model can respond. Sonnet 4.6 / Opus 4.7 accept the same shape but the constraint applies to every Anthropic model going forward.
- `import_native_app` was the only tool with the bad shape.
- Adjacent fix surfaced during review: `clone_native_app` and `import_native_app` both returned `{success: false, newAppId: null, note: "..."}` on the soft-failure path (cloner fires, child discovery returns null) with no `isError`/`error` envelope — clients branching on `isError` saw the failure as a successful tool result. Both now carry `isError: true` + an `error` field alongside the existing `success`/`note`.
- Regression guards added: runtime-throw spec for the no-payload case (sole enforcer of "jsonContent OR fromFile" now that the schema-level anyOf is gone), soft-failure shape specs for both cloner tools, and a catalog-shape guard on `tools/list` that iterates **every** tool and pins that no `inputSchema` carries top-level `anyOf`/`oneOf`/`allOf`.

## Type of change

- [ ] \`feat\` — new feature or capability
- [x] \`fix\` — bug fix
- [ ] \`chore\` — maintenance, dependency bump, or housekeeping
- [ ] \`refactor\` — code restructure with no behaviour change
- [ ] \`docs\` — documentation only
- [ ] \`test\` — tests only
- [ ] \`ci\` — CI/CD pipeline change

## Changes

**\`hubitat-mcp-server.groovy\`:**
- Drop the top-level \`anyOf\` from \`import_native_app\`'s \`inputSchema\`. Reposition + rewrite the surrounding comment to document that runtime is the source of truth and that the constraint is Anthropic-validator-wide, not Haiku-specific.
- \`toolCloneNativeApp\` / \`toolImportNativeApp\`: when \`_appClonerDiscoverNewChild\` returns null, attach \`isError: true\` + \`error\` matching the existing \`note\` text. \`success\`/\`newAppId\`/\`note\` fields preserved.

**\`src/test/groovy/server/ToolRmNativeCrudSpec.groovy\`:**
- \`import_native_app throws when neither jsonContent nor fromFile is provided\` — runtime-guard regression spec.
- \`clone_native_app surfaces isError + error when child discovery returns null\` — soft-failure shape regression spec.
- \`import_native_app surfaces isError + error when child discovery returns null\` — same for import.

**\`src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy\`:**
- Gateway-mode and flat-mode \`tools/list\` specs extended with assertion that no \`inputSchema\` carries top-level \`anyOf\`/\`oneOf\`/\`allOf\`. Catches the regression across the whole catalog, not just the patched tool.

Closes #204.

## Release Notes

- Fix: Hubitat MCP tool catalog no longer trips Anthropic's MCP \`input_schema\` validator (HTTP 400 on \`tools.<N>.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level\`). Claude Code users dispatching \`haiku\` subagents (or any Anthropic-API caller hitting Haiku 4.5) with the Hubitat MCP server connected will stop seeing the 400.
- Fix: \`clone_native_app\` and \`import_native_app\` now surface \`isError: true\` and an \`error\` field on the soft-failure path where the cloner fires but child discovery can't find the new app, so MCP clients branching on the error envelope see the failure instead of treating it as a successful result. Existing \`success: false\` + \`note\` fields are preserved.

## Testing



## Checklist

- [ ] **Unit tests added for any new MCP tools** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes) — no new MCP tools. Regression specs added for the PR's changes: runtime-throw on empty payload, soft-failure-shape guards on \`clone_native_app\` and \`import_native_app\`, and a catalog-wide guard against top-level \`anyOf\`/\`oneOf\`/\`allOf\` in any \`inputSchema\` (see Changes section).
- [x] Sandbox lint passes: \`python tests/sandbox_lint.py\`
- [ ] \`./gradlew test\` passes locally (or CI confirms)
- [x] Live-hub BAT tests updated if tool behaviour changed (see \`tests/BAT-v2.md\`)
- [ ] Documentation updated if user-facing behaviour or tool surface changed