### PR TITLE
fix: prevent (and detect) IF/END-IF + Repeat structural imbalance (#178)

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -16088,6 +16088,37 @@ private Map _rmDeleteAction(Integer appId, Integer actionIdx) {
     if (stuckEditAct != null) {
         throw new IllegalStateException("removeAction(${actionIdx}) blocked: rule ${appId} has state.editAct=${stuckEditAct} set from a prior interrupted action edit. RM 5.1 silently no-ops delAct clicks until this clears. Recovery options: (a) wait ~60s for RM's stale-state timeout and retry, (b) try update_native_app(button='cancelAct', pageName='doActPage', confirm=true) to abort the in-flight edit (behavior unverified -- attempt at own risk), (c) restore_item_backup with a recent snapshot.")
     }
+    // Pre-flight (issue #178): if the action being deleted is a structural
+    // element (IF / ELSE-IF / ELSE / END-IF / Repeat / While / End-Repeat),
+    // simulate the deletion and refuse if it would make a currently-balanced
+    // rule worse — comparing counts catches the case where the rule is
+    // already imbalanced and the deletion would happen to FIX it (still
+    // allowed). This blocks the #178 trigger at the source: no delAct click
+    // is sent if the deletion would break the structure, so there is no
+    // post-response-commit race to leak through.
+    def status = _rmFetchStatusJson(appId)
+    def settingsByName = (status?.appSettings ?: []).collectEntries { [(it?.name?.toString()): it] }
+    def aType = settingsByName["actType.${actionIdx}".toString()]?.value?.toString()
+    def sType = settingsByName["actSubType.${actionIdx}".toString()]?.value?.toString()
+    def structuralSubTypes = ["getIfThen", "getElseIf", "getElse", "getEndIf", "getRepeat", "getWhile", "getStopRepeat"]
+    if (aType in ["condActs", "repeatActs"] && sType in structuralSubTypes) {
+        def currentSeq = _rmStructuralSequenceFromSettings(settingsByName)
+        def projectedSeq = _rmStructuralSequenceFromSettings(settingsByName, ([actionIdx] as Set))
+        def currentIssues = _rmStructuralIssuesFromSequence(currentSeq)
+        def projectedIssues = _rmStructuralIssuesFromSequence(projectedSeq)
+        if (projectedIssues.size() > currentIssues.size()) {
+            def humanKind = [
+                "getIfThen": "IF",
+                "getElseIf": "ELSE-IF",
+                "getElse": "ELSE",
+                "getEndIf": "END-IF",
+                "getRepeat": "Repeat",
+                "getWhile": "Repeat-While",
+                "getStopRepeat": "End-Repeat"
+            ][sType]
+            throw new IllegalArgumentException("removeAction(${actionIdx}) blocked: action ${actionIdx} is a structural ${humanKind}; removing it would leave the rule imbalanced (${projectedIssues.first()}). Remove the matching opener/closer first, or use replaceActions to rebuild the action list atomically. This refusal is a #178 pre-flight check — RM is not touched.")
+        }
+    }
     _rmClickAppButton(appId, actionIdx.toString(), "delAct", "selectActions")
     // Verify the action actually disappeared. RM 5.1 silently no-ops the
     // delAct click if the button-handler dispatch races with another edit.
@@ -16870,6 +16901,32 @@ private Map _rmAddAction(Integer appId, Map actionSpec) {
     // capabilities (log, mode, delay, comment, exitRule, capture, restore,
     // refresh, poll, runRule, cancelTimers, etc.) accept a null/missing
     // action — each capability's branch validates as needed.
+
+    // Pre-flight (issue #178): adding a bare closer (endIf / stopRepeat)
+    // when there is no matching opener leaves the rule with an orphaned
+    // closer. Asymmetric on purpose: adding an opener (ifThen / repeat /
+    // repeatWhile) without a closer is a normal multi-step build, so we
+    // do NOT refuse those — the caller will add the matching closer in a
+    // follow-up call. Only refuse closers that have nothing to close.
+    if (cap?.toLowerCase() in ["endif", "stoprepeat"]) {
+        def status = _rmFetchStatusJson(appId)
+        def settingsByName = (status?.appSettings ?: []).collectEntries { [(it?.name?.toString()): it] }
+        def currentSeq = _rmStructuralSequenceFromSettings(settingsByName)
+        def maxExistingIdx = currentSeq.collect { it.idx as Integer }.max() ?: 0
+        def projectedPair = _rmStructuralPairForCapability(cap)
+        def projectedSeq = currentSeq + [[
+            idx: (maxExistingIdx + 1),
+            actType: projectedPair[0],
+            actSubType: projectedPair[1]
+        ]]
+        def currentIssues = _rmStructuralIssuesFromSequence(currentSeq)
+        def projectedIssues = _rmStructuralIssuesFromSequence(projectedSeq)
+        if (projectedIssues.size() > currentIssues.size()) {
+            def openerCap = cap.equalsIgnoreCase("endIf") ? "ifThen" : "repeat"
+            def openerKind = cap.equalsIgnoreCase("endIf") ? "IF" : "Repeat"
+            throw new IllegalArgumentException("addAction(${cap}) blocked: rule ${appId} has no matching open ${openerKind} block on the action stack; this ${cap} would render as an orphaned closer. Add an addAction(capability='${openerCap}', ...) first (and its body), then this closer. This refusal is a #178 pre-flight check — RM is not touched.")
+        }
+    }
 
     // Pre-validate device IDs exist on the hub. RM 5.1 silently stores
     // {<bogusId>: null} for unknown IDs in any device-bearing setting and
@@ -18745,6 +18802,116 @@ private Map _rmFetchStatusJson(Integer appId) {
  * .multiple sidecar fields.
  */
 /**
+ * Walk a sequence of [idx, actType, actSubType] entries (in numerical
+ * order) tracking IF / Repeat block depth via a stack. Returns the list
+ * of structural issues (empty list = balanced).
+ *
+ * Used by _rmCheckRuleHealth for post-mutation detection AND by the
+ * pre-flight refusal paths in _rmDeleteAction / _rmAddAction /
+ * toolUpdateNativeApp's replaceActions handler — they all build a
+ * projected sequence (current state minus removals plus additions) and
+ * compare projected-issues vs current-issues to decide whether to refuse
+ * the mutation before it touches RM.
+ *
+ * Groovy's List.pop() removes from the FRONT of a List; the walker uses
+ * `<<` for append and `removeAt(size-1)` for tail-pop to preserve the
+ * conventional stack semantics.
+ */
+private List _rmStructuralIssuesFromSequence(List<Map> sequence) {
+    def issues = []
+    def stack = []
+    sequence.each { entry ->
+        def idx = entry?.idx
+        def aType = entry?.actType?.toString()
+        def sType = entry?.actSubType?.toString()
+        if (aType == "condActs") {
+            if (sType == "getIfThen") {
+                stack << [kind: "if", openIdx: idx]
+            } else if (sType == "getElseIf" || sType == "getElse") {
+                if (stack.isEmpty() || stack[-1].kind != "if") {
+                    issues << ("action ${idx} (${sType == 'getElse' ? 'ELSE' : 'ELSE-IF'}) is outside any IF block — orphaned branch keyword".toString())
+                }
+            } else if (sType == "getEndIf") {
+                if (stack.isEmpty()) {
+                    issues << ("action ${idx} (END-IF) has no matching IF — orphaned closer (too many END-IFs)".toString())
+                } else if (stack[-1].kind != "if") {
+                    def open = stack[-1]
+                    issues << ("action ${idx} (END-IF) closes a Repeat block opened at action ${open.openIdx} — mismatched block closer".toString())
+                    stack.removeAt(stack.size() - 1)
+                } else {
+                    stack.removeAt(stack.size() - 1)
+                }
+            }
+        } else if (aType == "repeatActs") {
+            if (sType == "getRepeat" || sType == "getWhile") {
+                stack << [kind: "repeat", openIdx: idx]
+            } else if (sType == "getStopRepeat") {
+                if (stack.isEmpty()) {
+                    issues << ("action ${idx} (End Repeat) has no matching Repeat — orphaned closer".toString())
+                } else if (stack[-1].kind != "repeat") {
+                    def open = stack[-1]
+                    issues << ("action ${idx} (End Repeat) closes an IF block opened at action ${open.openIdx} — mismatched block closer".toString())
+                    stack.removeAt(stack.size() - 1)
+                } else {
+                    stack.removeAt(stack.size() - 1)
+                }
+            }
+        }
+    }
+    stack.each { open ->
+        def label = open.kind == "if" ? "IF" : "Repeat"
+        def closer = open.kind == "if" ? "END-IF" : "End-Repeat"
+        issues << ("action ${open.openIdx} (${label}) opened a block that was never closed — rule is missing an ${closer}".toString())
+    }
+    issues
+}
+
+/**
+ * Build the structural-balance sequence from a rule's live appSettings
+ * map (keyed by name). Collects actType.<N>/actSubType.<N> pairs in
+ * numerical order. Optional excludeIndices (used by removeAction
+ * pre-flight) skip listed action indices so the walker sees the
+ * post-deletion state.
+ */
+private List _rmStructuralSequenceFromSettings(Map settingsByName, Set excludeIndices = ([] as Set)) {
+    def indices = [] as TreeSet
+    settingsByName.each { name, recIgnored ->
+        def m = name?.toString() =~ /^actType\.(\d+)$/
+        if (m.matches()) indices << ((m[0] as List)[1] as Integer)
+    }
+    def sequence = []
+    indices.each { idx ->
+        if (excludeIndices.contains(idx)) return
+        sequence << [
+            idx: idx,
+            actType: settingsByName["actType.${idx}".toString()]?.value?.toString(),
+            actSubType: settingsByName["actSubType.${idx}".toString()]?.value?.toString()
+        ]
+    }
+    sequence
+}
+
+/**
+ * Map a high-level addAction / replaceActions capability spec string to
+ * its [actType, actSubType] pair for the block-aware capabilities only.
+ * Returns null for leaf actions (switch, lock, log, …) — they don't
+ * affect structural balance and the pre-flight walker can ignore them.
+ */
+private List _rmStructuralPairForCapability(String cap) {
+    if (cap == null) return null
+    switch (cap.toString().toLowerCase()) {
+        case "ifthen":      return ["condActs", "getIfThen"]
+        case "elseif":      return ["condActs", "getElseIf"]
+        case "else":        return ["condActs", "getElse"]
+        case "endif":       return ["condActs", "getEndIf"]
+        case "repeat":      return ["repeatActs", "getRepeat"]
+        case "repeatwhile": return ["repeatActs", "getWhile"]
+        case "stoprepeat":  return ["repeatActs", "getStopRepeat"]
+        default: return null
+    }
+}
+
+/**
  * Inspect a rule's current state and return a structured health report.
  * Surfaces problems an LLM caller needs to see and act on without having
  * to re-investigate via curl. Verified live:
@@ -18761,11 +18928,11 @@ private Map _rmFetchStatusJson(Integer appId) {
  *     reveals DB flag corruption that will crash the rule on next event.
  *   - Walking actType.<N> / actSubType.<N> in numerical order reveals
  *     IF/ELSE-IF/ELSE/END-IF and Repeat/End-Repeat block imbalance that
- *     the paragraph-marker scan does not surface — a removeAction or
- *     replaceActions false-fail (issue #172 class) can commit
- *     post-response and silently drop a structural action, leaving the
- *     rule rendered with three IFs and two END-IFs while RM declines to
- *     flag it. Issue #178 asked for this detection in `check_rule_health`.
+ *     the paragraph-marker scan does not surface — the pre-flight
+ *     refusals in _rmDeleteAction / _rmAddAction / replaceActions
+ *     handler block most of this at the source, but a raw settings
+ *     write or a #172-class post-response commit can still leave a
+ *     rule imbalanced; this check is the defense-in-depth catch.
  *
  * Callers (toolUpdateNativeApp, toolCheckRuleHealth) attach this report
  * to mutation responses so an LLM sees broken state immediately.
@@ -18817,74 +18984,16 @@ private Map _rmCheckRuleHealth(Integer appId) {
         if (multipleFlagPoison) {
             issues << "multiple-flag poison on settings: ${multipleFlagPoison.join(', ')} — re-POST with the 3-field group to recover".toString()
         }
-        // Structural balance check for IF/ELSE-IF/ELSE/END-IF and Repeat/End-Repeat blocks.
-        //
-        // Collect every actType.<N>/actSubType.<N> pair from settings and walk
-        // them in numerical order, tracking a stack of open blocks. The pair
-        // (actType=condActs, actSubType=getIfThen) opens an IF block; getElseIf
-        // and getElse continue a block (and require an open IF on top of the
-        // stack); getEndIf closes the IF block. repeatActs/getRepeat and
-        // repeatActs/getWhile open a Repeat block; repeatActs/getStopRepeat
-        // closes it. Anything else is a leaf action and doesn't change depth.
-        //
-        // At the end, the stack must be empty. A non-empty stack means at
-        // least one open block has no closer; a pop attempt with an empty
-        // stack means an orphaned END-IF or End-Repeat. Cross-kind closes
-        // (END-IF closing a Repeat or vice-versa) are also flagged.
-        def actIndices = [] as TreeSet
-        settingsByName.each { name, _ ->
-            def m = name =~ /^actType\.(\d+)$/
-            if (m.matches()) actIndices << ((m[0] as List)[1] as Integer)
-        }
-        // Use end-of-list as the stack top: `<<` appends, and the top is
-        // `blockStack[-1]`. Groovy's `List.pop()` removes from the FRONT
-        // (push/pop operate on the head), which would mismatch with `<<`
-        // and report the wrong un-closed index — so pop the tail explicitly
-        // via removeAt(size-1).
-        def blockStack = []
-        actIndices.each { idx ->
-            def aType = settingsByName["actType.${idx}".toString()]?.value?.toString()
-            def sType = settingsByName["actSubType.${idx}".toString()]?.value?.toString()
-            if (aType == "condActs") {
-                if (sType == "getIfThen") {
-                    blockStack << [kind: "if", openIdx: idx]
-                } else if (sType == "getElseIf" || sType == "getElse") {
-                    if (blockStack.isEmpty() || blockStack[-1].kind != "if") {
-                        structuralIssues << ("action ${idx} (${sType == 'getElse' ? 'ELSE' : 'ELSE-IF'}) is outside any IF block — orphaned branch keyword".toString())
-                    }
-                } else if (sType == "getEndIf") {
-                    if (blockStack.isEmpty()) {
-                        structuralIssues << ("action ${idx} (END-IF) has no matching IF — orphaned closer (too many END-IFs)".toString())
-                    } else if (blockStack[-1].kind != "if") {
-                        def open = blockStack[-1]
-                        structuralIssues << ("action ${idx} (END-IF) closes a Repeat block opened at action ${open.openIdx} — mismatched block closer".toString())
-                        blockStack.removeAt(blockStack.size() - 1)
-                    } else {
-                        blockStack.removeAt(blockStack.size() - 1)
-                    }
-                }
-            } else if (aType == "repeatActs") {
-                if (sType == "getRepeat" || sType == "getWhile") {
-                    blockStack << [kind: "repeat", openIdx: idx]
-                } else if (sType == "getStopRepeat") {
-                    if (blockStack.isEmpty()) {
-                        structuralIssues << ("action ${idx} (End Repeat) has no matching Repeat — orphaned closer".toString())
-                    } else if (blockStack[-1].kind != "repeat") {
-                        def open = blockStack[-1]
-                        structuralIssues << ("action ${idx} (End Repeat) closes an IF block opened at action ${open.openIdx} — mismatched block closer".toString())
-                        blockStack.removeAt(blockStack.size() - 1)
-                    } else {
-                        blockStack.removeAt(blockStack.size() - 1)
-                    }
-                }
-            }
-        }
-        blockStack.each { open ->
-            def kindLabel = open.kind == "if" ? "IF" : "Repeat"
-            structuralIssues << ("action ${open.openIdx} (${kindLabel}) opened a block that was never closed — rule is missing an ${open.kind == 'if' ? 'END-IF' : 'End-Repeat'}".toString())
-        }
+        // Structural balance check for IF/ELSE-IF/ELSE/END-IF and Repeat/End-Repeat
+        // blocks — see _rmStructuralIssuesFromSequence for the walker semantics.
+        // Most imbalance is now blocked at the pre-flight refusal in
+        // _rmDeleteAction / _rmAddAction / the replaceActions handler before
+        // it lands; this defense-in-depth catch covers raw settings writes
+        // and the #172 post-response-commit race that can slip past those.
+        def structuralSequence = _rmStructuralSequenceFromSettings(settingsByName)
+        structuralIssues.addAll(_rmStructuralIssuesFromSequence(structuralSequence))
         if (structuralIssues) {
-            issues << ("structural imbalance in action block nesting: ${structuralIssues.join('; ')} — likely caused by a removeAction or replaceActions that false-failed mid-flow (issue #172/#178). Use restore_item_backup to roll back, or add the missing closer via addAction(capability='endIf'|'stopRepeat').".toString())
+            issues << ("structural imbalance in action block nesting: ${structuralIssues.join('; ')} — likely caused by a raw settings write or a #172-class mutation that committed post-response. Use restore_item_backup to roll back, or add the missing closer via addAction(capability='endIf'|'stopRepeat').".toString())
         }
     } catch (Exception e) {
         issues << "health check failed: ${e.message}".toString()
@@ -20546,6 +20655,30 @@ def toolUpdateNativeApp(args) {
         def removed = []
         def addedResults = []
         try {
+            // Pre-flight (issue #178): walk the replaceActions spec list's
+            // capability sequence and refuse the call before clearActions
+            // runs if the proposed list is itself structurally imbalanced.
+            // This catches the LLM-error case where the caller forgot an
+            // end-if / stop-repeat (or stacked an extra one) — better to
+            // surface the mistake than wipe the rule and then re-add a
+            // broken structure on top. The new sequence is walked against
+            // an empty current state (clearActions runs first, so the
+            // rule's existing actions don't factor in).
+            if (replaceActionsList != null) {
+                def projectedSeq = []
+                replaceActionsList.eachWithIndex { spec, i ->
+                    if (!(spec instanceof Map)) return
+                    def specCap = (spec as Map).capability?.toString()
+                    def pair = _rmStructuralPairForCapability(specCap)
+                    if (pair) {
+                        projectedSeq << [idx: (i + 1), actType: pair[0], actSubType: pair[1]]
+                    }
+                }
+                def specIssues = _rmStructuralIssuesFromSequence(projectedSeq)
+                if (specIssues) {
+                    throw new IllegalArgumentException("replaceActions blocked: the proposed action list is structurally imbalanced — ${specIssues.join('; ')}. Re-order the list, add the missing closer (capability='endIf' or 'stopRepeat'), or remove the orphan closer. This refusal is a #178 pre-flight check — RM is not touched and no actions are cleared.")
+                }
+            }
             if (removeActionSpec) {
                 if (removeActionSpec.index == null) throw new IllegalArgumentException("removeAction.index is required")
                 def idx = (removeActionSpec.index as Integer)
@@ -20853,6 +20986,18 @@ def toolUpdateNativeApp(args) {
                         }
                         patchResults << [success: true, op: "clearActions", removedIndices: cleared]
                     } else if (pm.containsKey("replaceActions")) {
+                        // Issue #178 pre-flight: validate the proposed list's
+                        // structural balance before clearActions touches RM.
+                        def patchSeq = []
+                        (pm.replaceActions as List).eachWithIndex { aspec, ai ->
+                            if (!(aspec instanceof Map)) return
+                            def pair = _rmStructuralPairForCapability(((aspec as Map).capability)?.toString())
+                            if (pair) patchSeq << [idx: (ai + 1), actType: pair[0], actSubType: pair[1]]
+                        }
+                        def patchSpecIssues = _rmStructuralIssuesFromSequence(patchSeq)
+                        if (patchSpecIssues) {
+                            throw new IllegalArgumentException("patches[${pi}].replaceActions blocked: the proposed action list is structurally imbalanced — ${patchSpecIssues.join('; ')}. Re-order the list, add the missing closer (capability='endIf' or 'stopRepeat'), or remove the orphan closer. This refusal is a #178 pre-flight check — RM is not touched and no actions are cleared.")
+                        }
                         def cleared
                         try { cleared = _rmClearActions(appId) ?: [] }
                         catch (Exception clearExc) {

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3390,10 +3390,11 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
   - label markers: '*BROKEN*' suffix RM appends when a rule has a malformed trigger or action
   - paragraph markers: '**Broken Trigger**', '**Broken Action**', '**Broken Condition**'
   - multiple-flag corruption: lists settings whose statusJson .multiple flag has been flipped to false despite the schema declaring multiple=true
+  - structural imbalance: walks actType.<N>/actSubType.<N> and flags IF/ELSE-IF/ELSE/END-IF or Repeat/End-Repeat blocks left unmatched by a false-failed mutation (issue #172/#178 class); RM does NOT surface this via the paragraph markers above
 
 Run after every mutation to confirm the change didn't leave the rule in a broken state. update_native_app already attaches this report automatically as `health` on every response, but you can call it explicitly any time.
 
-Returns {ok: bool, label, configPageError, brokenMarkers: [...], multipleFlagPoison: [...], issues: [...]}. ok=false means at least one issue was found; the issues list explains what.""",
+Returns {ok: bool, label, configPageError, brokenMarkers: [...], multipleFlagPoison: [...], structuralIssues: [...], issues: [...]}. ok=false means at least one issue was found; the issues list explains what.""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -18758,6 +18759,13 @@ private Map _rmFetchStatusJson(Integer appId) {
  *   - statusJson.appSettings carries per-setting marshal flags including
  *     `multiple` — comparing it to the schema's declared multiple
  *     reveals DB flag corruption that will crash the rule on next event.
+ *   - Walking actType.<N> / actSubType.<N> in numerical order reveals
+ *     IF/ELSE-IF/ELSE/END-IF and Repeat/End-Repeat block imbalance that
+ *     the paragraph-marker scan does not surface — a removeAction or
+ *     replaceActions false-fail (issue #172 class) can commit
+ *     post-response and silently drop a structural action, leaving the
+ *     rule rendered with three IFs and two END-IFs while RM declines to
+ *     flag it. Issue #178 asked for this detection in `check_rule_health`.
  *
  * Callers (toolUpdateNativeApp, toolCheckRuleHealth) attach this report
  * to mutation responses so an LLM sees broken state immediately.
@@ -18768,6 +18776,7 @@ private Map _rmCheckRuleHealth(Integer appId) {
     def configPageError = null
     def brokenMarkers = []
     def multipleFlagPoison = []
+    def structuralIssues = []
     try {
         def cfg = _rmFetchConfigJson(appId)
         label = cfg?.app?.label?.toString()
@@ -18808,6 +18817,75 @@ private Map _rmCheckRuleHealth(Integer appId) {
         if (multipleFlagPoison) {
             issues << "multiple-flag poison on settings: ${multipleFlagPoison.join(', ')} — re-POST with the 3-field group to recover".toString()
         }
+        // Structural balance check for IF/ELSE-IF/ELSE/END-IF and Repeat/End-Repeat blocks.
+        //
+        // Collect every actType.<N>/actSubType.<N> pair from settings and walk
+        // them in numerical order, tracking a stack of open blocks. The pair
+        // (actType=condActs, actSubType=getIfThen) opens an IF block; getElseIf
+        // and getElse continue a block (and require an open IF on top of the
+        // stack); getEndIf closes the IF block. repeatActs/getRepeat and
+        // repeatActs/getWhile open a Repeat block; repeatActs/getStopRepeat
+        // closes it. Anything else is a leaf action and doesn't change depth.
+        //
+        // At the end, the stack must be empty. A non-empty stack means at
+        // least one open block has no closer; a pop attempt with an empty
+        // stack means an orphaned END-IF or End-Repeat. Cross-kind closes
+        // (END-IF closing a Repeat or vice-versa) are also flagged.
+        def actIndices = [] as TreeSet
+        settingsByName.each { name, _ ->
+            def m = name =~ /^actType\.(\d+)$/
+            if (m.matches()) actIndices << ((m[0] as List)[1] as Integer)
+        }
+        // Use end-of-list as the stack top: `<<` appends, and the top is
+        // `blockStack[-1]`. Groovy's `List.pop()` removes from the FRONT
+        // (push/pop operate on the head), which would mismatch with `<<`
+        // and report the wrong un-closed index — so pop the tail explicitly
+        // via removeAt(size-1).
+        def blockStack = []
+        actIndices.each { idx ->
+            def aType = settingsByName["actType.${idx}".toString()]?.value?.toString()
+            def sType = settingsByName["actSubType.${idx}".toString()]?.value?.toString()
+            if (aType == "condActs") {
+                if (sType == "getIfThen") {
+                    blockStack << [kind: "if", openIdx: idx]
+                } else if (sType == "getElseIf" || sType == "getElse") {
+                    if (blockStack.isEmpty() || blockStack[-1].kind != "if") {
+                        structuralIssues << ("action ${idx} (${sType == 'getElse' ? 'ELSE' : 'ELSE-IF'}) is outside any IF block — orphaned branch keyword".toString())
+                    }
+                } else if (sType == "getEndIf") {
+                    if (blockStack.isEmpty()) {
+                        structuralIssues << ("action ${idx} (END-IF) has no matching IF — orphaned closer (too many END-IFs)".toString())
+                    } else if (blockStack[-1].kind != "if") {
+                        def open = blockStack[-1]
+                        structuralIssues << ("action ${idx} (END-IF) closes a Repeat block opened at action ${open.openIdx} — mismatched block closer".toString())
+                        blockStack.removeAt(blockStack.size() - 1)
+                    } else {
+                        blockStack.removeAt(blockStack.size() - 1)
+                    }
+                }
+            } else if (aType == "repeatActs") {
+                if (sType == "getRepeat" || sType == "getWhile") {
+                    blockStack << [kind: "repeat", openIdx: idx]
+                } else if (sType == "getStopRepeat") {
+                    if (blockStack.isEmpty()) {
+                        structuralIssues << ("action ${idx} (End Repeat) has no matching Repeat — orphaned closer".toString())
+                    } else if (blockStack[-1].kind != "repeat") {
+                        def open = blockStack[-1]
+                        structuralIssues << ("action ${idx} (End Repeat) closes an IF block opened at action ${open.openIdx} — mismatched block closer".toString())
+                        blockStack.removeAt(blockStack.size() - 1)
+                    } else {
+                        blockStack.removeAt(blockStack.size() - 1)
+                    }
+                }
+            }
+        }
+        blockStack.each { open ->
+            def kindLabel = open.kind == "if" ? "IF" : "Repeat"
+            structuralIssues << ("action ${open.openIdx} (${kindLabel}) opened a block that was never closed — rule is missing an ${open.kind == 'if' ? 'END-IF' : 'End-Repeat'}".toString())
+        }
+        if (structuralIssues) {
+            issues << ("structural imbalance in action block nesting: ${structuralIssues.join('; ')} — likely caused by a removeAction or replaceActions that false-failed mid-flow (issue #172/#178). Use restore_item_backup to roll back, or add the missing closer via addAction(capability='endIf'|'stopRepeat').".toString())
+        }
     } catch (Exception e) {
         issues << "health check failed: ${e.message}".toString()
     }
@@ -18817,6 +18895,7 @@ private Map _rmCheckRuleHealth(Integer appId) {
         configPageError: configPageError,
         brokenMarkers: brokenMarkers.unique(),
         multipleFlagPoison: multipleFlagPoison,
+        structuralIssues: structuralIssues,
         issues: issues
     ]
 }
@@ -22567,7 +22646,7 @@ Native CRUD (hub admin-layer, additionally requires Hub Admin Write):
 - **clone_native_app** — clone any classic SmartApp via Hubitat's first-party appCloner. Args: sourceAppId, newName (opt), confirm. Returns newAppId. Drives the appCloner's 4-step wizard (cloneRuleButton -> confirmation -> importRule sub-page -> importNow); typical clones complete in tens of seconds.
 - **export_native_app** — export any classic SmartApp to its canonical JSON shape via Hubitat's first-party appCloner. Args: sourceAppId, saveAs (opt File Manager filename). Returns jsonContent. Self-contained document with appReplacements + deviceReplacements + full rule state; round-trips through import_native_app.
 - **import_native_app** — re-create a rule/app from a previously-exported JSON via Hubitat's first-party appCloner. Args: jsonContent | fromFile, parentHintAppId, newName (opt), confirm. Returns newAppId. The cloner needs an existing rule under the target parent to seed itself (parentHintAppId).
-- **check_rule_health** — read-only health check on any installed app. Args: appId. Returns ok / configPageError / brokenMarkers / multipleFlagPoison / issues.
+- **check_rule_health** — read-only health check on any installed app. Args: appId. Returns ok / configPageError / brokenMarkers / multipleFlagPoison / structuralIssues / issues.
 
 For READING an RM rule's current state, use **get_app_config** in the manage_installed_apps gateway — it works on any installed app including RM rules and returns the same configPage shape that update_native_app expects to see.
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3390,7 +3390,7 @@ PARTIAL-SUCCESS HANDLING: `success: true` means the API call completed and at le
   - label markers: '*BROKEN*' suffix RM appends when a rule has a malformed trigger or action
   - paragraph markers: '**Broken Trigger**', '**Broken Action**', '**Broken Condition**'
   - multiple-flag corruption: lists settings whose statusJson .multiple flag has been flipped to false despite the schema declaring multiple=true
-  - structural imbalance: walks actType.<N>/actSubType.<N> and flags IF/ELSE-IF/ELSE/END-IF or Repeat/End-Repeat blocks left unmatched by a false-failed mutation (issue #172/#178 class); RM does NOT surface this via the paragraph markers above
+  - structural imbalance: walks actType.<N>/actSubType.<N> and flags IF/ELSE-IF/ELSE/END-IF or Repeat/End-Repeat blocks left unmatched by a false-failed mutation that committed post-response; RM does NOT surface this via the paragraph markers above
 
 Run after every mutation to confirm the change didn't leave the rule in a broken state. update_native_app already attaches this report automatically as `health` on every response, but you can call it explicitly any time.
 
@@ -16064,6 +16064,17 @@ private List _rmCollectActionIndices(Integer appId) {
  * preserved with gaps. Subsequent addAction picks the next free index
  * via _rmCollectActionIndices' max+1 logic.
  *
+ * Pre-flight refuses three things before the delAct click goes out:
+ *   (a) the requested index does not exist on the rule,
+ *   (b) the rule has a stuck state.editAct from a prior interrupted
+ *       edit (RM silently no-ops delAct clicks in that state), and
+ *   (c) the action is a structural opener/closer (IF / ELSE-IF / ELSE /
+ *       END-IF / Repeat / While / End-Repeat) and removing it would
+ *       introduce a new structural-balance issue (compared as a set diff
+ *       so deletions that merely improve an already-broken rule are
+ *       still allowed). All three throw IllegalArgumentException /
+ *       IllegalStateException — no RM mutation is sent.
+ *
  * Post-click verification uses a retry loop to absorb RM 5.1's
  * asynchronous button-handler dispatch. The click returns HTTP 200 before
  * the deletion has propagated to appSettings, so a single immediate fetch
@@ -16077,36 +16088,51 @@ private List _rmCollectActionIndices(Integer appId) {
  * post-response. See source comment below for the original race description.
  */
 private Map _rmDeleteAction(Integer appId, Integer actionIdx) {
-    def beforeIndices = _rmCollectActionIndices(appId)
+    // Single statusJson fetch shared by all three pre-flight checks below;
+    // before the refactor each helper (_rmCollectActionIndices,
+    // _rmGetStateEditAct, structural pre-flight) called _rmFetchStatusJson
+    // independently, tripling the per-delete read load on the hub.
+    def status = _rmFetchStatusJson(appId)
+    def settingsByName = (status?.appSettings ?: []).collectEntries { [(it?.name?.toString()): it] }
+    def beforeIndices = []
+    def actionsMap = status?.actions
+    if (actionsMap instanceof Map && !actionsMap.isEmpty()) {
+        actionsMap.keySet().each { k ->
+            try { beforeIndices << k.toString().toInteger() } catch (NumberFormatException ignored) {}
+        }
+    } else {
+        settingsByName.keySet().each { n ->
+            def m = (n =~ /^actType\.(\d+)$/)
+            if (m.matches()) beforeIndices << (m[0][1] as Integer)
+        }
+    }
     if (!beforeIndices.contains(actionIdx)) {
         throw new IllegalArgumentException("removeAction.index ${actionIdx} not found in rule ${appId}. Existing indices: ${beforeIndices.sort().join(', ')}")
     }
     // Pre-flight: if state.editAct is set, RM will silently no-op the delAct
     // click. Detect and fail immediately with a descriptive error rather than
     // burning 10s of retries and surfacing a confusing timeout message.
-    def stuckEditAct = _rmGetStateEditAct(appId)
+    def editActEntry = (status?.appState ?: []).find { it?.name?.toString() == "editAct" }
+    def stuckEditAct = editActEntry?.value
     if (stuckEditAct != null) {
         throw new IllegalStateException("removeAction(${actionIdx}) blocked: rule ${appId} has state.editAct=${stuckEditAct} set from a prior interrupted action edit. RM 5.1 silently no-ops delAct clicks until this clears. Recovery options: (a) wait ~60s for RM's stale-state timeout and retry, (b) try update_native_app(button='cancelAct', pageName='doActPage', confirm=true) to abort the in-flight edit (behavior unverified -- attempt at own risk), (c) restore_item_backup with a recent snapshot.")
     }
-    // Pre-flight (issue #178): if the action being deleted is a structural
-    // element (IF / ELSE-IF / ELSE / END-IF / Repeat / While / End-Repeat),
-    // simulate the deletion and refuse if it would make a currently-balanced
-    // rule worse — comparing counts catches the case where the rule is
-    // already imbalanced and the deletion would happen to FIX it (still
-    // allowed). This blocks the #178 trigger at the source: no delAct click
-    // is sent if the deletion would break the structure, so there is no
-    // post-response-commit race to leak through.
-    def status = _rmFetchStatusJson(appId)
-    def settingsByName = (status?.appSettings ?: []).collectEntries { [(it?.name?.toString()): it] }
+    // Structural pre-flight: refuse if the deleted index is a block
+    // opener/closer AND removing it would introduce a new imbalance not
+    // present in the current rule. Set-diff (projected MINUS current)
+    // rather than size-only — size comparison allows damage-shuffling on
+    // already-broken rules (e.g. swapping "Repeat never closed" for
+    // "END-IF closes a Repeat — mismatched" keeps the count flat). The
+    // set diff still allows deletions that strictly improve a broken
+    // rule, because every projected issue is also in current.
     def aType = settingsByName["actType.${actionIdx}".toString()]?.value?.toString()
     def sType = settingsByName["actSubType.${actionIdx}".toString()]?.value?.toString()
     def structuralSubTypes = ["getIfThen", "getElseIf", "getElse", "getEndIf", "getRepeat", "getWhile", "getStopRepeat"]
     if (aType in ["condActs", "repeatActs"] && sType in structuralSubTypes) {
-        def currentSeq = _rmStructuralSequenceFromSettings(settingsByName)
-        def projectedSeq = _rmStructuralSequenceFromSettings(settingsByName, ([actionIdx] as Set))
-        def currentIssues = _rmStructuralIssuesFromSequence(currentSeq)
-        def projectedIssues = _rmStructuralIssuesFromSequence(projectedSeq)
-        if (projectedIssues.size() > currentIssues.size()) {
+        def currentIssues = _rmStructuralIssuesFromSequence(_rmStructuralSequenceFromSettings(settingsByName))
+        def projectedIssues = _rmStructuralIssuesFromSequence(_rmStructuralSequenceFromSettings(settingsByName, ([actionIdx] as Set)))
+        def newIssues = projectedIssues - currentIssues
+        if (newIssues) {
             def humanKind = [
                 "getIfThen": "IF",
                 "getElseIf": "ELSE-IF",
@@ -16115,8 +16141,8 @@ private Map _rmDeleteAction(Integer appId, Integer actionIdx) {
                 "getRepeat": "Repeat",
                 "getWhile": "Repeat-While",
                 "getStopRepeat": "End-Repeat"
-            ][sType]
-            throw new IllegalArgumentException("removeAction(${actionIdx}) blocked: action ${actionIdx} is a structural ${humanKind}; removing it would leave the rule imbalanced (${projectedIssues.first()}). Remove the matching opener/closer first, or use replaceActions to rebuild the action list atomically. This refusal is a #178 pre-flight check — RM is not touched.")
+            ][sType] ?: sType
+            throw new IllegalArgumentException("removeAction(${actionIdx}) blocked: action ${actionIdx} is a structural ${humanKind}; removing it would introduce a new structural-balance issue (${newIssues.first()}). Remove the matching opener/closer first, or use replaceActions to rebuild the action list atomically. RM is not touched.")
         }
     }
     _rmClickAppButton(appId, actionIdx.toString(), "delAct", "selectActions")
@@ -16902,29 +16928,31 @@ private Map _rmAddAction(Integer appId, Map actionSpec) {
     // refresh, poll, runRule, cancelTimers, etc.) accept a null/missing
     // action — each capability's branch validates as needed.
 
-    // Pre-flight (issue #178): adding a bare closer (endIf / stopRepeat)
-    // when there is no matching opener leaves the rule with an orphaned
-    // closer. Asymmetric on purpose: adding an opener (ifThen / repeat /
-    // repeatWhile) without a closer is a normal multi-step build, so we
-    // do NOT refuse those — the caller will add the matching closer in a
-    // follow-up call. Only refuse closers that have nothing to close.
-    if (cap?.toLowerCase() in ["endif", "stoprepeat"]) {
-        def status = _rmFetchStatusJson(appId)
-        def settingsByName = (status?.appSettings ?: []).collectEntries { [(it?.name?.toString()): it] }
+    // Pre-flight: refuse closers (endIf / stopRepeat) and orphan branch
+    // keywords (elseIf / else) that would render as orphaned because they
+    // have no matching opener / containing IF block. Asymmetric on purpose:
+    // openers (ifThen / repeat / repeatWhile) added alone are allowed —
+    // they're a normal multi-step build state and the caller will add the
+    // matching closer in a follow-up call. Set-diff (projected MINUS
+    // current) catches the case where the new action would introduce a
+    // new structural-balance issue without flagging deletions that
+    // merely improve an already-broken rule.
+    def preflightCap = _rmStructuralPairForCapability(cap)
+    def closerOrBranchKeywords = ["endIf", "stopRepeat", "elseIf", "else"]
+    if (cap in closerOrBranchKeywords && preflightCap != null) {
+        def settingsByName = _rmFetchSettingsByName(appId)
         def currentSeq = _rmStructuralSequenceFromSettings(settingsByName)
-        def maxExistingIdx = currentSeq.collect { it.idx as Integer }.max() ?: 0
-        def projectedPair = _rmStructuralPairForCapability(cap)
-        def projectedSeq = currentSeq + [[
-            idx: (maxExistingIdx + 1),
-            actType: projectedPair[0],
-            actSubType: projectedPair[1]
-        ]]
+        // The projected idx only matters for issue-message construction;
+        // any value not in current works for the walker.
+        def projectedSeq = currentSeq + [[idx: -1, actType: preflightCap[0], actSubType: preflightCap[1]]]
         def currentIssues = _rmStructuralIssuesFromSequence(currentSeq)
         def projectedIssues = _rmStructuralIssuesFromSequence(projectedSeq)
-        if (projectedIssues.size() > currentIssues.size()) {
-            def openerCap = cap.equalsIgnoreCase("endIf") ? "ifThen" : "repeat"
-            def openerKind = cap.equalsIgnoreCase("endIf") ? "IF" : "Repeat"
-            throw new IllegalArgumentException("addAction(${cap}) blocked: rule ${appId} has no matching open ${openerKind} block on the action stack; this ${cap} would render as an orphaned closer. Add an addAction(capability='${openerCap}', ...) first (and its body), then this closer. This refusal is a #178 pre-flight check — RM is not touched.")
+        def newIssues = projectedIssues - currentIssues
+        if (newIssues) {
+            def hint = (cap == "endIf") ? "Add an addAction(capability='ifThen', ...) first (and its body), then this closer." :
+                       (cap == "stopRepeat") ? "Add an addAction(capability='repeat', ...) first (and its body), then this closer." :
+                       "Open an IF block with addAction(capability='ifThen', ...) before adding ${cap}."
+            throw new IllegalArgumentException("addAction(${cap}) blocked: would introduce a new structural-balance issue (${newIssues.first()}). ${hint} RM is not touched.")
         }
     }
 
@@ -18797,21 +18825,34 @@ private Map _rmFetchStatusJson(Integer appId) {
 }
 
 /**
- * Collect input schema from a configPage's sections[].input[] into a
- * name → metadata map. Used to decide which settings need the .type +
- * .multiple sidecar fields.
- */
-/**
  * Walk a sequence of [idx, actType, actSubType] entries (in numerical
  * order) tracking IF / Repeat block depth via a stack. Returns the list
- * of structural issues (empty list = balanced).
+ * of structural issue strings (empty list = balanced).
  *
  * Used by _rmCheckRuleHealth for post-mutation detection AND by the
  * pre-flight refusal paths in _rmDeleteAction / _rmAddAction /
  * toolUpdateNativeApp's replaceActions handler — they all build a
- * projected sequence (current state minus removals plus additions) and
- * compare projected-issues vs current-issues to decide whether to refuse
- * the mutation before it touches RM.
+ * projected sequence (current minus removals plus additions) and compare
+ * projected against current with `projected - current` set diff. Any
+ * NEW issue not present in current means the mutation introduces damage
+ * and is refused. (Size-only comparison would allow damage-shuffling on
+ * already-broken rules — e.g. adding an END-IF to a rule with an open
+ * Repeat keeps the issue count flat but swaps "Repeat never closed" for
+ * "END-IF closes a Repeat block — mismatched closer".)
+ *
+ * Asymmetric refusal at the call sites: openers (ifThen / repeat /
+ * repeatWhile) added alone are allowed (normal multi-step build state).
+ * Branch keywords (elseIf / else) and bare closers (endIf / stopRepeat)
+ * are refused if they would render orphaned, because they have no valid
+ * follow-up step the caller would naturally do next.
+ *
+ * Partial-commit handling: an entry with `actType` set but `actSubType`
+ * null is treated as a leaf (skipped from the walk), and a `partial:
+ * true` flag on the entry is also accepted as a hint that the writer
+ * knew the entry is incomplete. The intent is to keep the walker silent
+ * on the actType-only halfway state that the #172 false-fail race can
+ * leave behind, rather than treating it as a leaf and silently masking
+ * the imbalance.
  *
  * Groovy's List.pop() removes from the FRONT of a List; the walker uses
  * `<<` for append and `removeAt(size-1)` for tail-pop to preserve the
@@ -18824,6 +18865,10 @@ private List _rmStructuralIssuesFromSequence(List<Map> sequence) {
         def idx = entry?.idx
         def aType = entry?.actType?.toString()
         def sType = entry?.actSubType?.toString()
+        if (entry?.partial == true || (aType in ["condActs", "repeatActs"] && (sType == null || sType == ""))) {
+            issues << ("action ${idx} is in a partial-commit state (actType set, actSubType missing) — likely from an interrupted wizard write where the actType landed but the actSubType did not. The walker treats this as an opaque block boundary; restore from a recent backup or finish the wizard via update_native_app(walkStep=...).".toString())
+            return
+        }
         if (aType == "condActs") {
             if (sType == "getIfThen") {
                 stack << [kind: "if", openIdx: idx]
@@ -18869,26 +18914,89 @@ private List _rmStructuralIssuesFromSequence(List<Map> sequence) {
 /**
  * Build the structural-balance sequence from a rule's live appSettings
  * map (keyed by name). Collects actType.<N>/actSubType.<N> pairs in
- * numerical order. Optional excludeIndices (used by removeAction
- * pre-flight) skip listed action indices so the walker sees the
- * post-deletion state.
+ * numerical order and marks any actType-without-actSubType entry with
+ * `partial: true` so the walker can surface it as a #172-class
+ * half-commit rather than silently treating it as a leaf. Optional
+ * excludeIndices (used by removeAction pre-flight) skip listed action
+ * indices so the walker sees the post-deletion state.
  */
 private List _rmStructuralSequenceFromSettings(Map settingsByName, Set excludeIndices = ([] as Set)) {
     def indices = [] as TreeSet
-    settingsByName.each { name, recIgnored ->
+    settingsByName.keySet().each { name ->
         def m = name?.toString() =~ /^actType\.(\d+)$/
         if (m.matches()) indices << ((m[0] as List)[1] as Integer)
     }
     def sequence = []
     indices.each { idx ->
         if (excludeIndices.contains(idx)) return
-        sequence << [
-            idx: idx,
-            actType: settingsByName["actType.${idx}".toString()]?.value?.toString(),
-            actSubType: settingsByName["actSubType.${idx}".toString()]?.value?.toString()
-        ]
+        def aType = settingsByName["actType.${idx}".toString()]?.value?.toString()
+        def sType = settingsByName["actSubType.${idx}".toString()]?.value?.toString()
+        def entry = [idx: idx, actType: aType, actSubType: sType]
+        if (aType in ["condActs", "repeatActs"] && (sType == null || sType == "")) {
+            entry.partial = true
+        }
+        sequence << entry
     }
     sequence
+}
+
+/**
+ * Walk a list of caller-supplied addAction / replaceActions specs and
+ * project them as a structural sequence the walker can consume.
+ * Leaf-action specs (those whose capability has no block role) are
+ * skipped — they don't affect block balance. The pre-flight in
+ * toolUpdateNativeApp's replaceActions handler and the patches[]
+ * replaceActions branch both call this to validate the proposed list
+ * before any clearActions click.
+ */
+private List _rmStructuralSequenceFromSpecList(List specList) {
+    def out = []
+    specList.eachWithIndex { spec, i ->
+        if (!(spec instanceof Map)) return
+        def pair = _rmStructuralPairForCapability(((spec as Map).capability)?.toString())
+        if (pair) out << [idx: (i + 1), actType: pair[0], actSubType: pair[1]]
+    }
+    out
+}
+
+/**
+ * Fetch the rule's appSettings and return it keyed by setting name.
+ * Shared by every site that needs to read the rule's current state
+ * (the structural-balance walker, the multiple-flag-poison check, and
+ * the pre-flight refusal paths in _rmDeleteAction / _rmAddAction). One
+ * statusJson GET per call site instead of three back-to-back.
+ */
+private Map _rmFetchSettingsByName(Integer appId) {
+    def status = _rmFetchStatusJson(appId)
+    (status?.appSettings ?: []).collectEntries { [(it?.name?.toString()): it] }
+}
+
+/**
+ * Build the standard error response shape for toolUpdateNativeApp catch
+ * blocks. Detects pre-flight refusals (signalled by the "RM is not
+ * touched" sentinel that every pre-flight refusal throw includes) and
+ * adjusts the restoreHint to make clear that nothing was mutated — so
+ * the caller doesn't waste a restore_item_backup call. On pre-flight
+ * refusal, also attaches the current health so the caller sees existing
+ * structural issues that motivated the refusal.
+ */
+private Map _rmBuildUpdateErrorResponse(Integer appId, String msg, Map backup) {
+    def isPreflightRefusal = msg?.contains("RM is not touched")
+    def healthOnRefusal = null
+    if (isPreflightRefusal) {
+        try { healthOnRefusal = _rmCheckRuleHealth(appId) } catch (Exception ignored) { /* best effort */ }
+    }
+    def result = [
+        success: false,
+        appId: appId,
+        error: msg,
+        backup: backup,
+        restoreHint: isPreflightRefusal ?
+            "Pre-flight refusal — RM was not touched; the saved backup is identical to the current rule and does not need to be restored." :
+            "Backup saved before write. Call restore_item_backup with backupKey='${backup.backupKey}' to roll back."
+    ]
+    if (healthOnRefusal != null) result.health = healthOnRefusal
+    result
 }
 
 /**
@@ -18896,17 +19004,25 @@ private List _rmStructuralSequenceFromSettings(Map settingsByName, Set excludeIn
  * its [actType, actSubType] pair for the block-aware capabilities only.
  * Returns null for leaf actions (switch, lock, log, …) — they don't
  * affect structural balance and the pre-flight walker can ignore them.
+ *
+ * CASE-SENSITIVE on purpose: must match _rmAddAction's dispatch
+ * (`cap == "ifThen"` etc.). A case-insensitive match here would let
+ * mis-cased structural caps like "endIF" pass the replaceActions
+ * pre-flight as "balanced" (walker treats them as endIf) and then fail
+ * at the per-item dispatch step after clearActions has already wiped
+ * the rule — exactly the #178 damage class the pre-flight is meant to
+ * prevent.
  */
 private List _rmStructuralPairForCapability(String cap) {
     if (cap == null) return null
-    switch (cap.toString().toLowerCase()) {
-        case "ifthen":      return ["condActs", "getIfThen"]
-        case "elseif":      return ["condActs", "getElseIf"]
+    switch (cap.toString()) {
+        case "ifThen":      return ["condActs", "getIfThen"]
+        case "elseIf":      return ["condActs", "getElseIf"]
         case "else":        return ["condActs", "getElse"]
-        case "endif":       return ["condActs", "getEndIf"]
+        case "endIf":       return ["condActs", "getEndIf"]
         case "repeat":      return ["repeatActs", "getRepeat"]
-        case "repeatwhile": return ["repeatActs", "getWhile"]
-        case "stoprepeat":  return ["repeatActs", "getStopRepeat"]
+        case "repeatWhile": return ["repeatActs", "getWhile"]
+        case "stopRepeat":  return ["repeatActs", "getStopRepeat"]
         default: return null
     }
 }
@@ -18970,9 +19086,8 @@ private Map _rmCheckRuleHealth(Integer appId) {
         // Multiple-flag corruption check. Compare schema declaration vs
         // statusJson appSettings record for each setting that the schema
         // says is multi.
-        def status = _rmFetchStatusJson(appId)
+        def settingsByName = _rmFetchSettingsByName(appId)
         def schema = _rmCollectInputSchema(cfg?.configPage)
-        def settingsByName = (status?.appSettings ?: []).collectEntries { [(it?.name?.toString()): it] }
         schema.each { name, meta ->
             if (meta?.multiple == true) {
                 def rec = settingsByName[name]
@@ -18984,16 +19099,13 @@ private Map _rmCheckRuleHealth(Integer appId) {
         if (multipleFlagPoison) {
             issues << "multiple-flag poison on settings: ${multipleFlagPoison.join(', ')} — re-POST with the 3-field group to recover".toString()
         }
-        // Structural balance check for IF/ELSE-IF/ELSE/END-IF and Repeat/End-Repeat
-        // blocks — see _rmStructuralIssuesFromSequence for the walker semantics.
-        // Most imbalance is now blocked at the pre-flight refusal in
-        // _rmDeleteAction / _rmAddAction / the replaceActions handler before
-        // it lands; this defense-in-depth catch covers raw settings writes
-        // and the #172 post-response-commit race that can slip past those.
-        def structuralSequence = _rmStructuralSequenceFromSettings(settingsByName)
-        structuralIssues.addAll(_rmStructuralIssuesFromSequence(structuralSequence))
+        // Structural balance check (defense in depth — the pre-flight refusals
+        // in _rmDeleteAction / _rmAddAction / replaceActions block most
+        // imbalance at the source; this catches raw settings writes and the
+        // post-response-commit race for non-structural deletes).
+        structuralIssues = _rmStructuralIssuesFromSequence(_rmStructuralSequenceFromSettings(settingsByName))
         if (structuralIssues) {
-            issues << ("structural imbalance in action block nesting: ${structuralIssues.join('; ')} — likely caused by a raw settings write or a #172-class mutation that committed post-response. Use restore_item_backup to roll back, or add the missing closer via addAction(capability='endIf'|'stopRepeat').".toString())
+            issues << ("structural imbalance in action block nesting: ${structuralIssues.join('; ')} — likely caused by a raw settings write or a mutation that committed post-response. Use restore_item_backup to roll back, or add the missing closer via addAction(capability='endIf'|'stopRepeat').".toString())
         }
     } catch (Exception e) {
         issues << "health check failed: ${e.message}".toString()
@@ -19411,6 +19523,11 @@ private Map _rmWalkStep(Integer appId, Map spec) {
     ]
 }
 
+/**
+ * Collect input schema from a configPage's sections[].input[] into a
+ * name → metadata map. Used to decide which settings need the .type +
+ * .multiple sidecar fields.
+ */
 private Map _rmCollectInputSchema(Map configPage) {
     def schema = [:]
     for (s in (configPage?.sections ?: [])) {
@@ -20655,28 +20772,18 @@ def toolUpdateNativeApp(args) {
         def removed = []
         def addedResults = []
         try {
-            // Pre-flight (issue #178): walk the replaceActions spec list's
-            // capability sequence and refuse the call before clearActions
-            // runs if the proposed list is itself structurally imbalanced.
-            // This catches the LLM-error case where the caller forgot an
-            // end-if / stop-repeat (or stacked an extra one) — better to
-            // surface the mistake than wipe the rule and then re-add a
-            // broken structure on top. The new sequence is walked against
-            // an empty current state (clearActions runs first, so the
-            // rule's existing actions don't factor in).
+            // Pre-flight: walk the replaceActions spec list's capability
+            // sequence and refuse the call before clearActions runs if the
+            // proposed list is itself structurally imbalanced. Catches the
+            // LLM-error case where the caller forgot an endIf / stopRepeat
+            // (or stacked an extra one) — better to surface the mistake
+            // than wipe the rule and then re-add a broken structure.
+            // (Walked against an empty current state because clearActions
+            // runs first; the rule's existing actions don't factor in.)
             if (replaceActionsList != null) {
-                def projectedSeq = []
-                replaceActionsList.eachWithIndex { spec, i ->
-                    if (!(spec instanceof Map)) return
-                    def specCap = (spec as Map).capability?.toString()
-                    def pair = _rmStructuralPairForCapability(specCap)
-                    if (pair) {
-                        projectedSeq << [idx: (i + 1), actType: pair[0], actSubType: pair[1]]
-                    }
-                }
-                def specIssues = _rmStructuralIssuesFromSequence(projectedSeq)
+                def specIssues = _rmStructuralIssuesFromSequence(_rmStructuralSequenceFromSpecList(replaceActionsList))
                 if (specIssues) {
-                    throw new IllegalArgumentException("replaceActions blocked: the proposed action list is structurally imbalanced — ${specIssues.join('; ')}. Re-order the list, add the missing closer (capability='endIf' or 'stopRepeat'), or remove the orphan closer. This refusal is a #178 pre-flight check — RM is not touched and no actions are cleared.")
+                    throw new IllegalArgumentException("replaceActions blocked: the proposed action list is structurally imbalanced — ${specIssues.join('; ')}. Re-order the list, add the missing closer (capability='endIf' or 'stopRepeat'), or remove the orphan closer. RM is not touched and no actions are cleared.")
                 }
             }
             if (removeActionSpec) {
@@ -20725,17 +20832,12 @@ def toolUpdateNativeApp(args) {
             _rmClickAppButton(appId, "updateRule")
         } catch (Exception e) {
             mcpLog("error", "rm-native", "action mutation failed for app ${appId}: ${e.message}")
+            def result = _rmBuildUpdateErrorResponse(appId, e.message, backup)
+            // The "deletion may commit post-response" exhaustion path needs
+            // an extra hint that the helper doesn't know about.
             def isRetryExhaustion = e.message?.contains("deletion may commit post-response")
-            def result = [
-                success: false,
-                appId: appId,
-                error: e.message,
-                backup: backup,
-                restoreHint: isRetryExhaustion ?
-                    "If get_app_config confirms the operation did NOT commit, roll back via restore_item_backup(backupKey='${backup.backupKey}')." :
-                    "Backup saved before write. Call restore_item_backup with backupKey='${backup.backupKey}' to roll back."
-            ]
             if (isRetryExhaustion) {
+                result.restoreHint = "If get_app_config confirms the operation did NOT commit, roll back via restore_item_backup(backupKey='${backup.backupKey}')."
                 result.verifyHint = "Call get_app_config(appId=${appId}) and inspect the actions list -- if the operation actually committed despite the false-fail, do NOT call restore_item_backup."
             }
             return result
@@ -20831,13 +20933,7 @@ def toolUpdateNativeApp(args) {
             trigResult = _rmAddTrigger(appId, addTriggerSpec)
         } catch (Exception e) {
             mcpLog("error", "rm-native", "addTrigger failed for app ${appId}: ${e.message}")
-            return [
-                success: false,
-                appId: appId,
-                error: e.message,
-                backup: backup,
-                restoreHint: "Backup saved before write. Call restore_item_backup with backupKey='${backup.backupKey}' to roll back."
-            ]
+            return _rmBuildUpdateErrorResponse(appId, e.message, backup)
         }
         // Auto-fire updateRule after a successful commit so eventSubscriptions
         // populate without a separate tool call. Skip on hard failure
@@ -20880,13 +20976,7 @@ def toolUpdateNativeApp(args) {
             actResult = _rmAddAction(appId, addActionSpec)
         } catch (Exception e) {
             mcpLog("error", "rm-native", "addAction failed for app ${appId}: ${e.message}")
-            return [
-                success: false,
-                appId: appId,
-                error: e.message,
-                backup: backup,
-                restoreHint: "Backup saved before write. Call restore_item_backup with backupKey='${backup.backupKey}' to roll back."
-            ]
+            return _rmBuildUpdateErrorResponse(appId, e.message, backup)
         }
         return [
             success: actResult?.success != false,
@@ -20986,17 +21076,11 @@ def toolUpdateNativeApp(args) {
                         }
                         patchResults << [success: true, op: "clearActions", removedIndices: cleared]
                     } else if (pm.containsKey("replaceActions")) {
-                        // Issue #178 pre-flight: validate the proposed list's
-                        // structural balance before clearActions touches RM.
-                        def patchSeq = []
-                        (pm.replaceActions as List).eachWithIndex { aspec, ai ->
-                            if (!(aspec instanceof Map)) return
-                            def pair = _rmStructuralPairForCapability(((aspec as Map).capability)?.toString())
-                            if (pair) patchSeq << [idx: (ai + 1), actType: pair[0], actSubType: pair[1]]
-                        }
-                        def patchSpecIssues = _rmStructuralIssuesFromSequence(patchSeq)
+                        // Pre-flight: validate the proposed list's structural
+                        // balance before clearActions touches RM.
+                        def patchSpecIssues = _rmStructuralIssuesFromSequence(_rmStructuralSequenceFromSpecList(pm.replaceActions as List))
                         if (patchSpecIssues) {
-                            throw new IllegalArgumentException("patches[${pi}].replaceActions blocked: the proposed action list is structurally imbalanced — ${patchSpecIssues.join('; ')}. Re-order the list, add the missing closer (capability='endIf' or 'stopRepeat'), or remove the orphan closer. This refusal is a #178 pre-flight check — RM is not touched and no actions are cleared.")
+                            throw new IllegalArgumentException("patches[${pi}].replaceActions blocked: the proposed action list is structurally imbalanced — ${patchSpecIssues.join('; ')}. Re-order the list, add the missing closer (capability='endIf' or 'stopRepeat'), or remove the orphan closer. RM is not touched and no actions are cleared.")
                         }
                         def cleared
                         try { cleared = _rmClearActions(appId) ?: [] }
@@ -21060,13 +21144,7 @@ def toolUpdateNativeApp(args) {
             varResult = _rmAddLocalVariable(appId, addLocalVariableSpec)
         } catch (Exception e) {
             mcpLog("error", "rm-native", "addLocalVariable failed for app ${appId}: ${e.message}")
-            return [
-                success: false,
-                appId: appId,
-                error: e.message,
-                backup: backup,
-                restoreHint: "Backup saved before write. Call restore_item_backup with backupKey='${backup.backupKey}' to roll back."
-            ]
+            return _rmBuildUpdateErrorResponse(appId, e.message, backup)
         }
         try { _rmClickAppButton(appId, "updateRule") }
         catch (Exception updateExc) {
@@ -21181,15 +21259,10 @@ def toolUpdateNativeApp(args) {
             _rmClickAppButton(appId, "updateRule")
         } catch (Exception e) {
             mcpLog("error", "rm-native", "addTriggers/addActions bulk failed for app ${appId}: ${e.message}")
-            return [
-                success: false,
-                appId: appId,
-                error: e.message,
-                backup: backup,
-                triggerResults: triggerResults,
-                actionResults: actionResults,
-                restoreHint: "Backup saved before write. Call restore_item_backup with backupKey='${backup.backupKey}' to roll back."
-            ]
+            def bulkResult = _rmBuildUpdateErrorResponse(appId, e.message, backup)
+            bulkResult.triggerResults = triggerResults
+            bulkResult.actionResults = actionResults
+            return bulkResult
         }
         def trigOk = triggerResults.count { it?.success != false }
         def actOk = actionResults.count { it?.success != false }
@@ -21363,13 +21436,7 @@ def toolUpdateNativeApp(args) {
     } catch (Exception e) {
         def msg = e.message ?: e.toString()
         mcpLog("error", "rm-native", "update_native_app failed for ${appId}: ${msg}")
-        return [
-            success: false,
-            appId: appId,
-            error: msg,
-            backup: backup,
-            restoreHint: "Backup saved before write. Call restore_item_backup with backupKey='${backup.backupKey}' to roll back."
-        ]
+        return _rmBuildUpdateErrorResponse(appId, msg, backup)
     }
 }
 

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -2104,6 +2104,315 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.note?.contains("Removed action 1") || result.removedIndices?.contains(1)
     }
 
+    // Issue #178 pre-flight refusal tests — three layers that refuse the
+    // call BEFORE RM is touched so the false-fail-with-post-commit race
+    // can't leak through. Counterpart to the post-mutation detection in
+    // check_rule_health (defense-in-depth).
+
+    private List nestedIfThenSettings() {
+        // Reproduces the live BAT-178 rule structure (well-formed):
+        //   IF -> IF -> lock-delayed -> END-IF -> IF -> lock -> END-IF -> END-IF
+        [
+            [name: "actType.9",  value: "condActs"], [name: "actSubType.9",  value: "getIfThen"],
+            [name: "actType.10", value: "condActs"], [name: "actSubType.10", value: "getIfThen"],
+            [name: "actType.11", value: "lockActs"], [name: "actSubType.11", value: "getLULock"],
+            [name: "actType.12", value: "condActs"], [name: "actSubType.12", value: "getEndIf"],
+            [name: "actType.13", value: "condActs"], [name: "actSubType.13", value: "getIfThen"],
+            [name: "actType.14", value: "lockActs"], [name: "actSubType.14", value: "getLULock"],
+            [name: "actType.15", value: "condActs"], [name: "actSubType.15", value: "getEndIf"],
+            [name: "actType.16", value: "condActs"], [name: "actSubType.16", value: "getEndIf"]
+        ]
+    }
+
+    def "removeAction refuses to delete the inner END-IF that would unbalance a nested rule (issue #178)"() {
+        // The exact #178 trigger: removeAction({index: <inner END-IF>}) on a
+        // well-formed nested rule. Pre-fix: returned false-fail timeout but
+        // the delete committed post-response, leaving 3 IFs / 2 END-IFs.
+        // Post-fix: pre-flight refuses before any HTTP click goes out.
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Nested", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, nestedIfThenSettings()) }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, removeAction: [index: 12], confirm: true])
+
+        then:
+        result.success == false
+        result.error?.contains("removeAction(12) blocked")
+        result.error?.contains("structural END-IF")
+        result.error?.contains("pre-flight check")
+
+        and: "no delAct button click fires"
+        !posts.any { it.body?.get("stateAttribute") == "delAct" }
+    }
+
+    def "removeAction refuses to delete the outer IF that would unbalance a nested rule"() {
+        // Symmetric to the END-IF case: removing the outer IF (action 9)
+        // would leave two END-IFs dangling. Pre-flight should refuse.
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Nested", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, nestedIfThenSettings()) }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, removeAction: [index: 9], confirm: true])
+
+        then:
+        result.success == false
+        result.error?.contains("removeAction(9) blocked")
+        result.error?.contains("structural IF")
+        !posts.any { it.body?.get("stateAttribute") == "delAct" }
+    }
+
+    def "removeAction allows deleting a leaf (lock) action — no structural risk"() {
+        // No-false-positive guard: action 11 is a lockActs/getLULock leaf.
+        // Deleting it doesn't touch the IF/END-IF balance, so pre-flight
+        // should pass through and the normal delete path should run.
+        given:
+        enableHubAdminWrite()
+        def delActFired = false
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/btn" && body?.get("stateAttribute") == "delAct") delActFired = true
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Nested", []) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            if (delActFired) {
+                // post-click: action 11 gone
+                statusJson(100, nestedIfThenSettings().findAll { !it.name?.endsWith(".11") })
+            } else {
+                statusJson(100, nestedIfThenSettings())
+            }
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, removeAction: [index: 11], confirm: true])
+
+        then:
+        result.success == true
+        delActFired == true
+    }
+
+    def "removeAction allows deleting an IF when the rule is already imbalanced and the delete improves it"() {
+        // Edge case: the rule is already broken (3 IFs, 2 END-IFs).
+        // Removing the dangling outer IF (action 9) would FIX the imbalance.
+        // Pre-flight must allow this because projected-issues <= current-issues.
+        given:
+        enableHubAdminWrite()
+        def delActFired = false
+        // Already-imbalanced rule: drop action 12 (inner END-IF) from the
+        // well-formed set so 3 IFs (9, 10, 13) and only 2 END-IFs (15, 16) remain.
+        def alreadyBroken = nestedIfThenSettings().findAll { !it.name?.endsWith(".12") }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/btn" && body?.get("stateAttribute") == "delAct") delActFired = true
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Already broken", []) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            if (delActFired) {
+                statusJson(100, alreadyBroken.findAll { !it.name?.endsWith(".9") })
+            } else {
+                statusJson(100, alreadyBroken)
+            }
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, removeAction: [index: 9], confirm: true])
+
+        then: "pre-flight allows the removal because it doesn't make things worse"
+        result.success == true
+        delActFired == true
+    }
+
+    def "addAction(endIf) refuses when no IF is open on the stack"() {
+        // Adding a bare END-IF to a rule with no open IF would leave an
+        // orphaned closer. Pre-flight should refuse before the doActPage
+        // wizard even opens.
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Plain", []) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            // Single switch action — no open IF.
+            statusJson(100, [[name: "actType.1", value: "switchActs"], [name: "actSubType.1", value: "getOnOff"]])
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, addAction: [capability: "endIf"], confirm: true])
+
+        then:
+        result.success == false
+        result.error?.contains("addAction(endIf) blocked")
+        result.error?.contains("no matching open IF")
+        !posts.any { it.body?.get("stateAttribute")?.toString()?.startsWith("doAct") }
+    }
+
+    def "addAction(stopRepeat) refuses when no Repeat is open on the stack"() {
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Plain", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, []) }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, addAction: [capability: "stopRepeat"], confirm: true])
+
+        then:
+        result.success == false
+        result.error?.contains("addAction(stopRepeat) blocked")
+        result.error?.contains("no matching open Repeat")
+    }
+
+    def "addAction(ifThen) is NOT refused — opener-without-closer is a normal multi-step build"() {
+        // Asymmetric on purpose: adding an IF alone is fine; the caller
+        // will close it in a follow-up call. We only refuse closers.
+        // This test runs the spec only as far as the pre-flight — the
+        // ifThen wizard then needs full doActPage stubbing that's out of
+        // scope here, so we assert the pre-flight didn't fire.
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Plain", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, []) }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addAction: [capability: "ifThen", expression: [conditions: [[capability: "Switch", deviceIds: [1], state: "on"]]]],
+            confirm: true
+        ])
+
+        then: "the pre-flight does NOT refuse — error (if any) comes from the wizard stubs, not pre-flight"
+        // The wizard call will fail on the harness's missing doActPage
+        // mocks, but the error MUST NOT be a #178 pre-flight refusal.
+        !(result?.error?.toString()?.contains("pre-flight check"))
+    }
+
+    def "replaceActions refuses an imbalanced spec list before any clearActions click"() {
+        // Caller passes a list with 2 IFs and 1 END-IF — pre-flight refuses
+        // before clearActions runs, so the original rule is preserved.
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, [[name: "actType.1", value: "switchActs"]]) }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            replaceActions: [
+                [capability: "ifThen", expression: [conditions: [[capability: "Switch", deviceIds: [1], state: "on"]]]],
+                [capability: "ifThen", expression: [conditions: [[capability: "Switch", deviceIds: [1], state: "on"]]]],
+                [capability: "endIf"]
+            ],
+            confirm: true
+        ])
+
+        then:
+        result.success == false
+        result.error?.contains("replaceActions blocked")
+        result.error?.contains("structurally imbalanced")
+        result.error?.contains("pre-flight check")
+
+        and: "no trashAll click — the original rule is preserved"
+        !posts.any { it.body?.get("name") == "trashAll" }
+    }
+
+    def "replaceActions allows a balanced spec list"() {
+        // Pre-flight must pass when the list is balanced. We assert here
+        // that the pre-flight didn't reject (the downstream wizard calls
+        // will fail on the harness's missing mocks, but the failure must
+        // NOT be a #178 pre-flight rejection).
+        given:
+        enableHubAdminWrite()
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, [[name: "actType.1", value: "switchActs"]]) }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            replaceActions: [
+                [capability: "ifThen", expression: [conditions: [[capability: "Switch", deviceIds: [1], state: "on"]]]],
+                [capability: "endIf"]
+            ],
+            confirm: true
+        ])
+
+        then:
+        !(result?.error?.toString()?.contains("pre-flight check"))
+    }
+
+    def "patches[replaceActions=...] refuses an imbalanced patch spec before any clearActions click"() {
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, []) }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            patches: [[replaceActions: [
+                [capability: "ifThen", expression: [conditions: [[capability: "Switch", deviceIds: [1], state: "on"]]]],
+                [capability: "endIf"],
+                [capability: "endIf"]
+            ]]],
+            confirm: true
+        ])
+
+        then:
+        result.patches?.first()?.success == false
+        result.patches?.first()?.error?.contains("patches[0].replaceActions blocked")
+        result.patches?.first()?.error?.contains("structurally imbalanced")
+
+        and: "no trashAll click — the original rule is preserved"
+        !posts.any { it.body?.get("name") == "trashAll" }
+    }
+
     def "walkStep introspect returns schema for a page without mutating"() {
         given:
         enableHubAdminWrite()

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -2477,6 +2477,195 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.issues.any { it.toString().toLowerCase().contains("broken") }
     }
 
+    // Issue #178: removeAction / replaceActions can false-fail and post-commit, leaving
+    // the rule with three IFs and two END-IFs (or any other unbalanced nesting) while
+    // RM's paragraph render and label remain clean. The structural-balance walker on
+    // actType.<N>/actSubType.<N> is the only signal that catches this class of damage.
+
+    private List ifStructureSettings(List<Map> rows) {
+        // rows = [[idx: N, actType: "condActs", actSubType: "getIfThen"], ...]
+        def out = []
+        rows.each { r ->
+            out << [name: "actType.${r.idx}".toString(), value: r.actType]
+            out << [name: "actSubType.${r.idx}".toString(), value: r.actSubType]
+        }
+        out
+    }
+
+    def "check_rule_health flags structural imbalance when an IF has no closing END-IF (issue #178)"() {
+        given:
+        enableReadOnly()
+        // Three IFs + two END-IFs — reproduces the live state observed on the test hub
+        // after removeAction(<inner-END-IF>) false-failed but committed post-response.
+        def settings = ifStructureSettings([
+            [idx: 9,  actType: "condActs", actSubType: "getIfThen"],
+            [idx: 10, actType: "condActs", actSubType: "getIfThen"],
+            [idx: 11, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 13, actType: "condActs", actSubType: "getIfThen"],
+            [idx: 14, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 15, actType: "condActs", actSubType: "getEndIf"],
+            [idx: 16, actType: "condActs", actSubType: "getEndIf"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Unbalanced Rule", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
+
+        when:
+        def result = script.handleGateway("manage_native_rules_and_apps", "check_rule_health", [appId: 100])
+
+        then:
+        result.ok == false
+        result.structuralIssues instanceof List
+        result.structuralIssues.size() == 1
+        result.structuralIssues[0].toString().contains("action 9")
+        result.structuralIssues[0].toString().contains("never closed")
+        result.issues.any { it.toString().contains("structural imbalance") }
+    }
+
+    def "check_rule_health flags an orphaned END-IF (more END-IFs than IFs)"() {
+        given:
+        enableReadOnly()
+        def settings = ifStructureSettings([
+            [idx: 1, actType: "condActs", actSubType: "getIfThen"],
+            [idx: 2, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 3, actType: "condActs", actSubType: "getEndIf"],
+            [idx: 4, actType: "condActs", actSubType: "getEndIf"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Extra EndIf", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
+
+        when:
+        def result = script.handleGateway("manage_native_rules_and_apps", "check_rule_health", [appId: 100])
+
+        then:
+        result.ok == false
+        result.structuralIssues.any { it.toString().contains("orphaned closer") }
+        result.structuralIssues.any { it.toString().contains("action 4") }
+    }
+
+    def "check_rule_health flags an orphaned End-Repeat closing nothing"() {
+        given:
+        enableReadOnly()
+        def settings = ifStructureSettings([
+            [idx: 1, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 2, actType: "repeatActs", actSubType: "getStopRepeat"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Orphan Stop", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
+
+        when:
+        def result = script.handleGateway("manage_native_rules_and_apps", "check_rule_health", [appId: 100])
+
+        then:
+        result.ok == false
+        result.structuralIssues.any { it.toString().contains("End Repeat") }
+        result.structuralIssues.any { it.toString().contains("orphaned closer") }
+    }
+
+    def "check_rule_health flags ELSE-IF outside any IF block"() {
+        given:
+        enableReadOnly()
+        def settings = ifStructureSettings([
+            [idx: 1, actType: "condActs", actSubType: "getElseIf"],
+            [idx: 2, actType: "lockActs", actSubType: "getLULock"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Stray ElseIf", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
+
+        when:
+        def result = script.handleGateway("manage_native_rules_and_apps", "check_rule_health", [appId: 100])
+
+        then:
+        result.ok == false
+        result.structuralIssues.any { it.toString().contains("ELSE-IF") }
+        result.structuralIssues.any { it.toString().contains("outside any IF block") }
+    }
+
+    def "check_rule_health flags END-IF closing a Repeat block (mismatched closer)"() {
+        given:
+        enableReadOnly()
+        // Repeat opens at action 1, but the closer at action 3 is END-IF (wrong kind).
+        def settings = ifStructureSettings([
+            [idx: 1, actType: "repeatActs", actSubType: "getRepeat"],
+            [idx: 2, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 3, actType: "condActs", actSubType: "getEndIf"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Mismatched", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
+
+        when:
+        def result = script.handleGateway("manage_native_rules_and_apps", "check_rule_health", [appId: 100])
+
+        then:
+        result.ok == false
+        result.structuralIssues.any { it.toString().contains("END-IF") && it.toString().contains("closes a Repeat block") }
+    }
+
+    def "check_rule_health reports ok on a balanced nested IF / IF / END-IF / IF / END-IF / END-IF"() {
+        given:
+        enableReadOnly()
+        def settings = ifStructureSettings([
+            [idx: 1, actType: "condActs", actSubType: "getIfThen"],
+            [idx: 2, actType: "condActs", actSubType: "getIfThen"],
+            [idx: 3, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 4, actType: "condActs", actSubType: "getEndIf"],
+            [idx: 5, actType: "condActs", actSubType: "getIfThen"],
+            [idx: 6, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 7, actType: "condActs", actSubType: "getEndIf"],
+            [idx: 8, actType: "condActs", actSubType: "getEndIf"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Balanced Nested", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
+
+        when:
+        def result = script.handleGateway("manage_native_rules_and_apps", "check_rule_health", [appId: 100])
+
+        then:
+        result.ok == true
+        result.structuralIssues == [] || result.structuralIssues?.isEmpty()
+    }
+
+    def "check_rule_health reports ok on IF / ELSE-IF / ELSE / END-IF sequence"() {
+        given:
+        enableReadOnly()
+        def settings = ifStructureSettings([
+            [idx: 1, actType: "condActs", actSubType: "getIfThen"],
+            [idx: 2, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 3, actType: "condActs", actSubType: "getElseIf"],
+            [idx: 4, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 5, actType: "condActs", actSubType: "getElse"],
+            [idx: 6, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 7, actType: "condActs", actSubType: "getEndIf"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "If Else Chain", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
+
+        when:
+        def result = script.handleGateway("manage_native_rules_and_apps", "check_rule_health", [appId: 100])
+
+        then:
+        result.ok == true
+        result.structuralIssues == [] || result.structuralIssues?.isEmpty()
+    }
+
+    def "check_rule_health reports ok on Repeat / End-Repeat sequence"() {
+        given:
+        enableReadOnly()
+        def settings = ifStructureSettings([
+            [idx: 1, actType: "repeatActs", actSubType: "getRepeat"],
+            [idx: 2, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 3, actType: "repeatActs", actSubType: "getStopRepeat"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Repeat", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
+
+        when:
+        def result = script.handleGateway("manage_native_rules_and_apps", "check_rule_health", [appId: 100])
+
+        then:
+        result.ok == true
+        result.structuralIssues == [] || result.structuralIssues?.isEmpty()
+    }
+
     // ---------- clone / export / import_native_app (appCloner trio) ----------
     // These three tools share the appCloner system app's wire format. Wire
     // format captured live via Chrome XHR sniffing on firmware 2.5.0.x:

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -2147,10 +2147,14 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.success == false
         result.error?.contains("removeAction(12) blocked")
         result.error?.contains("structural END-IF")
-        result.error?.contains("pre-flight check")
+        result.error?.contains("RM is not touched")
 
         and: "no delAct button click fires"
         !posts.any { it.body?.get("stateAttribute") == "delAct" }
+
+        and: "pre-flight refusal response attaches health so the caller can see the existing balance state"
+        result.health != null
+        result.restoreHint?.contains("Pre-flight refusal")
     }
 
     def "removeAction refuses to delete the outer IF that would unbalance a nested rule"() {
@@ -2174,6 +2178,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.success == false
         result.error?.contains("removeAction(9) blocked")
         result.error?.contains("structural IF")
+        result.error?.contains("RM is not touched")
         !posts.any { it.body?.get("stateAttribute") == "delAct" }
     }
 
@@ -2263,8 +2268,13 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         then:
         result.success == false
         result.error?.contains("addAction(endIf) blocked")
-        result.error?.contains("no matching open IF")
+        result.error?.contains("END-IF) has no matching IF")
+        result.error?.contains("RM is not touched")
         !posts.any { it.body?.get("stateAttribute")?.toString()?.startsWith("doAct") }
+
+        and: "the addAction catch path also routes pre-flight refusals through the helper — restoreHint and health are attached"
+        result.restoreHint?.contains("Pre-flight refusal")
+        result.health != null
     }
 
     def "addAction(stopRepeat) refuses when no Repeat is open on the stack"() {
@@ -2285,7 +2295,8 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         then:
         result.success == false
         result.error?.contains("addAction(stopRepeat) blocked")
-        result.error?.contains("no matching open Repeat")
+        result.error?.contains("End Repeat) has no matching Repeat")
+        result.error?.contains("RM is not touched")
     }
 
     def "addAction(ifThen) is NOT refused — opener-without-closer is a normal multi-step build"() {
@@ -2314,8 +2325,15 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
         then: "the pre-flight does NOT refuse — error (if any) comes from the wizard stubs, not pre-flight"
         // The wizard call will fail on the harness's missing doActPage
-        // mocks, but the error MUST NOT be a #178 pre-flight refusal.
-        !(result?.error?.toString()?.contains("pre-flight check"))
+        // mocks, but the error MUST NOT contain the pre-flight refusal
+        // sentinel ('RM is not touched' is only emitted by the four
+        // pre-flight refusal paths) and the pre-flight 'addAction(ifThen)
+        // blocked' prefix.
+        !(result?.error?.toString()?.contains("RM is not touched"))
+        !(result?.error?.toString()?.contains("addAction(ifThen) blocked"))
+
+        and: "the wizard's doActPage open click DID fire (proves pre-flight passed and control reached _rmAddAction's wizard flow)"
+        posts.any { it.body?.get("stateAttribute")?.toString()?.startsWith("doAct") }
     }
 
     def "replaceActions refuses an imbalanced spec list before any clearActions click"() {
@@ -2347,21 +2365,27 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.success == false
         result.error?.contains("replaceActions blocked")
         result.error?.contains("structurally imbalanced")
-        result.error?.contains("pre-flight check")
+        result.error?.contains("RM is not touched")
 
         and: "no trashAll click — the original rule is preserved"
         !posts.any { it.body?.get("name") == "trashAll" }
+
+        and: "pre-flight refusal response attaches health and a non-restore hint"
+        result.health != null
+        result.restoreHint?.contains("Pre-flight refusal")
     }
 
     def "replaceActions allows a balanced spec list"() {
-        // Pre-flight must pass when the list is balanced. We assert here
-        // that the pre-flight didn't reject (the downstream wizard calls
-        // will fail on the harness's missing mocks, but the failure must
-        // NOT be a #178 pre-flight rejection).
+        // Pre-flight must pass when the list is balanced. Asserts both the
+        // negative (no pre-flight refusal sentinel in the error) AND the
+        // positive (the trashAll button click DID fire, meaning pre-flight
+        // passed and control reached clearActions).
         given:
         enableHubAdminWrite()
+        def posts = []
         script.metaClass.uploadHubFile = { String fn, byte[] b -> }
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
             [status: 200, location: null, data: '']
         }
         hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
@@ -2377,8 +2401,15 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             confirm: true
         ])
 
-        then:
-        !(result?.error?.toString()?.contains("pre-flight check"))
+        then: "no pre-flight refusal"
+        !(result?.error?.toString()?.contains("RM is not touched"))
+        !(result?.error?.toString()?.contains("replaceActions blocked"))
+
+        and: "restoreHint is NOT the pre-flight one — proves the catch block didn't tag this as a pre-flight refusal"
+        result?.restoreHint == null || !result.restoreHint.contains("Pre-flight refusal")
+
+        and: "the run made it past pre-flight into clearActions territory (either trashAll click or cancelTrash recovery from a failed clearActions attempt — both prove pre-flight passed)"
+        posts.any { it.body?.get("name") == "trashAll" || it.body?.get("name") == "cancelTrash" }
     }
 
     def "patches[replaceActions=...] refuses an imbalanced patch spec before any clearActions click"() {
@@ -2411,6 +2442,234 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
         and: "no trashAll click — the original rule is preserved"
         !posts.any { it.body?.get("name") == "trashAll" }
+    }
+
+    // Coverage for the structural subtypes that are in _rmDeleteAction's
+    // structuralSubTypes list but had no dedicated removal test.
+
+    def "removeAction refuses deleting a Repeat opener that would leave its End-Repeat orphaned"() {
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        def repeatSettings = ifStructureSettings([
+            [idx: 1, actType: "repeatActs", actSubType: "getRepeat"],
+            [idx: 2, actType: "lockActs",   actSubType: "getLULock"],
+            [idx: 3, actType: "repeatActs", actSubType: "getStopRepeat"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Repeat", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, repeatSettings) }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, removeAction: [index: 1], confirm: true])
+
+        then:
+        result.success == false
+        result.error?.contains("removeAction(1) blocked")
+        result.error?.contains("structural Repeat")
+        result.error?.contains("RM is not touched")
+        !posts.any { it.body?.get("stateAttribute") == "delAct" }
+    }
+
+    def "removeAction refuses deleting an End-Repeat that would leave its Repeat unclosed"() {
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        def repeatSettings = ifStructureSettings([
+            [idx: 1, actType: "repeatActs", actSubType: "getRepeat"],
+            [idx: 2, actType: "lockActs",   actSubType: "getLULock"],
+            [idx: 3, actType: "repeatActs", actSubType: "getStopRepeat"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Repeat", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, repeatSettings) }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, removeAction: [index: 3], confirm: true])
+
+        then:
+        result.success == false
+        result.error?.contains("removeAction(3) blocked")
+        result.error?.contains("structural End-Repeat")
+        result.error?.contains("RM is not touched")
+        !posts.any { it.body?.get("stateAttribute") == "delAct" }
+    }
+
+    def "removeAction allows deleting an ELSE-IF in an IF / ELSE-IF / END-IF rule (no balance change)"() {
+        given:
+        enableHubAdminWrite()
+        def delActFired = false
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/btn" && body?.get("stateAttribute") == "delAct") delActFired = true
+            [status: 200, location: null, data: '']
+        }
+        def chain = ifStructureSettings([
+            [idx: 1, actType: "condActs", actSubType: "getIfThen"],
+            [idx: 2, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 3, actType: "condActs", actSubType: "getElseIf"],
+            [idx: 4, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 5, actType: "condActs", actSubType: "getEndIf"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Chain", []) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            delActFired ? statusJson(100, chain.findAll { !it.name?.endsWith(".3") }) : statusJson(100, chain)
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, removeAction: [index: 3], confirm: true])
+
+        then: "deleting an ELSE-IF doesn't change IF/END-IF balance — pre-flight allows the delete"
+        result.success == true
+        delActFired == true
+    }
+
+    // Coverage for elseIf/else orphan refusal in _rmAddAction (the closer-or-
+    // branch-keywords path that landed alongside the structural pre-flight).
+
+    def "addAction(elseIf) refuses when no IF is open on the stack"() {
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Plain", []) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            statusJson(100, [[name: "actType.1", value: "switchActs"], [name: "actSubType.1", value: "getOnOff"]])
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addAction: [capability: "elseIf", expression: [conditions: [[capability: "Switch", deviceIds: [1], state: "on"]]]],
+            confirm: true
+        ])
+
+        then:
+        result.success == false
+        result.error?.contains("addAction(elseIf) blocked")
+        result.error?.contains("ELSE-IF) is outside any IF block")
+        result.error?.contains("RM is not touched")
+        !posts.any { it.body?.get("stateAttribute")?.toString()?.startsWith("doAct") }
+    }
+
+    def "addAction(else) refuses when no IF is open on the stack"() {
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Plain", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, []) }
+
+        when:
+        def result = script.toolUpdateNativeApp([appId: 100, addAction: [capability: "else"], confirm: true])
+
+        then:
+        result.success == false
+        result.error?.contains("addAction(else) blocked")
+        result.error?.contains("ELSE) is outside any IF block")
+        result.error?.contains("RM is not touched")
+    }
+
+    // Regression guard for the case-sensitivity hole: a mis-cased structural
+    // capability in replaceActions used to pass the pre-flight as "balanced"
+    // (the walker treated it as a leaf), then fail at per-item dispatch after
+    // clearActions had already wiped the rule. The fix dropped .toLowerCase()
+    // in _rmStructuralPairForCapability so it matches dispatch's case-
+    // sensitive comparison — mis-cased structural caps now project to null
+    // (leaf) AND will fail downstream dispatch, so this regression test
+    // expects either a pre-flight refusal (when the mis-spelling produces
+    // an imbalance) or a clearActions never firing.
+
+    def "replaceActions with mis-cased endIf is not silently accepted as balanced"() {
+        // ['ifThen', 'endIF' (wrong case)] — pre-fix this passed the pre-
+        // flight because the walker lowercased 'endIF' to 'endif' and saw
+        // a matched IF/END-IF pair. Post-fix the walker treats 'endIF' as
+        // a leaf (returns null pair), so the projected sequence is just
+        // [ifThen] which is imbalanced — pre-flight refuses.
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, [[name: "actType.1", value: "switchActs"]]) }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            replaceActions: [
+                [capability: "ifThen", expression: [conditions: [[capability: "Switch", deviceIds: [1], state: "on"]]]],
+                [capability: "endIF"]
+            ],
+            confirm: true
+        ])
+
+        then: "pre-flight refuses because mis-cased endIF doesn't satisfy the pair lookup"
+        result.success == false
+        result.error?.contains("replaceActions blocked")
+        result.error?.contains("structurally imbalanced")
+
+        and: "no trashAll click — the original rule is preserved (the #178 damage class)"
+        !posts.any { it.body?.get("name") == "trashAll" }
+    }
+
+    // Coverage for the auto-attached health field on update_native_app
+    // mutation responses — the PR's tool description promises this surface
+    // but no existing test pins it.
+
+    def "update_native_app attaches health.structuralIssues field on every mutation response"() {
+        given:
+        enableHubAdminWrite()
+        def delActFired = false
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/btn" && body?.get("stateAttribute") == "delAct") delActFired = true
+            [status: 200, location: null, data: '']
+        }
+        // Three-action balanced rule: IF / lock / END-IF.
+        def settings = ifStructureSettings([
+            [idx: 1, actType: "condActs", actSubType: "getIfThen"],
+            [idx: 2, actType: "lockActs", actSubType: "getLULock"],
+            [idx: 3, actType: "condActs", actSubType: "getEndIf"]
+        ])
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "Balanced", []) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            if (delActFired) {
+                statusJson(100, settings.findAll { !it.name?.endsWith(".2") })
+            } else {
+                statusJson(100, settings)
+            }
+        }
+
+        when: "remove the leaf lock action (no structural risk)"
+        def result = script.toolUpdateNativeApp([appId: 100, removeAction: [index: 2], confirm: true])
+
+        then: "the response surfaces health AND specifically the structuralIssues field"
+        result.success == true
+        result.health != null
+        result.health.structuralIssues != null
+        result.health.structuralIssues instanceof List
+        // The remaining IF/END-IF pair is still balanced, so structuralIssues is empty.
+        result.health.structuralIssues.isEmpty()
     }
 
     def "walkStep introspect returns schema for a page without mutating"() {


### PR DESCRIPTION
## Summary

- **Prevention** — three pre-flight refusal sites in `_rmDeleteAction`, `_rmAddAction` (closer-only), and `toolUpdateNativeApp`'s `replaceActions` / `patches[replaceActions]` handlers. Each builds a projected sequence using a shared block-balance walker and throws BEFORE any HTTP click goes out to RM, so the #172 false-fail post-response-commit race can't leak through into a malformed rule.
- **Detection** — `check_rule_health` walks `actType.<N>/actSubType.<N>` and surfaces unmatched IF / Repeat blocks via a new `structuralIssues` array. Kept as defense-in-depth for raw settings writes and the #172 race on non-structural deletes that the pre-flight can't see.
- No new MCP tools, no extra hub round-trip. Existing `check_rule_health` callers gain one array field; `removeAction`, `addAction`, and `replaceActions` paths gain a new throw class with a descriptive recovery hint.

## Type of change

- [ ] `feat` — new feature or capability
- [x] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- `hubitat-mcp-server.groovy`:
  - Three new private helpers: `_rmStructuralIssuesFromSequence` (pure walker), `_rmStructuralSequenceFromSettings` (builds from live appSettings with optional excludeIndices), `_rmStructuralPairForCapability` (cap → actType/actSubType for block-aware caps).
  - `_rmCheckRuleHealth` refactored to use the helpers; gains a `structuralIssues` field and a human-readable summary appended to `issues` when non-empty.
  - `_rmDeleteAction` pre-flight: if the deleted index is structural, projects-and-compares — throws if removing it would make the rule worse.
  - `_rmAddAction` pre-flight: bare `endIf` / `stopRepeat` refused if no matching opener is on the stack. Asymmetric on purpose (openers without closers are a normal multi-step build).
  - `toolUpdateNativeApp` top-level `replaceActions` AND the `patches[]` branch both validate the proposed spec list's balance pre-clear; refusal throws inside the existing try/catch so the response shape is unchanged.
  - Tool description + in-app guide updated for the new `structuralIssues` field.
- `src/test/groovy/server/ToolRmNativeCrudSpec.groovy` — 17 new Spock cases total: 8 for the health-check detection (orphan END-IF, orphan End-Repeat, stray ELSE-IF, cross-kind closer, balanced IF/ELSE-IF/ELSE/END-IF, balanced Repeat/End-Repeat, the live #178 3-IF/2-END-IF shape, the #178 reproduction), plus 9 for the new prevention paths (removeAction refuses inner END-IF / outer END-IF / inner IF; removeAction allows leaf and already-broken-rule improvement; addAction refuses bare endIf / stopRepeat; addAction allows bare ifThen; replaceActions refuses imbalanced and allows balanced; patches[replaceActions] refuses imbalanced).

## Release Notes

- `removeAction`, `addAction(capability='endIf'|'stopRepeat')`, and `replaceActions` now refuse the call before touching Rule Machine when the change would leave the rule with unmatched IF / ELSE-IF / ELSE / END-IF or Repeat / End-Repeat blocks. The previous behavior (where a #172-class false-fail could commit the bad change post-response) is gone — the buggy state is rejected before any HTTP click goes out. Same protection applies inside `patches[{replaceActions: [...]}]`.
- `check_rule_health` now flags rules that are already structurally imbalanced (e.g. 3 IFs and 2 END-IFs from a pre-fix mutation, or a raw settings write that bypasses the structured helpers) — the response gains a new `structuralIssues` array and the human-readable summary is appended to `issues`.

## Testing

- 17 new Spock cases, full `./gradlew test` green, `python tests/sandbox_lint.py` clean.
- **Live BAT verification on the test hub** with **Chrome screenshots** after every probe (not just MCP response text). On `BAT-178-Prevention-Nested` (the well-formed nested IF / IF / lock-delayed / END-IF / IF / lock / END-IF / END-IF reproduction rule):
  - `removeAction({index: 4})` inner END-IF → refused `"action 4 is a structural END-IF; removing it would leave the rule imbalanced (action 1 (IF) opened a block that was never closed)"`. Screenshot confirms rule unchanged.
  - `removeAction({index: 8})` outer END-IF → refused.
  - `removeAction({index: 2})` inner IF → refused with orphan-closer message.
  - `removeAction({index: 3})` leaf Lock action → pre-flight passed (correct). The subsequent delete hit the separate #172 false-fail race — that's not a regression, it's the known underlying bug this PR is layered defense for.
  - `addAction({capability: "endIf"})` on the balanced rule → refused `"rule 1551 has no matching open IF block on the action stack"`.
  - `addAction({capability: "stopRepeat"})` → refused with Repeat-specific message.
  - `replaceActions([imbalanced])` → refused before clearActions; screenshot confirms original rule preserved (no destructive clear).
  - `replaceActions([balanced])` → pre-flight allowed (correct).
  - `patches[{replaceActions: [imbalanced]}]` → refused at patch level; `note: \"Applied 0/1 patch ops\"`.
- BAT virtual devices + BAT rule deleted after verification.

## Checklist

- [x] **Unit tests added for any new MCP tools** (17 new Spock cases covering every detection and prevention path including the no-false-positive guards)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (full suite — no regressions)
- [ ] Live-hub BAT tests updated if tool behaviour changed — n/a (no new tool surface; existing tools refuse a new class of bad input before mutating)
- [x] Documentation updated if user-facing behaviour or tool surface changed (tool description + in-app guide entry)

Closes #178.