### PR TITLE
docs: codify MCP tool design rules in AGENTS.md + derivative docs (part of #105)

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -61,3 +61,18 @@ Best-effort judgment: read the diff and decide whether the prefix and ticked che
 - If the title says `docs:` but the diff edits Groovy logic, suggest the appropriate code prefix.
 
 This check is judgmental and you may misread the diff. That is expected and acceptable. Raise it as a suggestion only ("This looks more like a refactor than a feature — would you consider relabeling?"), not as a hard finding. Author pushback ends the discussion.
+
+### 4. New MCP tools follow `AGENTS.md` Tool Design Rules
+
+When a PR adds or renames an MCP tool, best-effort judgement: does the tool follow the conventions in `AGENTS.md` § Tool design rules? Eight broad areas to look at:
+
+1. **Naming** — `hub_` prefix present; verb from the allowed vocabulary; `manage_` used only for gateways (or the documented flat-multi-action exception).
+2. **Parameter names** — unambiguous (e.g. `device_id` not `id`); semantic over wired.
+3. **Annotations** — all four hints (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`) set explicitly.
+4. **Description quality** — concise first line; usage guidance; write-tool safety warnings present; semantic IDs over opaque UUIDs.
+5. **Consolidation candidates** — verb-pair tools (enable/disable, pause/resume, etc.) suggested for merge into a single `set_<noun>_<attribute>` tool; always-called-in-sequence tools flagged.
+6. **Schema design** — `enum` for fixed-set free-text params; `required` only when applicable; `outputSchema` present for structured returns.
+7. **Error contracts** — validation throws `IllegalArgumentException`; runtime returns `[success: false, error, note]`; `isError: true` for tool-execution errors; error text is recovery-oriented.
+8. **Pagination** — cursor support on any tool that can return a long list.
+
+Raise mismatches as suggestions only (e.g. "Consider `hub_get_room_health` instead of `check_room_health` — `check` folds into `get` in the verb vocabulary"). Don't mark as blocking, don't lower the verdict for naming nits. Author pushback ends the discussion.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,3 +42,4 @@
 - [ ] `./gradlew test` passes locally (or CI confirms)
 - [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
 - [ ] Documentation updated if user-facing behaviour or tool surface changed
+- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Use `atomicState` for thread-safe persistence, `state` for UI/counters. Compare 
 
 ## Tool design rules
 
-These rules apply to every MCP tool added or renamed from PR1 onward. PR3 (this PR) establishes the rules; PR1 (forthcoming) renames existing tools to match. Cached MCP clients refresh their tool list on update — no deprecation aliases are shipped.
+These rules apply to every MCP tool added or renamed. Cached MCP clients refresh their tool list on update — no deprecation aliases are shipped.
 
 ### Tool naming
 
@@ -39,7 +39,7 @@ These rules apply to every MCP tool added or renamed from PR1 onward. PR3 (this 
 - **Gateways.** `manage_` is reserved for gateway tools (e.g., `hub_manage_rooms`, `hub_manage_logs`). One narrow exception: a flat tool that exposes a small set (≤4) of action-dispatched verbs on a single noun may use `manage_` (current example: `hub_manage_virtual_device` with `action: "create"/"delete"`). Don't introduce more flat-multi-action tools without explicit maintainer sign-off.
 - **Multi-gateway membership.** A tool MAY appear under more than one gateway when both gateway domains apply.
 - **Gateway read/write split.** Gateways SHOULD be read-only OR write-only where the domain permits. Mixed-mode gateways are accepted only when splitting genuinely doesn't fit the domain. Pure-mode gateways enable cleaner per-gateway disable in LLM client settings and clearer mental models for AI consumers.
-- **Hard rename, no aliases.** PR1 will rename every non-conforming tool in lockstep. The expectation: MCP clients refresh their cached tool list on server update. No deprecation aliases are shipped.
+- **Hard rename, no aliases.** Non-conforming tools are renamed in lockstep when the convention requires it. The expectation: MCP clients refresh their cached tool list on server update. No deprecation aliases are shipped.
 
 ### Verb vocabulary
 
@@ -54,7 +54,7 @@ Tools use exactly one verb from the table below. The table is the canonical list
 | `create` | Write that produces a new entity | `install` |
 | `update` | Write that mutates one or more existing fields in place (PATCH-like) | `rename` |
 | `delete` | Write that destroys an entity (no ID = delete all) | `clear`, `remove` |
-| `set` | Write that assigns a value/state (`set_X_<attr>`) or replaces an entity wholesale (`set_X`, PUT-like) | `pause`, `resume`, `enable`, `disable`, `assign`, `unassign` |
+| `set` | Write that assigns a value/state (`set_X_<attr>`) or replaces an entity wholesale (`set_X`, PUT-like) | `pause`, `resume`, `enable`, `disable`, `lock`, `unlock`, `mute`, `unmute`, `start`, `stop`, `open`, `close`, `assign`, `unassign` |
 | `call` | Invoke a method / service / dispatch / device command | `send`, `dispatch`, `invoke`, `request`, `evaluate`, `run`, `force` |
 | `manage` | Action-dispatch — gateways + narrow flat-multi-action exception | — |
 | `restore` | Re-apply a prior backup | — |
@@ -108,7 +108,7 @@ Defaults for unannotated tools are deliberately cautious (non-read-only, potenti
 - Use `enum` to constrain allowed values where there is a fixed set. Reduces invalid-arg errors and gives the LLM a usable hint.
 - The `required` array is present only when there ARE required parameters; absent for fully-optional tools (existing rule; reaffirmed).
 - **Add `outputSchema` for any new tool that returns structured content.** Servers MUST conform to a published `outputSchema`; clients SHOULD validate. Source: MCP spec 2025-06-18 — `/server/tools`.
-- **Forward-looking.** The MCP specification next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. PR3 does not require adoption; flagged here so future tool work doesn't re-discover it.
+- **Forward-looking.** The MCP specification next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. Not required today; flagged here so future tool work doesn't re-discover it.
 
 ### Error contracts
 
@@ -141,9 +141,9 @@ All rules above cite verified sources, re-checked on 2026-05-26.
 - OpenAI — *Function calling guide* — developers.openai.com/api/docs/guides/function-calling.
 - Cloudflare — *Code Mode* — blog.cloudflare.com/code-mode-mcp/ (2026-02-20).
 - FastMCP — gofastmcp.com/servers/tools (v3 docs). **Peer reference only — ideas worth considering, not enforced rules. The project is Groovy on the Hubitat sandbox; FastMCP is Python. Not every pattern transfers.**
-- MCP next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted in PR3.
+- MCP next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted yet.
 
-PR #202 (merged 2026-05-19) established the annotation-hints baseline on every shipped tool. PR3 codifies the rule going forward. PR1 (forthcoming) will rename existing tools to the new naming convention; PR2 (forthcoming) will audit non-tool conventions.
+PR #202 (merged 2026-05-19) established the annotation-hints baseline on every shipped tool.
 
 ## The custom MCP rule engine is legacy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ These rules apply to every MCP tool added or renamed from PR1 onward. PR3 (this 
 
 ### Verb vocabulary
 
-14 verbs + 2 destructive-ops exceptions + 1 locked-to-one-tool verb. Tools use exactly one verb from this table.
+Tools use exactly one verb from the table below. The table is the canonical list — `read`/`write` (file-manager domain), `report` (locked to one tool), and `reboot`/`shutdown` (destructive-ops domain) are narrow exceptions to the otherwise-general verb vocabulary.
 
 | Verb | Semantic | Folds in |
 |---|---|---|
@@ -77,7 +77,7 @@ Name parameters unambiguously. `device_id`, not `id`. `user_id`, not `user`. Whe
 1. **Verb-pair tools.** Two tools doing opposite state mutations on the same noun (enable/disable, pause/resume, lock/unlock, mute/unmute, start/stop, open/close) → merge into a single `set_<noun>_<attribute>` tool. Name the merged tool after the boolean/enum attribute being toggled, NOT after one of the two verbs (so `hub_set_rule_paused`, not `hub_set_rule_state` — the latter reads as a generic edit). Use boolean when binary; enum only when 3+ states or values aren't naturally true/false. Concrete: `pause_rm_rule` + `resume_rm_rule` → `hub_set_rule_paused`.
 2. **Flat multi-action tools.** A flat tool with an action enum is allowed ONLY when (a) actions share a noun, (b) action set is ≤4 verbs, and (c) a full `manage_` gateway would be overkill. Outside that, prefer separate tools or a real gateway. Concrete: `hub_manage_virtual_device` with `action: "create"/"delete"` fits.
 3. **Tools always called in sequence.** If callers always invoke A then B with no useful intermediate point, merge them. Anthropic's verified guidance: `get_customer_context` over three separate lookups; `schedule_event` over `list_users` + `list_events` + `create_event` — *writing-tools-for-agents*.
-4. **Overlapping noun + return shape.** Tools that only differ in a filter or projection should merge with an optional parameter. Precedent: PR #208's 103→95 reduction.
+4. **Overlapping noun + return shape.** Tools that only differ in a filter or projection should merge with an optional parameter. Recent example: PR #208 proposes a 103→95 tool reduction along these lines.
 5. **Single-action edge verbs.** Don't add a new verb for a single-action tool when an existing verb fits. `clear`/`remove` fold into `delete`; `rename` into `update`; `run`/`force` into `call`; `install` into `create`.
 6. **Anti-consolidation guardrails.** Don't merge tools whose error modes, safety gates, or payload shapes are fundamentally different (a Hub Admin Write tool with a no-gate read tool). Don't merge a time-critical tool with one whose schema would inflate context on every call. When in doubt, leave them separate.
 
@@ -108,13 +108,13 @@ Defaults for unannotated tools are deliberately cautious (non-read-only, potenti
 - Use `enum` to constrain allowed values where there is a fixed set. Reduces invalid-arg errors and gives the LLM a usable hint.
 - The `required` array is present only when there ARE required parameters; absent for fully-optional tools (existing rule; reaffirmed).
 - **Add `outputSchema` for any new tool that returns structured content.** Servers MUST conform to a published `outputSchema`; clients SHOULD validate. Source: MCP spec 2025-06-18 — `/server/tools`.
-- **Forward-looking.** The MCP 2026-07-28 Release Candidate (locked 2026-05-21) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. PR3 does not require adoption; flagged here so future tool work doesn't re-discover it.
+- **Forward-looking.** The MCP specification next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. PR3 does not require adoption; flagged here so future tool work doesn't re-discover it.
 
 ### Error contracts
 
 - **Validation errors** (caller-recoverable, bad args): throw `IllegalArgumentException`. Caught by `handleToolsCall` and mapped to JSON-RPC `-32602`. Existing pattern; reaffirmed.
 - **Runtime errors** (operation tried and failed for non-arg reasons): return `[success: false, error: <human-readable>, note: <actionable guidance>]`. Don't throw — the AI needs a structured error.
-- **`isError: true` envelope** for tool-execution errors per MCP spec 2025-06-18. Already adopted in v0.7.7+ (SKILL.md L449).
+- **`isError: true` envelope** for tool-execution errors per MCP spec 2025-06-18. Already adopted in v0.7.7+ (see SKILL.md § Version Management for the adoption note).
 - **Specific, actionable, recovery-oriented error text.** Tell the model how to recover. Anthropic recommends steering truncation errors toward recovery strategies like *"many small and targeted searches instead of a single, broad search."*
 
 ### Pagination & response-size discipline
@@ -141,7 +141,7 @@ All rules above cite verified sources, re-checked on 2026-05-26.
 - OpenAI — *Function calling guide* — developers.openai.com/api/docs/guides/function-calling.
 - Cloudflare — *Code Mode* — blog.cloudflare.com/code-mode-mcp/ (2026-02-20).
 - FastMCP — gofastmcp.com/servers/tools (v3 docs). **Peer reference only — ideas worth considering, not enforced rules. The project is Groovy on the Hubitat sandbox; FastMCP is Python. Not every pattern transfers.**
-- MCP 2026-07-28 Release Candidate (locked 2026-05-21) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted in PR3.
+- MCP next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted in PR3.
 
 PR #202 (merged 2026-05-19) established the annotation-hints baseline on every shipped tool. PR3 codifies the rule going forward. PR1 (forthcoming) will rename existing tools to the new naming convention; PR2 (forthcoming) will audit non-tool conventions.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,123 @@ Use `atomicState` for thread-safe persistence, `state` for UI/counters. Compare 
 
 **Comments**: only when the WHY is non-obvious. No multi-paragraph docblocks. Don't reference the current PR/issue/caller.
 
+## Tool design rules
+
+These rules apply to every MCP tool added or renamed from PR1 onward. PR3 (this PR) establishes the rules; PR1 (forthcoming) renames existing tools to match. Cached MCP clients refresh their tool list on update — no deprecation aliases are shipped.
+
+### Tool naming
+
+- **Universal service prefix.** Every MCP tool name begins with `hub_`. Anthropic's verified guidance: prefix-namespacing tools by service has "non-trivial effects on our tool-use evaluations" — *writing-tools-for-agents* (2025-09-11). Example: `hub_list_devices`, `hub_create_room`, `hub_call_device_command`.
+- **Verb-noun order.** After the `hub_` prefix, the name reads verb-noun. Verbs are drawn from the strict vocabulary table below. Nouns are the most natural English for the entity in context (drop redundant qualifiers — e.g., `rule` is preferred over `rm_rule` where context disambiguates).
+- **Gateways.** `manage_` is reserved for gateway tools (e.g., `hub_manage_rooms`, `hub_manage_logs`). One narrow exception: a flat tool that exposes a small set (≤4) of action-dispatched verbs on a single noun may use `manage_` (current example: `hub_manage_virtual_device` with `action: "create"/"delete"`). Don't introduce more flat-multi-action tools without explicit maintainer sign-off.
+- **Multi-gateway membership.** A tool MAY appear under more than one gateway when both gateway domains apply.
+- **Gateway read/write split.** Gateways SHOULD be read-only OR write-only where the domain permits. Mixed-mode gateways are accepted only when splitting genuinely doesn't fit the domain. Pure-mode gateways enable cleaner per-gateway disable in LLM client settings and clearer mental models for AI consumers.
+- **Hard rename, no aliases.** PR1 will rename every non-conforming tool in lockstep. The expectation: MCP clients refresh their cached tool list on server update. No deprecation aliases are shipped.
+
+### Verb vocabulary
+
+14 verbs + 2 destructive-ops exceptions + 1 locked-to-one-tool verb. Tools use exactly one verb from this table.
+
+| Verb | Semantic | Folds in |
+|---|---|---|
+| `list` | Plural read, returns array of summaries | — |
+| `get` | Singular read OR diagnostic verdict | `find`, `check`, `validate` |
+| `search` | Read with query, returns ranked array | — |
+| `test` | Dry-run with no side effects | — |
+| `create` | Write that produces a new entity | `install` |
+| `update` | Write that mutates one or more existing fields in place (PATCH-like) | `rename` |
+| `delete` | Write that destroys an entity (no ID = delete all) | `clear`, `remove` |
+| `set` | Write that assigns a value/state (`set_X_<attr>`) or replaces an entity wholesale (`set_X`, PUT-like) | `pause`, `resume`, `enable`, `disable`, `assign`, `unassign` |
+| `call` | Invoke a method / service / dispatch / device command | `send`, `dispatch`, `invoke`, `request`, `evaluate`, `run`, `force` |
+| `manage` | Action-dispatch — gateways + narrow flat-multi-action exception | — |
+| `restore` | Re-apply a prior backup | — |
+| `import` / `export` | Round-trip serialization counterpart | — |
+| `clone` | Duplicate an existing entity | — |
+| `read` / `write` | File-manager domain only — narrow exception | — |
+| `report` | LOCKED to `hub_report_issue` only | — |
+| `reboot` / `shutdown` | EXCEPTIONS — destructive-ops gateway only | — |
+
+**Don't introduce new verbs without a justification stronger than "I felt like it."** If an existing verb fits, use it. The `set` vs `update` distinction is intentional: `set_X_<attr>` assigns one specific value or state; `set_X` replaces wholesale; `update_X` mutates a subset of fields in place. Author judgement applies per-tool.
+
+Rule-engine action subtypes (`cancelTimers`, `cancelDelay`, etc. inside `custom_*` and `create_native_app` arguments) are separate from MCP tool names and not constrained by this vocabulary.
+
+### Parameter naming
+
+Name parameters unambiguously. `device_id`, not `id`. `user_id`, not `user`. Where the parameter takes a complex value, name the parameter after what it semantically IS, not how it's wired. Anthropic's verified guidance: *"instead of a parameter named user, try a parameter named user_id"* — *writing-tools-for-agents*.
+
+### Tool consolidation guidelines
+
+1. **Verb-pair tools.** Two tools doing opposite state mutations on the same noun (enable/disable, pause/resume, lock/unlock, mute/unmute, start/stop, open/close) → merge into a single `set_<noun>_<attribute>` tool. Name the merged tool after the boolean/enum attribute being toggled, NOT after one of the two verbs (so `hub_set_rule_paused`, not `hub_set_rule_state` — the latter reads as a generic edit). Use boolean when binary; enum only when 3+ states or values aren't naturally true/false. Concrete: `pause_rm_rule` + `resume_rm_rule` → `hub_set_rule_paused`.
+2. **Flat multi-action tools.** A flat tool with an action enum is allowed ONLY when (a) actions share a noun, (b) action set is ≤4 verbs, and (c) a full `manage_` gateway would be overkill. Outside that, prefer separate tools or a real gateway. Concrete: `hub_manage_virtual_device` with `action: "create"/"delete"` fits.
+3. **Tools always called in sequence.** If callers always invoke A then B with no useful intermediate point, merge them. Anthropic's verified guidance: `get_customer_context` over three separate lookups; `schedule_event` over `list_users` + `list_events` + `create_event` — *writing-tools-for-agents*.
+4. **Overlapping noun + return shape.** Tools that only differ in a filter or projection should merge with an optional parameter. Precedent: PR #208's 103→95 reduction.
+5. **Single-action edge verbs.** Don't add a new verb for a single-action tool when an existing verb fits. `clear`/`remove` fold into `delete`; `rename` into `update`; `run`/`force` into `call`; `install` into `create`.
+6. **Anti-consolidation guardrails.** Don't merge tools whose error modes, safety gates, or payload shapes are fundamentally different (a Hub Admin Write tool with a no-gate read tool). Don't merge a time-critical tool with one whose schema would inflate context on every call. When in doubt, leave them separate.
+
+### Annotations — all four hints, every new tool
+
+Every new MCP tool MUST set all four annotation hints explicitly:
+
+- `readOnlyHint` — true if no environment modification.
+- `destructiveHint` — true if the change is destructive / irreversible.
+- `idempotentHint` — true if safe to retry with identical args.
+- `openWorldHint` — true if the tool interacts with external entities.
+
+Defaults for unannotated tools are deliberately cautious (non-read-only, potentially destructive, non-idempotent, open-world). Explicit annotations are safer than implicit defaults. Source: MCP blog *Tool Annotations as Risk Vocabulary* (2026-03-16); baseline already shipped via PR #202 (merged 2026-05-19).
+
+**Annotations are UX/risk hints, NOT a security boundary.** The MCP blog is explicit: *"They don't make the model resist prompt injection… annotations alone are not a control."* Safety in this project still requires the existing Hub Admin Read / Hub Admin Write gates and `confirm` parameter checks. Annotations are advisory metadata to the client, nothing more.
+
+### Tool descriptions
+
+- **First line:** concise summary of what the tool does. Tool descriptions are what the LLM reads when deciding whether to call this tool; the first line is what gets noticed.
+- **Body:** usage guidance — when/how to use the tool, performance notes, pagination guidance, behavioural expectations.
+- **Write tools:** safety warning + mandatory pre-flight checklist directly in the description (already required; reaffirmed).
+- **Make implicit context explicit.** Terminology quirks, query-language constraints, resource relationships — write them in. Anthropic: *"Even small refinements to tool descriptions can yield dramatic improvements."*
+- **Semantic names beat opaque UUIDs.** Where a tool returns an identifier, prefer human-meaningful names over raw UUIDs; if a technical ID is needed for chaining, expose both name AND id. Anthropic: *"resolving arbitrary alphanumeric UUIDs to more semantically meaningful and interpretable language… significantly improves Claude's precision in retrieval tasks by reducing hallucinations."*
+
+### Schema design
+
+- `inputSchema` root is `type: "object"` with `properties` (existing rule; reaffirmed).
+- Use `enum` to constrain allowed values where there is a fixed set. Reduces invalid-arg errors and gives the LLM a usable hint.
+- The `required` array is present only when there ARE required parameters; absent for fully-optional tools (existing rule; reaffirmed).
+- **Add `outputSchema` for any new tool that returns structured content.** Servers MUST conform to a published `outputSchema`; clients SHOULD validate. Source: MCP spec 2025-06-18 — `/server/tools`.
+- **Forward-looking.** The MCP 2026-07-28 Release Candidate (locked 2026-05-21) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. PR3 does not require adoption; flagged here so future tool work doesn't re-discover it.
+
+### Error contracts
+
+- **Validation errors** (caller-recoverable, bad args): throw `IllegalArgumentException`. Caught by `handleToolsCall` and mapped to JSON-RPC `-32602`. Existing pattern; reaffirmed.
+- **Runtime errors** (operation tried and failed for non-arg reasons): return `[success: false, error: <human-readable>, note: <actionable guidance>]`. Don't throw — the AI needs a structured error.
+- **`isError: true` envelope** for tool-execution errors per MCP spec 2025-06-18. Already adopted in v0.7.7+ (SKILL.md L449).
+- **Specific, actionable, recovery-oriented error text.** Tell the model how to recover. Anthropic recommends steering truncation errors toward recovery strategies like *"many small and targeted searches instead of a single, broad search."*
+
+### Pagination & response-size discipline
+
+- Tools that can return long lists MUST support the project's universal cursor convention (`cursor` / `nextCursor`), unless the response naturally fits within the 120KB `tools/call` cap. Current cursor-paginated tools are listed in `TOOL_GUIDE.md`.
+- For tools where a "concise" vs "detailed" payload distinction is useful, support a `response_format` enum or equivalent. Anthropic's worked example reduced a response from 206 tokens to 72 just by adding the enum.
+- The universal 120KB response-size guard at `handleMcpRequest` remains the backstop — it is NOT a substitute for in-tool filtering, pagination, or projection.
+
+### Testing & eval
+
+- Every new MCP tool ships with BOTH a direct-call (unit) test AND a dispatch-envelope (integration) test under `src/test/groovy/` (existing CONTRIBUTING.md rule; reaffirmed).
+- If the tool's behaviour affects live-hub flows, add a `tests/BAT-v2.md` scenario in the same PR.
+- Track tool errors during eval. High invalid-parameter rates usually indicate the description or examples are the bug, not the model. Anthropic's example: Claude was appending `2025` to web-search queries until the description was fixed.
+
+### Sources
+
+All rules above cite verified sources, re-checked on 2026-05-26.
+
+- Anthropic — *Writing effective tools for agents* — anthropic.com/engineering/writing-tools-for-agents (2025-09-11).
+- Anthropic — *Code execution with MCP* — anthropic.com/engineering/code-execution-with-mcp (2025-11-04).
+- Anthropic — *Advanced tool use* — anthropic.com/engineering/advanced-tool-use (2025-11-24).
+- MCP Specification 2025-06-18 — `/server/tools` and `/client/elicitation` — modelcontextprotocol.io/specification/2025-06-18/.
+- MCP Blog — *Tool Annotations as Risk Vocabulary* — blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/ (2026-03-16).
+- OpenAI — *Function calling guide* — developers.openai.com/api/docs/guides/function-calling.
+- Cloudflare — *Code Mode* — blog.cloudflare.com/code-mode-mcp/ (2026-02-20).
+- FastMCP — gofastmcp.com/servers/tools (v3 docs). **Peer reference only — ideas worth considering, not enforced rules. The project is Groovy on the Hubitat sandbox; FastMCP is Python. Not every pattern transfers.**
+- MCP 2026-07-28 Release Candidate (locked 2026-05-21) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted in PR3.
+
+PR #202 (merged 2026-05-19) established the annotation-hints baseline on every shipped tool. PR3 codifies the rule going forward. PR1 (forthcoming) will rename existing tools to the new naming convention; PR2 (forthcoming) will audit non-tool conventions.
+
 ## The custom MCP rule engine is legacy
 
 `hubitat-mcp-rule.groovy` (the MCP child app, surfaced through the `custom_*` tools) is **legacy**. It still ships and still gets bug fixes, but it is **closed to new feature work** — Hubitat's native Rule Machine is the supported path now and exposes equivalent functionality through `create_native_app` / `update_native_app` / `delete_native_app` and the rest of the `manage_native_rules_and_apps` group. New rule-related capabilities should land on the parent app's native-RM tools, not on the child app. If a feature request lands on the child app, propose it for the native side instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Use `atomicState` for thread-safe persistence, `state` for UI/counters. Compare 
 
 ## Tool design rules
 
-These rules apply to every MCP tool added or renamed from PR1 onward. PR3 (this PR) establishes the rules; PR1 (forthcoming) renames existing tools to match. Cached MCP clients refresh their tool list on update — no deprecation aliases are shipped.
+These rules apply to every MCP tool added or renamed. Cached MCP clients refresh their tool list on update — no deprecation aliases are shipped.
 
 ### Tool naming
 
@@ -39,7 +39,7 @@ These rules apply to every MCP tool added or renamed from PR1 onward. PR3 (this 
 - **Gateways.** `manage_` is reserved for gateway tools (e.g., `hub_manage_rooms`, `hub_manage_logs`). One narrow exception: a flat tool that exposes a small set (≤4) of action-dispatched verbs on a single noun may use `manage_` (current example: `hub_manage_virtual_device` with `action: "create"/"delete"`). Don't introduce more flat-multi-action tools without explicit maintainer sign-off.
 - **Multi-gateway membership.** A tool MAY appear under more than one gateway when both gateway domains apply.
 - **Gateway read/write split.** Gateways SHOULD be read-only OR write-only where the domain permits. Mixed-mode gateways are accepted only when splitting genuinely doesn't fit the domain. Pure-mode gateways enable cleaner per-gateway disable in LLM client settings and clearer mental models for AI consumers.
-- **Hard rename, no aliases.** PR1 will rename every non-conforming tool in lockstep. The expectation: MCP clients refresh their cached tool list on server update. No deprecation aliases are shipped.
+- **Hard rename, no aliases.** Non-conforming tools are renamed in lockstep when the convention requires it. The expectation: MCP clients refresh their cached tool list on server update. No deprecation aliases are shipped.
 
 ### Verb vocabulary
 
@@ -54,7 +54,7 @@ Tools use exactly one verb from the table below. The table is the canonical list
 | `create` | Write that produces a new entity | `install` |
 | `update` | Write that mutates one or more existing fields in place (PATCH-like) | `rename` |
 | `delete` | Write that destroys an entity (no ID = delete all) | `clear`, `remove` |
-| `set` | Write that assigns a value/state (`set_X_<attr>`) or replaces an entity wholesale (`set_X`, PUT-like) | `pause`, `resume`, `enable`, `disable`, `assign`, `unassign` |
+| `set` | Write that assigns a value/state (`set_X_<attr>`) or replaces an entity wholesale (`set_X`, PUT-like) | `pause`, `resume`, `enable`, `disable`, `lock`, `unlock`, `mute`, `unmute`, `start`, `stop`, `open`, `close`, `assign`, `unassign` |
 | `call` | Invoke a method / service / dispatch / device command | `send`, `dispatch`, `invoke`, `request`, `evaluate`, `run`, `force` |
 | `manage` | Action-dispatch — gateways + narrow flat-multi-action exception | — |
 | `restore` | Re-apply a prior backup | — |
@@ -108,7 +108,7 @@ Defaults for unannotated tools are deliberately cautious (non-read-only, potenti
 - Use `enum` to constrain allowed values where there is a fixed set. Reduces invalid-arg errors and gives the LLM a usable hint.
 - The `required` array is present only when there ARE required parameters; absent for fully-optional tools (existing rule; reaffirmed).
 - **Add `outputSchema` for any new tool that returns structured content.** Servers MUST conform to a published `outputSchema`; clients SHOULD validate. Source: MCP spec 2025-06-18 — `/server/tools`.
-- **Forward-looking.** The MCP specification next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. PR3 does not require adoption; flagged here so future tool work doesn't re-discover it.
+- **Forward-looking.** The MCP specification next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. Not required today; flagged here so future tool work doesn't re-discover it.
 
 ### Error contracts
 
@@ -141,9 +141,9 @@ All rules above cite verified sources, re-checked on 2026-05-26.
 - OpenAI — *Function calling guide* — developers.openai.com/api/docs/guides/function-calling.
 - Cloudflare — *Code Mode* — blog.cloudflare.com/code-mode-mcp/ (2026-02-20).
 - FastMCP — gofastmcp.com/servers/tools (v3 docs). **Peer reference only — ideas worth considering, not enforced rules. The project is Groovy on the Hubitat sandbox; FastMCP is Python. Not every pattern transfers.**
-- MCP next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted in PR3.
+- MCP next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted yet.
 
-PR #202 (merged 2026-05-19) established the annotation-hints baseline on every shipped tool. PR3 codifies the rule going forward. PR1 (forthcoming) will rename existing tools to the new naming convention; PR2 (forthcoming) will audit non-tool conventions.
+PR #202 (merged 2026-05-19) established the annotation-hints baseline on every shipped tool.
 
 ## The custom MCP rule engine is legacy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ These rules apply to every MCP tool added or renamed from PR1 onward. PR3 (this 
 
 ### Verb vocabulary
 
-14 verbs + 2 destructive-ops exceptions + 1 locked-to-one-tool verb. Tools use exactly one verb from this table.
+Tools use exactly one verb from the table below. The table is the canonical list — `read`/`write` (file-manager domain), `report` (locked to one tool), and `reboot`/`shutdown` (destructive-ops domain) are narrow exceptions to the otherwise-general verb vocabulary.
 
 | Verb | Semantic | Folds in |
 |---|---|---|
@@ -77,7 +77,7 @@ Name parameters unambiguously. `device_id`, not `id`. `user_id`, not `user`. Whe
 1. **Verb-pair tools.** Two tools doing opposite state mutations on the same noun (enable/disable, pause/resume, lock/unlock, mute/unmute, start/stop, open/close) → merge into a single `set_<noun>_<attribute>` tool. Name the merged tool after the boolean/enum attribute being toggled, NOT after one of the two verbs (so `hub_set_rule_paused`, not `hub_set_rule_state` — the latter reads as a generic edit). Use boolean when binary; enum only when 3+ states or values aren't naturally true/false. Concrete: `pause_rm_rule` + `resume_rm_rule` → `hub_set_rule_paused`.
 2. **Flat multi-action tools.** A flat tool with an action enum is allowed ONLY when (a) actions share a noun, (b) action set is ≤4 verbs, and (c) a full `manage_` gateway would be overkill. Outside that, prefer separate tools or a real gateway. Concrete: `hub_manage_virtual_device` with `action: "create"/"delete"` fits.
 3. **Tools always called in sequence.** If callers always invoke A then B with no useful intermediate point, merge them. Anthropic's verified guidance: `get_customer_context` over three separate lookups; `schedule_event` over `list_users` + `list_events` + `create_event` — *writing-tools-for-agents*.
-4. **Overlapping noun + return shape.** Tools that only differ in a filter or projection should merge with an optional parameter. Precedent: PR #208's 103→95 reduction.
+4. **Overlapping noun + return shape.** Tools that only differ in a filter or projection should merge with an optional parameter. Recent example: PR #208 proposes a 103→95 tool reduction along these lines.
 5. **Single-action edge verbs.** Don't add a new verb for a single-action tool when an existing verb fits. `clear`/`remove` fold into `delete`; `rename` into `update`; `run`/`force` into `call`; `install` into `create`.
 6. **Anti-consolidation guardrails.** Don't merge tools whose error modes, safety gates, or payload shapes are fundamentally different (a Hub Admin Write tool with a no-gate read tool). Don't merge a time-critical tool with one whose schema would inflate context on every call. When in doubt, leave them separate.
 
@@ -108,13 +108,13 @@ Defaults for unannotated tools are deliberately cautious (non-read-only, potenti
 - Use `enum` to constrain allowed values where there is a fixed set. Reduces invalid-arg errors and gives the LLM a usable hint.
 - The `required` array is present only when there ARE required parameters; absent for fully-optional tools (existing rule; reaffirmed).
 - **Add `outputSchema` for any new tool that returns structured content.** Servers MUST conform to a published `outputSchema`; clients SHOULD validate. Source: MCP spec 2025-06-18 — `/server/tools`.
-- **Forward-looking.** The MCP 2026-07-28 Release Candidate (locked 2026-05-21) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. PR3 does not require adoption; flagged here so future tool work doesn't re-discover it.
+- **Forward-looking.** The MCP specification next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. PR3 does not require adoption; flagged here so future tool work doesn't re-discover it.
 
 ### Error contracts
 
 - **Validation errors** (caller-recoverable, bad args): throw `IllegalArgumentException`. Caught by `handleToolsCall` and mapped to JSON-RPC `-32602`. Existing pattern; reaffirmed.
 - **Runtime errors** (operation tried and failed for non-arg reasons): return `[success: false, error: <human-readable>, note: <actionable guidance>]`. Don't throw — the AI needs a structured error.
-- **`isError: true` envelope** for tool-execution errors per MCP spec 2025-06-18. Already adopted in v0.7.7+ (SKILL.md L449).
+- **`isError: true` envelope** for tool-execution errors per MCP spec 2025-06-18. Already adopted in v0.7.7+ (see SKILL.md § Version Management for the adoption note).
 - **Specific, actionable, recovery-oriented error text.** Tell the model how to recover. Anthropic recommends steering truncation errors toward recovery strategies like *"many small and targeted searches instead of a single, broad search."*
 
 ### Pagination & response-size discipline
@@ -141,7 +141,7 @@ All rules above cite verified sources, re-checked on 2026-05-26.
 - OpenAI — *Function calling guide* — developers.openai.com/api/docs/guides/function-calling.
 - Cloudflare — *Code Mode* — blog.cloudflare.com/code-mode-mcp/ (2026-02-20).
 - FastMCP — gofastmcp.com/servers/tools (v3 docs). **Peer reference only — ideas worth considering, not enforced rules. The project is Groovy on the Hubitat sandbox; FastMCP is Python. Not every pattern transfers.**
-- MCP 2026-07-28 Release Candidate (locked 2026-05-21) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted in PR3.
+- MCP next-revision Release Candidate (RC locked 2026-05-21, targets 2026-07-28 publication) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted in PR3.
 
 PR #202 (merged 2026-05-19) established the annotation-hints baseline on every shipped tool. PR3 codifies the rule going forward. PR1 (forthcoming) will rename existing tools to the new naming convention; PR2 (forthcoming) will audit non-tool conventions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,123 @@ Use `atomicState` for thread-safe persistence, `state` for UI/counters. Compare 
 
 **Comments**: only when the WHY is non-obvious. No multi-paragraph docblocks. Don't reference the current PR/issue/caller.
 
+## Tool design rules
+
+These rules apply to every MCP tool added or renamed from PR1 onward. PR3 (this PR) establishes the rules; PR1 (forthcoming) renames existing tools to match. Cached MCP clients refresh their tool list on update — no deprecation aliases are shipped.
+
+### Tool naming
+
+- **Universal service prefix.** Every MCP tool name begins with `hub_`. Anthropic's verified guidance: prefix-namespacing tools by service has "non-trivial effects on our tool-use evaluations" — *writing-tools-for-agents* (2025-09-11). Example: `hub_list_devices`, `hub_create_room`, `hub_call_device_command`.
+- **Verb-noun order.** After the `hub_` prefix, the name reads verb-noun. Verbs are drawn from the strict vocabulary table below. Nouns are the most natural English for the entity in context (drop redundant qualifiers — e.g., `rule` is preferred over `rm_rule` where context disambiguates).
+- **Gateways.** `manage_` is reserved for gateway tools (e.g., `hub_manage_rooms`, `hub_manage_logs`). One narrow exception: a flat tool that exposes a small set (≤4) of action-dispatched verbs on a single noun may use `manage_` (current example: `hub_manage_virtual_device` with `action: "create"/"delete"`). Don't introduce more flat-multi-action tools without explicit maintainer sign-off.
+- **Multi-gateway membership.** A tool MAY appear under more than one gateway when both gateway domains apply.
+- **Gateway read/write split.** Gateways SHOULD be read-only OR write-only where the domain permits. Mixed-mode gateways are accepted only when splitting genuinely doesn't fit the domain. Pure-mode gateways enable cleaner per-gateway disable in LLM client settings and clearer mental models for AI consumers.
+- **Hard rename, no aliases.** PR1 will rename every non-conforming tool in lockstep. The expectation: MCP clients refresh their cached tool list on server update. No deprecation aliases are shipped.
+
+### Verb vocabulary
+
+14 verbs + 2 destructive-ops exceptions + 1 locked-to-one-tool verb. Tools use exactly one verb from this table.
+
+| Verb | Semantic | Folds in |
+|---|---|---|
+| `list` | Plural read, returns array of summaries | — |
+| `get` | Singular read OR diagnostic verdict | `find`, `check`, `validate` |
+| `search` | Read with query, returns ranked array | — |
+| `test` | Dry-run with no side effects | — |
+| `create` | Write that produces a new entity | `install` |
+| `update` | Write that mutates one or more existing fields in place (PATCH-like) | `rename` |
+| `delete` | Write that destroys an entity (no ID = delete all) | `clear`, `remove` |
+| `set` | Write that assigns a value/state (`set_X_<attr>`) or replaces an entity wholesale (`set_X`, PUT-like) | `pause`, `resume`, `enable`, `disable`, `assign`, `unassign` |
+| `call` | Invoke a method / service / dispatch / device command | `send`, `dispatch`, `invoke`, `request`, `evaluate`, `run`, `force` |
+| `manage` | Action-dispatch — gateways + narrow flat-multi-action exception | — |
+| `restore` | Re-apply a prior backup | — |
+| `import` / `export` | Round-trip serialization counterpart | — |
+| `clone` | Duplicate an existing entity | — |
+| `read` / `write` | File-manager domain only — narrow exception | — |
+| `report` | LOCKED to `hub_report_issue` only | — |
+| `reboot` / `shutdown` | EXCEPTIONS — destructive-ops gateway only | — |
+
+**Don't introduce new verbs without a justification stronger than "I felt like it."** If an existing verb fits, use it. The `set` vs `update` distinction is intentional: `set_X_<attr>` assigns one specific value or state; `set_X` replaces wholesale; `update_X` mutates a subset of fields in place. Author judgement applies per-tool.
+
+Rule-engine action subtypes (`cancelTimers`, `cancelDelay`, etc. inside `custom_*` and `create_native_app` arguments) are separate from MCP tool names and not constrained by this vocabulary.
+
+### Parameter naming
+
+Name parameters unambiguously. `device_id`, not `id`. `user_id`, not `user`. Where the parameter takes a complex value, name the parameter after what it semantically IS, not how it's wired. Anthropic's verified guidance: *"instead of a parameter named user, try a parameter named user_id"* — *writing-tools-for-agents*.
+
+### Tool consolidation guidelines
+
+1. **Verb-pair tools.** Two tools doing opposite state mutations on the same noun (enable/disable, pause/resume, lock/unlock, mute/unmute, start/stop, open/close) → merge into a single `set_<noun>_<attribute>` tool. Name the merged tool after the boolean/enum attribute being toggled, NOT after one of the two verbs (so `hub_set_rule_paused`, not `hub_set_rule_state` — the latter reads as a generic edit). Use boolean when binary; enum only when 3+ states or values aren't naturally true/false. Concrete: `pause_rm_rule` + `resume_rm_rule` → `hub_set_rule_paused`.
+2. **Flat multi-action tools.** A flat tool with an action enum is allowed ONLY when (a) actions share a noun, (b) action set is ≤4 verbs, and (c) a full `manage_` gateway would be overkill. Outside that, prefer separate tools or a real gateway. Concrete: `hub_manage_virtual_device` with `action: "create"/"delete"` fits.
+3. **Tools always called in sequence.** If callers always invoke A then B with no useful intermediate point, merge them. Anthropic's verified guidance: `get_customer_context` over three separate lookups; `schedule_event` over `list_users` + `list_events` + `create_event` — *writing-tools-for-agents*.
+4. **Overlapping noun + return shape.** Tools that only differ in a filter or projection should merge with an optional parameter. Precedent: PR #208's 103→95 reduction.
+5. **Single-action edge verbs.** Don't add a new verb for a single-action tool when an existing verb fits. `clear`/`remove` fold into `delete`; `rename` into `update`; `run`/`force` into `call`; `install` into `create`.
+6. **Anti-consolidation guardrails.** Don't merge tools whose error modes, safety gates, or payload shapes are fundamentally different (a Hub Admin Write tool with a no-gate read tool). Don't merge a time-critical tool with one whose schema would inflate context on every call. When in doubt, leave them separate.
+
+### Annotations — all four hints, every new tool
+
+Every new MCP tool MUST set all four annotation hints explicitly:
+
+- `readOnlyHint` — true if no environment modification.
+- `destructiveHint` — true if the change is destructive / irreversible.
+- `idempotentHint` — true if safe to retry with identical args.
+- `openWorldHint` — true if the tool interacts with external entities.
+
+Defaults for unannotated tools are deliberately cautious (non-read-only, potentially destructive, non-idempotent, open-world). Explicit annotations are safer than implicit defaults. Source: MCP blog *Tool Annotations as Risk Vocabulary* (2026-03-16); baseline already shipped via PR #202 (merged 2026-05-19).
+
+**Annotations are UX/risk hints, NOT a security boundary.** The MCP blog is explicit: *"They don't make the model resist prompt injection… annotations alone are not a control."* Safety in this project still requires the existing Hub Admin Read / Hub Admin Write gates and `confirm` parameter checks. Annotations are advisory metadata to the client, nothing more.
+
+### Tool descriptions
+
+- **First line:** concise summary of what the tool does. Tool descriptions are what the LLM reads when deciding whether to call this tool; the first line is what gets noticed.
+- **Body:** usage guidance — when/how to use the tool, performance notes, pagination guidance, behavioural expectations.
+- **Write tools:** safety warning + mandatory pre-flight checklist directly in the description (already required; reaffirmed).
+- **Make implicit context explicit.** Terminology quirks, query-language constraints, resource relationships — write them in. Anthropic: *"Even small refinements to tool descriptions can yield dramatic improvements."*
+- **Semantic names beat opaque UUIDs.** Where a tool returns an identifier, prefer human-meaningful names over raw UUIDs; if a technical ID is needed for chaining, expose both name AND id. Anthropic: *"resolving arbitrary alphanumeric UUIDs to more semantically meaningful and interpretable language… significantly improves Claude's precision in retrieval tasks by reducing hallucinations."*
+
+### Schema design
+
+- `inputSchema` root is `type: "object"` with `properties` (existing rule; reaffirmed).
+- Use `enum` to constrain allowed values where there is a fixed set. Reduces invalid-arg errors and gives the LLM a usable hint.
+- The `required` array is present only when there ARE required parameters; absent for fully-optional tools (existing rule; reaffirmed).
+- **Add `outputSchema` for any new tool that returns structured content.** Servers MUST conform to a published `outputSchema`; clients SHOULD validate. Source: MCP spec 2025-06-18 — `/server/tools`.
+- **Forward-looking.** The MCP 2026-07-28 Release Candidate (locked 2026-05-21) adds `_meta` on every request and `ttlMs`/`cacheScope` cache hints on list responses. PR3 does not require adoption; flagged here so future tool work doesn't re-discover it.
+
+### Error contracts
+
+- **Validation errors** (caller-recoverable, bad args): throw `IllegalArgumentException`. Caught by `handleToolsCall` and mapped to JSON-RPC `-32602`. Existing pattern; reaffirmed.
+- **Runtime errors** (operation tried and failed for non-arg reasons): return `[success: false, error: <human-readable>, note: <actionable guidance>]`. Don't throw — the AI needs a structured error.
+- **`isError: true` envelope** for tool-execution errors per MCP spec 2025-06-18. Already adopted in v0.7.7+ (SKILL.md L449).
+- **Specific, actionable, recovery-oriented error text.** Tell the model how to recover. Anthropic recommends steering truncation errors toward recovery strategies like *"many small and targeted searches instead of a single, broad search."*
+
+### Pagination & response-size discipline
+
+- Tools that can return long lists MUST support the project's universal cursor convention (`cursor` / `nextCursor`), unless the response naturally fits within the 120KB `tools/call` cap. Current cursor-paginated tools are listed in `TOOL_GUIDE.md`.
+- For tools where a "concise" vs "detailed" payload distinction is useful, support a `response_format` enum or equivalent. Anthropic's worked example reduced a response from 206 tokens to 72 just by adding the enum.
+- The universal 120KB response-size guard at `handleMcpRequest` remains the backstop — it is NOT a substitute for in-tool filtering, pagination, or projection.
+
+### Testing & eval
+
+- Every new MCP tool ships with BOTH a direct-call (unit) test AND a dispatch-envelope (integration) test under `src/test/groovy/` (existing CONTRIBUTING.md rule; reaffirmed).
+- If the tool's behaviour affects live-hub flows, add a `tests/BAT-v2.md` scenario in the same PR.
+- Track tool errors during eval. High invalid-parameter rates usually indicate the description or examples are the bug, not the model. Anthropic's example: Claude was appending `2025` to web-search queries until the description was fixed.
+
+### Sources
+
+All rules above cite verified sources, re-checked on 2026-05-26.
+
+- Anthropic — *Writing effective tools for agents* — anthropic.com/engineering/writing-tools-for-agents (2025-09-11).
+- Anthropic — *Code execution with MCP* — anthropic.com/engineering/code-execution-with-mcp (2025-11-04).
+- Anthropic — *Advanced tool use* — anthropic.com/engineering/advanced-tool-use (2025-11-24).
+- MCP Specification 2025-06-18 — `/server/tools` and `/client/elicitation` — modelcontextprotocol.io/specification/2025-06-18/.
+- MCP Blog — *Tool Annotations as Risk Vocabulary* — blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/ (2026-03-16).
+- OpenAI — *Function calling guide* — developers.openai.com/api/docs/guides/function-calling.
+- Cloudflare — *Code Mode* — blog.cloudflare.com/code-mode-mcp/ (2026-02-20).
+- FastMCP — gofastmcp.com/servers/tools (v3 docs). **Peer reference only — ideas worth considering, not enforced rules. The project is Groovy on the Hubitat sandbox; FastMCP is Python. Not every pattern transfers.**
+- MCP 2026-07-28 Release Candidate (locked 2026-05-21) — blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/. Forward-looking direction; not adopted in PR3.
+
+PR #202 (merged 2026-05-19) established the annotation-hints baseline on every shipped tool. PR3 codifies the rule going forward. PR1 (forthcoming) will rename existing tools to the new naming convention; PR2 (forthcoming) will audit non-tool conventions.
+
 ## The custom MCP rule engine is legacy
 
 `hubitat-mcp-rule.groovy` (the MCP child app, surfaced through the `custom_*` tools) is **legacy**. It still ships and still gets bug fixes, but it is **closed to new feature work** — Hubitat's native Rule Machine is the supported path now and exposes equivalent functionality through `create_native_app` / `update_native_app` / `delete_native_app` and the rest of the `manage_native_rules_and_apps` group. New rule-related capabilities should land on the parent app's native-RM tools, not on the child app. If a feature request lands on the child app, propose it for the native side instead.

--- a/SKILL.md
+++ b/SKILL.md
@@ -188,7 +188,7 @@ in the room — it surfaces stale-state warnings the device-level tools don't.""
     inputSchema: [
         type: "object",
         properties: [
-            room_id: [type: "string", description: "Room ID (string). Use list_rooms to discover IDs."]
+            room_id: [type: "string", description: "Room ID (string). Use hub_list_rooms to discover IDs."]
         ],
         required: ["room_id"]
     ],

--- a/SKILL.md
+++ b/SKILL.md
@@ -130,6 +130,14 @@ The server uses a **category gateway proxy** pattern to reduce the MCP `tools/li
 
 Every new tool requires changes in exactly three places:
 
+**Design rules first** (see `AGENTS.md` § Tool design rules for full rationale and citations):
+
+0a. **Tool name follows the design rules** — `hub_` service prefix, verb from the allowed vocabulary, `manage_` only on gateways (or the narrow flat-multi-action exception), verb-noun order.
+0b. **All four annotation hints set explicitly** — `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. Defaults for unannotated tools are the cautious posture; explicit is safer than implicit.
+0c. **Parameter names are unambiguous** — `device_id` not `id`, `user_id` not `user`. Name parameters after what they semantically are.
+
+**Then the three placement changes:**
+
 1. **Tool definition** in `getAllToolDefinitions()` — a map with `name`, `description`, and `inputSchema` (JSON Schema format)
 2. **Case statement** in `executeTool()` — dispatches `toolName` to the implementation method
 3. **Implementation method** — prefixed with `tool` (e.g., `toolMyNewTool`)
@@ -166,6 +174,43 @@ For write tools, include safety warnings and mandatory pre-flight checklists."""
     ]
 ]
 ```
+
+**Canonical example with annotations + outputSchema (new tools should follow this shape):**
+
+```groovy
+[
+    name: "hub_get_room_health",
+    description: """Returns a health verdict for one room.
+
+Returns a structured map of room state plus a single `healthy` boolean roll-up so
+the AI can decide whether to drill in. Use this before sending commands to devices
+in the room — it surfaces stale-state warnings the device-level tools don't.""",
+    inputSchema: [
+        type: "object",
+        properties: [
+            room_id: [type: "string", description: "Room ID (string). Use list_rooms to discover IDs."]
+        ],
+        required: ["room_id"]
+    ],
+    outputSchema: [
+        type: "object",
+        properties: [
+            healthy: [type: "boolean", description: "True if every device in the room reported within the freshness window."],
+            stale_devices: [type: "array", items: [type: "string"], description: "device IDs with no recent activity"],
+            warnings: [type: "array", items: [type: "string"], description: "human-readable warnings, empty when healthy"]
+        ],
+        required: ["healthy", "stale_devices", "warnings"]
+    ],
+    annotations: [
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false
+    ]
+]
+```
+
+Full rationale and citations: `AGENTS.md` § Tool design rules.
 
 Rules:
 - `inputSchema` root is always `type: "object"` with `properties`

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -14,6 +14,15 @@ You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server.
 3. **Inform before acting** - Tell the user what you plan to do before executing write operations.
 4. **Respect access gates** - Hub Admin Read/Write tools are gated for a reason. Follow pre-flight checklists.
 
+## Tool Naming Conventions
+
+All tools in this server follow these conventions. Use the conventions to predict tool shape even before consulting the full reference.
+
+- Every tool name begins with `hub_`.
+- Tool names follow verb-noun order. The allowed verbs are: `list`, `get`, `search`, `test`, `create`, `update`, `delete`, `set`, `call`, `manage`, `restore`, `import`, `export`, `clone`, plus `read`/`write` for file-manager tools and the destructive-ops exceptions `reboot` / `shutdown`. There is one locked-to-one-tool verb: `report` (used only by `hub_report_issue`).
+- `manage_*` tools are gateways. Call with no args to see the catalog of sub-tools; call with `tool=<name>` and `args={...}` to execute one. There is a narrow exception: a flat tool with a small action enum (e.g. `hub_manage_virtual_device` with `action: "create"/"delete"`) may also use `manage_`.
+- Read tools never modify state. Write tools require user confirmation per the safety guide.
+
 ## Device Control
 
 ### Finding Devices

--- a/agent-skill/hubitat-mcp/safety-guide.md
+++ b/agent-skill/hubitat-mcp/safety-guide.md
@@ -171,3 +171,9 @@ If MCP itself is broken:
 - **Duration triggers max out at 2 hours** (7200 seconds)
 - **Captured states default to 20 max** (configurable 1-100)
 - **Hub properties can throw on some firmware versions** - This is normal; the tools handle it gracefully
+
+## Tool annotation hints
+
+Every tool now carries four annotation hints in its definition: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. These are UX / risk signals to the MCP client — they help a client decide how to render the tool, whether to confirm before calling, and how to interpret retries.
+
+**Annotations are NOT a security boundary.** They don't make the model resist prompt injection or substitute for the existing Hub Admin Read / Hub Admin Write gates and `confirm` parameter checks. The gates remain the authoritative safety surface; annotations are advisory metadata.

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -11,7 +11,7 @@ All tools in this server follow these conventions. Use the conventions to predic
 - Every tool name begins with `hub_`.
 - Tool names follow verb-noun order. The allowed verbs are: `list`, `get`, `search`, `test`, `create`, `update`, `delete`, `set`, `call`, `manage`, `restore`, `import`, `export`, `clone`, plus `read`/`write` for file-manager tools and the destructive-ops exceptions `reboot` / `shutdown`. There is one locked-to-one-tool verb: `report` (used only by `hub_report_issue`).
 - `manage_*` tools are gateways. Call with no args to see the catalog of sub-tools; call with `tool=<name>` and `args={...}` to execute one. There is a narrow exception: a flat tool with a small action enum (e.g. `hub_manage_virtual_device` with `action: "create"/"delete"`) may also use `manage_`.
-- Per-tool entries below use the names current at the time of writing; PR1 will rename tools to match the conventions above. Predict shape from the conventions, not the names.
+- Per-tool entries below use the names current at the time of writing. Predict shape from the conventions, not the names.
 
 ## Universal response-size guard + opt-in cursor pagination
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -4,6 +4,15 @@ Quick reference for all 103 MCP tools. The server exposes **36 items on `tools/l
 
 For the most authoritative reference, call `get_tool_guide` via MCP.
 
+## Tool Naming Conventions
+
+All tools in this server follow these conventions. Use the conventions to predict tool shape even before consulting the per-tool entries below.
+
+- Every tool name begins with `hub_`.
+- Tool names follow verb-noun order. The allowed verbs are: `list`, `get`, `search`, `test`, `create`, `update`, `delete`, `set`, `call`, `manage`, `restore`, `import`, `export`, `clone`, plus `read`/`write` for file-manager tools and the destructive-ops exceptions `reboot` / `shutdown`. There is one locked-to-one-tool verb: `report` (used only by `hub_report_issue`).
+- `manage_*` tools are gateways. Call with no args to see the catalog of sub-tools; call with `tool=<name>` and `args={...}` to execute one. There is a narrow exception: a flat tool with a small action enum (e.g. `hub_manage_virtual_device` with `action: "create"/"delete"`) may also use `manage_`.
+- Per-tool entries below use the names current at the time of writing; PR1 will rename tools to match the conventions above. Predict shape from the conventions, not the names.
+
 ## Universal response-size guard + opt-in cursor pagination
 
 Every `tools/call` response is bounded by a 120 KB wire-encoded size guard. Oversized responses come back as a structured `{response_too_large: true, truncated: true, estimatedBytes, sizeLimitBytes, tool, suggestion}` envelope rather than vanishing into a hub `-32603`. The `suggestion` field gives the LLM a specific narrowing hint per tool.


### PR DESCRIPTION
## Summary

- Codify the MCP tool-design rubric (naming, verb vocabulary, consolidation guidelines, annotation rules, schema / error / pagination / testing guidance) into `AGENTS.md` as the canonical source of truth for future tool PRs.
- Wire derivative pointers into `SKILL.md` (new "Adding a New Tool" preliminary checklist + canonical example), `.gemini/styleguide.md` (soft-check #4), `.github/pull_request_template.md` (one checklist line), and the `agent-skill/hubitat-mcp/` consumer-skill files (SKILL.md naming-conventions subsection, tool-reference.md preamble, safety-guide.md annotation-hints note).
- PR3 of issue #105's three-PR refactor. PR1 (forthcoming) will rename existing tools to the new convention; PR2 (forthcoming) will audit non-tool conventions.

## Type of change

- [x] `docs` — documentation only

## Changes

- **`AGENTS.md`** (+ byte-identical `CLAUDE.md` mirror) — new "Tool design rules" section between "Code style" and "The custom MCP rule engine is legacy". Covers: universal `hub_` service prefix, a strict 14-verb vocabulary with 3 narrow exception categories (`read`/`write` file-manager-only, `report` locked to `hub_report_issue`, `reboot`/`shutdown` destructive-ops-only), gateway placement rules (`manage_` reserved for gateways with one flat-multi-action exception, multi-gateway membership allowed, gateway read/write split SHOULD), 6 tool-consolidation guidelines, mandatory all-four-annotation-hints rule on every new tool, plus tool-description / schema-design / error-contracts / pagination / testing guidance. Every load-bearing rule cites a verified authoritative source.
- **`SKILL.md`** — three preliminary checklist items (0a / 0b / 0c) above the existing "Adding a New Tool" steps; canonical tool example with annotations + outputSchema in "Tool Definition Pattern". Existing items 1–7 stay numbered to keep cross-references stable.
- **`.gemini/styleguide.md`** — soft-check #4 covering eight broad areas (naming, parameter names, annotations, description quality, consolidation candidates, schema design, error contracts, pagination). Tone matches existing soft-checks 1–3 — suggestions only, no blocking, author pushback ends the discussion.
- **`.github/pull_request_template.md`** — one new checklist line referencing the new AGENTS.md section.
- **`agent-skill/hubitat-mcp/SKILL.md`** — new "Tool Naming Conventions" subsection after "Core Principles" so a consumer LLM can predict tool-name shape.
- **`agent-skill/hubitat-mcp/tool-reference.md`** — same naming-conventions preamble at the top of the per-tool reference, with an explicit note that per-tool entries still use current names (PR1 will rename).
- **`agent-skill/hubitat-mcp/safety-guide.md`** — new "Tool annotation hints" section: annotations are advisory metadata, NOT a security boundary; the existing Hub Admin Read / Write gates remain authoritative.

Out of scope (deliberately): renaming any existing tool, splitting any gateway, merging any verb-pair tools, adding `outputSchema` retroactively, server-side / backend audit, per-tool-name content updates in `TOOL_GUIDE.md` / consumer-skill files. Those land in PR1 / PR2.

Verification of every cited source completed 2026-05-26; the four broken citations in the original issue #105 reference section (SWE-Bench conflation, annotation-hints citation location, FastMCP docstring claim, Stripe-post miscitation) are corrected. Errata posted to issue #105 body the same day.

Part of #105

## Release Notes

- Documentation: added Tool design rules section to `AGENTS.md` covering naming convention, verb vocabulary, consolidation guidelines, and annotation requirements for future MCP tools.

## Testing

- `python3 tests/sandbox_lint.py` — PASS (0 errors, 0 warnings)
- `./gradlew test` — deferred to CI (no `.groovy` files changed, no test surface affected)
- `diff AGENTS.md CLAUDE.md` produces no output (byte-identical mirror, PR Guard invariant preserved)
- Contradiction scan across all 8 touched files and 4 out-of-scope files (CONTRIBUTING.md, README.md, TOOL_GUIDE.md, rule-patterns.md) — no contradictions found

## Checklist

- [ ] **Unit tests added for any new MCP tools** — N/A (no new tools)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms) — deferred to CI; no Groovy changed
- [ ] Live-hub BAT tests updated if tool behaviour changed — N/A (no tool behaviour changed)
- [x] Documentation updated if user-facing behaviour or tool surface changed — this PR IS the documentation update
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema) — N/A (no new tools)
