### PR TITLE
feat: importUrl + installAsUserApp + triggerUpdated for app/driver/library install + update tools

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6928,104 +6928,166 @@ def hubInternalGetRaw(String path, Map query = null, int timeout = 30, boolean i
 }
 
 /**
- * Fetch Groovy source from an external URL.
- * Mirrors the browser fetch() the Hubitat code editor uses behind its
- * "Import Code from Website" dialog: relocated server-side so MCP callers
- * can deploy from a URL in one tool call instead of paste-then-save.
+ * Fetch Groovy source from an external URL. Mirrors the editor's "Import
+ * Code from Website" + Save flow, relocated server-side so MCP callers
+ * can deploy from a URL in one tool call.
  *
- * Probe verified 1.25 MB hubitat-mcp-server.groovy fetched from
- * raw.githubusercontent.com in <1s with no sandbox cap.
- *
- * Throws IllegalArgumentException with a structured message on bad scheme,
- * non-200 status, fetch exception, or empty body. Returns the body String
- * on success.
- *
- * The actual httpGet call lives in _httpFetchUrl so tests can stub the
- * single seam method instead of the closure-style httpGet (which the
- * Hubitat sandbox dispatches through a path that bypasses metaClass).
+ * Throws IllegalArgumentException with a structured message + class name on
+ * bad scheme, non-200 status, fetch exception, or empty body. mcpLogs each
+ * failure at error level so the MCP log buffer carries the URL + cause.
  */
-private String _fetchSourceFromUrl(String url) {
-    if (!(url?.startsWith("http://") || url?.startsWith("https://"))) {
-        throw new IllegalArgumentException("importUrl must start with http:// or https://")
+private String _fetchSourceFromUrl(urlArg) {
+    // Accept Object so we can validate at the boundary; a typed `String url`
+    // signature would let Groovy reject non-Strings with MissingMethodException
+    // before our structured IAE could fire.
+    if (urlArg == null) {
+        mcpLog("error", "hub-admin", "_fetchSourceFromUrl called with null url")
+        throw new IllegalArgumentException("importUrl is required")
+    }
+    if (!(urlArg instanceof String)) {
+        mcpLog("error", "hub-admin", "_fetchSourceFromUrl: importUrl is not a String (got ${urlArg})")
+        throw new IllegalArgumentException("importUrl must be a String")
+    }
+    String url = (String) urlArg
+    def lower = url.toLowerCase()
+    if (!(lower.startsWith("http://") || lower.startsWith("https://"))) {
+        mcpLog("error", "hub-admin", "_fetchSourceFromUrl: bad scheme in ${url.take(40)}")
+        throw new IllegalArgumentException("importUrl scheme must be http or https (got '${url.take(40)}')")
     }
     def resp
     try {
         resp = _httpFetchUrl(url)
     } catch (Exception e) {
-        throw new IllegalArgumentException("importUrl fetch failed: ${e.message}")
+        // Include class via toString() since sandbox forbids getClass().
+        // e.message can be null on SSL/socket exceptions; toString() always returns something.
+        def cause = e.toString()
+        mcpLog("error", "hub-admin", "_fetchSourceFromUrl ${url}: ${cause}")
+        throw new IllegalArgumentException("importUrl fetch failed: ${cause}")
     }
     def status = resp?.status
     def body = resp?.body
+    if (status == null) {
+        // httpGet returned without invoking the closure -- shouldn't happen on the
+        // synchronous path, but if it does the misleading "HTTP null" error helps
+        // distinguish "no response" from "non-200 response".
+        mcpLog("error", "hub-admin", "_fetchSourceFromUrl ${url}: httpGet returned without status (closure never invoked)")
+        throw new IllegalArgumentException("importUrl fetch returned no response (status null) -- httpGet closure never invoked for ${url}")
+    }
     if (status != 200) {
-        throw new IllegalArgumentException("importUrl returned HTTP ${status}")
+        mcpLog("error", "hub-admin", "_fetchSourceFromUrl ${url}: HTTP ${status}")
+        throw new IllegalArgumentException("importUrl returned HTTP ${status} for ${url}")
     }
     if (!body) {
+        mcpLog("error", "hub-admin", "_fetchSourceFromUrl ${url}: empty body")
         throw new IllegalArgumentException("importUrl returned empty body from ${url}")
+    }
+    // Surface content-type at info level so a user debugging "import succeeds but
+    // hub returns syntax error pointing at line 1" can see if the URL returned HTML
+    // or JSON instead of Groovy. Not load-bearing -- we still let the hub be the
+    // arbiter of valid source -- but it's the difference between "unexpected token: <"
+    // being mysterious vs the log line saying contentType=text/html;charset=utf-8.
+    def ct = resp.contentType
+    if (ct) {
+        mcpLog("info", "hub-admin", "_fetchSourceFromUrl ${url}: ${body.length()} bytes, contentType=${ct}")
+    } else {
+        mcpLog("info", "hub-admin", "_fetchSourceFromUrl ${url}: ${body.length()} bytes")
     }
     return body
 }
 
 /**
- * Synchronous httpGet wrapped as a plain Map-returning method so tests can
- * stub via script.metaClass. Returns [status: int, body: String].
- * Sandbox-safe pattern (same shape as hubInternalGet). textParser:true so
- * resp.data is a Reader and large bodies stream cleanly; 60s timeout is
- * generous headroom for the largest known payload (~1.3 MB).
+ * Synchronous httpGet wrapped as a plain Map-returning method.
+ * Returns [status: int, body: String, contentType: String].
+ *
+ * Body read failures (network reset mid-stream, gzip CRC, encoding decode)
+ * are re-thrown rather than swallowed. The previous "fall back to toString()
+ * on a Reader" pattern produces strings like "java.io.BufferedReader@..." that
+ * would silently pass downstream as source code -- not safe for a deploy path.
+ *
+ * Cert validation is NOT disabled for external URLs (unlike hubInternalGet
+ * which targets localhost). A hub-side fetch of executable code over a
+ * trusted-CA-signed connection is the floor; self-signed or MITM-d URLs
+ * fail the handshake.
  */
 private Map _httpFetchUrl(String url) {
     def status = null
     def body = null
+    def contentType = null
+    def readError = null
     httpGet([
         uri: url,
         textParser: true,
-        timeout: 60,
-        ignoreSSLIssues: true
+        timeout: 60
     ]) { resp ->
         status = resp.status
+        contentType = resp.headers?.'Content-Type'?.toString()
         try { body = resp.data.text }
-        catch (Exception readErr) { body = resp.data?.toString() ?: "" }
+        catch (Exception readErr) { readError = readErr }
     }
-    return [status: status, body: body]
+    if (readError != null) {
+        // Surface the read error to _fetchSourceFromUrl's outer catch, which wraps
+        // with class name + mcpLogs. Don't swallow with toString() junk.
+        throw readError
+    }
+    return [status: status, body: body, contentType: contentType]
 }
 
 /**
  * Create a running user-app instance from already-installed code. Replicates
  * the hub UI's "Add user app -> select code -> Done" flow in one HTTP call.
  *
- * Hub responds to GET /installedapp/create/<codeId> with a 302 redirect to
- * /installedapp/configure/<newInstanceId>/mainPage; the new instance is
- * created and installed() fires as a side effect of the redirect.
+ * The hub creates the instance (firing installed()) on GET to
+ * /installedapp/create/<codeId>, then 302-redirects to
+ * /installedapp/configure/<newInstanceId>/mainPage. We don't follow the
+ * redirect -- the new instance id is parsed from the Location header.
  *
- * Returns {success, codeAppId, instanceAppId, ...} on success or
- * {success:false, error, ...} on failure (codeAppId not a user app, hub
- * returned non-302, etc). Never throws.
+ * Returns a structured envelope on every input. Caller (toolInstallApp) is
+ * responsible for range-checking codeAppId before this is called.
  */
 private Map _createUserAppInstance(Integer codeAppId) {
-    if (codeAppId == null || codeAppId < 1) {
-        throw new IllegalArgumentException(
-            "installAsUserApp must be a positive integer (the codeAppId from Apps Code)"
-        )
-    }
     def result
     try {
         result = hubInternalGetRaw("/installedapp/create/${codeAppId}")
     } catch (Exception e) {
+        mcpLog("error", "hub-admin", "_createUserAppInstance(${codeAppId}): ${e.toString()}")
         return [
             success: false,
-            error: "User app instantiation failed: ${e.message}",
+            error: "User app instantiation failed: ${e.toString()}",
             codeAppId: codeAppId
         ]
     }
     if (result?.status != 302 || !result.location) {
+        def status = result?.status
+        def hint
+        switch (status) {
+            case 401:
+            case 403:
+                hint = "Hub Security authentication failed (status ${status}). Verify MCP credentials and Hub Security state."
+                break
+            case 404:
+                hint = "codeAppId ${codeAppId} does not exist in Apps Code."
+                break
+            case 500:
+                hint = "Hub returned a server error (status 500). Code ${codeAppId} may be in a compile-error state -- inspect via get_app_source."
+                break
+            case 200:
+                hint = "Hub returned the configure page without redirect (status 200). codeAppId ${codeAppId} may be a driver/library, or an already-instantiated app."
+                break
+            default:
+                hint = "Hub returned unexpected status ${status}. The codeAppId may not exist or may not be a user app."
+        }
+        mcpLog("warn", "hub-admin", "_createUserAppInstance(${codeAppId}): non-302 (status=${status})")
         return [
             success: false,
-            error: "Hub did not redirect to a new instance (status=${result?.status}). The codeAppId may not exist or may not be a user app.",
+            error: hint,
             codeAppId: codeAppId,
-            hubResponse: result?.data?.toString()?.take(200)
+            status: status,
+            hubResponse: result?.data?.toString()?.take(500)
         ]
     }
     def m = (result.location =~ /\/installedapp\/configure\/(\d+)/)
     if (!m) {
+        mcpLog("warn", "hub-admin", "_createUserAppInstance(${codeAppId}): could not parse instance id from Location ${result.location}")
         return [
             success: false,
             error: "Could not parse new instance id from Location header: ${result.location}",
@@ -7033,6 +7095,7 @@ private Map _createUserAppInstance(Integer codeAppId) {
         ]
     }
     def newId = m[0][1] as Integer
+    mcpLog("info", "hub-admin", "_createUserAppInstance: created instance ${newId} from codeAppId ${codeAppId}")
     return [
         success: true,
         message: "User app instance created and installed() fired",
@@ -10651,6 +10714,11 @@ def toolInstallApp(args) {
         catch (Exception e) {
             throw new IllegalArgumentException("installAsUserApp must be a positive integer (got '${args.installAsUserApp}')")
         }
+        // Range-check at the caller so _createUserAppInstance can keep a clean
+        // "always returns an envelope, never throws" contract.
+        if (codeAppId == null || codeAppId < 1) {
+            throw new IllegalArgumentException("installAsUserApp must be a positive integer (got '${args.installAsUserApp}')")
+        }
         return _createUserAppInstance(codeAppId)
     }
 
@@ -10747,8 +10815,6 @@ private Map toolInstallItemSingle(String type, args) {
         sourceCode = new String(bytes, "UTF-8")
         mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from ${args.sourceFile}")
     } else if (args.importUrl) {
-        // Hub fetches the source bytes directly. Mirrors the UI's Import-from-Website
-        // dialog, but server-side so it can run in one tool call.
         sourceMode = "importUrl"
         mcpLog("info", "hub-admin", "Reading ${type} source from importUrl: ${args.importUrl}")
         sourceCode = _fetchSourceFromUrl(args.importUrl)
@@ -10876,9 +10942,16 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
     def itemId = args[idParam]
     if (!itemId) throw new IllegalArgumentException("${idParam} is required")
 
-    // Validate source mode early (presence only) so subsequent guards / I/O fire against a well-formed call.
-    if (!args.resave && !args.sourceFile && !args.source && !args.importUrl) {
+    // Validate source mode: exactly one of resave/sourceFile/source/importUrl. The
+    // mutex matches toolInstallItemSingle's strict check -- tool schemas advertise
+    // these as mutually exclusive, so the API boundary must reject the combination
+    // rather than silently picking one via if/else precedence.
+    def modesSet = [args.resave, args.sourceFile, args.source, args.importUrl].count { it }
+    if (modesSet == 0) {
         throw new IllegalArgumentException("One of 'source', 'sourceFile', 'importUrl', or 'resave' is required")
+    }
+    if (modesSet > 1) {
+        throw new IllegalArgumentException("Provide exactly one of 'source', 'sourceFile', 'importUrl', or 'resave'")
     }
 
     // Reject explicit-null expectedVersion: a templated null arg would otherwise read as "no lock
@@ -10934,9 +11007,6 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
         sourceCode = new String(bytes, "UTF-8")
         mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from ${args.sourceFile}")
     } else if (args.importUrl) {
-        // Import URL mode: hub fetches the source bytes directly. Mirrors what the
-        // Hubitat code editor's "Import Code from Website" + Save flow does, but
-        // server-side so the whole thing is one tool call.
         sourceMode = "importUrl"
         mcpLog("info", "hub-admin", "Reading ${type} source from importUrl: ${args.importUrl}")
         sourceCode = _fetchSourceFromUrl(args.importUrl)
@@ -11074,9 +11144,16 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
                     successResult.updatedFired = true
                     mcpLog("info", "hub-admin", "triggerUpdated: fired updated() on instance ${triggerId} after app code save")
                 } catch (Exception updErr) {
+                    // Half-failure: the code was deployed (success:true holds) but the
+                    // opt-in lifecycle refresh failed. The whole point of triggerUpdated
+                    // was the lifecycle refresh -- so flag this as partial so callers
+                    // checking `result.partial` see the half-failure without having to
+                    // drill into updatedFired. Mirrors the partial:true pattern used
+                    // elsewhere (e.g. the RM wizard's partial-success envelope).
                     successResult.updatedFired = false
-                    successResult.repairHints = ["triggerUpdated requested but lifecycle-fire POST failed: ${updErr.message}. The new code is deployed but subscriptions/schedules may not have refreshed -- toggle the app off/on, or POST /installedapp/configure/${triggerId}/mainPage manually."]
-                    mcpLog("warn", "hub-admin", "triggerUpdated failed on instance ${triggerId}: ${updErr.message}")
+                    successResult.partial = true
+                    successResult.repairHints = ["triggerUpdated requested but lifecycle-fire POST failed: ${updErr.toString()}. The new code is deployed (success:true) but subscriptions/schedules may not have refreshed -- toggle the app off/on, or POST /installedapp/configure/${triggerId}/mainPage manually."]
+                    mcpLog("warn", "hub-admin", "triggerUpdated failed on instance ${triggerId}: ${updErr.toString()}")
                 }
             }
 
@@ -11561,10 +11638,16 @@ def toolUpdateLibraryCode(args) {
     if (!libraryId) throw new IllegalArgumentException("libraryId is required")
     if (!libraryId.toString().isInteger() || libraryId.toString().toInteger() <= 0) throw new IllegalArgumentException("libraryId must be a positive integer (got: '${libraryId}')")
 
-    // Resolve source from one of three modes: source, sourceFile, or resave
+    // Resolve source: exactly one of resave/sourceFile/source/importUrl. Matches
+    // the mutex enforcement in toolInstallItemSingle / toolUpdateItemCodeInner --
+    // tool schema advertises these as mutually exclusive.
     def sourceCode = null
     def sourceMode = null
     def freshVersion = null
+    def modesSet = [args.resave, args.sourceFile, args.source, args.importUrl].count { it }
+    if (modesSet > 1) {
+        throw new IllegalArgumentException("Provide exactly one of 'source', 'sourceFile', 'importUrl', or 'resave'")
+    }
 
     if (args.resave) {
         sourceMode = "resave"

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -2406,20 +2406,21 @@ Requires Hub Admin Write.""",
             name: "install_app",
             description: """⚠️ Install new app. Show code to user and get confirmation first.
 
-PREFERRED workflow (avoids reading source into agent transcript):
-  1) Upload bytes to File Manager via local CLI tool that bypasses agent context:
-       curl -F 'uploadFile=@./app.groovy' -F 'folder=/' 'http://<hub>/hub/fileManager/upload'
-       (Hub Security: first run 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload command. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
-  2) install_app(sourceFile: 'app.groovy', confirm: true)
+Three source modes (mutually exclusive):
+- source (inline) -- stubs only, fills agent transcript
+- sourceFile -- read from File Manager (upload first via curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload; Hub Security: prefix with curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login then add -b cookies.txt)
+- importUrl -- hub fetches the URL directly (mirrors UI's "Import Code from Website" then Save flow)
 
-Inline 'source' is acceptable for stub-size snippets only. The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
+After installing the code, create a running instance with a SECOND call: install_app(installAsUserApp: <newAppId>, confirm: true). Mutually exclusive with code-install args.
 
-Verifies install succeeded: if the hub accepted the request but the app failed to compile, install_app returns success=false with the error. Requires Hub Admin Write + confirm + backup <24h. Returns new app ID. After install, add via Apps > Add User App in Hubitat UI.""",
+Verifies install succeeded: if the hub accepted the request but the app failed to compile, install_app returns success=false with the error. Requires Hub Admin Write + confirm + backup <24h. Returns new app ID.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    source: [type: "string", description: "Inline Groovy source. ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install/redeploy. For non-trivial apps, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    source: [type: "string", description: "Inline Groovy source. Stubs only -- fills agent transcript. For non-trivial apps prefer sourceFile or importUrl."],
+                    sourceFile: [type: "string", description: "File Manager filename (upload first via curl per tool description; bypasses agent transcript)."],
+                    importUrl: [type: "string", description: "URL the hub fetches directly. Mirrors the editor's Import Code from Website + Save. http:// or https://. Mutually exclusive with source/sourceFile."],
+                    installAsUserApp: [type: "integer", description: "Second-step mode: create a running instance from already-installed code (the codeAppId returned by a prior install_app call). Mutually exclusive with code-install args (source/sourceFile/importUrl). Fires installed() on the new instance."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
                 required: ["confirm"]
@@ -2429,33 +2430,29 @@ Verifies install succeeded: if the hub accepted the request but the app failed t
             name: "install_driver",
             description: """⚠️ Install new driver. Show code to user and get confirmation first.
 
-PREFERRED workflow (avoids reading source into agent transcript):
-  1) Upload bytes to File Manager via local CLI tool that bypasses agent context:
-       curl -F 'uploadFile=@./driver.groovy' -F 'folder=/' 'http://<hub>/hub/fileManager/upload'
-       (Hub Security: first run 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload command. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
-  2) install_driver(sourceFile: 'driver.groovy', confirm: true)
+Three source modes (mutually exclusive per item):
+- source (inline) -- stubs only
+- sourceFile -- File Manager filename (upload first via curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload)
+- importUrl -- hub fetches the URL directly
 
-Inline 'source' is acceptable for stub-size snippets only. The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
-
-For >1 driver: USE BULK mode (single round-trip, not N separate calls): installs=[{sourceFile}, ...]. Each driver's bytes still uploaded once via CLI per the same recipe -- bulk mode references them by filename.
-
-Single-driver mode: supply one of source|sourceFile.
-Bulk mode: 'installs' array of {source|sourceFile} objects. Errors on individual items do not abort the rest (continue-on-error). Practical limit: ~10-20 drivers per call. Cannot mix bulk and single-driver fields.
+For >1 driver: USE BULK mode (single round-trip, not N separate calls): installs=[{source|sourceFile|importUrl}, ...]. Cannot mix bulk and single-driver fields.
 
 Verifies install succeeded: if the hub accepted the request but the driver failed to compile, install_driver returns success=false with the error. Requires Hub Admin Write + confirm + backup <24h. Returns new driver ID(s).""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    source: [type: "string", description: "Inline Groovy source (single-driver mode). ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install/redeploy. For non-trivial drivers, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
+                    source: [type: "string", description: "Inline Groovy source (single-driver mode). Stubs only -- fills agent transcript."],
+                    sourceFile: [type: "string", description: "File Manager filename (single-driver mode). Upload first via curl per tool description."],
+                    importUrl: [type: "string", description: "URL the hub fetches directly (single-driver mode). http:// or https://. Mutually exclusive with source/sourceFile."],
                     installs: [
                         type: "array",
-                        description: "BULK MODE -- USE THIS WHEN INSTALLING >1 DRIVER (single round-trip vs N separate calls; same arg structure, just an array). Each entry: {source|sourceFile}. Cannot mix with single-driver fields (source/sourceFile). Continue-on-error: failures on individual items don't abort the rest. Practical limit ~10-20 drivers/call. Authorization is controlled by top-level 'confirm' only. PREFER each item's sourceFile (after CLI upload per recipe in tool description) over inline source.",
+                        description: "BULK MODE -- one round-trip for many drivers. Each entry: {source|sourceFile|importUrl}. Cannot mix with single-driver fields. Continue-on-error.",
                         items: [
                             type: "object",
                             properties: [
-                                sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED -- upload first via CLI per tool description recipe to bypass agent transcript)"],
-                                source: [type: "string", description: "Inline source (stubs only -- fills agent transcript)"]
+                                sourceFile: [type: "string", description: "File Manager filename (preferred)."],
+                                source: [type: "string", description: "Inline source (stubs only)."],
+                                importUrl: [type: "string", description: "URL the hub fetches directly."]
                             ]
                         ]
                     ],
@@ -2468,22 +2465,25 @@ Verifies install succeeded: if the hub accepted the request but the driver faile
             name: "update_app_code",
             description: """⚠️ CRITICAL: Modify existing app code. Read current source first, explain changes, get confirmation.
 
-PREFERRED workflow for any iterative app dev (avoids reading source into agent transcript):
-  1) Upload bytes via local CLI: 'curl -F uploadFile=@./app.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
-  2) update_app_code(appId: <id>, sourceFile: 'app.groovy', confirm: true)
+Four source modes (mutually exclusive):
+- source (inline) -- stubs only, fills agent transcript
+- sourceFile -- File Manager filename (upload first via curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload)
+- importUrl -- hub fetches the URL directly (mirrors UI's "Import Code from Website" then Save flow)
+- resave -- recompile without changes (on-hub only, no source touched)
 
-Modes: source (inline -- stubs only, fills agent transcript), sourceFile (RECOMMENDED -- bytes bypass agent context after CLI upload), resave (recompile without changes -- on-hub only, no source touched).
 Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h.
 
-Self-update guard: refuses to overwrite the MCP server's own app source unless Developer Mode is on (a bad self-update bricks the MCP loop). Optional expectedVersion arg enables optimistic locking -- supply it to abort cleanly on a concurrent edit instead of overwriting.""",
+Self-update guard: refuses to overwrite the MCP server's own app source unless Developer Mode is on (a bad self-update bricks the MCP loop). Optional expectedVersion arg enables optimistic locking. Optional triggerUpdated arg fires updated() on a named instance after save (UI Save does NOT do this -- opt-in only).""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    appId: [type: "string", description: "The app ID to update"],
-                    source: [type: "string", description: "Inline Groovy source. ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial apps, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial apps). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
-                    resave: [type: "boolean", description: "Re-save the current source code without changes. Runs entirely on-hub -- no source touches the agent transcript."],
-                    expectedVersion: [type: "integer", description: "OPTIONAL optimistic-lock guard. If supplied, the update aborts with success:false + conflict:true when the hub's current version differs. Stringified integers (e.g. \"7\") are coerced for JSON-RPC clients that don't preserve numeric types; explicit null is rejected."],
+                    appId: [type: "string", description: "The app ID (Apps Code id) to update"],
+                    source: [type: "string", description: "Inline Groovy source. Stubs only -- fills agent transcript."],
+                    sourceFile: [type: "string", description: "File Manager filename. Upload first via curl per tool description."],
+                    importUrl: [type: "string", description: "URL the hub fetches directly (http:// or https://). Mirrors UI's Import Code from Website + Save."],
+                    resave: [type: "boolean", description: "Re-save the current source code without changes. Runs entirely on-hub."],
+                    expectedVersion: [type: "integer", description: "OPTIONAL optimistic-lock guard. If supplied, the update aborts with success:false + conflict:true on version mismatch. Stringified integers coerced; explicit null rejected."],
+                    triggerUpdated: [type: "integer", description: "OPTIONAL post-save lifecycle refresh. Set to the running instance appId; after save succeeds, the tool also fires updated() on that instance so subscriptions/schedules re-initialize. Default: omitted (matches UI behavior; UI does NOT fire updated() on save)."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
                 required: ["appId", "confirm"]
@@ -2493,36 +2493,36 @@ Self-update guard: refuses to overwrite the MCP server's own app source unless D
             name: "update_driver_code",
             description: """⚠️ CRITICAL: Modify existing driver code. Read current source first, explain changes, get confirmation.
 
-PREFERRED workflow for any iterative driver dev (avoids reading source into agent transcript):
-  1) Upload bytes via local CLI: 'curl -F uploadFile=@./driver.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives where curl is unavailable).
-  2) update_driver_code(driverId: <id>, sourceFile: 'driver.groovy', confirm: true)
+Four source modes (mutually exclusive per item):
+- source (inline) -- stubs only
+- sourceFile -- File Manager filename (upload first via curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload)
+- importUrl -- hub fetches the URL directly
+- resave -- recompile without changes (on-hub only)
 
-For >1 driver: USE BULK mode (single round-trip, not N): updates=[{driverId, sourceFile}, ...]. Each driver's bytes still uploaded once via CLI per the same recipe -- bulk-mode references them by filename.
+For >1 driver: USE BULK mode (single round-trip): updates=[{driverId, source|sourceFile|importUrl|resave, optional expectedVersion}, ...]. Cannot mix bulk and single-driver fields. Continue-on-error.
 
-Single-driver mode: driverId + one of source|sourceFile|resave.
-Bulk mode: 'updates' array of {driverId, sourceFile|source|resave} objects. Errors on individual items do not abort the rest (continue-on-error). Practical limit: ~20 drivers per call. Cannot mix bulk and single-driver fields.
-
-Modes: source (inline -- stubs only, fills agent transcript), sourceFile (RECOMMENDED -- bytes bypass agent context after CLI upload), resave (recompile without changes -- on-hub only, no source touched).
 Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    driverId: [type: "string", description: "The driver ID to update (single-driver mode). Omit when using 'updates' array for bulk."],
-                    source: [type: "string", description: "Inline Groovy source (single-driver mode). ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial drivers, prefer sourceFile (recipe in tool description)."],
-                    sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED for non-trivial drivers, single-driver mode). Upload bytes first via local CLI to bypass agent transcript: 'curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload' (Hub Security: authenticate first with 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod / Python requests / Node fetch as alternatives). Subsequent redeploys reference the same file at ~50 bytes per call."],
-                    resave: [type: "boolean", description: "Re-save the current source code without changes (single-driver mode). Runs entirely on-hub -- no source touches the agent transcript."],
-                    expectedVersion: [type: "integer", description: "OPTIONAL optimistic-lock guard (single-driver mode). Update aborts with success:false + conflict:true on version mismatch. Stringified integers coerced; explicit null rejected. Bulk mode: put expectedVersion inside each updates[] entry instead."],
+                    driverId: [type: "string", description: "The driver ID to update (single-driver mode). Omit when using 'updates' array."],
+                    source: [type: "string", description: "Inline Groovy source. Stubs only -- fills agent transcript."],
+                    sourceFile: [type: "string", description: "File Manager filename. Upload first via curl per tool description."],
+                    importUrl: [type: "string", description: "URL the hub fetches directly. http:// or https://. Mutually exclusive with source/sourceFile/resave."],
+                    resave: [type: "boolean", description: "Re-save the current source without changes. Runs entirely on-hub."],
+                    expectedVersion: [type: "integer", description: "OPTIONAL optimistic-lock guard. Update aborts with conflict:true on version mismatch. Bulk mode: put expectedVersion inside each updates[] entry."],
                     updates: [
                         type: "array",
-                        description: "BULK MODE -- USE THIS WHEN UPDATING >1 DRIVER (single round-trip vs N separate calls; same arg structure, just an array). Each entry: {driverId, sourceFile|source|resave, optional expectedVersion}. Cannot mix with single-driver fields (driverId/source/sourceFile/resave/expectedVersion). Continue-on-error: failures on individual items don't abort the rest (including per-item version conflicts -- other items still apply). Practical limit ~20 drivers/call. Authorization is controlled by top-level 'confirm' only; item-level 'confirm' is ignored. PREFER each item's sourceFile (after CLI upload per recipe in tool description) over inline source.",
+                        description: "BULK MODE -- one round-trip for many drivers. Each entry: {driverId, sourceFile|source|importUrl|resave, optional expectedVersion}. Cannot mix with single-driver fields. Continue-on-error.",
                         items: [
                             type: "object",
                             properties: [
                                 driverId: [type: "string", description: "The driver ID to update"],
-                                sourceFile: [type: "string", description: "Filename in hub File Manager (RECOMMENDED -- upload first via CLI per tool description recipe to bypass agent transcript)"],
-                                source: [type: "string", description: "Inline source (stubs only -- fills agent transcript)"],
-                                resave: [type: "boolean", description: "Re-save without changes (no source touched)"],
-                                expectedVersion: [type: "integer", description: "OPTIONAL optimistic-lock guard for this item only. On mismatch the entry fails with conflict:true; sibling entries still apply. Stringified integers coerced; explicit null rejected."]
+                                sourceFile: [type: "string", description: "File Manager filename (preferred)."],
+                                source: [type: "string", description: "Inline source (stubs only)."],
+                                importUrl: [type: "string", description: "URL the hub fetches directly."],
+                                resave: [type: "boolean", description: "Re-save without changes."],
+                                expectedVersion: [type: "integer", description: "OPTIONAL optimistic-lock guard for this item only."]
                             ],
                             required: ["driverId"]
                         ]
@@ -2577,23 +2577,20 @@ Tell user driver name/ID, warn it's permanent, get confirmation. Requires Hub Ad
         ],
         [
             name: "install_library",
-            description: """⚠️ Install new Groovy library code. Libraries are shared code modules included by drivers/apps via the #include namespace.LibraryName directive. Show code to user and get confirmation first.
+            description: """⚠️ Install new Groovy library code. Libraries are #include'd by drivers/apps. Show code to user and get confirmation first.
 
-PREFERRED workflow (avoids reading source into agent transcript):
-  1) Upload bytes to File Manager via a local CLI tool that bypasses agent context:
-       curl -F "uploadFile=@library.groovy" -F "folder=/" "http://<HUB_IP>/hub/fileManager/upload"
-       (Hub Security: first run 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload command. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
-  2) install_library(sourceFile: 'library.groovy', confirm: true)
+Three source modes (mutually exclusive):
+- source (inline) -- stubs only
+- sourceFile -- File Manager filename (upload first via curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload)
+- importUrl -- hub fetches the URL directly
 
-Inline 'source' is acceptable for stub-size snippets only.
-The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
-
-Library source must include a library() definition block with these 4 required fields: name, namespace, author, description. The `category` field is optional. Hubitat rejects missing required fields with errors like "author cannot be empty in library section" or "description,author cannot be empty in library section". NOTE: the hub does NOT compile-check libraries at install time -- syntax errors only surface later when an app or driver tries to #include the library. install_library returns verified:true when the library record exists in the hub catalog; that does NOT guarantee the Groovy compiles. Requires Hub Admin Write + confirm + backup <24h. Returns new libraryId.""",
+Library source must include a library() definition block with 4 required fields: name, namespace, author, description. The hub does NOT compile-check libraries at install time -- syntax errors only surface later when an app or driver tries to #include the library. Requires Hub Admin Write + confirm + backup <24h. Returns new libraryId.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    source: [type: "string", description: "ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every install. For non-trivial libraries, prefer sourceFile (curl recipe in tool description). Must include a library() definition block with these 4 required fields: name, namespace, author, description (category is optional). Install fails with 'author cannot be empty in library section' (or similar for the missing field) if any required field is absent."],
-                    sourceFile: [type: "string", description: "PREFERRED: File Manager filename after curl upload (e.g., 'my-library.groovy'). Upload first: curl -F 'uploadFile=@mylib.groovy' -F 'folder=/' http://<HUB_IP>/hub/fileManager/upload (Hub Security: run 'curl -c cookies.txt -d username=USER&password=PASS http://<HUB_IP>/login' first, then add '-b cookies.txt' to the upload; no auth needed without Hub Security)"],
+                    source: [type: "string", description: "Inline source. Stubs only -- fills agent transcript. Must include library() block with name/namespace/author/description."],
+                    sourceFile: [type: "string", description: "File Manager filename. Upload first via curl per tool description."],
+                    importUrl: [type: "string", description: "URL the hub fetches directly. http:// or https://. Mutually exclusive with source/sourceFile."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
                 required: ["confirm"]
@@ -2603,24 +2600,21 @@ Library source must include a library() definition block with these 4 required f
             name: "update_library_code",
             description: """⚠️ CRITICAL: Modify existing library code. Read current source first, explain changes, get confirmation.
 
-PREFERRED workflow for any iterative library dev (avoids reading source into agent transcript):
-  1) Upload bytes to File Manager via a local CLI tool that bypasses agent context:
-       curl -F "uploadFile=@library.groovy" -F "folder=/" "http://<HUB_IP>/hub/fileManager/upload"
-       (Hub Security: first run 'curl -c cookies.txt -d username=USER&password=PASS http://<hub>/login', then add '-b cookies.txt' to the upload command. Without Hub Security no auth is needed. PowerShell Invoke-RestMethod, Python requests via uv, or Node fetch all work as alternatives.)
-  2) update_library_code(libraryId: '<id>', sourceFile: 'library.groovy', confirm: true)
+Four source modes (mutually exclusive):
+- source (inline) -- stubs only
+- sourceFile -- File Manager filename (upload first via curl -F uploadFile=@./X.groovy -F folder=/ http://<hub>/hub/fileManager/upload)
+- importUrl -- hub fetches the URL directly
+- resave -- recompile without changes (on-hub only)
 
-Inline 'source' is acceptable for stub-size snippets only.
-The 'manage_files write_file' MCP tool ALSO pulls content through agent context -- prefer the CLI-tool upload above.
-
-Modes: source (inline -- stubs only, fills agent transcript), sourceFile (RECOMMENDED -- bytes bypass agent context after CLI upload), resave (recompile without changes -- on-hub only, no source touched).
 Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h.""",
             inputSchema: [
                 type: "object",
                 properties: [
                     libraryId: [type: "string", description: "The library ID to update"],
-                    source: [type: "string", description: "ACCEPTABLE for stub-size snippets only -- inline source goes into agent transcript on every update. For non-trivial libraries, prefer sourceFile (curl recipe in tool description)."],
-                    sourceFile: [type: "string", description: "PREFERRED: File Manager filename after curl upload (e.g., 'mcp-source-library-123.groovy'). Upload first: curl -F 'uploadFile=@mylib.groovy' -F 'folder=/' http://<HUB_IP>/hub/fileManager/upload (Hub Security: run 'curl -c cookies.txt -d username=USER&password=PASS http://<HUB_IP>/login' first, then add '-b cookies.txt' to the upload; no auth needed without Hub Security)"],
-                    resave: [type: "boolean", description: "Re-save the current source code without changes. Runs entirely on-hub -- no cloud round-trip needed."],
+                    source: [type: "string", description: "Inline source. Stubs only -- fills agent transcript."],
+                    sourceFile: [type: "string", description: "File Manager filename. Upload first via curl per tool description."],
+                    importUrl: [type: "string", description: "URL the hub fetches directly. http:// or https://. Mutually exclusive with source/sourceFile/resave."],
+                    resave: [type: "boolean", description: "Re-save the current source without changes. Runs entirely on-hub."],
                     confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
                 ],
                 required: ["libraryId", "confirm"]
@@ -6934,6 +6928,104 @@ def hubInternalGetRaw(String path, Map query = null, int timeout = 30, boolean i
 }
 
 /**
+ * Fetch Groovy source from an external URL via synchronous httpGet.
+ * Mirrors the browser fetch() the Hubitat code editor uses behind its
+ * "Import Code from Website" dialog: relocated server-side so MCP callers
+ * can deploy from a URL in one tool call instead of paste-then-save.
+ *
+ * Sandbox-safe pattern (same shape as hubInternalGet). textParser:true so
+ * resp.data is a Reader and large bodies stream cleanly; probe verified
+ * 1.25 MB hubitat-mcp-server.groovy fetched from raw.githubusercontent.com
+ * in <1s with no sandbox cap. 60s timeout is generous headroom.
+ *
+ * Throws IllegalArgumentException with a structured message on bad scheme,
+ * non-200 status, fetch exception, or empty body. Returns the body String
+ * on success.
+ */
+private String _fetchSourceFromUrl(String url) {
+    if (!(url?.startsWith("http://") || url?.startsWith("https://"))) {
+        throw new IllegalArgumentException("importUrl must start with http:// or https://")
+    }
+    def source = null
+    def status = null
+    try {
+        httpGet([
+            uri: url,
+            textParser: true,
+            timeout: 60,
+            ignoreSSLIssues: true
+        ]) { resp ->
+            status = resp.status
+            try { source = resp.data.text }
+            catch (Exception readErr) { source = resp.data?.toString() ?: "" }
+        }
+    } catch (Exception e) {
+        throw new IllegalArgumentException("importUrl fetch failed: ${e.message}")
+    }
+    if (status != 200) {
+        throw new IllegalArgumentException("importUrl returned HTTP ${status}")
+    }
+    if (!source) {
+        throw new IllegalArgumentException("importUrl returned empty body from ${url}")
+    }
+    return source
+}
+
+/**
+ * Create a running user-app instance from already-installed code. Replicates
+ * the hub UI's "Add user app -> select code -> Done" flow in one HTTP call.
+ *
+ * Hub responds to GET /installedapp/create/<codeId> with a 302 redirect to
+ * /installedapp/configure/<newInstanceId>/mainPage; the new instance is
+ * created and installed() fires as a side effect of the redirect.
+ *
+ * Returns {success, codeAppId, instanceAppId, ...} on success or
+ * {success:false, error, ...} on failure (codeAppId not a user app, hub
+ * returned non-302, etc). Never throws.
+ */
+private Map _createUserAppInstance(Integer codeAppId) {
+    if (codeAppId == null || codeAppId < 1) {
+        throw new IllegalArgumentException(
+            "installAsUserApp must be a positive integer (the codeAppId from Apps Code)"
+        )
+    }
+    def result
+    try {
+        result = hubInternalGetRaw("/installedapp/create/${codeAppId}")
+    } catch (Exception e) {
+        return [
+            success: false,
+            error: "User app instantiation failed: ${e.message}",
+            codeAppId: codeAppId
+        ]
+    }
+    if (result?.status != 302 || !result.location) {
+        return [
+            success: false,
+            error: "Hub did not redirect to a new instance (status=${result?.status}). The codeAppId may not exist or may not be a user app.",
+            codeAppId: codeAppId,
+            hubResponse: result?.data?.toString()?.take(200)
+        ]
+    }
+    def m = (result.location =~ /\/installedapp\/configure\/(\d+)/)
+    if (!m) {
+        return [
+            success: false,
+            error: "Could not parse new instance id from Location header: ${result.location}",
+            codeAppId: codeAppId
+        ]
+    }
+    def newId = m[0][1] as Integer
+    return [
+        success: true,
+        message: "User app instance created and installed() fired",
+        codeAppId: codeAppId,
+        instanceAppId: newId,
+        mode: "installAsUserApp"
+    ]
+}
+
+/**
  * Make an authenticated POST request to the hub's internal API.
  * Automatically includes Hub Security cookie if configured.
  * Returns the response body as text.
@@ -10522,6 +10614,29 @@ def toolInstallApp(args) {
         throw new IllegalArgumentException("Bulk mode ('installs' array) is not supported for install_app. Apps do not cluster the way drivers do; install each app individually.")
     }
     requireHubAdminWrite(args.confirm)
+
+    // installAsUserApp mode: create a running instance from already-installed code.
+    // Closes the "install_app installs code but not an instance" gap. Mutually
+    // exclusive with code-install args -- callers can't combine the two in one
+    // call (avoids confusion about which appId the response refers to).
+    if (args.installAsUserApp != null) {
+        if (args.source || args.sourceFile || args.importUrl) {
+            throw new IllegalArgumentException(
+                "installAsUserApp is mutually exclusive with source/sourceFile/importUrl. " +
+                "Use two calls: (1) install_app(source|sourceFile|importUrl, confirm:true) " +
+                "to install the code, then " +
+                "(2) install_app(installAsUserApp:<codeAppId>, confirm:true) " +
+                "to create the running instance."
+            )
+        }
+        def codeAppId
+        try { codeAppId = args.installAsUserApp as Integer }
+        catch (Exception e) {
+            throw new IllegalArgumentException("installAsUserApp must be a positive integer (got '${args.installAsUserApp}')")
+        }
+        return _createUserAppInstance(codeAppId)
+    }
+
     return toolInstallItemSingle("app", args)
 }
 
@@ -10536,11 +10651,11 @@ private Map toolInstallItem(String type, args) {
 
     // Bulk mode: installs array present -- validate then dispatch per-item
     if (args.installs != null) {
-        if (args.source != null || args.sourceFile != null) {
-            throw new IllegalArgumentException("Cannot supply both 'installs' (bulk mode) and single-item fields (source/sourceFile). Use one mode or the other.")
+        if (args.source != null || args.sourceFile != null || args.importUrl != null) {
+            throw new IllegalArgumentException("Cannot supply both 'installs' (bulk mode) and single-item fields (source/sourceFile/importUrl). Use one mode or the other.")
         }
         if (!(args.installs instanceof List)) {
-            throw new IllegalArgumentException("'installs' must be an array of objects, each with 'source' or 'sourceFile'.")
+            throw new IllegalArgumentException("'installs' must be an array of objects, each with 'source', 'sourceFile', or 'importUrl'.")
         }
         if (args.installs.isEmpty()) {
             throw new IllegalArgumentException("'installs' array must not be empty.")
@@ -10550,8 +10665,8 @@ private Map toolInstallItem(String type, args) {
         def itemResults = []
         def allSucceeded = true
         args.installs.eachWithIndex { item, idx ->
-            if (!(item instanceof Map) || (item.source == null && item.sourceFile == null)) {
-                itemResults << [(idField): null, success: false, error: "Each installs entry must have a 'source' or 'sourceFile' field."]
+            if (!(item instanceof Map) || (item.source == null && item.sourceFile == null && item.importUrl == null)) {
+                itemResults << [(idField): null, success: false, error: "Each installs entry must have a 'source', 'sourceFile', or 'importUrl' field."]
                 allSucceeded = false
                 return
             }
@@ -10559,6 +10674,7 @@ private Map toolInstallItem(String type, args) {
                 def singleArgs = [confirm: args.confirm]
                 if (item.sourceFile != null) singleArgs.sourceFile = item.sourceFile
                 if (item.source != null) singleArgs.source = item.source
+                if (item.importUrl != null) singleArgs.importUrl = item.importUrl
                 def r = toolInstallItemSingle(type, singleArgs)
                 def entry = [(idField): r[idField], success: r.success == true]
                 if (r.success) {
@@ -10598,23 +10714,33 @@ private Map toolInstallItem(String type, args) {
 private Map toolInstallItemSingle(String type, args) {
     def idField = (type == "app") ? "appId" : "driverId"
 
-    // Resolve source: sourceFile takes precedence when both are supplied
+    // Resolve source: exactly one of sourceFile / source / importUrl must be supplied.
+    // Mutual exclusion: surface a clear error rather than silently picking one.
     def sourceCode = null
     def sourceMode = null
-    if (args.sourceFile && args.source) {
-        throw new IllegalArgumentException("Provide either 'source' (inline) OR 'sourceFile' (File Manager filename), not both.")
-    } else if (args.sourceFile) {
+    def modesSet = [args.sourceFile, args.source, args.importUrl].count { it }
+    if (modesSet > 1) {
+        throw new IllegalArgumentException("Provide exactly one of 'source' (inline), 'sourceFile' (File Manager filename), or 'importUrl' (URL the hub will fetch).")
+    }
+    if (args.sourceFile) {
         sourceMode = "sourceFile"
         mcpLog("info", "hub-admin", "Reading ${type} source from File Manager: ${args.sourceFile}")
         def bytes = downloadHubFile(args.sourceFile)
         if (bytes == null) throw new IllegalArgumentException("Source file '${args.sourceFile}' not found in File Manager")
         sourceCode = new String(bytes, "UTF-8")
         mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from ${args.sourceFile}")
+    } else if (args.importUrl) {
+        // Hub fetches the source bytes directly. Mirrors the UI's Import-from-Website
+        // dialog, but server-side so it can run in one tool call.
+        sourceMode = "importUrl"
+        mcpLog("info", "hub-admin", "Reading ${type} source from importUrl: ${args.importUrl}")
+        sourceCode = _fetchSourceFromUrl(args.importUrl)
+        mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from importUrl")
     } else if (args.source) {
         sourceMode = "source"
         sourceCode = args.source
     } else {
-        throw new IllegalArgumentException("Either 'source' (inline Groovy code) or 'sourceFile' (File Manager filename) is required")
+        throw new IllegalArgumentException("One of 'source' (inline Groovy code), 'sourceFile' (File Manager filename), or 'importUrl' (URL the hub will fetch) is required")
     }
 
     def savePath = (type == "app") ? "/app/save" : "/driver/save"
@@ -10711,6 +10837,7 @@ private Map toolInstallItemSingle(String type, args) {
         ]
         if (verifyError != null) installResult.verifyError = "${verifyError} -- use get_${type}_source with ID ${newItemId} to confirm."
         if (sourceMode == "sourceFile") installResult.note = "Source was read from File Manager file '${args.sourceFile}'."
+        if (sourceMode == "importUrl") installResult.note = "Source was fetched from importUrl '${args.importUrl}' (hub-side fetch, no agent transcript)."
         return installResult
     } catch (Exception e) {
         mcpLog("error", "hub-admin", "${type.capitalize()} installation failed: ${e.message}")
@@ -10733,8 +10860,8 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
     if (!itemId) throw new IllegalArgumentException("${idParam} is required")
 
     // Validate source mode early (presence only) so subsequent guards / I/O fire against a well-formed call.
-    if (!args.resave && !args.sourceFile && !args.source) {
-        throw new IllegalArgumentException("One of 'source', 'sourceFile', or 'resave' is required")
+    if (!args.resave && !args.sourceFile && !args.source && !args.importUrl) {
+        throw new IllegalArgumentException("One of 'source', 'sourceFile', 'importUrl', or 'resave' is required")
     }
 
     // Reject explicit-null expectedVersion: a templated null arg would otherwise read as "no lock
@@ -10789,6 +10916,14 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
         if (bytes == null) throw new IllegalArgumentException("Source file '${args.sourceFile}' not found in File Manager")
         sourceCode = new String(bytes, "UTF-8")
         mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from ${args.sourceFile}")
+    } else if (args.importUrl) {
+        // Import URL mode: hub fetches the source bytes directly. Mirrors what the
+        // Hubitat code editor's "Import Code from Website" + Save flow does, but
+        // server-side so the whole thing is one tool call.
+        sourceMode = "importUrl"
+        mcpLog("info", "hub-admin", "Reading ${type} source from importUrl: ${args.importUrl}")
+        sourceCode = _fetchSourceFromUrl(args.importUrl)
+        mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from importUrl")
     } else {
         // Direct source mode -- presence already validated above.
         sourceMode = "source"
@@ -10892,6 +11027,42 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
             ]
             if (sourceMode == "resave") successResult.note = "Source was fetched and re-saved entirely on-hub — no cloud round-trip."
             if (sourceMode == "sourceFile") successResult.note = "Source was read from File Manager file '${args.sourceFile}' — no cloud size limits."
+            if (sourceMode == "importUrl") successResult.note = "Source was fetched from importUrl '${args.importUrl}' (hub-side fetch, no agent transcript)."
+
+            // Optional triggerUpdated: fire updated() on the named running instance so
+            // subscriptions/schedules/atomicState re-initialize against the new code.
+            // The UI Save flow does NOT do this (empirically verified via JS bundle +
+            // Chrome network capture); this is deliberately extra behavior, opt-in only.
+            // Apps only -- drivers refresh per-device, libraries are #include'd at compile.
+            if (type == "app" && args.containsKey('triggerUpdated') && args.triggerUpdated != null) {
+                def triggerId = null
+                try { triggerId = args.triggerUpdated as Integer }
+                catch (Exception coerceErr) {
+                    successResult.triggerUpdated = args.triggerUpdated
+                    successResult.updatedFired = false
+                    successResult.repairHints = ["triggerUpdated must be a positive integer (instance appId); got '${args.triggerUpdated}'. The code save succeeded; lifecycle was NOT refreshed."]
+                    return successResult
+                }
+                if (triggerId == null || triggerId < 1) {
+                    successResult.triggerUpdated = args.triggerUpdated
+                    successResult.updatedFired = false
+                    successResult.repairHints = ["triggerUpdated must be a positive integer (instance appId). The code save succeeded; lifecycle was NOT refreshed."]
+                    return successResult
+                }
+                successResult.triggerUpdated = triggerId
+                try {
+                    hubInternalPostForm("/installedapp/configure/${triggerId}/mainPage", [
+                        "_action_Done": "Done"
+                    ])
+                    successResult.updatedFired = true
+                    mcpLog("info", "hub-admin", "triggerUpdated: fired updated() on instance ${triggerId} after app code save")
+                } catch (Exception updErr) {
+                    successResult.updatedFired = false
+                    successResult.repairHints = ["triggerUpdated requested but lifecycle-fire POST failed: ${updErr.message}. The new code is deployed but subscriptions/schedules may not have refreshed -- toggle the app off/on, or POST /installedapp/configure/${triggerId}/mainPage manually."]
+                    mcpLog("warn", "hub-admin", "triggerUpdated failed on instance ${triggerId}: ${updErr.message}")
+                }
+            }
+
             return successResult
         } else {
             return [
@@ -10924,11 +11095,11 @@ def toolUpdateDriverCode(args) {
 
     // Bulk mode validation: updates array and single-driver fields are mutually exclusive
     if (args.updates != null) {
-        if (args.driverId != null || args.source != null || args.sourceFile != null || args.resave != null || args.expectedVersion != null) {
-            throw new IllegalArgumentException("Cannot supply both 'updates' (bulk mode) and single-driver fields (driverId/source/sourceFile/resave/expectedVersion). Use one mode or the other -- expectedVersion belongs on each entry inside updates[] for bulk.")
+        if (args.driverId != null || args.source != null || args.sourceFile != null || args.importUrl != null || args.resave != null || args.expectedVersion != null) {
+            throw new IllegalArgumentException("Cannot supply both 'updates' (bulk mode) and single-driver fields (driverId/source/sourceFile/importUrl/resave/expectedVersion). Use one mode or the other -- expectedVersion belongs on each entry inside updates[] for bulk.")
         }
         if (!(args.updates instanceof List)) {
-            throw new IllegalArgumentException("'updates' must be an array of objects, each with 'driverId' and 'sourceFile' (or 'source' or 'resave').")
+            throw new IllegalArgumentException("'updates' must be an array of objects, each with 'driverId' and 'sourceFile' (or 'source', 'importUrl', or 'resave').")
         }
         if (args.updates.isEmpty()) {
             throw new IllegalArgumentException("'updates' array must not be empty.")
@@ -10947,6 +11118,7 @@ def toolUpdateDriverCode(args) {
                 def singleArgs = [driverId: item.driverId]
                 if (item.sourceFile != null) singleArgs.sourceFile = item.sourceFile
                 if (item.source != null) singleArgs.source = item.source
+                if (item.importUrl != null) singleArgs.importUrl = item.importUrl
                 if (item.resave != null) singleArgs.resave = item.resave
                 // Use containsKey so explicit `expectedVersion: null` propagates and hits Inner's
                 // null-rejector; the resulting IAE is caught below and recorded per-item.
@@ -11224,12 +11396,12 @@ def toolGetLibrarySource(args) {
 def toolInstallLibrary(args) {
     requireHubAdminWrite(args.confirm)
 
-    // Resolve source: sourceFile takes precedence over inline source
+    // Resolve source: exactly one of sourceFile / source / importUrl
     def sourceCode = null
     def sourceMode = null
-
-    if (args.sourceFile && args.source) {
-        throw new IllegalArgumentException("Provide either 'source' or 'sourceFile', not both")
+    def modesSet = [args.sourceFile, args.source, args.importUrl].count { it }
+    if (modesSet > 1) {
+        throw new IllegalArgumentException("Provide exactly one of 'source', 'sourceFile', or 'importUrl'")
     }
     if (args.sourceFile) {
         sourceMode = "sourceFile"
@@ -11238,11 +11410,16 @@ def toolInstallLibrary(args) {
         if (bytes == null) throw new IllegalArgumentException("Source file '${args.sourceFile}' not found in File Manager")
         sourceCode = new String(bytes, "UTF-8")
         mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from ${args.sourceFile}")
+    } else if (args.importUrl) {
+        sourceMode = "importUrl"
+        mcpLog("info", "hub-admin", "Reading library source from importUrl: ${args.importUrl}")
+        sourceCode = _fetchSourceFromUrl(args.importUrl)
+        mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from importUrl")
     } else if (args.source) {
         sourceMode = "source"
         sourceCode = args.source
     } else {
-        throw new IllegalArgumentException("One of 'source' or 'sourceFile' is required")
+        throw new IllegalArgumentException("One of 'source', 'sourceFile', or 'importUrl' is required")
     }
 
     mcpLog("info", "hub-admin", "Installing new library (mode: ${sourceMode}, sourceLength: ${sourceCode.length()})")
@@ -11397,11 +11574,16 @@ def toolUpdateLibraryCode(args) {
         if (bytes == null) throw new IllegalArgumentException("Source file '${args.sourceFile}' not found in File Manager")
         sourceCode = new String(bytes, "UTF-8")
         mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from ${args.sourceFile}")
+    } else if (args.importUrl) {
+        sourceMode = "importUrl"
+        mcpLog("info", "hub-admin", "Reading library source from importUrl: ${args.importUrl}")
+        sourceCode = _fetchSourceFromUrl(args.importUrl)
+        mcpLog("info", "hub-admin", "Read ${sourceCode.length()} chars from importUrl")
     } else if (args.source) {
         sourceMode = "source"
         sourceCode = args.source
     } else {
-        throw new IllegalArgumentException("One of 'source', 'sourceFile', or 'resave' is required")
+        throw new IllegalArgumentException("One of 'source', 'sourceFile', 'importUrl', or 'resave' is required")
     }
 
     // Check 1-hour dedup BEFORE any backup-related fetch -- preserves the original

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6928,47 +6928,64 @@ def hubInternalGetRaw(String path, Map query = null, int timeout = 30, boolean i
 }
 
 /**
- * Fetch Groovy source from an external URL via synchronous httpGet.
+ * Fetch Groovy source from an external URL.
  * Mirrors the browser fetch() the Hubitat code editor uses behind its
  * "Import Code from Website" dialog: relocated server-side so MCP callers
  * can deploy from a URL in one tool call instead of paste-then-save.
  *
- * Sandbox-safe pattern (same shape as hubInternalGet). textParser:true so
- * resp.data is a Reader and large bodies stream cleanly; probe verified
- * 1.25 MB hubitat-mcp-server.groovy fetched from raw.githubusercontent.com
- * in <1s with no sandbox cap. 60s timeout is generous headroom.
+ * Probe verified 1.25 MB hubitat-mcp-server.groovy fetched from
+ * raw.githubusercontent.com in <1s with no sandbox cap.
  *
  * Throws IllegalArgumentException with a structured message on bad scheme,
  * non-200 status, fetch exception, or empty body. Returns the body String
  * on success.
+ *
+ * The actual httpGet call lives in _httpFetchUrl so tests can stub the
+ * single seam method instead of the closure-style httpGet (which the
+ * Hubitat sandbox dispatches through a path that bypasses metaClass).
  */
 private String _fetchSourceFromUrl(String url) {
     if (!(url?.startsWith("http://") || url?.startsWith("https://"))) {
         throw new IllegalArgumentException("importUrl must start with http:// or https://")
     }
-    def source = null
-    def status = null
+    def resp
     try {
-        httpGet([
-            uri: url,
-            textParser: true,
-            timeout: 60,
-            ignoreSSLIssues: true
-        ]) { resp ->
-            status = resp.status
-            try { source = resp.data.text }
-            catch (Exception readErr) { source = resp.data?.toString() ?: "" }
-        }
+        resp = _httpFetchUrl(url)
     } catch (Exception e) {
         throw new IllegalArgumentException("importUrl fetch failed: ${e.message}")
     }
+    def status = resp?.status
+    def body = resp?.body
     if (status != 200) {
         throw new IllegalArgumentException("importUrl returned HTTP ${status}")
     }
-    if (!source) {
+    if (!body) {
         throw new IllegalArgumentException("importUrl returned empty body from ${url}")
     }
-    return source
+    return body
+}
+
+/**
+ * Synchronous httpGet wrapped as a plain Map-returning method so tests can
+ * stub via script.metaClass. Returns [status: int, body: String].
+ * Sandbox-safe pattern (same shape as hubInternalGet). textParser:true so
+ * resp.data is a Reader and large bodies stream cleanly; 60s timeout is
+ * generous headroom for the largest known payload (~1.3 MB).
+ */
+private Map _httpFetchUrl(String url) {
+    def status = null
+    def body = null
+    httpGet([
+        uri: url,
+        textParser: true,
+        timeout: 60,
+        ignoreSSLIssues: true
+    ]) { resp ->
+        status = resp.status
+        try { body = resp.data.text }
+        catch (Exception readErr) { body = resp.data?.toString() ?: "" }
+    }
+    return [status: status, body: body]
 }
 
 /**

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6935,6 +6935,8 @@ def hubInternalGetRaw(String path, Map query = null, int timeout = 30, boolean i
  * Throws IllegalArgumentException with a structured message + class name on
  * bad scheme, non-200 status, fetch exception, or empty body. mcpLogs each
  * failure at error level so the MCP log buffer carries the URL + cause.
+ *
+ * (Live-deployed via importUrl: marker comment to verify end-to-end smoke.)
  */
 private String _fetchSourceFromUrl(urlArg) {
     // Accept Object so we can validate at the boundary; a typed `String url`

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -141,7 +141,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message.contains("not both")
+        ex.message.contains('exactly one')
     }
 
     @spock.lang.Unroll
@@ -155,7 +155,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         then:
         response.error.code == -32602
-        response.error.message.contains('not both')
+        response.error.message.contains('exactly one')
 
         where:
         useGateways << [true, false]
@@ -999,7 +999,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message.contains('not both')
+        ex.message.contains('exactly one')
     }
 
     @spock.lang.Unroll
@@ -1013,7 +1013,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         then:
         response.error.code == -32602
-        response.error.message.contains('not both')
+        response.error.message.contains('exactly one')
 
         where:
         useGateways << [true, false]
@@ -1525,9 +1525,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.installs.size() == 3
         result.installs[0].success == true
         result.installs[1].success == false
-        result.installs[1].error.contains("'source' or 'sourceFile'")
+        result.installs[1].error.contains("'source', 'sourceFile', or 'importUrl'")
         result.installs[2].success == false
-        result.installs[2].error.contains("'source' or 'sourceFile'")
+        result.installs[2].error.contains("'source', 'sourceFile', or 'importUrl'")
     }
 
     @spock.lang.Unroll
@@ -1560,9 +1560,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         inner.installs.size() == 3
         inner.installs[0].success == true
         inner.installs[1].success == false
-        inner.installs[1].error.contains("'source' or 'sourceFile'")
+        inner.installs[1].error.contains("'source', 'sourceFile', or 'importUrl'")
         inner.installs[2].success == false
-        inner.installs[2].error.contains("'source' or 'sourceFile'")
+        inner.installs[2].error.contains("'source', 'sourceFile', or 'importUrl'")
 
         where:
         useGateways << [true, false]

--- a/src/test/groovy/server/ToolImportUrlSpec.groovy
+++ b/src/test/groovy/server/ToolImportUrlSpec.groovy
@@ -6,16 +6,7 @@ import support.ToolSpecBase
 
 /**
  * Spec for the importUrl + installAsUserApp + triggerUpdated additions to the
- * install/update tools. Mirrors the pattern in ToolAppDriverCodeSpec --
- * httpGet is stubbed via script.metaClass; the deploy POST + verify GET
- * paths re-use the same stubs the existing source/sourceFile tests use.
- *
- * Coverage:
- *   - _fetchSourceFromUrl helper: happy + 4 failure paths
- *   - importUrl on update_app_code, install_app, install_library (one happy path each)
- *   - importUrl mutual exclusion + scheme validation
- *   - installAsUserApp: happy + 404 + mutual exclusion
- *   - triggerUpdated: happy + lifecycle-fire-failure + negative pin
+ * install/update tools.
  */
 class ToolImportUrlSpec extends ToolSpecBase {
 
@@ -25,20 +16,24 @@ class ToolImportUrlSpec extends ToolSpecBase {
     // The setupSpec-level httpGet stub reads these; specs swap them between tests.
     @Shared private int nextHttpGetStatus = 200
     @Shared private String nextHttpGetBody = ''
+    @Shared private String nextHttpGetContentType = null
     @Shared private Throwable nextHttpGetThrow = null
     @Shared private Map nextHttpGetCaptured = [:]
 
     def setupSpec() {
         appExecutor.getApp() >> sharedAppStub
-        // Install ONE global httpGet stub at spec-class scope -- mirrors the
-        // rule harness pattern (RuleHarnessSpec.groovy:209). Per-test state is
-        // mutated via the stubHttpGet / stubHttpGetThrows helpers below.
+        // Install ONE global httpGet stub at spec-class scope. Per-test state is
+        // mutated via the stubHttpGet / stubHttpGetThrows helpers below. (Spock
+        // dispatches httpGet from the script through the appExecutor mock; the
+        // script.metaClass route doesn't intercept this path, hence the
+        // appExecutor stub.)
         appExecutor.httpGet(*_) >> { args ->
             if (nextHttpGetThrow) throw nextHttpGetThrow
             Map params = args[0] as Map
             Closure handler = args[1] as Closure
             nextHttpGetCaptured.uri = params?.uri
-            handler.call([status: nextHttpGetStatus, data: [text: nextHttpGetBody]])
+            def headers = nextHttpGetContentType ? ['Content-Type': nextHttpGetContentType] : [:]
+            handler.call([status: nextHttpGetStatus, data: [text: nextHttpGetBody], headers: headers])
         }
     }
 
@@ -46,6 +41,7 @@ class ToolImportUrlSpec extends ToolSpecBase {
         // Reset per-test state so prior-test stub config doesn't leak.
         nextHttpGetStatus = 200
         nextHttpGetBody = ''
+        nextHttpGetContentType = null
         nextHttpGetThrow = null
         nextHttpGetCaptured.clear()
     }
@@ -93,8 +89,7 @@ class ToolImportUrlSpec extends ToolSpecBase {
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message.contains('http://')
-        ex.message.contains('https://')
+        ex.message.contains('http or https')
         nextHttpGetCaptured.uri == null  // scheme check fires before any network attempt
     }
 
@@ -104,7 +99,31 @@ class ToolImportUrlSpec extends ToolSpecBase {
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message.contains('http://')
+        ex.message.contains('required')
+    }
+
+    def "_fetchSourceFromUrl: throws IAE when scheme is uppercase HTTPS (not normalized as a valid scheme today)"() {
+        // Lowercase comparison: uppercase schemes are rejected. Pins the toLowerCase
+        // normalization step so a future refactor doesn't accidentally bypass it.
+        given:
+        stubHttpGet(200, 'unused')
+
+        when:
+        script._fetchSourceFromUrl('HTTPS://example.com/x.groovy')
+
+        then:
+        // The lowercase normalization means uppercase HTTPS IS accepted by the
+        // scheme check. This test pins that behavior.
+        noExceptionThrown()
+    }
+
+    def "_fetchSourceFromUrl: throws IAE on non-String importUrl"() {
+        when:
+        script._fetchSourceFromUrl(123)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('String')
     }
 
     def "_fetchSourceFromUrl: throws IAE on non-200 status"() {
@@ -174,7 +193,7 @@ class ToolImportUrlSpec extends ToolSpecBase {
         result.success == true
         result.sourceMode == 'importUrl'
         result.sourceLength == 'fetched-source-here'.length()
-        result.note?.contains('importUrl')
+        result.note?.contains('hub-side fetch')  // pins the "no agent transcript" semantic, not just the substring
         captured.path == '/app/ajax/update'
         captured.body.source == 'fetched-source-here'
     }
@@ -207,7 +226,7 @@ class ToolImportUrlSpec extends ToolSpecBase {
         result.sourceMode == 'importUrl'
         captured.path == '/app/save'
         captured.body.source == 'definition(name: "FromUrl")'
-        result.note?.contains('importUrl')
+        result.note?.contains('hub-side fetch')  // pins the "no agent transcript" semantic, not just the substring
     }
 
     // -------- importUrl integration: install_library --------
@@ -238,11 +257,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
     }
 
     // -------- mutual exclusion --------
-    // For install_*_code, modesSet counts the present modes and throws if > 1.
-    // For update_*_code, the existing if-else chain naturally takes the first
-    // present mode in the order resave > sourceFile > importUrl > source --
-    // tool schema documents these as mutually exclusive; explicit mutex
-    // enforcement at the API boundary is a follow-up if it proves needed.
+    // All install/update tools enforce: exactly one of source / sourceFile /
+    // importUrl / resave (resave is install-irrelevant). modesSet count > 1 throws.
 
     def "install_app rejects multiple source modes together"() {
         given:
@@ -315,7 +331,34 @@ class ToolImportUrlSpec extends ToolSpecBase {
         then:
         result.success == false
         result.codeAppId == 99999
-        result.error.contains('404')
+        result.status == 404
+        result.error.contains('does not exist')  // status-aware hint for 404
+    }
+
+    @spock.lang.Unroll
+    def "install_app installAsUserApp returns status-aware error for status #status"() {
+        // Pins the status-aware error hints so a 401 auth-expired case doesn't get
+        // misread as "codeAppId wrong" the way a generic non-302 message would.
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalGetRaw = { String path, Map query = null, int timeout = 30, boolean isRetry = false ->
+            [status: status, location: null, data: 'body']
+        }
+
+        when:
+        def result = script.toolInstallApp([installAsUserApp: 310, confirm: true])
+
+        then:
+        result.success == false
+        result.status == status
+        result.error.contains(hint)
+
+        where:
+        status | hint
+        401    | 'authentication'
+        403    | 'authentication'
+        500    | 'server error'
+        200    | 'without redirect'
     }
 
     def "install_app rejects installAsUserApp combined with importUrl"() {
@@ -430,5 +473,353 @@ class ToolImportUrlSpec extends ToolSpecBase {
         result.containsKey('updatedFired') == false
         posts.size() == 1
         posts[0].path == '/app/ajax/update'  // only the code-save POST, no lifecycle POST
+    }
+
+    def "update_app_code with triggerUpdated lifecycle failure also sets partial:true"() {
+        // Pins the half-failure flag added so callers checking result.partial see
+        // the lifecycle-fire failure without drilling into updatedFired.
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "source": "old", "version": 5}'
+        }
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            if (path.startsWith('/installedapp/configure/')) throw new RuntimeException('hub rejected lifecycle POST')
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
+
+        when:
+        def result = script.toolUpdateAppCode([
+            appId: '42',
+            source: 'new',
+            triggerUpdated: 194,
+            confirm: true
+        ])
+
+        then:
+        result.success == true       // code save committed
+        result.partial == true       // lifecycle refresh failed
+        result.updatedFired == false
+    }
+
+    // -------- mutual exclusion on update paths (mirrors install paths) --------
+
+    def "update_app_code rejects multiple source modes together"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolUpdateAppCode([
+            appId: '42',
+            source: 'inline',
+            importUrl: 'https://x.com/a.groovy',
+            confirm: true
+        ])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('exactly one')
+    }
+
+    def "update_library_code rejects multiple source modes together"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolUpdateLibraryCode([
+            libraryId: '7',
+            sourceFile: 'lib.groovy',
+            importUrl: 'https://x.com/lib.groovy',
+            confirm: true
+        ])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('exactly one')
+    }
+
+    // -------- self-update guard + importUrl (no SSRF via importUrl) --------
+
+    def "update_app_code self-update guard blocks importUrl mode (no outbound fetch happens)"() {
+        // If a refactor reorders mode resolution above the self-update guard, the hub
+        // could be tricked into fetching attacker-controlled URLs (SSRF probe) even
+        // though the guard would later block the write. Pins guard-before-fetch ordering.
+        given:
+        enableHubAdminWrite()
+        settingsMap.enableDeveloperMode = false
+        stubHttpGet(200, 'pwn')
+
+        when:
+        // appId '1' matches the sharedAppStub id, triggering the self-update guard.
+        script.toolUpdateAppCode([appId: '1', importUrl: 'http://attacker.example/x.groovy', confirm: true])
+
+        then:
+        thrown(IllegalArgumentException)
+        nextHttpGetCaptured.uri == null  // guard ran before _fetchSourceFromUrl
+    }
+
+    // -------- installAsUserApp validation edge cases --------
+
+    @spock.lang.Unroll
+    def "install_app installAsUserApp rejects invalid value (#value)"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallApp([installAsUserApp: value, confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('positive integer')
+
+        where:
+        value << [0, -5, 'not-a-number']
+    }
+
+    def "install_app installAsUserApp coerces stringified integer"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, int t = 30, boolean r = false ->
+            [status: 302, location: '/installedapp/configure/9999/mainPage', data: '']
+        }
+
+        when:
+        def result = script.toolInstallApp([installAsUserApp: '310', confirm: true])
+
+        then:
+        result.success == true
+        result.codeAppId == 310
+        result.instanceAppId == 9999
+    }
+
+    // -------- triggerUpdated validation edge cases --------
+
+    @spock.lang.Unroll
+    def "update_app_code triggerUpdated #value returns success+updatedFired:false+repairHints (code save still committed)"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/app/ajax/code') { params -> '{"status":"ok","source":"old","version":5}' }
+        def lifecyclePostCount = 0
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            if (path.startsWith('/installedapp/configure/')) lifecyclePostCount++
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
+
+        when:
+        def result = script.toolUpdateAppCode([
+            appId: '42',
+            source: 'new',
+            triggerUpdated: value,
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.updatedFired == false
+        result.repairHints?.any { it.toString().contains('positive integer') }
+        lifecyclePostCount == 0  // never reached the lifecycle POST
+
+        where:
+        value << [0, -1, 'abc']
+    }
+
+    // -------- per-tool importUrl smoke (install_driver / update_driver_code / update_library_code) --------
+
+    def "install_driver with importUrl fetches via httpGet and POSTs to /driver/save"() {
+        given:
+        enableHubAdminWrite()
+        stubHttpGet(200, 'metadata { definition (name: "FromUrl") {} }')
+        def captured = [:]
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            captured.path = path; captured.body = body
+            [status: 302, location: 'http://127.0.0.1:8080/driver/editor/8888', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params -> '{"status":"ok","source":"stub","version":1}' }
+
+        when:
+        def result = script.toolInstallDriver([importUrl: 'https://raw.example/d.groovy', confirm: true])
+
+        then:
+        result.success == true
+        result.driverId == '8888'
+        captured.path == '/driver/save'
+    }
+
+    def "update_driver_code with importUrl POSTs the fetched source to /driver/ajax/update"() {
+        given:
+        enableHubAdminWrite()
+        stubHttpGet(200, 'updated-driver-source')
+        hubGet.register('/driver/ajax/code') { params -> '{"status":"ok","source":"old","version":3}' }
+        def captured = [:]
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            captured.path = path; captured.body = body
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.backupItemSource = { String type, String itemId -> [version: 3, fileName: 'b.json'] }
+
+        when:
+        def result = script.toolUpdateDriverCode([driverId: '55', importUrl: 'https://raw.example/d.groovy', confirm: true])
+
+        then:
+        result.success == true
+        result.sourceMode == 'importUrl'
+        captured.path == '/driver/ajax/update'
+        captured.body.source == 'updated-driver-source'
+    }
+
+    def "update_library_code with importUrl posts to /library/saveOrUpdateJson"() {
+        given:
+        enableHubAdminWrite()
+        stubHttpGet(200, 'library(name: "Updated")')
+        hubGet.register('/library/list/single/data/22') { params -> '[{"version":4,"source":"old"}]' }
+        // Stub File Manager so library backup doesn't blow up trying to write.
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def captured = [:]
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.path = path; captured.body = body
+            [success: true, id: 22, version: 5]
+        }
+
+        when:
+        def result = script.toolUpdateLibraryCode([libraryId: '22', importUrl: 'https://raw.example/lib.groovy', confirm: true])
+
+        then:
+        result.success == true
+        result.sourceMode == 'importUrl'
+        captured.path == '/library/saveOrUpdateJson'
+        captured.body.contains('library(name: \\"Updated\\")')
+    }
+
+    // -------- bulk-mode importUrl per-item forwarding --------
+
+    def "install_driver bulk: per-item importUrl is forwarded and fetched"() {
+        given:
+        enableHubAdminWrite()
+        stubHttpGet(200, 'driver-from-url')
+        def postPaths = []
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            postPaths << path
+            [status: 302, location: 'http://127.0.0.1:8080/driver/editor/9001', data: '']
+        }
+        hubGet.register('/driver/ajax/code') { params -> '{"status":"ok","source":"stub","version":1}' }
+
+        when:
+        def result = script.toolInstallDriver([
+            installs: [[importUrl: 'https://raw.example/d1.groovy']],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.installs.size() == 1
+        result.installs[0].success == true
+        result.installs[0].sourceMode == 'importUrl'
+        nextHttpGetCaptured.uri == 'https://raw.example/d1.groovy'
+        postPaths.contains('/driver/save')
+    }
+
+    def "update_driver_code bulk: per-item importUrl is forwarded and fetched"() {
+        given:
+        enableHubAdminWrite()
+        stubHttpGet(200, 'updated-bulk-driver')
+        hubGet.register('/driver/ajax/code') { params -> '{"status":"ok","source":"old","version":2}' }
+        def postPaths = []
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            postPaths << path
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.backupItemSource = { String type, String itemId -> [version: 2, fileName: 'b.json'] }
+
+        when:
+        def result = script.toolUpdateDriverCode([
+            updates: [[driverId: '77', importUrl: 'https://raw.example/d.groovy']],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.updates.size() == 1
+        result.updates[0].success == true
+        result.updates[0].sourceMode == 'importUrl'
+        nextHttpGetCaptured.uri == 'https://raw.example/d.groovy'
+        postPaths.contains('/driver/ajax/update')
+    }
+
+    // -------- JSON-RPC dispatch envelope (-32602 on mutex, success on happy path) --------
+
+    @spock.lang.Unroll
+    def "install_app installAsUserApp via dispatch returns success envelope (useGateways=#useGateways)"() {
+        given:
+        settingsMap.useGateways = useGateways
+        enableHubAdminWrite()
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, int t = 30, boolean r = false ->
+            [status: 302, location: '/installedapp/configure/8888/mainPage', data: '']
+        }
+
+        when:
+        def response = mcpDriver.callTool('install_app', [installAsUserApp: 310, confirm: true])
+
+        then:
+        response.error == null
+        !response.result.isError
+        def inner = mcpDriver.parseInner(response)
+        inner.success == true
+        inner.instanceAppId == 8888
+
+        where:
+        useGateways << [true, false]
+    }
+
+    @spock.lang.Unroll
+    def "install_app installAsUserApp + importUrl via dispatch returns -32602 (useGateways=#useGateways)"() {
+        given:
+        settingsMap.useGateways = useGateways
+        enableHubAdminWrite()
+
+        when:
+        def response = mcpDriver.callTool('install_app', [
+            installAsUserApp: 310,
+            importUrl: 'https://example.com/x.groovy',
+            confirm: true
+        ])
+
+        then:
+        response.error.code == -32602
+        response.error.message.contains('mutually exclusive')
+
+        where:
+        useGateways << [true, false]
+    }
+
+    @spock.lang.Unroll
+    def "update_app_code with importUrl via dispatch returns success envelope (useGateways=#useGateways)"() {
+        given:
+        settingsMap.useGateways = useGateways
+        enableHubAdminWrite()
+        stubHttpGet(200, 'dispatch-fetched-source')
+        hubGet.register('/app/ajax/code') { params -> '{"status":"ok","source":"old","version":9}' }
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.backupItemSource = { String type, String itemId -> [version: 9, fileName: 'b.json'] }
+
+        when:
+        def response = mcpDriver.callTool('update_app_code', [
+            appId: '42',
+            importUrl: 'https://example.com/app.groovy',
+            confirm: true
+        ])
+
+        then:
+        response.error == null
+        !response.result.isError
+        def inner = mcpDriver.parseInner(response)
+        inner.success == true
+        inner.sourceMode == 'importUrl'
+
+        where:
+        useGateways << [true, false]
     }
 }

--- a/src/test/groovy/server/ToolImportUrlSpec.groovy
+++ b/src/test/groovy/server/ToolImportUrlSpec.groovy
@@ -22,8 +22,33 @@ class ToolImportUrlSpec extends ToolSpecBase {
 
     @Shared private TestChildApp sharedAppStub = new TestChildApp(id: 1L, label: 'MCP')
 
+    // Mutable per-test response state set by stubHttpGet / stubHttpGetThrows.
+    // The setupSpec-level httpGet stub reads these; specs swap them between tests.
+    @Shared private int nextHttpGetStatus = 200
+    @Shared private String nextHttpGetBody = ''
+    @Shared private Throwable nextHttpGetThrow = null
+    @Shared private Map nextHttpGetCaptured = [:]
+
     def setupSpec() {
         appExecutor.getApp() >> sharedAppStub
+        // Install ONE global httpGet stub at spec-class scope -- mirrors the
+        // rule harness pattern (RuleHarnessSpec.groovy:209). Per-test state is
+        // mutated via the stubHttpGet / stubHttpGetThrows helpers below.
+        appExecutor.httpGet(*_) >> { args ->
+            if (nextHttpGetThrow) throw nextHttpGetThrow
+            Map params = args[0] as Map
+            Closure handler = args[1] as Closure
+            nextHttpGetCaptured.uri = params?.uri
+            handler.call([status: nextHttpGetStatus, data: [text: nextHttpGetBody]])
+        }
+    }
+
+    def setup() {
+        // Reset per-test state so prior-test stub config doesn't leak.
+        nextHttpGetStatus = 200
+        nextHttpGetBody = ''
+        nextHttpGetThrow = null
+        nextHttpGetCaptured.clear()
     }
 
     private void enableHubAdminWrite() {
@@ -32,28 +57,17 @@ class ToolImportUrlSpec extends ToolSpecBase {
     }
 
     /**
-     * Stub httpGet to return the given body with the given status. Captures
-     * the URL the helper requested so tests can assert on what was fetched.
-     * Returns the captured map; mutate it from the test body if needed.
+     * Configure the next httpGet response. Returns the captured map (the URL the
+     * helper requested lands in captured.uri after the call).
      */
     private Map stubHttpGet(int status, String body) {
-        def captured = [:]
-        script.metaClass.httpGet = { Map params, Closure handler ->
-            captured.uri = params?.uri
-            captured.timeout = params?.timeout
-            captured.textParser = params?.textParser
-            handler.call([
-                status: status,
-                data: [text: body]
-            ])
-        }
-        captured
+        nextHttpGetStatus = status
+        nextHttpGetBody = body
+        nextHttpGetCaptured
     }
 
     private void stubHttpGetThrows(String message) {
-        script.metaClass.httpGet = { Map params, Closure handler ->
-            throw new RuntimeException(message)
-        }
+        nextHttpGetThrow = new RuntimeException(message)
     }
 
     // -------- _fetchSourceFromUrl helper --------
@@ -68,16 +82,12 @@ class ToolImportUrlSpec extends ToolSpecBase {
         then:
         result == 'definition(name: "Hello")'
         captured.uri == 'https://example.com/test.groovy'
-        captured.textParser == true
-        captured.timeout == 60
     }
 
     def "_fetchSourceFromUrl: throws IAE on non-http/https scheme before any I/O"() {
         given:
-        def httpGetCalled = false
-        script.metaClass.httpGet = { Map params, Closure handler ->
-            httpGetCalled = true
-        }
+        // If httpGet ever fires for this test, the stub would set captured.uri.
+        stubHttpGet(200, 'should-not-be-reached')
 
         when:
         script._fetchSourceFromUrl('ftp://example.com/x.groovy')
@@ -86,7 +96,7 @@ class ToolImportUrlSpec extends ToolSpecBase {
         def ex = thrown(IllegalArgumentException)
         ex.message.contains('http://')
         ex.message.contains('https://')
-        !httpGetCalled  // scheme check fires before any network attempt
+        nextHttpGetCaptured.uri == null  // scheme check fires before any network attempt
     }
 
     def "_fetchSourceFromUrl: throws IAE on null url"() {

--- a/src/test/groovy/server/ToolImportUrlSpec.groovy
+++ b/src/test/groovy/server/ToolImportUrlSpec.groovy
@@ -1,0 +1,421 @@
+package server
+
+import spock.lang.Shared
+import spock.lang.Unroll
+import support.TestChildApp
+import support.ToolSpecBase
+
+/**
+ * Spec for the importUrl + installAsUserApp + triggerUpdated additions to the
+ * install/update tools. Mirrors the pattern in ToolAppDriverCodeSpec --
+ * httpGet is stubbed via script.metaClass; the deploy POST + verify GET
+ * paths re-use the same stubs the existing source/sourceFile tests use.
+ *
+ * Coverage:
+ *   - _fetchSourceFromUrl helper: happy + 4 failure paths
+ *   - importUrl on update_app_code, install_app, install_library (one happy path each)
+ *   - importUrl mutual exclusion + scheme validation
+ *   - installAsUserApp: happy + 404 + mutual exclusion
+ *   - triggerUpdated: happy + lifecycle-fire-failure + negative pin
+ */
+class ToolImportUrlSpec extends ToolSpecBase {
+
+    @Shared private TestChildApp sharedAppStub = new TestChildApp(id: 1L, label: 'MCP')
+
+    def setupSpec() {
+        appExecutor.getApp() >> sharedAppStub
+    }
+
+    private void enableHubAdminWrite() {
+        settingsMap.enableHubAdminWrite = true
+        stateMap.lastBackupTimestamp = 1234567890000L
+    }
+
+    /**
+     * Stub httpGet to return the given body with the given status. Captures
+     * the URL the helper requested so tests can assert on what was fetched.
+     * Returns the captured map; mutate it from the test body if needed.
+     */
+    private Map stubHttpGet(int status, String body) {
+        def captured = [:]
+        script.metaClass.httpGet = { Map params, Closure handler ->
+            captured.uri = params?.uri
+            captured.timeout = params?.timeout
+            captured.textParser = params?.textParser
+            handler.call([
+                status: status,
+                data: [text: body]
+            ])
+        }
+        captured
+    }
+
+    private void stubHttpGetThrows(String message) {
+        script.metaClass.httpGet = { Map params, Closure handler ->
+            throw new RuntimeException(message)
+        }
+    }
+
+    // -------- _fetchSourceFromUrl helper --------
+
+    def "_fetchSourceFromUrl: happy path returns body string and uses requested URL"() {
+        given:
+        def captured = stubHttpGet(200, 'definition(name: "Hello")')
+
+        when:
+        def result = script._fetchSourceFromUrl('https://example.com/test.groovy')
+
+        then:
+        result == 'definition(name: "Hello")'
+        captured.uri == 'https://example.com/test.groovy'
+        captured.textParser == true
+        captured.timeout == 60
+    }
+
+    def "_fetchSourceFromUrl: throws IAE on non-http/https scheme before any I/O"() {
+        given:
+        def httpGetCalled = false
+        script.metaClass.httpGet = { Map params, Closure handler ->
+            httpGetCalled = true
+        }
+
+        when:
+        script._fetchSourceFromUrl('ftp://example.com/x.groovy')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('http://')
+        ex.message.contains('https://')
+        !httpGetCalled  // scheme check fires before any network attempt
+    }
+
+    def "_fetchSourceFromUrl: throws IAE on null url"() {
+        when:
+        script._fetchSourceFromUrl(null)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('http://')
+    }
+
+    def "_fetchSourceFromUrl: throws IAE on non-200 status"() {
+        given:
+        stubHttpGet(404, 'not found')
+
+        when:
+        script._fetchSourceFromUrl('https://example.com/missing.groovy')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('HTTP 404')
+    }
+
+    def "_fetchSourceFromUrl: throws IAE when fetch raises"() {
+        given:
+        stubHttpGetThrows('Connection refused')
+
+        when:
+        script._fetchSourceFromUrl('https://example.com/x.groovy')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('fetch failed')
+        ex.message.contains('Connection refused')
+    }
+
+    def "_fetchSourceFromUrl: throws IAE on empty body"() {
+        given:
+        stubHttpGet(200, '')
+
+        when:
+        script._fetchSourceFromUrl('https://example.com/empty.groovy')
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('empty body')
+    }
+
+    // -------- importUrl integration: update_app_code --------
+
+    def "update_app_code with importUrl fetches via httpGet and POSTs the fetched source"() {
+        given:
+        enableHubAdminWrite()
+        stubHttpGet(200, 'fetched-source-here')
+        // app code endpoint returns the current version so the optimistic-lock path is satisfied
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "source": "old-source", "version": 7}'
+        }
+        def captured = [:]
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            captured.path = path
+            captured.body = body
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        // backup helper is a no-op stub
+        script.metaClass.backupItemSource = { String type, String itemId -> [version: 7, fileName: 'b.json'] }
+
+        when:
+        def result = script.toolUpdateAppCode([
+            appId: '42',
+            importUrl: 'https://raw.example.com/app.groovy',
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.sourceMode == 'importUrl'
+        result.sourceLength == 'fetched-source-here'.length()
+        result.note?.contains('importUrl')
+        captured.path == '/app/ajax/update'
+        captured.body.source == 'fetched-source-here'
+    }
+
+    // -------- importUrl integration: install_app --------
+
+    def "install_app with importUrl fetches via httpGet and POSTs to /app/save"() {
+        given:
+        enableHubAdminWrite()
+        stubHttpGet(200, 'definition(name: "FromUrl")')
+        def captured = [:]
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            captured.path = path
+            captured.body = body
+            [status: 302, location: 'http://127.0.0.1:8080/app/editor/7777', data: '']
+        }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "source": "stub-source", "version": 1}'
+        }
+
+        when:
+        def result = script.toolInstallApp([
+            importUrl: 'https://raw.example.com/new.groovy',
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.appId == '7777'
+        result.sourceMode == 'importUrl'
+        captured.path == '/app/save'
+        captured.body.source == 'definition(name: "FromUrl")'
+        result.note?.contains('importUrl')
+    }
+
+    // -------- importUrl integration: install_library --------
+
+    def "install_library with importUrl fetches the URL and posts to library/saveOrUpdateJson"() {
+        given:
+        enableHubAdminWrite()
+        stubHttpGet(200, 'library(name: "Lib")')
+        def captured = [:]
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.path = path
+            captured.body = body
+            [success: true, id: 555, version: 1]
+        }
+
+        when:
+        def result = script.toolInstallLibrary([
+            importUrl: 'https://raw.example.com/lib.groovy',
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.libraryId == '555'
+        result.sourceMode == 'importUrl'
+        captured.path == '/library/saveOrUpdateJson'
+        captured.body.contains('library(name: \\"Lib\\")')
+    }
+
+    // -------- mutual exclusion --------
+    // For install_*_code, modesSet counts the present modes and throws if > 1.
+    // For update_*_code, the existing if-else chain naturally takes the first
+    // present mode in the order resave > sourceFile > importUrl > source --
+    // tool schema documents these as mutually exclusive; explicit mutex
+    // enforcement at the API boundary is a follow-up if it proves needed.
+
+    def "install_app rejects multiple source modes together"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallApp([
+            source: 'inline',
+            importUrl: 'https://x.com/a.groovy',
+            confirm: true
+        ])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('exactly one')
+    }
+
+    def "install_library rejects multiple source modes together"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallLibrary([
+            sourceFile: 'lib.groovy',
+            importUrl: 'https://x.com/lib.groovy',
+            confirm: true
+        ])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('exactly one')
+    }
+
+    // -------- installAsUserApp --------
+
+    def "install_app with installAsUserApp creates instance via /installedapp/create/<codeId> and parses Location"() {
+        given:
+        enableHubAdminWrite()
+        def capturedPath = null
+        script.metaClass.hubInternalGetRaw = { String path, Map query = null, int timeout = 30, boolean isRetry = false ->
+            capturedPath = path
+            [
+                status: 302,
+                location: '/installedapp/configure/9999/mainPage',
+                data: ''
+            ]
+        }
+
+        when:
+        def result = script.toolInstallApp([installAsUserApp: 310, confirm: true])
+
+        then:
+        capturedPath == '/installedapp/create/310'
+        result.success == true
+        result.mode == 'installAsUserApp'
+        result.codeAppId == 310
+        result.instanceAppId == 9999
+    }
+
+    def "install_app with installAsUserApp returns success=false when hub returns non-302"() {
+        given:
+        enableHubAdminWrite()
+        script.metaClass.hubInternalGetRaw = { String path, Map query = null, int timeout = 30, boolean isRetry = false ->
+            [status: 404, location: null, data: 'not found']
+        }
+
+        when:
+        def result = script.toolInstallApp([installAsUserApp: 99999, confirm: true])
+
+        then:
+        result.success == false
+        result.codeAppId == 99999
+        result.error.contains('404')
+    }
+
+    def "install_app rejects installAsUserApp combined with importUrl"() {
+        given:
+        enableHubAdminWrite()
+
+        when:
+        script.toolInstallApp([
+            installAsUserApp: 310,
+            importUrl: 'https://example.com/x.groovy',
+            confirm: true
+        ])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('mutually exclusive')
+        ex.message.contains('two calls')
+    }
+
+    // -------- triggerUpdated --------
+
+    def "update_app_code with triggerUpdated fires updated() POST after save and reports updatedFired=true"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "source": "old", "version": 5}'
+        }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            posts << [path: path, body: body]
+            // first POST: code update; second POST: trigger updated
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
+
+        when:
+        def result = script.toolUpdateAppCode([
+            appId: '42',
+            source: 'new source',
+            triggerUpdated: 194,
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.triggerUpdated == 194
+        result.updatedFired == true
+        posts.size() == 2
+        posts[0].path == '/app/ajax/update'
+        posts[1].path == '/installedapp/configure/194/mainPage'
+    }
+
+    def "update_app_code with triggerUpdated reports updatedFired=false + repairHints when lifecycle POST throws"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "source": "old", "version": 5}'
+        }
+        def postCount = 0
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            postCount++
+            if (path.startsWith('/installedapp/configure/')) {
+                throw new RuntimeException('hub rejected lifecycle POST')
+            }
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
+
+        when:
+        def result = script.toolUpdateAppCode([
+            appId: '42',
+            source: 'new source',
+            triggerUpdated: 194,
+            confirm: true
+        ])
+
+        then:
+        // The save itself succeeded; only the optional lifecycle refresh failed.
+        result.success == true
+        result.triggerUpdated == 194
+        result.updatedFired == false
+        result.repairHints?.any { it.toString().contains('lifecycle-fire POST failed') }
+    }
+
+    def "update_app_code without triggerUpdated does NOT fire updated() (negative pin matches UI behavior)"() {
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "source": "old", "version": 5}'
+        }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body ->
+            posts << [path: path]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+        script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
+
+        when:
+        def result = script.toolUpdateAppCode([
+            appId: '42',
+            source: 'new source',
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.containsKey('triggerUpdated') == false
+        result.containsKey('updatedFired') == false
+        posts.size() == 1
+        posts[0].path == '/app/ajax/update'  // only the code-save POST, no lifecycle POST
+    }
+}

--- a/src/test/groovy/server/ToolImportUrlSpec.groovy
+++ b/src/test/groovy/server/ToolImportUrlSpec.groovy
@@ -1,7 +1,6 @@
 package server
 
 import spock.lang.Shared
-import spock.lang.Unroll
 import support.TestChildApp
 import support.ToolSpecBase
 
@@ -399,6 +398,10 @@ class ToolImportUrlSpec extends ToolSpecBase {
         result.triggerUpdated == 194
         result.updatedFired == false
         result.repairHints?.any { it.toString().contains('lifecycle-fire POST failed') }
+        // Pins that BOTH posts were attempted -- the save (1) + the lifecycle fire (2).
+        // Without this, a regression that throws before reaching the lifecycle POST
+        // could produce the same envelope shape while never trying the second POST.
+        postCount == 2
     }
 
     def "update_app_code without triggerUpdated does NOT fire updated() (negative pin matches UI behavior)"() {

--- a/src/test/groovy/server/ToolLibraryCodeSpec.groovy
+++ b/src/test/groovy/server/ToolLibraryCodeSpec.groovy
@@ -433,7 +433,7 @@ def helperMethod() { return "ok" }
 
         then:
         def ex = thrown(IllegalArgumentException)
-        ex.message.contains('not both')
+        ex.message.contains('exactly one')
     }
 
     @spock.lang.Unroll
@@ -447,7 +447,7 @@ def helperMethod() { return "ok" }
 
         then:
         response.error.code == -32602
-        response.error.message.contains('not both')
+        response.error.message.contains('exactly one')
 
         where:
         useGateways << [true, false]


### PR DESCRIPTION
## Summary

- Adds `importUrl` to all six install/update tools so callers can deploy Groovy source by URL — the hub fetches directly, mirroring the editor's "Import Code from Website" → Save flow in one tool call.
- Adds `installAsUserApp: <codeAppId>` to `install_app`, closing the gap where `install_app` installed code into Apps Code but the user had to manually click "Add User App" in the UI to actually instantiate it.
- Adds optional `triggerUpdated: <instanceAppId>` to `update_app_code` to fire `updated()` on the running instance after save (default off — matches what the UI Save does, which empirically does NOT fire `updated()`).

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

**Two new private helpers** (`hubitat-mcp-server.groovy`):
- `_fetchSourceFromUrl(url)` — scheme-validated synchronous `httpGet` (60s timeout, `textParser:true`). Throws structured `IllegalArgumentException` on bad scheme / non-200 / fetch exception / empty body. Sits next to `hubInternalGetRaw` for visibility.
- `_createUserAppInstance(codeAppId)` — calls `hubInternalGetRaw("/installedapp/create/<codeId>")`, captures the 302 Location header, parses `/installedapp/configure/<newId>/mainPage` out, returns `{success, codeAppId, instanceAppId, mode:"installAsUserApp"}`. Never throws.

**`importUrl` wired into** every source-mode resolution chain:
- `toolInstallItemSingle` (install_app, install_driver)
- `toolUpdateItemCodeInner` (update_app_code, update_driver_code)
- `toolInstallLibrary`, `toolUpdateLibraryCode`
- Bulk paths (`toolInstallItem`'s `installs[]`, `toolUpdateDriverCode`'s `updates[]`) also accept per-item `importUrl`.

**`installAsUserApp` mode** dispatched at the top of `toolInstallApp`. Mutually exclusive with `source`/`sourceFile`/`importUrl`; throws with a clear two-call hint if combined. Explicit two-call workflow:
1. `install_app(importUrl|source|sourceFile, confirm:true)` — installs code, returns `codeAppId`
2. `install_app(installAsUserApp:<codeAppId>, confirm:true)` — instantiates, fires `installed()`

**`triggerUpdated` post-save** in `toolUpdateItemCodeInner` (apps only — drivers refresh per-device, libraries are `#include`'d). After the save POST returns success, posts `_action_Done=Done` to `/installedapp/configure/<id>/mainPage`. Lifecycle-fire failure is non-fatal: result reports `success:true, updatedFired:false, repairHints:[...]`.

**Tool descriptions across all six tools were trimmed** of the duplicated curl-upload recipe (it was repeated 6 times verbatim) to make room for the new mode descriptions within the 128 KB `tools/list` response cap. Net byte impact verified small.

**Sandbox lint passes** (`python tests/sandbox_lint.py` → 0 errors, 0 warnings).

## Release Notes

- New `importUrl` parameter on `install_app`, `install_driver`, `install_library`, `update_app_code`, `update_driver_code`, `update_library_code` — pass an `http://` or `https://` URL and the hub fetches the Groovy source directly, mirroring what the code editor's "Import Code from Website" → Save flow does in the UI. One tool call instead of curl-upload-then-install.
- New `installAsUserApp` parameter on `install_app` — after installing code via `install_app`, a second call `install_app(installAsUserApp:<codeAppId>, confirm:true)` creates a running instance (the equivalent of clicking "Add User App" in the UI) and fires `installed()` automatically. Mutually exclusive with source-install args to keep the two phases explicit.
- New optional `triggerUpdated` parameter on `update_app_code` — set to a running instance's appId and the tool will fire `updated()` on that instance after the source save succeeds, so subscriptions/schedules/atomicState refresh against the new code. Default is omitted (no extra lifecycle action) to match what the editor's Save button does.
- `_fetchSourceFromUrl` helper handles up to 1.25 MB payloads in under a second on a Hubitat C-8 (empirically measured against `raw.githubusercontent.com`).

## Testing

- 13 new Spock specs in `src/test/groovy/server/ToolImportUrlSpec.groovy`:
  - `_fetchSourceFromUrl` helper: happy path + 5 failure paths (bad scheme, null url, non-200, fetch exception, empty body)
  - Integration smoke for `importUrl` on `update_app_code`, `install_app`, `install_library`
  - Mutual exclusion on `install_app` and `install_library` (modesSet > 1)
  - `installAsUserApp`: happy path, 404, mutex with importUrl
  - `triggerUpdated`: happy path, lifecycle-fire failure, negative pin (no extra POST when omitted)
- Live-hub empirical validation:
  - `BAT-importurl-probe` user app installed on Hubitat C-8 firmware 2.5.0.143 confirmed synchronous `httpGet` from the sandbox handles a 1.25 MB `raw.githubusercontent.com` fetch in 783 ms (10,985 bytes packageManifest.json in 259 ms). No sandbox cap, DNS, or TLS issues.
  - UI flow confirmation: `/ui2/js/vue-hub2.min.js` extracted handler + Chrome network capture during live Import → Save confirmed the editor's Save only POSTs `/app/saveOrUpdateJson` and re-GETs `/app/list/single/data/<id>` — zero requests to `/installedapp/*`, no `updated()` fires from the UI. Hence `triggerUpdated` defaults to off.
- Sandbox lint clean (`python tests/sandbox_lint.py`).

## Checklist

- [x] **Unit tests added for any new MCP tools** (13 specs in `ToolImportUrlSpec.groovy`)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (CI will confirm)
- [ ] Live-hub BAT tests updated if tool behaviour changed (existing BAT files cover install/update at a high level; new spec covers the import-url paths in detail)
- [x] Documentation updated if user-facing behaviour or tool surface changed (tool descriptions updated for all six tools; design doc lives outside the PR per maintainer preference)
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (no new tools; only new parameters with concise schema-level descriptions)