### PR TITLE
docs: introducing security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+*placeholder*
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+*placeholder*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,19 @@
 
 ## Supported Versions
 
-*placeholder*
+Security fixes are provided for the latest released Hubitat Package Manager version of MCP Rule Server.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+The current release is `1.4.2`, released on `2026-05-27`. The package currently requires Hubitat firmware `2.3.0+`.
+
+| Version | Supported |
+| ------- | --------- |
+| 1.4.2   | Yes       |
+| < 1.4.2 | No        |
 
 ## Reporting a Vulnerability
 
-*placeholder*
+Please report security issues privately through GitHub's **Report a vulnerability** flow for this repository if it is available.
+
+Do not include access tokens, hub IDs, endpoint URLs, or other secrets in public issues or pull requests. If private reporting is not available, open a GitHub issue with a brief, non-sensitive summary and state that you have security details to share privately.
+
+We will review reports as time allows and publish fixes in the latest release when appropriate.


### PR DESCRIPTION
<!-- Prefix your PR title with the type that matches what you tick below.
     Valid prefixes: feat: | fix: | chore: | refactor: | docs: | test: | ci:
     Example: "feat: add device health polling tool"
     Note: build: is reserved for Dependabot — contributors should not use it. -->

## Summary

Beginning the security policy so contributors can securely report security issues should they arise 

## Type of change

<!-- Tick exactly one. -->

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [c] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

<!-- Key changes. Reference issue numbers (Closes #N / Fixes #N / Part of #N). -->

## Release Notes

<!-- These bullets are what HPM users will see when prompted to update — write for end users, not developers.
     Sub-bullets are supported (nest with 2-space indent).
     If you skip this section, the release entry will fall back to just the PR title. -->

- 

## Testing

<!-- How you verified this works. -->

## Checklist

- [ ] **Unit tests added for any new MCP tools** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes)
- [ ] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
- [ ] Documentation updated if user-facing behaviour or tool surface changed
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema)
