### PR TITLE
Potential fix for code scanning alerts: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,6 +14,9 @@ on:
       - 'tests/e2e_test.py'
       - '.github/workflows/python-tests.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/sandbox-lint.yml
+++ b/.github/workflows/sandbox-lint.yml
@@ -7,6 +7,9 @@ on:
       - 'packageManifest.json'
       - 'tests/sandbox_lint.py'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   matrix-test:
     runs-on: ubuntu-latest
@@ -67,6 +70,7 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
+    permissions: {}
     needs: matrix-test
     if: always()
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/kingpanther13/Hubitat-local-MCP-server/security/code-scanning/1](https://github.com/kingpanther13/Hubitat-local-MCP-server/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (currently just `test`). For this workflow, the minimal required scope is `contents: read`, which allows checkout/read operations while preventing unnecessary write privileges.

Best single fix without changing functionality:
- Edit `.github/workflows/python-tests.yml`.
- Insert a top-level `permissions:` section between the trigger (`on:` block) and `jobs:`.
- Set:
  - `contents: read`

No imports, methods, or dependency changes are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
