### PR TITLE
chore: pin commons-collections to 3.2.2 (test-only deserialization fix)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,8 +97,9 @@ dependencies {
     testImplementation 'net.bytebuddy:byte-buddy:1.18.8'
 
     // Security pin: commons-collections 3.2.x carries the InvokeTransformer
-    // deserialization RCE (CVE-2015-7501, CVE-2015-6420). 3.2.2 is a same-line,
-    // drop-in patch — adds FunctorUtils serialization guards, no API change.
+    // deserialization RCE (CVE-2015-7501, CVE-2015-6420). 3.2.2 is a drop-in
+    // patch on the same 3.2.x release line — adds FunctorUtils serialization
+    // guards, no API change.
     // Reaches the test classpath transitively only
     // (hubitat_ci -> http-builder -> json-lib -> commons-collections) and is
     // never shipped — packageManifest.json deploys only the two .groovy files.

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,18 @@ dependencies {
     // Spock 2.x can use either byte-buddy or cglib-nodep as its class-gen
     // backend; neither is a transitive dep of spock-core.
     testImplementation 'net.bytebuddy:byte-buddy:1.18.8'
+
+    // Security pin: commons-collections 3.2.x carries the InvokeTransformer
+    // deserialization RCE (CVE-2015-7501, CVE-2015-6420). 3.2.2 is a same-line,
+    // drop-in patch — adds FunctorUtils serialization guards, no API change.
+    // Reaches the test classpath transitively only
+    // (hubitat_ci -> http-builder -> json-lib -> commons-collections) and is
+    // never shipped — packageManifest.json deploys only the two .groovy files.
+    constraints {
+        testImplementation('commons-collections:commons-collections:3.2.2') {
+            because 'CVE-2015-7501/-6420 — drop-in security patch on a test-only transitive'
+        }
+    }
 }
 
 java {


### PR DESCRIPTION
## Summary

- Pins the `commons-collections` test-classpath transitive to `3.2.2`, the drop-in patch for the InvokeTransformer deserialization RCE (CVE-2015-7501 / CVE-2015-6420).
- Test-only and never shipped — `packageManifest.json` deploys only the two `.groovy` files; the main runtime classpath contains none of this.

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [x] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- `build.gradle`: add a test-scoped `constraints { testImplementation('commons-collections:commons-collections:3.2.2') }` block with a WHY comment. Resolves `3.2.1 -> 3.2.2` (verified). Clears the repo's only *critical* Dependabot alert and its `high` companion. The dependency arrives transitively (`hubitat_ci -> http-builder -> json-lib -> commons-collections`), so Dependabot cannot bump it on its own (Gradle transitive security updates are unsupported); a constraint is the supported fix.

## Release Notes

- No user-facing changes — internal test-only dependency security pin.

## Testing

- Full Spock suite green on the JDK 11 toolchain: 2716 passed, 0 failed.
- `python tests/sandbox_lint.py` passes.

## Checklist

- [ ] **Unit tests added for any new MCP tools** (n/a — no new tools)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (n/a)
- [ ] Documentation updated if user-facing behaviour or tool surface changed (n/a)
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (n/a)
