### PR TITLE
fix: complete RM 5.1 Periodic Schedule trigger support

### DIFF
--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -575,18 +575,27 @@ Reference for the `update_native_app` structured shortcuts (`addTrigger`, `addAc
 - **Periodic Schedule** (`capability='Periodic Schedule'`): recurring schedule via the dedicated periodic sub-page. Spec:
   ```
   periodic={
-    frequency: 'Hourly'|'Daily'|'Cron String'|...,
-    everyN: <int>,                 // for "every N <unit>" mode (Hourly/Daily)
-    startingTime: 'HH:mm',         // start-time for everyN modes
+    frequency: 'Seconds'|'Minutes'|'Hourly'|'Daily'|'Weekly'|'Monthly'|'Yearly'|'Cron String',
+    everyN: <int>,                 // "every N <unit>" mode (Seconds/Minutes/Hourly/Daily)
+                                   //   REQUIRED even when =1 for Daily AND Hourly (omitting renders null)
+                                   //   Seconds/Minutes: whole number from [1,2,3,4,5,6,10,12,15,20,30] (firmware-imposed; Hourly/Daily accept any positive integer; fractional truncates, 5.5->5)
+    startingTime: 'HH:mm',         // start-time (Hourly/Daily/Weekly/Monthly/Yearly; Seconds has none); for Hourly-everyN, pass it (omitting renders a cosmetic trailing "starting at " blank)
     weekdaysOnly: <bool>,          // Daily-only
     selectedHours: [9,12],         // Hourly-only, alternative to everyN
+    selectedMinutes: [0,30],       // Minutes-only, "at specific minutes", alternative to everyN
     selectedDaysOfMonth: [1,15],   // Daily-only, alternative to everyN/weekdays
+    daysOfWeek: ['Monday','Friday'], // Weekly-only, MULTI day-of-week
+    dayOfWeek: 'Monday',           // Monthly/Yearly nth-weekday, SINGLE day-of-week (distinct from daysOfWeek)
+    dayOfMonth: <int>,             // Monthly by-day "on day number" (pair with everyNMonths; exclusive with weekOfMonth)
+    everyNMonths: <int>,           // "of every N months" (Monthly, both modes; free integer)
+    months: 'December',            // Yearly only -- single nth-weekday month (String); Monthly does NOT take months
+    weekOfMonth: 'First',          // Monthly/Yearly nth-weekday: First|Second|Third|Fourth|Last (presence selects nth-weekday)
     minutesOffset: <int>,          // Hourly-only, when not using everyN (startingHCX1)
     cronString: '0 * * * *',       // Cron String mode
     rawSettings: {…}               // escape hatch for periodic-page fields not yet mapped
   }
   ```
-  Without `periodic`, RM commits a phantom row with description `?`. The tool walks the periodic sub-page (`whichPeriod1` → `everyN`/select → time → Done) so the trigger description bakes correctly.
+  **Monthly has two mutually-exclusive modes:** *by-day* (`dayOfMonth` + `everyNMonths` -- BOTH required or the row renders `null`) and *nth-weekday* (`weekOfMonth` + `dayOfWeek` + `everyNMonths` -- e.g. "the Second Monday of every month"). Passing both `dayOfMonth` and `weekOfMonth` is rejected. Monthly "specific months" ("on day N of selected months") is NOT yet supported (an order-sensitive third sub-mode) -- use `rawSettings`. **Yearly is ALWAYS nth-weekday:** `weekOfMonth` + `dayOfWeek` + single `months` (e.g. "the First Monday of December"); the month alone never completes, because RM 5.1 exposes no by-day calendar-day field for Yearly -- only the nth-weekday picker. **Seconds** exposes only the count enum -- no toggle, no `startingTime`. The Seconds/Minutes restricted enum is firmware-imposed; Hourly/Daily `everyN` accept any positive integer. Without `periodic`, RM commits a phantom row with description `?`. The tool walks the periodic sub-page (`whichPeriod<N>` → `everyN`/select → time → Done, where `<N>` is the per-trigger sub-page index) so the trigger description bakes correctly. A Seconds/Minutes `everyN` outside the restricted enum, or a Monthly `dayOfMonth`+`weekOfMonth` combo, is rejected with `success=false` and a structured error (the whole-tool backup-and-catch envelope surfaces the validation failure as a structured map, not a thrown -32602).
 
 - **Inline conditional trigger** (`trigger.condition` Map): `{capability, deviceIds?, state?, comparator?, value?, attribute?, variable?, compareToVariable?, not?, rawSettings?}`. Drives the conditional-trigger sub-wizard inline (sets `isCondTrig.<N>=true` + `condTrig.<N>=a` + the condition fields + clicks hasAll). Convenience: pass singular `deviceId: N` (integer) instead of `deviceIds: [N]` (array) -- the dispatcher normalizes before writing. If both `deviceId` and `deviceIds` are supplied, `deviceIds` wins.
   - The following per-capability extended shapes work on `trigger.condition`: Variable (incl. `compareToVariable`), Custom Attribute (`attribute` + `comparator` + `state`/`value`), and enum/numeric device-state conditions. **Mode-via-picker (`modeIds`), Between two times (`start`/`end`), and `compareToDevice` Maps are NOT yet supported on `trigger.condition`** -- `_rmBuildCondition` is a static direct-write helper, not the shared `_rmWalkConditionReveal` walker. For those shapes use `addRequiredExpression.conditions[]` or `addAction.expression.conditions[]` instead.

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3045,7 +3045,7 @@ Capability families and the spec fields each accepts:
       everyNMonths: <int>,     // "of every N months" (Monthly, both modes; free integer)
       months: 'December',      // Yearly only -- single month String (the nth-weekday month)
       weekOfMonth: 'First',    // Monthly/Yearly nth-weekday: First|Second|Third|Fourth|Last (presence selects nth-weekday mode)
-      minutesOffset: <int>,    // Hourly-only, when not using everyN (startingHCX1)
+      minutesOffset: <int>,    // Hourly-only, when not using everyN (startingHCX<n>)
       cronString: '0 * * * *', // Cron String mode
       rawSettings: {…}         // escape hatch for periodic-page fields not yet mapped
     }
@@ -15040,8 +15040,13 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
 
     // Periodic argument validation, run before the moreCond click opens the
     // wizard so a bad spec surfaces a structured failure without leaving an
-    // in-flight trigger editor half-open. The full per-frequency field map
-    // lives in the periodic block further down; these are just the arg guards.
+    // in-flight trigger editor half-open. NOTE: this half-open guarantee is
+    // PER-SPEC -- it protects the single trigger being added here. The bulk
+    // addTriggers/patches paths share one pre-batch backup, so a mid-batch reject
+    // leaves earlier triggers in the batch already committed; batch callers should
+    // verify rule state and restore from the batch backup if needed. The full
+    // per-frequency field map lives in the periodic block further down; these are
+    // just the arg guards.
     if (cap.equalsIgnoreCase("Periodic Schedule") && triggerSpec.periodic instanceof Map) {
         def perEarly = triggerSpec.periodic as Map
         def freqEarly = perEarly.frequency?.toString()
@@ -15340,9 +15345,11 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
     // Without this dance, hasAll commits a phantom row with description="?"
     // because the parent's renderer can't reach the sub-page state.
     //
-    // Field names are IRREGULAR across frequencies (no extractable suffix
-    // pattern), so freqFieldMap below carries the exact RM 5.1 setting name
-    // for each role of each frequency, captured live against fw 5.1.8.
+    // Field BASE names are IRREGULAR across frequencies (everyNHC vs everyNDC
+    // vs everyNSecs -- no shared stem to extract), so freqFieldMap below carries
+    // the exact RM 5.1 base name for each role of each frequency, captured live
+    // against fw 5.1.8. The per-trigger SUFFIX, by contrast, is uniform: every
+    // field ends in the resolved sub-page index pn (interpolated below).
     if (capCanonical == "Periodic Schedule" && triggerSpec.periodic instanceof Map) {
         def per = triggerSpec.periodic as Map
         def freq = per.frequency?.toString()
@@ -15367,6 +15374,7 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
         def periodicHrefName = "periodic1"
         def periodicHrefParams = [n: 1]
         def periodicHrefFound = false
+        def periodicHrefDiscoveryError = null
         try {
             def stCfg = _rmFetchConfigJson(appId, "selectTriggers")
             def periodicHref = (stCfg?.configPage?.sections ?: []).collectMany { sect ->
@@ -15378,7 +15386,8 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
                 if (periodicHref.params instanceof Map) periodicHrefParams = periodicHref.params as Map
             }
         } catch (Exception hrefExc) {
-            mcpLog("warn", "rm-native", "_rmAddTrigger: periodic href discovery on selectTriggers failed for app ${appId} (${hrefExc.class.simpleName}: ${hrefExc.message}) -- falling back to periodic1/n=1; a non-first periodic trigger may collide with the first")
+            periodicHrefDiscoveryError = "${hrefExc.class.simpleName}: ${hrefExc.message}".toString()
+            mcpLog("warn", "rm-native", "_rmAddTrigger: periodic href discovery on selectTriggers failed for app ${appId} (in-flight trigger idx ${idx}) (${periodicHrefDiscoveryError}) -- falling back to periodic1/n=1; a non-first periodic trigger may collide with the first")
         }
         // Href absent (not an exception, but still a discovery failure): warn the
         // same way, because suffix-1 fallback is only safe for the FIRST periodic
@@ -15390,27 +15399,50 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
         }
         // The marker form-index suffix uses params.n (matches walkStep navigate).
         // Guard the cast: a malformed params.n (non-integer) would otherwise escape
-        // to the outer catch as a raw context-less JVM message; fall back to 1.
+        // to the outer catch as a raw context-less JVM message; fall back to 1 and
+        // flag it so the fallback decision below treats a discovered-but-malformed
+        // href the same as an absent one (both leave us unable to target the right
+        // sub-page index, which is unsafe for a non-first trigger).
         def periodicHrefIndex = 1
+        def periodicNMalformed = false
         if (periodicHrefParams?.n != null) {
             try {
                 periodicHrefIndex = periodicHrefParams.n as Integer
             } catch (Exception nCastExc) {
-                mcpLog("warn", "rm-native", "_rmAddTrigger: periodic href params.n='${periodicHrefParams.n}' is not an integer for app ${appId} (${nCastExc.class.simpleName}: ${nCastExc.message}) -- falling back to n=1")
+                periodicNMalformed = true
+                mcpLog("warn", "rm-native", "_rmAddTrigger: periodic href params.n='${periodicHrefParams.n}' is not an integer for app ${appId} (in-flight trigger idx ${idx}) (${nCastExc.class.simpleName}: ${nCastExc.message}) -- falling back to n=1")
                 periodicHrefIndex = 1
             }
         }
-        def hrefParams = periodicHrefParams
-        // If the periodic href was NOT discovered AND this is not the first
-        // trigger slot, suffix-1 fallback would silently overwrite an earlier
-        // periodic trigger. Refuse to write a guaranteed clobber: record a skip
-        // so the row surfaces partial=true with an actionable repair hint, and
-        // leave the periodic sub-page writes unattempted for this trigger.
-        def periodicUnsafeFallback = (!periodicHrefFound && (idx as Integer) > 1)
+        // Normalize params.n to the resolved integer index. Downstream re-casts
+        // (_rmSubmitSubPageDone re-reads hrefParams.n as Integer) must operate on a
+        // clean Integer so a malformed value the cast guard above already absorbed
+        // can't re-throw past this point. Build a fresh map -- never mutate the
+        // discovered params.
+        def hrefParams = (periodicHrefParams instanceof Map ? (periodicHrefParams as Map) : [:]) + [n: periodicHrefIndex]
+        // If we cannot reliably target this trigger's own sub-page index -- the href
+        // was NOT discovered OR its params.n was malformed -- AND this is not the
+        // first trigger slot, suffix-1 fallback would silently overwrite an earlier
+        // periodic trigger. Refuse to write a guaranteed clobber: record a skip so
+        // the row surfaces partial=true with an actionable repair hint, and leave
+        // the periodic sub-page writes unattempted for this trigger. (idx is provably
+        // Integer here -- assigned from the resolved trigger index -- so its cast is
+        // unguarded, unlike the hub-supplied params.n above.)
+        def periodicUnsafeFallback = ((!periodicHrefFound || periodicNMalformed) && (idx as Integer) > 1)
         if (periodicUnsafeFallback) {
-            skipped << [key: "periodic", reason: "periodic_href_absent_nonfirst_trigger", value: freq,
-                        note: "No periodic href in selectTriggers schema for trigger idx ${idx}; writing suffix-1 fields would overwrite an earlier periodic trigger. Periodic sub-page not written."]
-            mcpLog("warn", "rm-native", "_rmAddTrigger: skipping periodic sub-page writes for app ${appId} trigger idx ${idx} -- periodic href absent and idx>1, suffix-1 fallback would clobber the first periodic trigger")
+            def unsafeReason = periodicHrefDiscoveryError != null ? "periodic href discovery failed (${periodicHrefDiscoveryError})"
+                             : !periodicHrefFound ? "periodic href absent from selectTriggers schema"
+                             : "periodic href params.n malformed"
+            skipped << [key: "periodic", reason: "periodic_href_unresolved_nonfirst_trigger", value: freq,
+                        note: "Cannot resolve the periodic sub-page index for trigger idx ${idx} (${unsafeReason}); writing suffix-1 fields would overwrite an earlier periodic trigger. Periodic sub-page not written."]
+            mcpLog("warn", "rm-native", "_rmAddTrigger: skipping periodic sub-page writes for app ${appId} trigger idx ${idx} -- ${unsafeReason} and idx>1, suffix-1 fallback would clobber the first periodic trigger")
+        } else if (periodicNMalformed || periodicHrefDiscoveryError != null) {
+            // Safe path (idx==1, suffix-1 is correct) but a discovery anomaly still
+            // occurred. Surface a breadcrumb in the response so a hub systematically
+            // emitting bad periodic hrefs shows up as more than scattered hub logs.
+            def anomaly = periodicNMalformed ? "periodic href params.n malformed (resolved to 1)" : "periodic href discovery threw (${periodicHrefDiscoveryError})"
+            skipped << [key: "periodic", reason: "periodic_href_anomaly_firsttrigger", value: freq,
+                        note: "${anomaly}; suffix-1 was used and is correct for the first periodic trigger, but verify the schedule rendered via get_app_config."]
         }
         // Periodic field names are suffixed by the per-trigger sub-page index
         // (pn). For pn=1 the field names end in ...C1; for a later periodic
@@ -15424,9 +15456,11 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
         // Role keys (not all frequencies have all roles):
         //   everyNToggle  -- bool, "every n <unit>?"; must land BEFORE everyNCount
         //   everyNCount   -- the count; for Hourly/Daily a free integer, for
-        //                    Minutes a restricted enum (validated up front)
+        //                    Minutes a restricted enum (validated up front). Seconds
+        //                    is equally restricted, via secondsCount below.
         //   secondsCount  -- Seconds has NO toggle; the count enum IS the mode
-        //   selectMulti   -- multi-enum picker (hours / days-of-month / days-of-week / months)
+        //                    (restricted enum, same allowed set as Minutes)
+        //   selectMulti   -- multi-enum picker (hours / days-of-month / days-of-week / minutes)
         //   weekdayToggle -- Daily-only "weekdays only"
         //   dayOfMonth    -- Monthly by-day "on day number"
         //   everyNMonths  -- Monthly by-day "of every n months"
@@ -15465,6 +15499,11 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
         // Skip the entire periodic sub-page dance when the suffix-1 fallback
         // would clobber an earlier periodic trigger (see periodicUnsafeFallback).
         if (!periodicUnsafeFallback) {
+        // Forward-nav into the periodic sub-page. Its return is intentionally NOT
+        // folded into skipped: _rmNavigateToPage returns null on BOTH a POST failure
+        // AND a non-JSON response (the latter is benign -- the caller plain-fetches),
+        // so null is ambiguous here. A genuine nav failure surfaces deterministically
+        // anyway via the writePeriodic persistence checks below (every field skips).
         _rmNavigateToPage(appId, "selectTriggers", "periodic", periodicHrefIndex, periodicHrefName, hrefParams)
         // Closure that wraps _rmWriteSubPageField with applied/skipped routing
         // based on the helper's persistence verification (Map return). Use this
@@ -15517,22 +15556,22 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
                 if (per.weekOfMonth != null && fields.weekOfMonth) {
                     writePeriodic(fields.weekOfMonth, per.weekOfMonth)
                 }
-                // Single day-of-week enum (dailyMC1 / dailyYC1). The dayOfWeek
+                // Single day-of-week enum (dailyMC<n> / dailyYC<n>). The dayOfWeek
                 // alias is SINGULAR -- distinct from Weekly's daysOfWeek multi.
                 if (per.dayOfWeek != null && fields.dayOfWeek) {
                     writePeriodic(fields.dayOfWeek, per.dayOfWeek)
                 }
-                // Monthly nth-weekday cadence is a FREE number in everyNMCX1
-                // (NOT the by-day everyNMC1, and NOT the restricted enum).
+                // Monthly nth-weekday cadence is a FREE number in everyNMCX<n>
+                // (NOT the by-day everyNMC<n>, and NOT the restricted enum).
                 if (per.everyNMonths != null && fields.everyNMonthsNth) {
                     writePeriodic(fields.everyNMonthsNth, per.everyNMonths)
                 }
-                // Yearly nth-weekday month is a single enum in yearlyMonthCX1.
+                // Yearly nth-weekday month is a single enum in yearlyMonthCX<n>.
                 if (per.months != null && fields.monthEnum) {
                     writePeriodic(fields.monthEnum, per.months)
                 }
             } else {
-                // by-day mode (Monthly without weekOfMonth). dayMC1 + everyNMC1;
+                // by-day mode (Monthly without weekOfMonth). dayMC<n> + everyNMC<n>;
                 // an incomplete combo (e.g. dayOfMonth without everyNMonths)
                 // renders "null" -- documented in the arg shape.
                 if (per.dayOfMonth != null && fields.dayOfMonth) {
@@ -15544,16 +15583,21 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
             }
             // Multi-enum selection. Each frequency exposes ONE selectMulti
             // field but under a different alias; route the matching one.
-            //   Hourly  selectedHours        -> selectHoursC1
-            //   Daily   selectedDaysOfMonth  -> selectDoMC1
-            //   Weekly  daysOfWeek           -> selectDoWC1
-            //   Minutes selectedMinutes      -> selectMinutesC1 (alt to everyN)
+            //   Hourly  selectedHours        -> selectHoursC<n>
+            //   Daily   selectedDaysOfMonth  -> selectDoMC<n>
+            //   Weekly  daysOfWeek           -> selectDoWC<n>
+            //   Minutes selectedMinutes      -> selectMinutesC<n> (alt to everyN)
+            // CONTRACT for the Elvis chain below: it relies on (a) each frequency
+            // exposing AT MOST ONE selectMulti alias, so no two of these are set at
+            // once, and (b) empty-list falsiness -- an empty [] for one alias falls
+            // through to the next. If a future frequency exposes two multi-pickers,
+            // this collapses them to one and must be reworked into per-frequency routing.
             def selectVals = per.selectedHours ?: per.selectedDaysOfMonth ?: per.daysOfWeek ?:
                              per.selectedMinutes
             if (selectVals != null && fields.selectMulti) {
                 writePeriodic(fields.selectMulti, selectVals)
             }
-            // Time field (startingHC1 / startingDC1 / startingWC1 / ...).
+            // Time field (startingHC<n> / startingDC<n> / startingWC<n> / ...).
             if (per.startingTime != null && fields.time) {
                 writePeriodic(fields.time, per.startingTime.toString())
             }
@@ -15568,8 +15612,19 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
                 writePeriodic(rk.toString(), rv)
             }
         }
-        // Submit Done -- bakes the description into the trigger row.
-        _rmSubmitSubPageDone(appId, "periodic", "selectTriggers", periodicHrefName, hrefParams)
+        // Submit Done -- bakes the description into the trigger row. _rmSubmitSubPageDone
+        // lets a Done-POST failure throw (so its other callers surface it as success:false);
+        // here we catch it locally and fold it into skipped, because the periodic sub-page is
+        // write-after-commit (the trigger row already exists) so a Done failure is a repairable
+        // partial -- not the full success:false the abort-style callers want.
+        try {
+            _rmSubmitSubPageDone(appId, "periodic", "selectTriggers", periodicHrefName, hrefParams)
+        } catch (Exception periodicDoneExc) {
+            def doneErr = "${periodicDoneExc.class.simpleName}: ${periodicDoneExc.message}".toString()
+            mcpLog("warn", "rm-native", "_rmAddTrigger: periodic sub-page Done submit failed for app ${appId} (in-flight trigger idx ${idx}) (${doneErr})")
+            skipped << [key: "periodic", reason: "subpage_done_failed", value: freq,
+                        note: "Periodic sub-page Done submit failed (${doneErr}); the trigger row description may not have baked. Verify via get_app_config and re-add if the row shows '?'."]
+        }
         } // end if (!periodicUnsafeFallback)
     }
 
@@ -15735,8 +15790,8 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
         if ((health?.brokenMarkers as List)?.size() > 0 && !hasBrokenLabel) {
             repairHints << "Rule has pre-existing broken markers: ${(health.brokenMarkers as List).unique().join(', ')}. The new trigger committed, but run check_rule_health(${appId}) and repair the existing broken trigger/action rows before this rule fires correctly."
         }
-        if (skipped?.any { it?.reason == "periodic_href_absent_nonfirst_trigger" }) {
-            repairHints << "The periodic sub-page link was not found in the trigger schema for this (non-first) trigger, so its schedule was NOT written -- writing it would have overwritten an earlier periodic trigger's schedule. Retry the add: re-fetch with update_native_app(walkStep={page:'selectTriggers', operation:'introspect'}) to confirm the periodic href is present, or rebuild the rule's triggers in order. If the rule has only one periodic trigger, this should not recur."
+        if (skipped?.any { it?.reason == "periodic_href_unresolved_nonfirst_trigger" }) {
+            repairHints << "The periodic sub-page index could not be resolved for this (non-first) trigger -- its href was absent from the trigger schema, or the href's params.n was malformed -- so its schedule was NOT written, because writing it would have overwritten an earlier periodic trigger's schedule. Retry the add: re-fetch with update_native_app(walkStep={page:'selectTriggers', operation:'introspect'}) to confirm the periodic href is present with an integer params.n, or rebuild the rule's triggers in order. If the rule has only one periodic trigger, this should not recur."
         }
         if (hubRenderError) {
             repairHints << "WARNING: selectTriggers may have rendered with an error (configPageError=${err}, or skipped items have empty available list). This is a hub-side issue. Consider deleting the trigger and trying with different deviceIds or trigger shape."
@@ -17250,6 +17305,16 @@ private void _rmSubmitSubPageDone(Integer appId, String page, String parentPage,
         }
     }
     if (cfg?.app?.version != null) body.version = cfg.app.version.toString()
+    // Let a Done-POST failure PROPAGATE (hubInternalPostForm throws on a real failure).
+    // Callers handle that throw three ways, by intent -- this is why the catch is scoped at
+    // each call site, not here:
+    //   - addRequiredExpression STPage Done, walkStep done: UNGUARDED -- the throw bubbles to
+    //     the dispatcher's backup-and-catch and surfaces as success:false (abort the op).
+    //   - addTrigger periodic Done: wraps THIS call and folds the failure into skipped as a
+    //     repairable partial (the trigger row already committed).
+    //   - create_native_app trailing Done: wraps THIS call but discards the exception
+    //     (log-only) -- best-effort cleanup, the following updateRule handles the commit.
+    // Catching inside the helper would erase all three distinctions, so it does not.
     hubInternalPostForm("/installedapp/update/json", body)
 }
 
@@ -25133,7 +25198,7 @@ Reference for the three `update_native_app` structured shortcuts (`addTrigger`, 
     everyNMonths: <int>,           // "of every N months" (Monthly, both modes; free integer)
     months: 'December',            // Yearly only -- single nth-weekday month (String); Monthly does NOT take months
     weekOfMonth: 'First',          // Monthly/Yearly nth-weekday: First|Second|Third|Fourth|Last (presence selects nth-weekday)
-    minutesOffset: <int>,          // Hourly-only, when not using everyN (startingHCX1)
+    minutesOffset: <int>,          // Hourly-only, when not using everyN (startingHCX<n>)
     cronString: '0 * * * *',       // Cron String mode
     rawSettings: {…}               // escape hatch for periodic-page fields not yet mapped
   }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3032,17 +3032,25 @@ Capability families and the spec fields each accepts:
     OR modeIds=['3'] OR modeIds=['3','5'] (IDs directly, from get_modes).
     IMPORTANT: writes modesX<N> internally -- do NOT pass tstate or rawSettings.tstate for Mode triggers (silently ignored; trigger renders as Broken Trigger). Use get_modes to list valid mode names/IDs.
   - Periodic Schedule (recurring schedule via the dedicated periodic sub-page):
-    capability='Periodic Schedule', periodic={frequency: 'Hourly'|'Daily'|'Cron String'|...,
-      everyN: <int>,           // for "every N <unit>" mode (Hourly/Daily)
-      startingTime: 'HH:mm',   // start-time for everyN modes
+    capability='Periodic Schedule', periodic={frequency: 'Seconds'|'Minutes'|'Hourly'|'Daily'|'Weekly'|'Monthly'|'Yearly'|'Cron String',
+      everyN: <int>,           // "every N <unit>" mode (Seconds/Minutes/Hourly/Daily). REQUIRED even when =1 for Daily AND Hourly (omitting it renders null). Seconds/Minutes: whole number from restricted enum [1,2,3,4,5,6,10,12,15,20,30] (firmware-imposed; Hourly/Daily accept any positive integer). Fractional truncates (5.5->5).
+      startingTime: 'HH:mm',   // start-time (Hourly/Daily/Weekly/Monthly/Yearly). For Hourly-everyN, pass it: omitting renders a cosmetic trailing "starting at " blank. (Seconds exposes no startingTime.)
       weekdaysOnly: <bool>,    // Daily-only
       selectedHours: [9,12],   // Hourly-only, alternative to everyN
+      selectedMinutes: [0,30], // Minutes-only, "at specific minutes", alternative to everyN
       selectedDaysOfMonth: [1,15], // Daily-only, alternative to everyN/weekdays
+      daysOfWeek: ['Monday','Friday'], // Weekly-only, MULTI day-of-week
+      dayOfWeek: 'Monday',     // Monthly/Yearly nth-weekday mode, SINGLE day-of-week (distinct from Weekly's daysOfWeek)
+      dayOfMonth: <int>,       // Monthly by-day "on day number" (pair with everyNMonths; exclusive with weekOfMonth)
+      everyNMonths: <int>,     // "of every N months" (Monthly, both modes; free integer)
+      months: 'December',      // Yearly only -- single month String (the nth-weekday month)
+      weekOfMonth: 'First',    // Monthly/Yearly nth-weekday: First|Second|Third|Fourth|Last (presence selects nth-weekday mode)
       minutesOffset: <int>,    // Hourly-only, when not using everyN (startingHCX1)
       cronString: '0 * * * *', // Cron String mode
       rawSettings: {…}         // escape hatch for periodic-page fields not yet mapped
     }
-    Without `periodic`, RM commits a phantom row with description="?". The tool walks the periodic sub-page (whichPeriod1 → everyN/select → time → Done) so the trigger description bakes correctly.
+    Monthly has TWO mutually-exclusive modes: by-day (dayOfMonth + everyNMonths -- BOTH required or it renders null) and nth-weekday (weekOfMonth + dayOfWeek + everyNMonths). Passing both dayOfMonth and weekOfMonth is rejected. Yearly is ALWAYS nth-weekday (weekOfMonth + dayOfWeek + months-single) because RM 5.1 exposes no by-day calendar-day field for Yearly -- only the nth-weekday picker. Monthly "specific months" ("on day N of selected months") is NOT yet supported (an order-sensitive third sub-mode) -- use rawSettings if needed.
+    Without `periodic`, RM commits a phantom row with description="?". The tool walks the periodic sub-page (whichPeriod<N> -> everyN/select -> time -> Done, where <N> is the per-trigger sub-page index) so the trigger description bakes correctly.
 [[/FLAT_TRIM]]
 
 Optional fields on every spec:
@@ -15030,6 +15038,39 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
         _rmValidateDeviceIdsExist("addTrigger.condition.deviceIds", cm.deviceIds)
     }
 
+    // Periodic argument validation, run before the moreCond click opens the
+    // wizard so a bad spec surfaces a structured failure without leaving an
+    // in-flight trigger editor half-open. The full per-frequency field map
+    // lives in the periodic block further down; these are just the arg guards.
+    if (cap.equalsIgnoreCase("Periodic Schedule") && triggerSpec.periodic instanceof Map) {
+        def perEarly = triggerSpec.periodic as Map
+        def freqEarly = perEarly.frequency?.toString()
+        // Seconds/Minutes count is a restricted RM enum, not a free integer.
+        // Fractional values truncate toward zero (5.5 -> 5) and are then
+        // range-checked against the enum. Normalize everyN to the truncated
+        // integer in place so the downstream write sends the enum-valid value,
+        // not the raw fractional (RM's enum field would silent-reject "5.5").
+        if ((freqEarly == "Seconds" || freqEarly == "Minutes") && perEarly.everyN != null) {
+            def allowedCounts = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30]
+            def reqCount = null
+            // Broad catch: everyN may arrive as a non-numeric String
+            // (NumberFormatException) or a Map/List (GroovyCastException);
+            // both mean "not a usable count" and route to the throw below.
+            try { reqCount = perEarly.everyN as Integer } catch (Exception ignored) { reqCount = null }
+            if (reqCount == null || !(reqCount in allowedCounts)) {
+                throw new IllegalArgumentException("Periodic ${freqEarly} everyN must be one of ${allowedCounts} (RM restricts the count to this enum); got '${perEarly.everyN}'.")
+            }
+            perEarly.everyN = reqCount
+        }
+        // Monthly has two mutually-exclusive modes whose field sets hide each
+        // other: by-day (dayOfMonth) and nth-weekday (weekOfMonth). Reject a
+        // spec that mixes them so the caller gets a clear error instead of an
+        // unrenderable half-written sub-page.
+        if (freqEarly == "Monthly" && perEarly.dayOfMonth != null && perEarly.weekOfMonth != null) {
+            throw new IllegalArgumentException("Periodic Monthly: dayOfMonth and weekOfMonth are mutually exclusive -- dayOfMonth selects a calendar day (e.g. the 15th), weekOfMonth selects the Nth weekday (e.g. the Second Monday). Pass one mode's fields, not both.")
+        }
+    }
+
     // Snapshot committed trigger indices (settings) BEFORE clicking moreCond.
     // The actual in-flight trigger idx is discovered from the schema after
     // the click — see "schema-aware index discovery" block below. We do not
@@ -15299,38 +15340,138 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
     // Without this dance, hasAll commits a phantom row with description="?"
     // because the parent's renderer can't reach the sub-page state.
     //
-    // Verified field-name suffixes per frequency live 2026-04-25:
-    //   Hourly  → everyNHoursC1, everyNHC1, startingHC1, selectHoursC1, startingHCX1
-    //   Daily   → everyNDoMC1, everyNDC1, everyWeekDay1, selectDoMC1, startingDC1
-    // Other frequencies (Seconds/Minutes/Weekly/Monthly/Yearly/Cron String)
-    // share the suffix pattern; caller can pass extra fields via rawSettings
-    // until each is verified.
+    // Field names are IRREGULAR across frequencies (no extractable suffix
+    // pattern), so freqFieldMap below carries the exact RM 5.1 setting name
+    // for each role of each frequency, captured live against fw 5.1.8.
     if (capCanonical == "Periodic Schedule" && triggerSpec.periodic instanceof Map) {
         def per = triggerSpec.periodic as Map
         def freq = per.frequency?.toString()
         if (!freq) {
             throw new IllegalArgumentException("Periodic Schedule trigger requires periodic.frequency (one of: Seconds, Minutes, Hourly, Daily, Weekly, Monthly, Yearly, 'Cron String')")
         }
-        // Field-name maps. Keys are LLM-friendly aliases; values are the
-        // RM 5.1 setting names. Trigger index is always 1 for the in-flight
-        // trigger row (RM uses idx 1 inside the periodic sub-page regardless
-        // of the parent trigger index — verified live).
+        // Monthly mode detection: weekOfMonth present selects nth-weekday mode,
+        // which hides the by-day fields. (A by-day+weekOfMonth mix was already
+        // rejected up front, so here weekOfMonth presence unambiguously means
+        // nth-weekday.)
+        def monthlyNthWeekday = (freq == "Monthly" && per.weekOfMonth != null)
+        // Resolve the periodic sub-page navigation from the LIVE selectTriggers
+        // schema rather than hardcoding it. RM renders the periodic href once
+        // the in-flight trigger's capability is Periodic Schedule; the href
+        // carries params={n: <trigger index>} keyed to THIS trigger, and the
+        // sub-page's field names are suffixed by that same n (whichPeriod<n>,
+        // everyNDoMC<n>, ...). For a single periodic trigger n=1 -- byte-identical
+        // to suffix-1. For a 2nd periodic trigger RM renders a periodic<n> sub-page
+        // with whichPeriod<n>/everyN*C<n>/etc.; routing to the right n AND writing
+        // the n-suffixed field names is what keeps the two triggers from colliding.
+        // Mirrors the walkStep navigate href-discovery.
+        def periodicHrefName = "periodic1"
+        def periodicHrefParams = [n: 1]
+        def periodicHrefFound = false
+        try {
+            def stCfg = _rmFetchConfigJson(appId, "selectTriggers")
+            def periodicHref = (stCfg?.configPage?.sections ?: []).collectMany { sect ->
+                (sect?.body ?: []).findAll { b -> b instanceof Map && b.element == "href" && b.page?.toString() == "periodic" }
+            }.find { it != null }
+            if (periodicHref != null) {
+                periodicHrefFound = true
+                if (periodicHref.name != null) periodicHrefName = periodicHref.name.toString()
+                if (periodicHref.params instanceof Map) periodicHrefParams = periodicHref.params as Map
+            }
+        } catch (Exception hrefExc) {
+            mcpLog("warn", "rm-native", "_rmAddTrigger: periodic href discovery on selectTriggers failed for app ${appId} (${hrefExc.class.simpleName}: ${hrefExc.message}) -- falling back to periodic1/n=1; a non-first periodic trigger may collide with the first")
+        }
+        // Href absent (not an exception, but still a discovery failure): warn the
+        // same way, because suffix-1 fallback is only safe for the FIRST periodic
+        // trigger. RM keys the periodic sub-page by trigger index, so without the
+        // discovered href a later periodic trigger would write suffix-1 fields and
+        // clobber the first trigger's schedule.
+        if (!periodicHrefFound) {
+            mcpLog("warn", "rm-native", "_rmAddTrigger: no periodic href found in selectTriggers schema for app ${appId} (in-flight trigger idx ${idx}) -- falling back to periodic1/n=1")
+        }
+        // The marker form-index suffix uses params.n (matches walkStep navigate).
+        // Guard the cast: a malformed params.n (non-integer) would otherwise escape
+        // to the outer catch as a raw context-less JVM message; fall back to 1.
+        def periodicHrefIndex = 1
+        if (periodicHrefParams?.n != null) {
+            try {
+                periodicHrefIndex = periodicHrefParams.n as Integer
+            } catch (Exception nCastExc) {
+                mcpLog("warn", "rm-native", "_rmAddTrigger: periodic href params.n='${periodicHrefParams.n}' is not an integer for app ${appId} (${nCastExc.class.simpleName}: ${nCastExc.message}) -- falling back to n=1")
+                periodicHrefIndex = 1
+            }
+        }
+        def hrefParams = periodicHrefParams
+        // If the periodic href was NOT discovered AND this is not the first
+        // trigger slot, suffix-1 fallback would silently overwrite an earlier
+        // periodic trigger. Refuse to write a guaranteed clobber: record a skip
+        // so the row surfaces partial=true with an actionable repair hint, and
+        // leave the periodic sub-page writes unattempted for this trigger.
+        def periodicUnsafeFallback = (!periodicHrefFound && (idx as Integer) > 1)
+        if (periodicUnsafeFallback) {
+            skipped << [key: "periodic", reason: "periodic_href_absent_nonfirst_trigger", value: freq,
+                        note: "No periodic href in selectTriggers schema for trigger idx ${idx}; writing suffix-1 fields would overwrite an earlier periodic trigger. Periodic sub-page not written."]
+            mcpLog("warn", "rm-native", "_rmAddTrigger: skipping periodic sub-page writes for app ${appId} trigger idx ${idx} -- periodic href absent and idx>1, suffix-1 fallback would clobber the first periodic trigger")
+        }
+        // Periodic field names are suffixed by the per-trigger sub-page index
+        // (pn). For pn=1 the field names end in ...C1; for a later periodic
+        // trigger pn follows the discovered sub-page index, so the names become
+        // ...C<pn> and target that trigger's own sub-page slots.
+        def pn = periodicHrefIndex
+
+        // Field-name maps. Keys are role aliases; values are the RM 5.1 setting
+        // names with the per-trigger suffix interpolated.
+        //
+        // Role keys (not all frequencies have all roles):
+        //   everyNToggle  -- bool, "every n <unit>?"; must land BEFORE everyNCount
+        //   everyNCount   -- the count; for Hourly/Daily a free integer, for
+        //                    Minutes a restricted enum (validated up front)
+        //   secondsCount  -- Seconds has NO toggle; the count enum IS the mode
+        //   selectMulti   -- multi-enum picker (hours / days-of-month / days-of-week / months)
+        //   weekdayToggle -- Daily-only "weekdays only"
+        //   dayOfMonth    -- Monthly by-day "on day number"
+        //   everyNMonths  -- Monthly by-day "of every n months"
+        //   weekOfMonth   -- Monthly/Yearly nth-weekday "in the week of month" (First..Last)
+        //   dayOfWeek     -- Monthly/Yearly nth-weekday SINGLE day-of-week (Sunday..Saturday)
+        //   everyNMonthsNth -- Monthly nth-weekday cadence (everyNMCX<n>, the X-suffixed field)
+        //   monthEnum     -- Yearly nth-weekday single month (yearlyMonthCX<n>, the X-suffixed field)
+        //   time          -- "starting at" time field
+        //   offset        -- Hourly-only minute offset
+        //   cron          -- Cron String text field
+        //
+        // Monthly and Yearly are MODE-PROGRESSIVE: writing the week-of-month
+        // field swaps the visible field set (mutually exclusive with the by-day
+        // fields). The dispatch below routes by whether weekOfMonth is present.
         def freqFieldMap = [
-            "Hourly": [everyNToggle: "everyNHoursC1", everyNCount: "everyNHC1", time: "startingHC1", selectMulti: "selectHoursC1", offset: "startingHCX1"],
-            "Daily":  [everyNToggle: "everyNDoMC1",   everyNCount: "everyNDC1", time: "startingDC1", weekdayToggle: "everyWeekDay1", selectMulti: "selectDoMC1"],
-            "Cron String": [cron: "cronString1"]
+            "Seconds": [secondsCount: "everyNSecs${pn}"],
+            "Minutes": [everyNToggle: "everyNMinutesC${pn}", everyNCount: "everyNC${pn}", selectMulti: "selectMinutesC${pn}"],
+            "Hourly":  [everyNToggle: "everyNHoursC${pn}", everyNCount: "everyNHC${pn}", time: "startingHC${pn}", selectMulti: "selectHoursC${pn}", offset: "startingHCX${pn}"],
+            "Daily":   [everyNToggle: "everyNDoMC${pn}",   everyNCount: "everyNDC${pn}", time: "startingDC${pn}", weekdayToggle: "everyWeekDay${pn}", selectMulti: "selectDoMC${pn}"],
+            "Weekly":  [selectMulti: "selectDoWC${pn}", time: "startingWC${pn}"],
+            // Monthly carries BOTH mode field sets; dispatch picks one by weekOfMonth presence.
+            // (Specific-months "on day N of selected months" is a THIRD, order-sensitive
+            // sub-mode that the flat routing can't satisfy -- not supported here.)
+            "Monthly": [dayOfMonth: "dayMC${pn}", everyNMonths: "everyNMC${pn}",
+                        weekOfMonth: "weeklyMC${pn}", dayOfWeek: "dailyMC${pn}", everyNMonthsNth: "everyNMCX${pn}",
+                        time: "startingMC${pn}"],
+            // Yearly is ALWAYS nth-weekday; yearlyMonthC<n> alone never completes,
+            // so the month lives in yearlyMonthCX<n> (the X-suffixed reveal field).
+            "Yearly":  [weekOfMonth: "weeklyYC${pn}", dayOfWeek: "dailyYC${pn}", monthEnum: "yearlyMonthCX${pn}", time: "startingYC${pn}"],
+            "Cron String": [cron: "cronStr${pn}"]
         ]
         def fields = freqFieldMap[freq] ?: [:]
-        // Navigate forward into periodic sub-page. n=1 is RM's per-trigger
-        // sub-page param.
-        def hrefParams = [n: 1]
-        _rmNavigateToPage(appId, "selectTriggers", "periodic", 1, "periodic1", hrefParams)
+        // (Periodic arg validation -- Seconds/Minutes restricted-enum count and
+        // the Monthly dayOfMonth/weekOfMonth mutual-exclusivity -- already ran
+        // up front, before the trigger editor opened.)
+        // Skip the entire periodic sub-page dance when the suffix-1 fallback
+        // would clobber an earlier periodic trigger (see periodicUnsafeFallback).
+        if (!periodicUnsafeFallback) {
+        _rmNavigateToPage(appId, "selectTriggers", "periodic", periodicHrefIndex, periodicHrefName, hrefParams)
         // Closure that wraps _rmWriteSubPageField with applied/skipped routing
         // based on the helper's persistence verification (Map return). Use this
         // for every periodic-sub-page field write so silent rejections are
         // caught and surfaced rather than optimistically claimed as applied.
         def writePeriodic = { String fieldKey, Object fieldValue ->
-            def wr = _rmWriteSubPageField(appId, "periodic", "selectTriggers", "periodic1", 1, hrefParams, fieldKey, fieldValue)
+            def wr = _rmWriteSubPageField(appId, "periodic", "selectTriggers", periodicHrefName, periodicHrefIndex, hrefParams, fieldKey, fieldValue)
             if (wr?.persisted) {
                 applied << fieldKey
             } else if (wr?.verifyFetchFailed) {
@@ -15339,17 +15480,24 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
                 skipped << [key: fieldKey, reason: "silent_rejection", value: fieldValue, schemaUnchanged: true, available: wr?.afterKeys]
             }
         }
-        // Write frequency first — schema-progressive, so subsequent fields
-        // only appear after this lands.
-        writePeriodic("whichPeriod1", freq)
-        // Cron String mode: just one text field.
+        // Write frequency first -- schema-progressive, so subsequent fields
+        // only appear after this lands. whichPeriod<pn> is the per-trigger
+        // mode selector (whichPeriod1 for the 1st periodic trigger).
+        writePeriodic("whichPeriod${pn}".toString(), freq)
         if (freq == "Cron String") {
+            // Cron String mode: just one text field.
             if (per.cronString != null && fields.cron) {
                 writePeriodic(fields.cron, per.cronString.toString())
             }
         } else {
-            // everyN toggle + count. Order matters: toggle must land first
-            // because the count field only appears after the toggle is true.
+            // Seconds: single count enum, no toggle.
+            if (per.everyN != null && fields.secondsCount) {
+                writePeriodic(fields.secondsCount, per.everyN)
+            }
+            // everyN toggle + count (Minutes / Hourly / Daily). Order matters:
+            // the toggle must land first because the count field only appears
+            // (and only accepts a value) after the toggle is true. Writing the
+            // count into the toggle field is the original "rendered null" bug.
             if (per.everyN != null && fields.everyNToggle) {
                 writePeriodic(fields.everyNToggle, true)
                 if (fields.everyNCount) {
@@ -15360,12 +15508,52 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
             if (per.weekdaysOnly == true && fields.weekdayToggle) {
                 writePeriodic(fields.weekdayToggle, true)
             }
-            // Multi-enum selection (selectedHours / selectedDaysOfMonth).
-            def selectVals = per.selectedHours ?: per.selectedDaysOfMonth
+            // nth-weekday mode (Monthly with weekOfMonth, OR Yearly which is
+            // always nth-weekday). Writing the week-of-month field HIDES the
+            // by-day fields and reveals the day-of-week + X-suffixed cadence/
+            // month fields, so the by-day branch below must NOT also run.
+            def nthWeekday = (freq == "Yearly") || monthlyNthWeekday
+            if (nthWeekday) {
+                if (per.weekOfMonth != null && fields.weekOfMonth) {
+                    writePeriodic(fields.weekOfMonth, per.weekOfMonth)
+                }
+                // Single day-of-week enum (dailyMC1 / dailyYC1). The dayOfWeek
+                // alias is SINGULAR -- distinct from Weekly's daysOfWeek multi.
+                if (per.dayOfWeek != null && fields.dayOfWeek) {
+                    writePeriodic(fields.dayOfWeek, per.dayOfWeek)
+                }
+                // Monthly nth-weekday cadence is a FREE number in everyNMCX1
+                // (NOT the by-day everyNMC1, and NOT the restricted enum).
+                if (per.everyNMonths != null && fields.everyNMonthsNth) {
+                    writePeriodic(fields.everyNMonthsNth, per.everyNMonths)
+                }
+                // Yearly nth-weekday month is a single enum in yearlyMonthCX1.
+                if (per.months != null && fields.monthEnum) {
+                    writePeriodic(fields.monthEnum, per.months)
+                }
+            } else {
+                // by-day mode (Monthly without weekOfMonth). dayMC1 + everyNMC1;
+                // an incomplete combo (e.g. dayOfMonth without everyNMonths)
+                // renders "null" -- documented in the arg shape.
+                if (per.dayOfMonth != null && fields.dayOfMonth) {
+                    writePeriodic(fields.dayOfMonth, per.dayOfMonth)
+                }
+                if (per.everyNMonths != null && fields.everyNMonths) {
+                    writePeriodic(fields.everyNMonths, per.everyNMonths)
+                }
+            }
+            // Multi-enum selection. Each frequency exposes ONE selectMulti
+            // field but under a different alias; route the matching one.
+            //   Hourly  selectedHours        -> selectHoursC1
+            //   Daily   selectedDaysOfMonth  -> selectDoMC1
+            //   Weekly  daysOfWeek           -> selectDoWC1
+            //   Minutes selectedMinutes      -> selectMinutesC1 (alt to everyN)
+            def selectVals = per.selectedHours ?: per.selectedDaysOfMonth ?: per.daysOfWeek ?:
+                             per.selectedMinutes
             if (selectVals != null && fields.selectMulti) {
                 writePeriodic(fields.selectMulti, selectVals)
             }
-            // Time field (startingHC1 / startingDC1 etc.).
+            // Time field (startingHC1 / startingDC1 / startingWC1 / ...).
             if (per.startingTime != null && fields.time) {
                 writePeriodic(fields.time, per.startingTime.toString())
             }
@@ -15374,15 +15562,15 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
                 writePeriodic(fields.offset, per.minutesOffset)
             }
         }
-        // Caller escape hatch for periodic-page fields not yet mapped above
-        // (Weekly/Monthly/Yearly suffix patterns, future fields).
+        // Caller escape hatch for periodic-page fields not yet mapped above.
         if (per.rawSettings instanceof Map) {
             (per.rawSettings as Map).each { rk, rv ->
                 writePeriodic(rk.toString(), rv)
             }
         }
-        // Submit Done — bakes the description into the trigger row.
-        _rmSubmitSubPageDone(appId, "periodic", "selectTriggers", "periodic1", hrefParams)
+        // Submit Done -- bakes the description into the trigger row.
+        _rmSubmitSubPageDone(appId, "periodic", "selectTriggers", periodicHrefName, hrefParams)
+        } // end if (!periodicUnsafeFallback)
     }
 
     // Conditional-trigger binding MUST be written BEFORE hasAll while the
@@ -15546,6 +15734,9 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
         }
         if ((health?.brokenMarkers as List)?.size() > 0 && !hasBrokenLabel) {
             repairHints << "Rule has pre-existing broken markers: ${(health.brokenMarkers as List).unique().join(', ')}. The new trigger committed, but run check_rule_health(${appId}) and repair the existing broken trigger/action rows before this rule fires correctly."
+        }
+        if (skipped?.any { it?.reason == "periodic_href_absent_nonfirst_trigger" }) {
+            repairHints << "The periodic sub-page link was not found in the trigger schema for this (non-first) trigger, so its schedule was NOT written -- writing it would have overwritten an earlier periodic trigger's schedule. Retry the add: re-fetch with update_native_app(walkStep={page:'selectTriggers', operation:'introspect'}) to confirm the periodic href is present, or rebuild the rule's triggers in order. If the rule has only one periodic trigger, this should not recur."
         }
         if (hubRenderError) {
             repairHints << "WARNING: selectTriggers may have rendered with an error (configPageError=${err}, or skipped items have empty available list). This is a hub-side issue. Consider deleting the trigger and trying with different deviceIds or trigger shape."
@@ -15797,16 +15988,23 @@ private Map _rmTriggerSchemaForDiscover() {
                 name: "Periodic Schedule",
                 family: "time",
                 requiredFields: [
-                    [name: "periodic", type: "Map", description: "{frequency, everyN?, startingTime?, weekdaysOnly?, selectedHours?, selectedDaysOfMonth?, minutesOffset?, cronString?, rawSettings?}"]
+                    [name: "periodic", type: "Map", description: "{frequency, everyN?, startingTime?, weekdaysOnly?, selectedHours?, selectedMinutes?, selectedDaysOfMonth?, daysOfWeek?, dayOfWeek?, dayOfMonth?, everyNMonths?, months?, weekOfMonth?, minutesOffset?, cronString?, rawSettings?}"]
                 ],
-                notes: "frequency values: 'Hourly', 'Daily', 'Cron String'. Without periodic the trigger renders as description='?'. The helper walks the periodic sub-page automatically.",
+                notes: "frequency values: 'Seconds', 'Minutes', 'Hourly', 'Daily', 'Weekly', 'Monthly', 'Yearly', 'Cron String'. everyN is REQUIRED even when =1 for Daily AND Hourly -- omitting it renders 'null'. For Seconds and Minutes, everyN is a restricted enum -- one of [1,2,3,4,5,6,10,12,15,20,30] and must be a whole number (firmware-imposed; Hourly/Daily accept any positive integer. Fractional values truncate, e.g. 5.5 -> 5; anything outside the set fails). Seconds exposes ONLY the count enum -- no toggle and no startingTime. For Hourly-everyN, pass startingTime too -- omitting it renders a cosmetic trailing 'starting at ' blank. Monthly has TWO mutually-exclusive modes: by-day (dayOfMonth + everyNMonths) and nth-weekday (weekOfMonth + dayOfWeek + everyNMonths) -- passing both dayOfMonth and weekOfMonth is rejected. Monthly by-day needs BOTH dayOfMonth AND everyNMonths or it renders 'null'. Monthly 'specific months' ('on day N of selected months') is NOT yet supported (an order-sensitive third sub-mode) -- use rawSettings if needed. Yearly is ALWAYS nth-weekday: weekOfMonth + dayOfWeek + months (single month) -- because RM 5.1 exposes no by-day calendar-day field for Yearly, only the nth-weekday picker; the month alone never completes. Without periodic the trigger renders as description='?'. The helper walks the periodic sub-page automatically.",
                 periodicShape: [
-                    frequency: "Hourly | Daily | Cron String",
-                    everyN: "Integer -- for 'every N <unit>' mode",
-                    startingTime: "HH:mm -- start time for everyN modes",
+                    frequency: "Seconds | Minutes | Hourly | Daily | Weekly | Monthly | Yearly | Cron String",
+                    everyN: "Integer -- 'every N <unit>' mode (Seconds/Minutes/Hourly/Daily). REQUIRED even when =1 for Daily AND Hourly (omitting renders null). For Seconds/Minutes restricted to a whole number in [1,2,3,4,5,6,10,12,15,20,30] (firmware-imposed; Hourly/Daily accept any positive integer. Fractional values truncate, e.g. 5.5 -> 5).",
+                    startingTime: "HH:mm -- start time (Hourly/Daily/Weekly/Monthly/Yearly; Seconds has none). For Hourly-everyN, pass it -- omitting renders a cosmetic trailing 'starting at ' blank.",
                     weekdaysOnly: "Boolean -- Daily only",
                     selectedHours: "List<Integer> -- Hourly only, alternative to everyN",
-                    selectedDaysOfMonth: "List<Integer> -- Daily only",
+                    selectedMinutes: "List<Integer> -- Minutes only, 'at specific minutes' mode, alternative to everyN",
+                    selectedDaysOfMonth: "List<Integer> -- Daily only, alternative to everyN/weekdays",
+                    daysOfWeek: "List<String> -- Weekly only, MULTI day-of-week (e.g. ['Monday','Friday'])",
+                    dayOfWeek: "String -- Monthly/Yearly nth-weekday mode, SINGLE day-of-week (e.g. 'Monday'). Distinct from Weekly's daysOfWeek (multi).",
+                    dayOfMonth: "Integer -- Monthly by-day 'on day number' (pair with everyNMonths; mutually exclusive with weekOfMonth)",
+                    everyNMonths: "Integer -- 'of every N months' (Monthly, both modes; free integer)",
+                    months: "String -- Yearly only; the single nth-weekday month (e.g. 'December'). Yearly exposes a single-month picker. (Monthly does NOT take months -- its specific-months sub-mode is unsupported.)",
+                    weekOfMonth: "String -- Monthly/Yearly nth-weekday 'in the week of month' (First | Second | Third | Fourth | Last). Its presence selects nth-weekday mode.",
                     minutesOffset: "Integer -- Hourly only, when not using everyN",
                     cronString: "String -- Cron String mode (e.g. '0 * * * *')",
                     rawSettings: "Map -- escape hatch for periodic-page fields not yet mapped"
@@ -24718,6 +24916,8 @@ MCP-managed virtual devices:
 
         rules: '''## Rule Structure Reference
 
+NOTE: this section describes the LEGACY custom MCP rule engine (the custom_* tools). For native Rule Machine rules built via create_native_app / update_native_app (addTrigger), the periodic shape is DIFFERENT -- use periodic={frequency, everyN, ...}, NOT {type, interval, unit}. See get_tool_guide section "update_native_app_reference" for the native addTrigger periodic field shape.
+
 ### Rule JSON Structure
 {"name": "Rule name", "description": "Optional", "enabled": true, "triggers": [...], "conditions": [...], "conditionLogic": "all|any", "actions": [...]}
 
@@ -24918,18 +25118,27 @@ Reference for the three `update_native_app` structured shortcuts (`addTrigger`, 
 - **Periodic Schedule** (`capability='Periodic Schedule'`): recurring schedule via the dedicated periodic sub-page. Spec:
   ```
   periodic={
-    frequency: 'Hourly'|'Daily'|'Cron String'|...,
-    everyN: <int>,                 // for "every N <unit>" mode (Hourly/Daily)
-    startingTime: 'HH:mm',         // start-time for everyN modes
+    frequency: 'Seconds'|'Minutes'|'Hourly'|'Daily'|'Weekly'|'Monthly'|'Yearly'|'Cron String',
+    everyN: <int>,                 // "every N <unit>" mode (Seconds/Minutes/Hourly/Daily)
+                                   //   REQUIRED even when =1 for Daily AND Hourly (omitting renders null)
+                                   //   Seconds/Minutes: whole number from [1,2,3,4,5,6,10,12,15,20,30] (firmware-imposed; Hourly/Daily accept any positive integer; fractional truncates, 5.5->5)
+    startingTime: 'HH:mm',         // start-time (Hourly/Daily/Weekly/Monthly/Yearly; Seconds has none); for Hourly-everyN, pass it (omitting renders a cosmetic trailing "starting at " blank)
     weekdaysOnly: <bool>,          // Daily-only
     selectedHours: [9,12],         // Hourly-only, alternative to everyN
+    selectedMinutes: [0,30],       // Minutes-only, "at specific minutes", alternative to everyN
     selectedDaysOfMonth: [1,15],   // Daily-only, alternative to everyN/weekdays
+    daysOfWeek: ['Monday','Friday'], // Weekly-only, MULTI day-of-week
+    dayOfWeek: 'Monday',           // Monthly/Yearly nth-weekday, SINGLE day-of-week (distinct from daysOfWeek)
+    dayOfMonth: <int>,             // Monthly by-day "on day number" (pair with everyNMonths; exclusive with weekOfMonth)
+    everyNMonths: <int>,           // "of every N months" (Monthly, both modes; free integer)
+    months: 'December',            // Yearly only -- single nth-weekday month (String); Monthly does NOT take months
+    weekOfMonth: 'First',          // Monthly/Yearly nth-weekday: First|Second|Third|Fourth|Last (presence selects nth-weekday)
     minutesOffset: <int>,          // Hourly-only, when not using everyN (startingHCX1)
     cronString: '0 * * * *',       // Cron String mode
     rawSettings: {…}               // escape hatch for periodic-page fields not yet mapped
   }
   ```
-  Without `periodic`, RM commits a phantom row with description `?`. The tool walks the periodic sub-page (`whichPeriod1` → `everyN`/select → time → Done) so the trigger description bakes correctly.
+  Monthly has TWO mutually-exclusive modes: by-day (`dayOfMonth` + `everyNMonths` -- BOTH required or renders null) and nth-weekday (`weekOfMonth` + `dayOfWeek` + `everyNMonths`). Passing both `dayOfMonth` and `weekOfMonth` is rejected. Monthly "specific months" ("on day N of selected months") is NOT yet supported (an order-sensitive third sub-mode) -- use `rawSettings`. Yearly is ALWAYS nth-weekday (`weekOfMonth` + `dayOfWeek` + single `months`) because RM 5.1 exposes no by-day calendar-day field for Yearly -- only the nth-weekday picker. Without `periodic`, RM commits a phantom row with description `?`. The tool walks the periodic sub-page (`whichPeriod<N>` → `everyN`/select → time → Done, where `<N>` is the per-trigger sub-page index) so the trigger description bakes correctly. Seconds/Minutes `everyN` outside the restricted enum (and Monthly dayOfMonth+weekOfMonth) is rejected with `success=false` and a structured error.
 
 ### `addAction` capability families
 

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -4024,6 +4024,59 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.opResult?.done?.parent == "selectTriggers"
     }
 
+    def "walkStep done Done-POST failure propagates as success:false (unguarded sibling caller of _rmSubmitSubPageDone)"() {
+        // SIBLING guard, walkStep variant. Like addRequiredExpression STPage Done, the
+        // walkStep 'done' op is an UNGUARDED caller of _rmSubmitSubPageDone -- a Done-POST
+        // failure must propagate to the dispatcher's backup-and-catch and surface as
+        // success:false, NOT be swallowed. Goes RED if _rmSubmitSubPageDone reverts to
+        // wrapping its Done POST in an internal try/catch (the swallow regression).
+        given:
+        enableHubAdminWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/periodic') { params ->
+            JsonOutput.toJson([
+                app: [id: 100, version: 7],
+                configPage: [name: "periodic", title: "Periodic", install: false, error: null,
+                             sections: [[title: "", input: [
+                                 [name: "whichPeriod1", type: "enum", options: ["Hourly"], value: "Hourly"]
+                             ]]]],
+                settings: [:]
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [[name: "periodic1", type: "href", page: "periodic", params: [n: 1]]])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            statusJson(100, [[name: "whichPeriod1", type: "enum", value: "Hourly"]])
+        }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            // Fail ONLY the periodic Done submit; let the nav round-trip succeed.
+            if (body?.currentPage == "periodic" && body?._action_previous == "Done") {
+                throw new RuntimeException("simulated walkStep periodic Done POST failure")
+            }
+            [status: 200, location: null, data: JsonOutput.toJson([
+                app: [id: 100, version: 7],
+                configPage: [name: "periodic", sections: [[input: [[name: "whichPeriod1", type: "enum", value: "Hourly"]]]]]
+            ])]
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            walkStep: [
+                page: "periodic",
+                operation: "done",
+                hrefContext: [fromPage: "selectTriggers", hrefName: "periodic1", hrefParams: [n: 1]]
+            ],
+            confirm: true
+        ])
+
+        then: "the Done throw propagated to the dispatcher backup-and-catch -- success:false naming the failure, not a swallowed success"
+        result.success == false
+        result.error?.toString()?.contains("simulated walkStep periodic Done POST failure")
+    }
+
     def "walkStep done on a top-level page (no hrefContext) submits Done with no paramsForPage and root-only breadcrumbs"() {
         // Coverage for the top-level branch of walkStep done. When the caller
         // does NOT supply hrefContext, _rmSubmitSubPageDone is invoked with
@@ -5595,8 +5648,13 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
      * Periodic sub-page schema fixture. Exposes whichPeriod1 plus every
      * frequency's settable fields so _rmBuildSettingsBody can marshal each
      * write (multi-enum fields carry multiple:true so they serialize as JSON
-     * arrays). The schema is intentionally static across fetches -- these
-     * specs assert on the POST bodies, not on applied/skipped routing.
+     * arrays). The schema is intentionally STATIC across fetches: because the
+     * render never shifts on the periodic sub-page, _rmWriteSubPageField's
+     * persistence-hash check never discriminates here and every periodic write
+     * routes to `applied`. So these specs prove the WIRE FORMAT (which field
+     * name carries which value, off the POST bodies) -- they are NOT proof of
+     * live persistence; that is covered by the BAT-v2 periodic scenarios against
+     * a real hub. Do not read a green spec here as "the value persisted."
      */
     private String periodicSchemaJson(int ruleId) {
         JsonOutput.toJson([
@@ -5931,6 +5989,34 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         !periodicWroteValue(posts, "yearlyMonthC1")
     }
 
+    def "addTrigger Periodic Yearly drops everyNMonths (Yearly map has no every-N-months role)"() {
+        // De-tautologize the Yearly pin: the Yearly field map carries NO everyNMonths
+        // or everyNMonthsNth role (Yearly is once-a-year nth-weekday). Passing
+        // everyNMonths must NOT write either Monthly cadence field. everyNMC1 AND
+        // everyNMCX1 are BOTH present in the periodic fixture schema, so a regression
+        // that added an every-N-months entry to the Yearly map (routing to either
+        // field) would write a real value here and fail this guard.
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Yearly", months: "December", weekOfMonth: "First", dayOfWeek: "Monday", everyNMonths: 3, startingTime: "08:00"]],
+            confirm: true
+        ])
+
+        then: "the Yearly nth-weekday fields still land"
+        result.success == true
+        periodicWrite(posts, "yearlyMonthCX1") == "December"
+        periodicWrite(posts, "weeklyYC1") == "First"
+
+        and: "neither Monthly every-N-months cadence field is written -- everyNMonths is dropped for Yearly"
+        !periodicWroteValue(posts, "everyNMC1")
+        !periodicWroteValue(posts, "everyNMCX1")
+    }
+
     def "addTrigger Periodic Cron String writes cronStr1 (not the non-existent cronString1)"() {
         given:
         enableHubAdminWrite()
@@ -5947,6 +6033,9 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.success == true
         periodicWrite(posts, "whichPeriod1") == "Cron String"
         periodicWrite(posts, "cronStr1") == "0 0 12 * * ?"
+
+        and: "a clean first-trigger discovery (well-formed href, integer n) does NOT emit the anomaly breadcrumb -- it must fire only on a malformed/exception discovery, not unconditionally"
+        !(result.settingsSkipped ?: []).any { it instanceof Map && it.reason == "periodic_href_anomaly_firsttrigger" }
     }
 
     def "addTrigger Periodic #freq everyN outside the restricted enum is rejected as success=false before opening the wizard"() {
@@ -5982,7 +6071,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.success == false
         result.error.toString().toLowerCase().contains("everyn")
         result.error.toString().contains("10, 12, 15, 20, 30")
-        result.error.toString().contains("7")
+        result.error.toString().contains("'7'")
 
         and: "no moreCond click / wizard write POST fired -- the editor never opened"
         !posts.any { it.path == "/installedapp/update/json" }
@@ -6105,6 +6194,15 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         periodicWrite(posts, "everyNHC1") == "2"
         periodicWrite(posts, "startingHC1") == "06:15"
 
+        and: "toggle write precedes count write (Hourly shares the toggle-before-count path)"
+        def hTogIdx = posts.findIndexOf {
+            !it.body?.containsKey("_action_previous") && it.body?.containsKey("settings[everyNHoursC1]")
+        }
+        def hCntIdx = posts.findIndexOf {
+            !it.body?.containsKey("_action_previous") && it.body?.containsKey("settings[everyNHC1]")
+        }
+        hTogIdx >= 0 && hCntIdx >= 0 && hTogIdx < hCntIdx
+
         when: "Hourly specific-hours alt mode (selectedHours) with a minute offset"
         def posts2 = registerPeriodicHubSurface(101)
         def result2 = script.toolUpdateNativeApp([
@@ -6117,6 +6215,29 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result2.success == true
         periodicWrite(posts2, "selectHoursC1") == '["9","12"]'
         periodicWrite(posts2, "startingHCX1") == "15"
+    }
+
+    def "addTrigger Periodic Hourly everyN is a FREE integer -- 7 (outside the Seconds/Minutes enum) is accepted"() {
+        // The restricted-enum [1,2,3,4,5,6,10,12,15,20,30] applies ONLY to Seconds and
+        // Minutes (validated up front). Hourly/Daily take a free integer. 7 is NOT in
+        // the restricted set, so this guards against a regression that widened the
+        // Seconds/Minutes restriction onto Hourly -- which would reject everyN:7 with
+        // success=false instead of writing it.
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Hourly", everyN: 7, startingTime: "06:00"]],
+            confirm: true
+        ])
+
+        then: "the free integer 7 is accepted and lands in everyNHC1 (no up-front enum rejection)"
+        result.success == true
+        periodicWrite(posts, "everyNHoursC1") == "true"
+        periodicWrite(posts, "everyNHC1") == "7"
     }
 
     def "addTrigger Periodic Daily weekdaysOnly writes everyWeekDay1, selectedDaysOfMonth writes selectDoMC1"() {
@@ -6139,6 +6260,15 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         periodicWrite(posts, "everyNDC1") == "1"
         periodicWrite(posts, "everyWeekDay1") == "true"
         periodicWrite(posts, "startingDC1") == "07:00"
+
+        and: "the everyN toggle write precedes the count write (Daily shares the toggle-before-count path)"
+        def dTogIdx = posts.findIndexOf {
+            !it.body?.containsKey("_action_previous") && it.body?.containsKey("settings[everyNDoMC1]")
+        }
+        def dCntIdx = posts.findIndexOf {
+            !it.body?.containsKey("_action_previous") && it.body?.containsKey("settings[everyNDC1]")
+        }
+        dTogIdx >= 0 && dCntIdx >= 0 && dTogIdx < dCntIdx
 
         when: "Daily specific-days alt mode (selectedDaysOfMonth)"
         def posts2 = registerPeriodicHubSurface(101)
@@ -6214,7 +6344,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     }
 
     def "addTrigger 2nd periodic trigger routes to periodic2 sub-page and writes suffix-2 fields, not suffix-1"() {
-        // Regression guard for the multi-periodic-trigger fix (OUTCOME A). The
+        // Regression guard for the multi-periodic-trigger fix. The
         // rule already has periodic trigger 1; adding a 2nd periodic (Daily)
         // trigger must navigate to ITS periodic sub-page (href periodic2,
         // params n:2) and write the n-suffixed field names (whichPeriod2,
@@ -6294,7 +6424,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     }
 
     def "addTrigger 2nd periodic trigger with NO periodic href in schema refuses suffix-1 fallback (no clobber)"() {
-        // BLOCKING-2 guard: when the periodic href is ABSENT from the discovered
+        // When the periodic href is ABSENT from the discovered
         // selectTriggers schema AND this is not the first trigger slot (idx>1),
         // suffix-1 fallback would silently overwrite trigger 1's schedule. The
         // dispatcher must refuse to write the periodic sub-page and surface a
@@ -6352,8 +6482,213 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
         and: "the result surfaces the refusal as partial with an actionable repair hint"
         result.partial == true
-        result.settingsSkipped?.any { it?.reason == "periodic_href_absent_nonfirst_trigger" }
-        result.repairHints?.any { it?.toString()?.contains("periodic sub-page link was not found") }
+        result.settingsSkipped?.any { it?.reason == "periodic_href_unresolved_nonfirst_trigger" }
+        result.repairHints?.any { it?.toString()?.contains("periodic sub-page index could not be resolved") }
+    }
+
+    def "addTrigger 2nd periodic trigger with a MALFORMED href params.n refuses suffix-1 fallback (no clobber)"() {
+        // Completes the malformed-params.n guard. The periodic href IS discovered for
+        // trigger 2, but its params.n is non-integer ("2x"). The dispatcher cannot
+        // resolve the sub-page index, so -- exactly as for an absent href -- a non-first
+        // trigger must refuse the suffix-1 fallback rather than clobber trigger 1. This
+        // guard goes RED if the malformed-n catch does not feed periodicUnsafeFallback
+        // (the half-applied-guard regression).
+        given:
+        enableHubAdminWrite()
+        def fetchSeq = 0
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        // trigger 1 committed (Periodic), trigger 2 in-flight (Periodic). The periodic
+        // body href IS present, but its params.n is a non-integer string -- the n-cast
+        // guard absorbs it and must treat the href as unresolved for fallback purposes.
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            fetchSeq++
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "selectTriggers", title: "T", install: false, error: null,
+                             sections: [[title: "", input: [
+                                 [name: "tCapab1", type: "enum", options: ["Periodic Schedule"], value: "Periodic Schedule"],
+                                 [name: "tCapab2", type: "enum", options: ["Periodic Schedule"]],
+                                 [name: "isCondTrig.2", type: "bool"],
+                                 [name: "hasAll", type: "button"]
+                             ],
+                             // href present but params.n is malformed (non-integer).
+                             body: [[element: "href", name: "periodic2", page: "periodic", params: [n: "2x"]]],
+                             paragraphs: ["seq ${fetchSeq}".toString()]]]],
+                settings: ["tCapab1": "Periodic Schedule"],
+                childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> mainPageJson(100, "r", true) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            statusJson(100, [[name: "tCapab1", type: "enum", value: "Periodic Schedule"]])
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Daily", everyN: 1, startingTime: "07:00"]],
+            confirm: true
+        ])
+
+        then: "no suffix-1 field is written -- trigger 1 is not clobbered"
+        result.triggerIndex == 2
+        !periodicWriteAny(posts, "whichPeriod1")
+        !periodicWriteAny(posts, "everyNDoMC1")
+        !periodicWriteAny(posts, "everyNDC1")
+        !periodicWriteAny(posts, "startingDC1")
+
+        and: "the malformed-n refusal surfaces as partial with the unresolved-href reason"
+        result.partial == true
+        result.settingsSkipped?.any { it?.reason == "periodic_href_unresolved_nonfirst_trigger" }
+        result.repairHints?.any { it?.toString()?.contains("periodic sub-page index could not be resolved") }
+    }
+
+    def "addTrigger FIRST periodic trigger with a malformed href params.n proceeds on suffix-1 without throwing (n normalized)"() {
+        // Pins the OTHER half of the malformed-n guard: index normalization. For the
+        // FIRST periodic trigger (idx==1) a malformed params.n is NOT a clobber risk --
+        // suffix-1 is correct -- so the dance proceeds. But hrefParams.n must be
+        // normalized to the resolved integer (1) before the Done submit, or
+        // _rmSubmitSubPageDone's `hrefParams.n as Integer` re-cast throws on "1x" and
+        // surfaces as success=false. This guard goes RED if the normalization is dropped.
+        given:
+        enableHubAdminWrite()
+        def fetchSeq = 0
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: periodicSchemaJson(100)]
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        // Single in-flight Periodic trigger; the periodic href params.n is malformed.
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            fetchSeq++
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "selectTriggers", title: "T", install: false, error: null,
+                             sections: [[title: "", input: [
+                                 [name: "tCapab1", type: "enum", options: ["Periodic Schedule"]],
+                                 [name: "isCondTrig.1", type: "bool"],
+                                 [name: "hasAll", type: "button"]
+                             ],
+                             body: [[element: "href", name: "periodic1", page: "periodic", params: [n: "1x"]]],
+                             paragraphs: ["seq ${fetchSeq}".toString()]]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/periodic') { params -> periodicSchemaJson(100) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> mainPageJson(100, "r", true) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Daily", everyN: 1, startingTime: "07:00"]],
+            confirm: true
+        ])
+
+        then: "the trigger commits -- the Done re-cast did not throw on the malformed n (it was normalized to 1)"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Daily"
+        periodicWrite(posts, "everyNDC1") == "1"
+
+        and: "the first-trigger anomaly is surfaced as a breadcrumb (suffix-1 was correct, but the malformed n is noted)"
+        result.settingsSkipped?.any { it?.reason == "periodic_href_anomaly_firsttrigger" }
+    }
+
+    def "addTrigger periodic Done-POST failure is caught at the call site and folded into skipped (not a hard fail)"() {
+        // _rmSubmitSubPageDone lets a Done-POST failure THROW. The periodic path catches that
+        // throw LOCALLY and folds it into skipped as subpage_done_failed (partial=true) -- the
+        // trigger still commits via hasAll. Goes RED if the periodic try/catch is removed (the
+        // throw would then propagate and hard-fail the add as success:false).
+        given:
+        enableHubAdminWrite()
+        def fetchSeq = 0
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            // Fail ONLY the periodic sub-page Done submit (back-nav to selectTriggers).
+            if (body?.currentPage == "periodic" && body?._action_previous == "Done") {
+                throw new RuntimeException("simulated periodic Done POST failure")
+            }
+            [status: 200, location: null, data: periodicSchemaJson(100)]
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            fetchSeq++
+            periodicSelectTriggersJson(100, fetchSeq)
+        }
+        hubGet.register('/installedapp/configure/json/100/periodic') { params -> periodicSchemaJson(100) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> mainPageJson(100, "r", true) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Daily", everyN: 1, startingTime: "07:00"]],
+            confirm: true
+        ])
+
+        then: "the periodic Done back-nav was actually attempted (so the throw fired there)"
+        posts.any { it.body?.currentPage == "periodic" && it.body?._action_previous == "Done" }
+
+        and: "the Done failure is folded into skipped as subpage_done_failed -- caught locally, not propagated"
+        (result.settingsSkipped ?: []).any { it instanceof Map && it.reason == "subpage_done_failed" }
+
+        and: "it flips partial but the trigger still committed (success stays true)"
+        result.partial == true
+        result.success == true
+    }
+
+    def "addRequiredExpression STPage Done-POST failure propagates as success:false (shared helper still throws for unguarded callers)"() {
+        // SIBLING guard. Unlike the periodic path, addRequiredExpression does NOT wrap its
+        // _rmSubmitSubPageDone call -- a Done-POST failure must PROPAGATE to the dispatcher's
+        // backup-and-catch and surface as success:false, not be swallowed as a silent success.
+        // This pins that scoping the periodic try/catch to the call site did not regress the
+        // shared helper's throw-on-failure for the STPage/walkStep callers. Goes RED if the
+        // helper reverts to wrapping the Done POST in its own try/catch (the swallow bug).
+        given:
+        enableHubAdminWrite()
+        def stPageInputs = [
+            [name: "cond", type: "enum", options: ["": "Click to set", "a": "--> New Condition"]],
+            [name: "rCapab_1", type: "enum", options: ["Switch"]],
+            [name: "RelrDev_1", type: "enum", options: ["="]],
+            [name: "state_1", type: "enum", options: ["on", "off"]],
+            [name: "doneST", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", [[name: "useST", type: "bool"]]) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", [[name: "useST", type: "bool"]]) }
+        hubGet.register('/installedapp/configure/json/100/STPage') { params -> ruleConfigJson(100, "r", stPageInputs) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        hubGet.register('/device/fullJson/8') { params -> '{"id":"8","name":"S1"}' }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            // Fail ONLY the STPage Done back-nav submit.
+            if (body?.currentPage == "STPage" && body?._action_previous == "Done") {
+                throw new RuntimeException("simulated STPage Done POST failure")
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addRequiredExpression: [conditions: [[capability: "Switch", deviceIds: [8], state: "on"]]],
+            confirm: true
+        ])
+
+        then: "the Done throw propagated to the backup-and-catch -- success:false naming the Done failure, not a swallowed success"
+        result.success == false
+        result.error?.toString()?.contains("simulated STPage Done POST failure")
     }
 
     // ---------- addTrigger auto-updateRule parity with addAction ----------

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -5581,6 +5581,781 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         (result.settingsApplied == null || (result.settingsApplied as List).isEmpty())
     }
 
+    // ---------- addTrigger Periodic Schedule frequency completeness ----------
+    //
+    // These specs pin the exact RM 5.1 setting names each periodic frequency
+    // writes, and the toggle-before-count ordering. They drive the real
+    // _rmAddTrigger through the sandbox and capture the field writes off the
+    // /installedapp/update/json POST bodies (settings[<field>]). The
+    // load-bearing assertion is WHICH field carries the value -- a regression
+    // that wrote the count into the bool toggle (the original "renders null"
+    // bug) or used the wrong field name (cronString1 vs cronStr1) flips these.
+
+    /**
+     * Periodic sub-page schema fixture. Exposes whichPeriod1 plus every
+     * frequency's settable fields so _rmBuildSettingsBody can marshal each
+     * write (multi-enum fields carry multiple:true so they serialize as JSON
+     * arrays). The schema is intentionally static across fetches -- these
+     * specs assert on the POST bodies, not on applied/skipped routing.
+     */
+    private String periodicSchemaJson(int ruleId) {
+        JsonOutput.toJson([
+            app: [id: ruleId, version: 7],
+            configPage: [name: "periodic", title: "Periodic", install: false, error: null,
+                         sections: [[title: "", input: [
+                             [name: "whichPeriod1", type: "enum", options: ["Seconds", "Minutes", "Hourly", "Daily", "Weekly", "Monthly", "Yearly", "Cron String"]],
+                             [name: "everyNSecs1", type: "enum", options: ["1", "5", "30"]],
+                             [name: "everyNMinutesC1", type: "bool"],
+                             [name: "everyNC1", type: "enum", options: ["1", "5", "15"]],
+                             [name: "selectMinutesC1", type: "enum", multiple: true, options: ["0", "30"]],
+                             // Hourly fields.
+                             [name: "everyNHoursC1", type: "bool"],
+                             [name: "everyNHC1", type: "enum", options: ["1", "2", "3"]],
+                             [name: "startingHC1", type: "time"],
+                             [name: "selectHoursC1", type: "enum", multiple: true, options: ["9", "12"]],
+                             [name: "startingHCX1", type: "number"],
+                             // Daily fields.
+                             [name: "everyNDoMC1", type: "bool"],
+                             [name: "everyNDC1", type: "enum", options: ["1", "2"]],
+                             [name: "startingDC1", type: "time"],
+                             [name: "everyWeekDay1", type: "bool"],
+                             [name: "selectDoMC1", type: "enum", multiple: true, options: ["1", "15"]],
+                             [name: "selectDoWC1", type: "enum", multiple: true, options: ["Monday", "Friday"]],
+                             [name: "startingWC1", type: "time"],
+                             [name: "dayMC1", type: "number"],
+                             [name: "everyNMC1", type: "number"],
+                             [name: "selectMonthC1", type: "enum", multiple: true, options: ["January", "July"]],
+                             [name: "weeklyMC1", type: "enum", options: ["First", "Last"]],
+                             [name: "startingMC1", type: "time"],
+                             [name: "yearlyMonthC1", type: "enum", options: ["December"]],
+                             [name: "weeklyYC1", type: "enum", options: ["First", "Last"]],
+                             [name: "startingYC1", type: "time"],
+                             // nth-weekday reveal fields (Monthly dailyMC1/everyNMCX1, Yearly dailyYC1/yearlyMonthCX1).
+                             [name: "dailyMC1", type: "enum", options: ["Sunday", "Monday", "Saturday"]],
+                             [name: "everyNMCX1", type: "number"],
+                             [name: "dailyYC1", type: "enum", options: ["Sunday", "Monday", "Saturday"]],
+                             [name: "yearlyMonthCX1", type: "enum", options: ["January", "December"]],
+                             [name: "cronStr1", type: "text"]
+                         ], paragraphs: []]]],
+            settings: [:]
+        ])
+    }
+
+    /**
+     * selectTriggers schema for a Periodic Schedule trigger. tCapab1 options
+     * include "Periodic Schedule" so capability normalization passes; the seq
+     * paragraph shifts the render between fetches so tCapab1 routes to applied
+     * (giving success=true). No tDev/tstate -- Periodic takes no deviceIds.
+     */
+    private String periodicSelectTriggersJson(int ruleId, int seqNum) {
+        JsonOutput.toJson([
+            app: [id: ruleId, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                  appType: [name: "Rule-5.1", namespace: "hubitat"]],
+            configPage: [name: "selectTriggers", title: "T", install: false, error: null,
+                         sections: [[title: "", input: [
+                             [name: "tCapab1", type: "enum", options: ["Periodic Schedule"]],
+                             [name: "isCondTrig.1", type: "bool"],
+                             [name: "hasAll", type: "button"]
+                         ],
+                         // The periodic sub-page link renders as a body href
+                         // carrying params={n:<triggerIdx>} -- this is what the
+                         // dispatcher's schema-driven nav discovery reads.
+                         body: [[element: "href", name: "periodic1", page: "periodic", params: [n: 1]]],
+                         paragraphs: ["seq ${seqNum}".toString()]]]],
+            settings: [:],
+            childApps: []
+        ])
+    }
+
+    /**
+     * Register the standard hub-GET surface for a periodic addTrigger spec and
+     * return the captured POST list. mainPage reports the trigger as baked.
+     */
+    private List registerPeriodicHubSurface(int ruleId) {
+        def fetchSeq = 0
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: periodicSchemaJson(ruleId)]
+        }
+        hubGet.register("/installedapp/configure/json/${ruleId}".toString()) { params -> ruleConfigJson(ruleId, "r", []) }
+        hubGet.register("/installedapp/configure/json/${ruleId}/selectTriggers".toString()) { params ->
+            fetchSeq++
+            periodicSelectTriggersJson(ruleId, fetchSeq)
+        }
+        hubGet.register("/installedapp/configure/json/${ruleId}/periodic".toString()) { params -> periodicSchemaJson(ruleId) }
+        hubGet.register("/installedapp/configure/json/${ruleId}/mainPage".toString()) { params -> mainPageJson(ruleId, "r", true) }
+        hubGet.register("/installedapp/statusJson/${ruleId}".toString()) { params -> statusJson(ruleId) }
+        return posts
+    }
+
+    // Helper: pull the value of a genuine per-field write off the POST list.
+    // The Done-submit POST (carries _action_previous) echoes EVERY periodic
+    // schema field as an empty string; it is not a real write, so it is
+    // excluded here. Returns the value written by the field-write POST, or null
+    // if the field was never written by one.
+    private static String periodicWrite(List posts, String field) {
+        def hit = posts.find {
+            it.path == "/installedapp/update/json" &&
+            !it.body?.containsKey("_action_previous") &&
+            it.body?.containsKey("settings[${field}]".toString())
+        }
+        return hit?.body?."settings[${field}]"?.toString()
+    }
+
+    // Helper for negative pins: true when the field was written with a
+    // NON-EMPTY value by a genuine field-write POST (not the Done-clear). A
+    // negative pin asserting "this field was never written with a value" uses
+    // !periodicWroteValue(...) so the empty-string Done echo cannot satisfy it.
+    private static boolean periodicWroteValue(List posts, String field) {
+        def v = periodicWrite(posts, field)
+        return v != null && !v.isEmpty()
+    }
+
+    // Helper for the href-absent skip path: true when the field appears in ANY
+    // /installedapp/update/json POST (field-write OR Done-clear). When the whole
+    // periodic dance is skipped there is no nav, no write, and no Done, so
+    // !periodicWriteAny(...) proves the field was never touched at all.
+    private static boolean periodicWriteAny(List posts, String field) {
+        return posts.any {
+            it.path == "/installedapp/update/json" &&
+            it.body?.containsKey("settings[${field}]".toString())
+        }
+    }
+
+    def "addTrigger Periodic Seconds writes everyNSecs1 count enum directly (no toggle)"() {
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Seconds", everyN: 5]],
+            confirm: true
+        ])
+
+        then: "whichPeriod1 selects Seconds and the count lands in everyNSecs1 -- no toggle field is written"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Seconds"
+        periodicWrite(posts, "everyNSecs1") == "5"
+        // Seconds has NO toggle -- the Minutes-style toggle field must not be
+        // written with a value (the Done-clear echoes it as empty; that does
+        // not count).
+        !periodicWroteValue(posts, "everyNMinutesC1")
+    }
+
+    def "addTrigger Periodic Minutes writes toggle=true BEFORE count, count into everyNC1 not the toggle"() {
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Minutes", everyN: 15]],
+            confirm: true
+        ])
+
+        then: "the bool toggle lands true and the count goes into the separate everyNC1 field"
+        result.success == true
+        periodicWrite(posts, "everyNMinutesC1") == "true"
+        periodicWrite(posts, "everyNC1") == "15"
+
+        and: "toggle write precedes count write (count field only appears after toggle is true)"
+        // Match only genuine field-write POSTs, never the Done-clear (which
+        // carries _action_previous and echoes both fields as empty strings).
+        def togIdx = posts.findIndexOf {
+            !it.body?.containsKey("_action_previous") && it.body?.containsKey("settings[everyNMinutesC1]")
+        }
+        def cntIdx = posts.findIndexOf {
+            !it.body?.containsKey("_action_previous") && it.body?.containsKey("settings[everyNC1]")
+        }
+        togIdx >= 0 && cntIdx >= 0 && togIdx < cntIdx
+
+        and: "the count was NOT written into the bool toggle (the original renders-null bug)"
+        periodicWrite(posts, "everyNMinutesC1") != "15"
+    }
+
+    def "addTrigger Periodic Weekly writes selectDoWC1 day-of-week multi-enum and startingWC1 time"() {
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Weekly", daysOfWeek: ["Monday", "Friday"], startingTime: "08:00"]],
+            confirm: true
+        ])
+
+        then: "the day list serializes as a JSON array into selectDoWC1 and the time into startingWC1"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Weekly"
+        periodicWrite(posts, "selectDoWC1") == '["Monday","Friday"]'
+        periodicWrite(posts, "startingWC1") == "08:00"
+    }
+
+    def "addTrigger Periodic Monthly by-day writes dayMC1/everyNMC1/startingMC1"() {
+        // by-day mode (no weekOfMonth): the numeric fields + time land. The
+        // specific-months sub-mode is NOT supported (order-sensitive on the live
+        // hub), so months is not routed and selectMonthC1 is not written.
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Monthly", dayOfMonth: 15, everyNMonths: 2, startingTime: "09:30"]],
+            confirm: true
+        ])
+
+        then: "the Monthly by-day fields land under their irregular names"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Monthly"
+        periodicWrite(posts, "dayMC1") == "15"
+        periodicWrite(posts, "everyNMC1") == "2"
+        periodicWrite(posts, "startingMC1") == "09:30"
+
+        and: "by-day mode must NOT touch the nth-weekday fields"
+        !periodicWroteValue(posts, "weeklyMC1")
+        !periodicWroteValue(posts, "dailyMC1")
+    }
+
+    def "addTrigger Periodic Monthly does NOT route months to selectMonthC1 (specific-months sub-mode unsupported)"() {
+        // Pin the removal: passing months on a Monthly by-day spec must not write
+        // selectMonthC1 -- the order-sensitive specific-months sub-mode was
+        // deferred. selectMonthC1 IS in the periodic fixture schema, so a
+        // regression that re-added the routing would write a real value here.
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Monthly", dayOfMonth: 15, everyNMonths: 1, months: ["January", "July"], startingTime: "09:30"]],
+            confirm: true
+        ])
+
+        then: "the by-day fields land but months is silently ignored (not written to selectMonthC1)"
+        result.success == true
+        periodicWrite(posts, "dayMC1") == "15"
+        !periodicWroteValue(posts, "selectMonthC1")
+    }
+
+    def "addTrigger Periodic Monthly nth-weekday writes weeklyMC1/dailyMC1/everyNMCX1, NOT the by-day fields"() {
+        // nth-weekday mode (weekOfMonth present) hides the by-day fields and
+        // reveals the day-of-week + X-suffixed cadence. "On the Second Monday
+        // of every month at 8:00 AM".
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Monthly", weekOfMonth: "Second", dayOfWeek: "Monday", everyNMonths: 1, startingTime: "08:00"]],
+            confirm: true
+        ])
+
+        then: "the nth-weekday field set lands under its irregular names"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Monthly"
+        periodicWrite(posts, "weeklyMC1") == "Second"
+        periodicWrite(posts, "dailyMC1") == "Monday"
+        // nth-weekday cadence is the X-suffixed field, NOT the by-day everyNMC1.
+        periodicWrite(posts, "everyNMCX1") == "1"
+        periodicWrite(posts, "startingMC1") == "08:00"
+
+        and: "the by-day fields (which ARE in the Monthly map) are NOT written -- the modes are mutually exclusive"
+        !periodicWroteValue(posts, "dayMC1")
+        !periodicWroteValue(posts, "everyNMC1")
+    }
+
+    def "addTrigger Periodic Monthly dayOfMonth + weekOfMonth is rejected as success=false (mutually exclusive)"() {
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        // Only the backup-snapshot GETs are needed: the mutual-exclusivity
+        // guard fires before the trigger editor opens.
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Monthly", dayOfMonth: 15, weekOfMonth: "Second"]],
+            confirm: true
+        ])
+
+        then: "structured failure naming both modes; no wizard write POST fired"
+        result.success == false
+        result.error.toString().toLowerCase().contains("mutually exclusive")
+        result.error.toString().contains("dayOfMonth")
+        result.error.toString().contains("weekOfMonth")
+        !posts.any { it.path == "/installedapp/update/json" }
+    }
+
+    def "addTrigger Periodic Yearly writes yearlyMonthCX1/weeklyYC1/dailyYC1, NOT the dead yearlyMonthC1"() {
+        // Yearly is ALWAYS nth-weekday. The month lives in yearlyMonthCX1 (the
+        // X-suffixed reveal field); yearlyMonthC1 alone never completes.
+        // "On the First Monday of December at 8:00 AM".
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Yearly", months: "December", weekOfMonth: "First", dayOfWeek: "Monday", startingTime: "08:00"]],
+            confirm: true
+        ])
+
+        then: "the Yearly nth-weekday field set lands under the X-suffixed month/day names"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Yearly"
+        periodicWrite(posts, "yearlyMonthCX1") == "December"
+        periodicWrite(posts, "weeklyYC1") == "First"
+        periodicWrite(posts, "dailyYC1") == "Monday"
+        periodicWrite(posts, "startingYC1") == "08:00"
+
+        and: "the dead non-X month field (present in the schema) is never written -- months routes to yearlyMonthCX1, not the suffix-less yearlyMonthC1 that never completes"
+        !periodicWroteValue(posts, "yearlyMonthC1")
+    }
+
+    def "addTrigger Periodic Cron String writes cronStr1 (not the non-existent cronString1)"() {
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Cron String", cronString: "0 0 12 * * ?"]],
+            confirm: true
+        ])
+
+        then: "the cron value lands in the live cronStr1 field (the pre-fix code wrote the non-existent cronString1, which silently dropped the value)"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Cron String"
+        periodicWrite(posts, "cronStr1") == "0 0 12 * * ?"
+    }
+
+    def "addTrigger Periodic #freq everyN outside the restricted enum is rejected as success=false before opening the wizard"() {
+        // The up-front IllegalArgumentException is caught by the whole-tool
+        // backup-and-catch envelope in toolUpdateNativeApp and surfaced as a
+        // structured success=false map (consistent with the sibling
+        // compareToDevice missing-comparator guard on this same addTrigger
+        // path), NOT a propagated -32602. The validation still fires before the
+        // trigger editor opens, so no wizard write POST is sent.
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        // Base config + statusJson are needed only for the pre-write backup
+        // snapshot. selectTriggers/periodic are intentionally NOT registered:
+        // the validation fires before the trigger editor opens (before
+        // moreCond), so no selectTriggers GET should occur.
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: freq, everyN: 7]],
+            confirm: true
+        ])
+
+        then: "structured failure naming the bad value and the allowed set"
+        result.success == false
+        result.error.toString().toLowerCase().contains("everyn")
+        result.error.toString().contains("10, 12, 15, 20, 30")
+        result.error.toString().contains("7")
+
+        and: "no moreCond click / wizard write POST fired -- the editor never opened"
+        !posts.any { it.path == "/installedapp/update/json" }
+
+        where:
+        freq << ["Seconds", "Minutes"]
+    }
+
+    def "addTrigger Periodic Minutes accepts a count that IS in the restricted enum"() {
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when: "30 is in the allowed set"
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Minutes", everyN: 30]],
+            confirm: true
+        ])
+
+        then: "no validation rejection; the count lands in everyNC1"
+        result.success == true
+        periodicWrite(posts, "everyNC1") == "30"
+    }
+
+    def "addTrigger Periodic Minutes selectedMinutes routes to selectMinutesC1 (at-specific-minutes mode)"() {
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when: "the alternative 'at specific minutes' mode is used instead of everyN"
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Minutes", selectedMinutes: [0, 30]]],
+            confirm: true
+        ])
+
+        then: "the minute list serializes as a JSON array into selectMinutesC1"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Minutes"
+        periodicWrite(posts, "selectMinutesC1") == '["0","30"]'
+        // No everyN was passed, so the toggle must not be written with a value.
+        !periodicWroteValue(posts, "everyNMinutesC1")
+    }
+
+    def "addTrigger Periodic Minutes fractional everyN #everyN truncates to the in-enum integer and is accepted"() {
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when: "a fractional everyN whose floor IS in the restricted enum"
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Minutes", everyN: everyN]],
+            confirm: true
+        ])
+
+        then: "the value truncates toward zero and lands in everyNC1 as the integer"
+        result.success == true
+        periodicWrite(posts, "everyNC1") == expected
+
+        where:
+        everyN | expected
+        5.5    | "5"
+        15.9   | "15"
+    }
+
+    def "addTrigger Periodic #freq non-numeric everyN is rejected as success=false naming the allowed set"() {
+        given:
+        enableHubAdminWrite()
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        // Only the backup-snapshot GETs are needed: the unparseable-everyN guard
+        // fires before the trigger editor opens.
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+
+        when: "everyN is a non-numeric string"
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: freq, everyN: "abc"]],
+            confirm: true
+        ])
+
+        then: "structured failure naming the bad value and the allowed set; no wizard write POST"
+        result.success == false
+        result.error.toString().toLowerCase().contains("everyn")
+        result.error.toString().contains("10, 12, 15, 20, 30")
+        result.error.toString().contains("abc")
+        !posts.any { it.path == "/installedapp/update/json" }
+
+        where:
+        freq << ["Seconds", "Minutes"]
+    }
+
+    def "addTrigger Periodic Hourly everyN writes toggle/count/time, Hourly alt-mode writes selectHoursC1 + startingHCX1"() {
+        // Covers the Hourly ${pn}-suffixed fields (everyNHoursC1/everyNHC1/
+        // startingHC1 for everyN mode; selectHoursC1/startingHCX1 for the
+        // alternative specific-hours mode). pn=1 here, so these pin the
+        // byte-identical single-trigger names.
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when: "Hourly everyN mode with a start time"
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Hourly", everyN: 2, startingTime: "06:15"]],
+            confirm: true
+        ])
+
+        then: "toggle lands true, count into everyNHC1, time into startingHC1"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Hourly"
+        periodicWrite(posts, "everyNHoursC1") == "true"
+        periodicWrite(posts, "everyNHC1") == "2"
+        periodicWrite(posts, "startingHC1") == "06:15"
+
+        when: "Hourly specific-hours alt mode (selectedHours) with a minute offset"
+        def posts2 = registerPeriodicHubSurface(101)
+        def result2 = script.toolUpdateNativeApp([
+            appId: 101,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Hourly", selectedHours: [9, 12], minutesOffset: 15]],
+            confirm: true
+        ])
+
+        then: "the hour list serializes into selectHoursC1 and the offset into startingHCX1"
+        result2.success == true
+        periodicWrite(posts2, "selectHoursC1") == '["9","12"]'
+        periodicWrite(posts2, "startingHCX1") == "15"
+    }
+
+    def "addTrigger Periodic Daily weekdaysOnly writes everyWeekDay1, selectedDaysOfMonth writes selectDoMC1"() {
+        // Covers the Daily ${pn}-suffixed alt-mode fields. pn=1.
+        given:
+        enableHubAdminWrite()
+        def posts = registerPeriodicHubSurface(100)
+
+        when: "Daily everyN with weekdaysOnly toggle"
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Daily", everyN: 1, weekdaysOnly: true, startingTime: "07:00"]],
+            confirm: true
+        ])
+
+        then: "the weekdays-only toggle lands and the everyN/time fields write under Daily names"
+        result.success == true
+        periodicWrite(posts, "whichPeriod1") == "Daily"
+        periodicWrite(posts, "everyNDoMC1") == "true"
+        periodicWrite(posts, "everyNDC1") == "1"
+        periodicWrite(posts, "everyWeekDay1") == "true"
+        periodicWrite(posts, "startingDC1") == "07:00"
+
+        when: "Daily specific-days alt mode (selectedDaysOfMonth)"
+        def posts2 = registerPeriodicHubSurface(101)
+        def result2 = script.toolUpdateNativeApp([
+            appId: 101,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Daily", selectedDaysOfMonth: [1, 15]]],
+            confirm: true
+        ])
+
+        then: "the day list serializes into selectDoMC1"
+        result2.success == true
+        periodicWrite(posts2, "selectDoMC1") == '["1","15"]'
+    }
+
+    // ---------- addTrigger Periodic Schedule index!=1 regression pin ----------
+
+    def "addTrigger Periodic at trigger index 2 writes tCapab2 / isCondTrig.2 cleanly (no self-deadlock)"() {
+        // Regression pin for the historical "2nd periodic trigger self-deadlocks"
+        // bug. The fix lives in the shared reveal-walker; this spec asserts a
+        // periodic trigger added when index 1 is already committed writes its
+        // capability and conditional-toggle at suffix 2 -- not stomping suffix 1
+        // and not deadlocking on a stale wizard accumulator.
+        given:
+        enableHubAdminWrite()
+        def fetchSeq = 0
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: periodicSchemaJson(100)]
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        // selectTriggers already has a committed trigger at index 1 (tCapab1 +
+        // settings), so index discovery picks 2 for the in-flight periodic row.
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            fetchSeq++
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "selectTriggers", title: "T", install: false, error: null,
+                             sections: [[title: "", input: [
+                                 [name: "tCapab1", type: "enum", options: ["Switch"], value: "Switch"],
+                                 [name: "tCapab2", type: "enum", options: ["Periodic Schedule"]],
+                                 [name: "periodic1", type: "href", page: "periodic", params: [n: 2]],
+                                 [name: "isCondTrig.2", type: "bool"],
+                                 [name: "hasAll", type: "button"]
+                             ], paragraphs: ["seq ${fetchSeq}".toString()]]]],
+                // settings carry the committed index-1 trigger so _rmCollectTriggerIndices
+                // returns [1] and the in-flight row lands at 2.
+                settings: ["tCapab1": "Switch", "tDev1": ["8"]],
+                childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/periodic') { params -> periodicSchemaJson(100) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> mainPageJson(100, "r", true) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            statusJson(100, [[name: "tCapab1", type: "enum", value: "Switch"]])
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Hourly", everyN: 1]],
+            confirm: true
+        ])
+
+        then: "the in-flight periodic row writes capability and conditional-toggle at suffix 2, not 1"
+        result.triggerIndex == 2
+        posts.any { it.body?.containsKey("settings[tCapab2]") }
+        posts.any { it.body?.keySet()?.any { k -> k.toString().startsWith("settings[isCondTrig.2]") } }
+        // index-1's committed capability is never overwritten by this add.
+        !posts.any { it.body?."settings[tCapab1]"?.toString() == "Periodic Schedule" }
+    }
+
+    def "addTrigger 2nd periodic trigger routes to periodic2 sub-page and writes suffix-2 fields, not suffix-1"() {
+        // Regression guard for the multi-periodic-trigger fix (OUTCOME A). The
+        // rule already has periodic trigger 1; adding a 2nd periodic (Daily)
+        // trigger must navigate to ITS periodic sub-page (href periodic2,
+        // params n:2) and write the n-suffixed field names (whichPeriod2,
+        // everyNDoMC2, everyNDC2, startingDC2). Writing suffix-1 names would
+        // clobber trigger 1's periodic config (the original collision bug).
+        given:
+        enableHubAdminWrite()
+        def fetchSeq = 0
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        // The periodic sub-page for trigger 2 exposes suffix-2 fields. Returned
+        // as the nav-POST data so href discovery + field writes resolve to n=2.
+        def periodic2SchemaJson = JsonOutput.toJson([
+            app: [id: 100, version: 7],
+            configPage: [name: "periodic", title: "Periodic", install: false, error: null,
+                         sections: [[title: "", input: [
+                             [name: "whichPeriod2", type: "enum", options: ["Daily"]],
+                             [name: "everyNDoMC2", type: "bool"],
+                             [name: "everyNDC2", type: "enum", options: ["1", "2"]],
+                             [name: "startingDC2", type: "time"]
+                         ], paragraphs: []]]],
+            settings: [:]
+        ])
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: periodic2SchemaJson]
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        // selectTriggers: trigger 1 committed (Periodic), trigger 2 in-flight
+        // (Periodic). The periodic body href carries params n:2 for trigger 2.
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            fetchSeq++
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "selectTriggers", title: "T", install: false, error: null,
+                             sections: [[title: "", input: [
+                                 [name: "tCapab1", type: "enum", options: ["Periodic Schedule"], value: "Periodic Schedule"],
+                                 [name: "tCapab2", type: "enum", options: ["Periodic Schedule"]],
+                                 [name: "isCondTrig.2", type: "bool"],
+                                 [name: "hasAll", type: "button"]
+                             ],
+                             body: [[element: "href", name: "periodic2", page: "periodic", params: [n: 2]]],
+                             paragraphs: ["seq ${fetchSeq}".toString()]]]],
+                settings: ["tCapab1": "Periodic Schedule"],
+                childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/periodic') { params -> periodic2SchemaJson }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> mainPageJson(100, "r", true) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            statusJson(100, [[name: "tCapab1", type: "enum", value: "Periodic Schedule"]])
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Daily", everyN: 1, startingTime: "07:00"]],
+            confirm: true
+        ])
+
+        then: "trigger 2's periodic writes target the suffix-2 field set"
+        result.triggerIndex == 2
+        periodicWrite(posts, "whichPeriod2") == "Daily"
+        periodicWrite(posts, "everyNDoMC2") == "true"
+        periodicWrite(posts, "everyNDC2") == "1"
+        periodicWrite(posts, "startingDC2") == "07:00"
+
+        and: "no suffix-1 periodic field is written with a value (trigger 1 is not clobbered)"
+        !periodicWroteValue(posts, "whichPeriod1")
+        !periodicWroteValue(posts, "everyNDoMC1")
+        !periodicWroteValue(posts, "everyNDC1")
+        !periodicWroteValue(posts, "startingDC1")
+
+        and: "the navigation used the discovered n=2 href (periodic2)"
+        posts.any { it.body?.keySet()?.any { k -> k.toString().contains("_action_href_periodic2|periodic|2") } }
+    }
+
+    def "addTrigger 2nd periodic trigger with NO periodic href in schema refuses suffix-1 fallback (no clobber)"() {
+        // BLOCKING-2 guard: when the periodic href is ABSENT from the discovered
+        // selectTriggers schema AND this is not the first trigger slot (idx>1),
+        // suffix-1 fallback would silently overwrite trigger 1's schedule. The
+        // dispatcher must refuse to write the periodic sub-page and surface a
+        // partial with a repair hint, NOT a guaranteed clobber.
+        given:
+        enableHubAdminWrite()
+        def fetchSeq = 0
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        // trigger 1 committed (Periodic), trigger 2 in-flight (Periodic), but the
+        // schema has NO periodic body href -- discovery returns nothing.
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            fetchSeq++
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "selectTriggers", title: "T", install: false, error: null,
+                             sections: [[title: "", input: [
+                                 [name: "tCapab1", type: "enum", options: ["Periodic Schedule"], value: "Periodic Schedule"],
+                                 [name: "tCapab2", type: "enum", options: ["Periodic Schedule"]],
+                                 [name: "isCondTrig.2", type: "bool"],
+                                 [name: "hasAll", type: "button"]
+                             ],
+                             // NO body href for periodic -- discovery fails.
+                             paragraphs: ["seq ${fetchSeq}".toString()]]]],
+                settings: ["tCapab1": "Periodic Schedule"],
+                childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> mainPageJson(100, "r", true) }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            statusJson(100, [[name: "tCapab1", type: "enum", value: "Periodic Schedule"]])
+        }
+
+        when:
+        def result = script.toolUpdateNativeApp([
+            appId: 100,
+            addTrigger: [capability: "Periodic Schedule", periodic: [frequency: "Daily", everyN: 1, startingTime: "07:00"]],
+            confirm: true
+        ])
+
+        then: "the periodic sub-page is NOT written -- no suffix-1 field carries a value"
+        result.triggerIndex == 2
+        !periodicWriteAny(posts, "whichPeriod1")
+        !periodicWriteAny(posts, "everyNDoMC1")
+        !periodicWriteAny(posts, "everyNDC1")
+        !periodicWriteAny(posts, "startingDC1")
+        // Also no suffix-2 writes -- the whole periodic dance is skipped.
+        !periodicWriteAny(posts, "whichPeriod2")
+
+        and: "the result surfaces the refusal as partial with an actionable repair hint"
+        result.partial == true
+        result.settingsSkipped?.any { it?.reason == "periodic_href_absent_nonfirst_trigger" }
+        result.repairHints?.any { it?.toString()?.contains("periodic sub-page link was not found") }
+    }
+
     // ---------- addTrigger auto-updateRule parity with addAction ----------
 
     def "addTrigger single-trigger path auto-fires updateRule after successful commit"() {

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -2320,7 +2320,7 @@ All 103 tools are covered by at least one test, excluding the destructive operat
 
 Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
 
-**Total: 217 test scenarios** (113 explicit + 65 natural language + 21 built-in-app integration + 9 library management + 2 reveal-walker coverage + 3 deviceId normalization + 1 subExpression rejection + 1 reveal-fallback sentinel + 1 compareToDevice fallback + 1 Between-two-times sunrise/sunset) plus 13 excluded destructive operations documented for manual testing
+**Total: 227 test scenarios** (113 explicit + 65 natural language + 21 built-in-app integration + 9 library management + 2 reveal-walker coverage + 3 deviceId normalization + 1 subExpression rejection + 1 reveal-fallback sentinel + 1 compareToDevice fallback + 1 Between-two-times sunrise/sunset + 10 periodic-frequency completeness) plus 13 excluded destructive operations documented for manual testing
 
 ---
 
@@ -3242,6 +3242,166 @@ Tools in this section require **Hub Admin Read** and HPM itself must be installe
 
 ---
 
+### T623 — addTrigger Periodic Seconds: single count-enum field (no toggle)
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Periodic Seconds'.",
+  "test_prompt": "Add a trigger to 'BAT Periodic Seconds' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Seconds', everyN:5}}. Inspect the trigger paragraph on mainPage.",
+  "teardown_prompt": "Delete 'BAT Periodic Seconds'."
+}
+```
+
+**Expected**: `addTrigger` returns `success=true` and `partial!=true`. The trigger paragraph bakes to "Every 5 seconds" (not "?"/"null"). `result.brokenMarkers` is empty AND `result.health.ok=true`. Exercises the Seconds single-enum path (`everyNSecs1`) which has NO toggle -- the count enum IS the mode.
+
+**Failure modes**: paragraph renders "?" or "null" (the `everyNSecs1` write was silently rejected). `partial=true` with a `silent_rejection` sentinel on `everyNSecs1`. A two-step toggle->count was attempted (Seconds has no toggle, so writing one would land nothing).
+
+---
+
+### T624 — addTrigger Periodic Minutes: toggle-before-count two-step
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Periodic Minutes'.",
+  "test_prompt": "Add a trigger to 'BAT Periodic Minutes' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Minutes', everyN:15}}. Inspect the trigger paragraph on mainPage.",
+  "teardown_prompt": "Delete 'BAT Periodic Minutes'."
+}
+```
+
+**Expected**: `addTrigger` returns `success=true` and `partial!=true`. The trigger paragraph bakes to "Every 15 minutes". `result.brokenMarkers` is empty AND `result.health.ok=true`. Exercises the toggle-before-count two-step: `everyNMinutesC1=true` must land FIRST, then the count goes into `everyNC1` (a separate field), NOT into the bool toggle.
+
+**Failure modes**: paragraph renders "?"/"null" because the count was written into the bool `everyNMinutesC1` (the original bug) and the real count field `everyNC1` never got the value. `partial=true` with a sentinel on `everyNC1`.
+
+---
+
+### T625 — addTrigger Periodic Weekly: day-of-week multi-picker + starting time
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Periodic Weekly'.",
+  "test_prompt": "Add a trigger to 'BAT Periodic Weekly' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Weekly', daysOfWeek:['Monday','Friday'], startingTime:'08:00'}}. Inspect the trigger paragraph on mainPage.",
+  "teardown_prompt": "Delete 'BAT Periodic Weekly'."
+}
+```
+
+**Expected**: `addTrigger` returns `success=true` and `partial!=true`. The trigger paragraph names Monday and Friday and the 8:00 AM start. `result.brokenMarkers` is empty AND `result.health.ok=true`. Exercises `selectDoWC1` (day-of-week multi-enum) + `startingWC1` (time).
+
+**Failure modes**: paragraph renders "?"/"null" or omits the day list (the `selectDoWC1` multi-enum was sent in the wrong serialization). `partial=true` with a sentinel on `selectDoWC1` or `startingWC1`.
+
+---
+
+### T626 — addTrigger Periodic Monthly by-day: day number + every-N-months + starting time
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Periodic Monthly'.",
+  "test_prompt": "Add a trigger to 'BAT Periodic Monthly' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Monthly', dayOfMonth:15, everyNMonths:2, startingTime:'09:30'}}. Inspect the trigger paragraph on mainPage.",
+  "teardown_prompt": "Delete 'BAT Periodic Monthly'."
+}
+```
+
+**Expected**: `addTrigger` returns `success=true` and `partial!=true`. The trigger paragraph reflects day 15 of every 2 months, starting 9:30 AM. `result.brokenMarkers` is empty AND `result.health.ok=true`. by-day mode (no `weekOfMonth`) exercises `dayMC1` + `everyNMC1` + `startingMC1`. (nth-weekday mode is the mutually-exclusive alternative, covered by T630/T631. The "on day N of selected months" specific-months sub-mode is order-sensitive on the live hub and NOT yet supported.)
+
+**Failure modes**: paragraph renders "?"/"null" (one of the numeric fields silently rejected). `partial=true` with a sentinel on `dayMC1`, `everyNMC1`, or `startingMC1`.
+
+---
+
+### T627 — addTrigger Periodic Yearly: nth-weekday (always) -- weekOfMonth + dayOfWeek + month
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Periodic Yearly'.",
+  "test_prompt": "Add a trigger to 'BAT Periodic Yearly' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Yearly', months:'December', weekOfMonth:'First', dayOfWeek:'Monday', startingTime:'08:00'}}. Inspect the trigger paragraph on mainPage.",
+  "teardown_prompt": "Delete 'BAT Periodic Yearly'."
+}
+```
+
+**Expected**: `addTrigger` returns `success=true` and `partial!=true`. The trigger paragraph renders "On the First Monday of December at 8:00 AM". `result.brokenMarkers` is empty AND `result.health.ok=true`. Yearly is ALWAYS nth-weekday: exercises `yearlyMonthCX1` (the X-suffixed reveal month field -- `yearlyMonthC1` alone never completes) + `weeklyYC1` (week-of-month) + `dailyYC1` (single day-of-week, from `dayOfWeek`) + `startingYC1`. Note `months` is a single String here (Yearly), `dayOfWeek` is singular (vs Weekly's multi `daysOfWeek`).
+
+**Failure modes**: paragraph renders "?"/"null" or omits the month/day (a regression to the dead `yearlyMonthC1`, or the `dailyYC1` day write was dropped). `partial=true` with a sentinel on `yearlyMonthCX1`, `weeklyYC1`, or `dailyYC1`.
+
+---
+
+### T628 — addTrigger Periodic Cron String: field-name fix (cronStr1)
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Periodic Cron'.",
+  "test_prompt": "Add a trigger to 'BAT Periodic Cron' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Cron String', cronString:'0 0 12 * * ?'}}. Inspect the trigger paragraph on mainPage.",
+  "teardown_prompt": "Delete 'BAT Periodic Cron'."
+}
+```
+
+**Expected**: `addTrigger` returns `success=true` and `partial!=true`. The trigger paragraph renders the cron expression (not "?"/"null"). `result.brokenMarkers` is empty AND `result.health.ok=true`. Pins the Cron field-name fix: the value lands in `cronStr1` (the live field) -- the prior code wrote `cronString1`, a field that does not exist, so the value was silently dropped and the trigger rendered "null".
+
+**Failure modes**: paragraph renders "?"/"null" (the cron value was written to the non-existent `cronString1` and silently dropped -- the typo regression). `partial=true` with a sentinel on the cron field.
+
+---
+
+### T629 — addTrigger Periodic Minutes everyN outside restricted enum: validation rejection
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Periodic Enum'.",
+  "test_prompt": "Add a trigger to 'BAT Periodic Enum' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Minutes', everyN:7}}. Observe the tool's response.",
+  "teardown_prompt": "Delete 'BAT Periodic Enum'."
+}
+```
+
+**Expected**: the call returns a structured `success=false` map before any sub-page write. The `error` field names the allowed set `[1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30]` and the rejected value (7), and a `backup`/`restoreHint` accompanies it. No trigger row is committed. The up-front `IllegalArgumentException` is caught by the whole-tool backup-and-catch envelope and surfaced as `success=false` (NOT a thrown -32602) -- consistent with the sibling compareToDevice missing-comparator guard on this same addTrigger path. This is fail-loud: RM restricts the Seconds/Minutes count to a fixed enum, and 7 is not in it, so the tool surfaces a recoverable structured error instead of silently rendering "null".
+
+**Failure modes**: the call returns `success=true` and the trigger renders "null"/"?" (validation was skipped and the out-of-enum count was silently rejected by the hub). The `error` omits the valid-options list (less actionable for the LLM).
+
+---
+
+### T630 — addTrigger Periodic Monthly nth-weekday mode: weekOfMonth + dayOfWeek + everyNMonths
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Periodic Monthly Nth'.",
+  "test_prompt": "Add a trigger to 'BAT Periodic Monthly Nth' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Monthly', weekOfMonth:'Second', dayOfWeek:'Monday', everyNMonths:1, startingTime:'08:00'}}. Inspect the trigger paragraph on mainPage.",
+  "teardown_prompt": "Delete 'BAT Periodic Monthly Nth'."
+}
+```
+
+**Expected**: `addTrigger` returns `success=true` and `partial!=true`. The trigger paragraph renders "On the Second Monday of every month at 8:00 AM". `result.brokenMarkers` is empty AND `result.health.ok=true`. nth-weekday mode (selected by `weekOfMonth` presence) hides the by-day fields and exercises `weeklyMC1` + `dailyMC1` (single day-of-week from `dayOfWeek`) + `everyNMCX1` (the X-suffixed cadence, NOT the by-day `everyNMC1`) + `startingMC1`. `dayOfWeek` is singular here (vs Weekly's multi `daysOfWeek`).
+
+**Failure modes**: paragraph renders "?"/"null" (a regression that wrote the by-day `everyNMC1` instead of `everyNMCX1`, or dropped `dailyMC1`). `partial=true` with a sentinel on `dailyMC1` or `everyNMCX1`. The by-day fields (`dayMC1`/`everyNMC1`) being written would corrupt the mutually-exclusive mode.
+
+---
+
+### T631 — addTrigger Periodic Monthly dayOfMonth + weekOfMonth: mutually-exclusive rejection
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Periodic Monthly Excl'.",
+  "test_prompt": "Add a trigger to 'BAT Periodic Monthly Excl' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Monthly', dayOfMonth:15, weekOfMonth:'Second'}}. Observe the tool's response.",
+  "teardown_prompt": "Delete 'BAT Periodic Monthly Excl'."
+}
+```
+
+**Expected**: the call returns a structured `success=false` map before any sub-page write. The `error` field states the two modes are mutually exclusive and names both `dayOfMonth` and `weekOfMonth`, and a `backup`/`restoreHint` accompanies it. No trigger row is committed. The up-front `IllegalArgumentException` is caught by the whole-tool backup-and-catch envelope and surfaced as `success=false` (NOT a thrown -32602), consistent with the Seconds/Minutes everyN guard and the sibling compareToDevice guard. Monthly by-day (calendar day) and nth-weekday (Nth weekday) are distinct RM modes whose field sets hide each other; mixing them is unrenderable.
+
+**Failure modes**: the call returns `success=true` and the trigger renders "null"/"?" (the guard was skipped and both field sets were written, leaving an ambiguous/incomplete sub-page). The `error` names only one of the two conflicting fields (less actionable).
+
+---
+
+### T632 — two Periodic Schedule triggers in one rule: no sub-page collision
+
+```json
+{
+  "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT Two Periodic'.",
+  "test_prompt": "Add TWO triggers to 'BAT Two Periodic': first addTrigger {capability:'Periodic Schedule', periodic:{frequency:'Minutes', everyN:5}}, then addTrigger {capability:'Periodic Schedule', periodic:{frequency:'Daily', everyN:1, startingTime:'07:00'}}. Inspect both trigger paragraphs on mainPage.",
+  "teardown_prompt": "Delete 'BAT Two Periodic'."
+}
+```
+
+**Expected**: both addTrigger calls return `success=true` and `partial!=true`. mainPage renders BOTH periodic rows intact -- e.g. "Every 5 minutes" OR "Every day at 7:00 AM" -- with neither rendering "null". `result.brokenMarkers` is empty AND `result.health.ok=true`. The 2nd trigger navigates to its OWN periodic sub-page (RM exposes a `periodic2` href with params n:2 and suffix-2 fields `whichPeriod2`/`everyNDoMC2`/`everyNDC2`/`startingDC2`); the tool discovers the per-trigger index from the live schema and writes the n-suffixed field names, so trigger 1's suffix-1 fields are untouched. This is the regression scenario for the multi-periodic-trigger fix.
+
+**Failure modes**: trigger 1 renders "null" while trigger 2's frequency wins (the classic collision -- the 2nd trigger wrote suffix-1 fields, clobbering `whichPeriod1`/`everyN*C1`). The 2nd addTrigger's `settingsSkipped` shows silent_rejection with `available:["whichPeriod2"]` (the tool navigated correctly but wrote suffix-1 names the sub-page does not expose). Both rows render the same frequency (one trigger's config overwrote the other's slot).
+
+---
+
 ## Changes from BAT v1
 
 Key differences from the original BAT.md (which targets the pre-v0.8.0 architecture):
@@ -3255,7 +3415,7 @@ Key differences from the original BAT.md (which targets the pre-v0.8.0 architect
 7. **T62 rewritten**: Was testing `manage_virtual_devices` catalog (removed gateway) → now tests `manage_diagnostics` catalog
 8. **T104 updated**: Anti-recursion test uses `manage_diagnostics` gateway
 9. **Excluded tests expanded**: 10 → 13 (separate rows for each app/driver operation, added gateway column)
-10. **Corrected test count**: 159 → 172 (was undercounted in v1); addAction capability completeness adds T607/T608/T609/T610 (176 total); walker parity adds T611 (177 total); Between two times coverage adds T612 (178 total); singular deviceId normalization adds T613 (179 total); paired-tool singular-deviceId coverage adds T614 (addTrigger.condition) + T615 (addAction expression) (181 total); subExpression rejection on addAction adds T616 (182 total -- T616 previously covered recursive subExpression normalization, which production now rejects at the doActPage pre-pass; T616 was rewritten to pin the rejection path); reveal-fallback sentinel adds T617 (183 total); compareToDevice fallback adds T618 (184 total); Between two times sunrise/sunset adds T619 (185 total); Variable compareToVariable on the walker pages adds T620, compareToDevice missing-comparator reject adds T621, and Custom-Attribute '*changed*' cosmetic-partial filter adds T622 (188 total). Note: `Total: 217 test scenarios` in the header above counts ALL scenarios including the NL (T501-T565 range), built-in-app integration (T801-T821 range), library management (T901-T909 range), and the unnumbered walker/normalization sub-scenarios. The cumulative T-numbered tally in this item (ending at 188) reflects only sequentially-numbered tests in the explicit-coverage section.
+10. **Corrected test count**: 159 → 172 (was undercounted in v1); addAction capability completeness adds T607/T608/T609/T610 (176 total); walker parity adds T611 (177 total); Between two times coverage adds T612 (178 total); singular deviceId normalization adds T613 (179 total); paired-tool singular-deviceId coverage adds T614 (addTrigger.condition) + T615 (addAction expression) (181 total); subExpression rejection on addAction adds T616 (182 total -- T616 previously covered recursive subExpression normalization, which production now rejects at the doActPage pre-pass; T616 was rewritten to pin the rejection path); reveal-fallback sentinel adds T617 (183 total); compareToDevice fallback adds T618 (184 total); Between two times sunrise/sunset adds T619 (185 total); Variable compareToVariable on the walker pages adds T620, compareToDevice missing-comparator reject adds T621, and Custom-Attribute '*changed*' cosmetic-partial filter adds T622 (188 total); periodic-frequency completeness adds T623/T624/T625/T626/T627 (the five newly-supported frequencies: Seconds/Minutes/Weekly/Monthly/Yearly -- Monthly by-day and Yearly nth-weekday) + T628 (Cron field-name fix) + T629 (count-enum validation rejection) + T630 (Monthly nth-weekday mode) + T631 (Monthly dayOfMonth/weekOfMonth mutual-exclusivity rejection) + T632 (two periodic triggers in one rule -- no sub-page collision) (198 total). Note: `Total: 227 test scenarios` in the header above counts ALL scenarios including the NL (T501-T565 range), built-in-app integration (T801-T821 range), library management (T901-T909 range), and the unnumbered walker/normalization sub-scenarios. The cumulative T-numbered tally in this item (ending at 198) reflects only sequentially-numbered tests in the explicit-coverage section.
 11. **Spec-only coverage by necessity**: the trailing-updateRule failure paths on `addTrigger`, `addRequiredExpression`, `addLocalVariable`, `addTriggers`/`addActions` (bulk), `patches`, and the action-mutation/trigger-mutation dispatchers (`removeAction`, `clearActions`, `replaceActions`, `moveAction`, `removeTrigger`, `modifyTrigger`) -- response slots `updateRuleFailed`, `subscriptionsNotLive` / `expressionNotLive` / `variableNotLive` / `patchesNotLive`, `updateRuleError`, and the recovery `repairHints` line -- are covered exclusively by Spock specs in `src/test/groovy/server/ToolRmNativeCrudSpec.groovy` (the single-path failure/SUCCESS pairs for `addTrigger` / `addRequiredExpression` / `addLocalVariable`, the three-row `@Unroll` failure/SUCCESS pairs for the bulk path covering `addTriggers`-only / `addActions`-only / both, and the corresponding patches and action-mutation envelope specs). The defensive `asyncCommitLikely` path on `clearActions` / `replaceActions` -- response slots `asyncCommitLikely`, `stage`, `actionsRequestedForRemoval`, `actionsStillPresent`, `pendingActionsToAdd`, `clearActionsResult`, `safeRecovery` -- is also spec-only: with the synchronous full-form trashActs submit the delete commits in-band, so this rare residual path (stuck `state.editAct` or a firmware commit lag still showing the actions present after the verify-retry) is not reproducible from an agent prompt against a live hub. Live-hub BAT coverage was considered but skipped: deterministically forcing the trailing `_rmClickAppButton(updateRule)` to throw against a real hub requires hub-side disruption (firmware downgrade / network partition mid-call / hub-config corruption) that is not realistically scriptable from an agent prompt. The Spock specs exercise the production response-shape contract directly via stub injection and constitute the regression gate.
 
 ---


### PR DESCRIPTION
## Summary

- Completes Hubitat Rule Machine 5.1 **Periodic Schedule** trigger support via `addTrigger`: all 8 frequencies (Seconds → Yearly + Cron String), both Monthly/Yearly sub-modes, and **multiple periodic triggers per rule**.
- Fixes a set of latent wire-format bugs that made several periodic frequencies render as `null` or silently overwrite each other — every fix verified live on firmware 5.1.8.

## Type of change

- [ ] `feat` — new feature or capability
- [x] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

Part of #195 (Group C — periodic triggers).

- **Cron String**: write the live field `cronStr1` (the dispatcher wrote the non-existent `cronString1`, which silently rejected → trigger rendered `null`).
- **Five missing frequencies** (Seconds, Minutes, Weekly, Monthly, Yearly): mapped using their per-frequency RM field names. The names are irregular across frequencies (e.g. `everyNSecs1`, `everyNMinutesC1`+`everyNC1`, `selectDoWC1`) and were captured from the live wizard rather than extrapolated.
- **Monthly/Yearly nth-weekday-of-month sub-mode** (`weekOfMonth` + `dayOfWeek`): RM exposes a second, schema-progressive field set (`weeklyMC1`/`dailyMC1`/`everyNMCX1`, `weeklyYC1`/`dailyYC1`/`yearlyMonthCX1`) when a week-of-month is chosen. Dispatched by `weekOfMonth` presence; mutually exclusive with the by-day mode. Yearly is always this form.
- **Multiple periodic triggers per rule**: the periodic sub-page navigation + field-name suffixes are now keyed to the trigger index (`whichPeriod<n>`, `everyN*C<n>`, …), read from the live `selectTriggers` schema. Previously the index was hardcoded to `1`, so a second periodic trigger edited the first's sub-page slot and clobbered it. Single-trigger rules resolve `n=1` and are byte-identical to before.
- **Validation**: the Seconds/Minutes `everyN` value is checked against RM's restricted enum `[1,2,3,4,5,6,10,12,15,20,30]` up front; a Monthly `dayOfMonth` + `weekOfMonth` mix is rejected as mutually exclusive. Both surface as a structured `success=false` map via the existing backup-and-catch envelope.

## Release Notes

- Rule Machine **Periodic Schedule** triggers created via the MCP now work for every schedule type:
  - Every N seconds / minutes / hours, daily, weekly (specific days), and cron-string schedules.
  - Monthly and yearly schedules, including "the Nth weekday of the month/year" (e.g. *the second Monday of every month*, *the third Thursday of November*).
  - **Multiple periodic triggers in a single rule** (e.g. *every 5 minutes OR daily at 7 AM*) — previously a second periodic trigger would silently overwrite the first.
- Clear, actionable errors for invalid periodic input (out-of-range interval, or mixing a calendar day with an Nth-weekday).

## Testing

- New Spock unit + dispatch specs for every frequency, both nth-weekday sub-modes, the restricted-enum and mutual-exclusivity rejections, and a two-periodic-trigger regression guard.
- `tests/BAT-v2.md` scenarios added for the new paths (incl. two periodic triggers in one rule).
- Verified live on a Hubitat hub (firmware 5.1.8): every frequency + sub-mode renders its correct description; multiple periodic triggers coexist without collision; the validation paths reject as designed.
- Independently confirmed by fresh zero-context agents building these schedules through the documented tool surface alone.

## Checklist

- [x] **Unit tests added** (Spock specs for every new path + a two-periodic regression guard)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally
- [x] Live-hub BAT tests updated (`tests/BAT-v2.md`)
- [x] Documentation updated (`TOOL_GUIDE.md` + inline tool-guide)
- [x] No new/renamed MCP tools (existing `addTrigger` arg surface only)
