### PR TITLE
feat: split MCP tool gateways into read-only (hub_read_*) and write-bearing (hub_manage_*)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,14 +36,14 @@ These rules apply to every MCP tool added or renamed. Cached MCP clients refresh
 
 - **Universal service prefix.** Every MCP tool name begins with `hub_`. Anthropic's verified guidance: prefix-namespacing tools by service has "non-trivial effects on our tool-use evaluations" — *writing-tools-for-agents* (2025-09-11). Example: `hub_list_devices`, `hub_create_room`, `hub_call_device_command`.
 - **Verb-noun order.** After the `hub_` prefix, the name reads verb-noun. Verbs are drawn from the strict vocabulary table below. Nouns are the most natural English for the entity in context (drop redundant qualifiers — e.g., `rule` is preferred over `rm_rule` where context disambiguates).
-- **Gateways and flat-only `manage_` tools.** `manage_` is the verb for gateway tools (e.g., `hub_manage_rooms`, `hub_manage_logs`). It MAY also be used by a **flat-only tool** — one that never sits behind any gateway and is always kept top-level on `tools/list` — even though it is not itself a gateway. The canonical case is a flat tool that action-dispatches a small set (≤4) of verbs on a single noun (current example: `hub_manage_virtual_device` with `action: "create"/"delete"`). Don't introduce more flat `manage_` tools without explicit maintainer sign-off.
+- **Gateway verbs — `manage_` (write-bearing) and `read_` (pure-read).** A gateway's verb encodes whether it can mutate. **`manage_`** names any gateway that contains at least one write tool, whether mixed read+write or write-only (e.g., `hub_manage_rooms`, `hub_manage_code`, `hub_manage_destructive_ops`). **`read_`** names a gateway whose every sub-tool is read-only (e.g., `hub_read_apps_code`, `hub_read_diagnostics`). This lets an AI consumer enable the `hub_read_*` gateways for safe read-only access while gating every write-bearing `hub_manage_*` gateway behind a write permission. `manage_` MAY also be used by a **flat-only tool** — one that never sits behind any gateway and is always kept top-level on `tools/list` — even though it is not itself a gateway. The canonical case is a flat tool that action-dispatches a small set (≤4) of verbs on a single noun (current example: `hub_manage_virtual_device` with `action: "create"/"delete"`). Don't introduce more flat `manage_` tools without explicit maintainer sign-off. A gateway `read_` prefix is distinct from the file-manager **leaf** tools `hub_read_file`/`hub_write_file` (see the verb table) — those keep their own `read`/`write` verbs; the noun (`file` vs a gateway domain) disambiguates.
 - **Multi-gateway membership.** A tool MAY appear under more than one gateway when both gateway domains apply.
-- **Gateway read/write split.** Gateways SHOULD be read-only OR write-only where the domain permits. Mixed-mode gateways are accepted only when splitting genuinely doesn't fit the domain. Pure-mode gateways enable cleaner per-gateway disable in LLM client settings and clearer mental models for AI consumers.
+- **Gateway read/write split.** A read-only tool MUST be reachable from a `hub_read_*` gateway (or be a flat top-level tool) — it may never be unique to a `hub_manage_*` gateway. A `hub_manage_*` gateway MAY be mixed (carry its read tools too, for workflow cohesion) as long as those reads are *also* surfaced in a `hub_read_*` gateway via multi-gateway membership (same tool listed in both; no code duplication). This guarantees an AI consumer can reach every read through a pure-read surface while disabling every write-bearing `manage_` gateway. Pure-read gateways enable cleaner per-gateway disable in LLM client settings and clearer mental models for AI consumers.
 - **Hard rename, no aliases.** Non-conforming tools are renamed in lockstep when the convention requires it. The expectation: MCP clients refresh their cached tool list on server update. No deprecation aliases are shipped.
 
 ### Verb vocabulary
 
-Tools use exactly one verb from the table below. The table is the canonical list — `read`/`write` (file-manager domain), `report` (locked to one tool), and `reboot`/`shutdown` (destructive-ops domain) are narrow exceptions to the otherwise-general verb vocabulary.
+Tools use exactly one verb from the table below. The table is the canonical list — `write` (file-manager leaf tools), `report` (locked to one tool), and `reboot`/`shutdown` (destructive-ops domain) are narrow exceptions to the otherwise-general verb vocabulary. `read` is dual-purpose: the file-manager leaf verb (`hub_read_file`) AND the verb for pure-read **gateways** (`hub_read_*`). `manage` is the verb for write-bearing gateways (see Tool naming).
 
 | Verb | Semantic | Folds in |
 |---|---|---|
@@ -56,11 +56,11 @@ Tools use exactly one verb from the table below. The table is the canonical list
 | `delete` | Write that destroys an entity (no ID = delete all) | `clear`, `remove` |
 | `set` | Write that assigns a value/state (`set_X_<attr>`) or replaces an entity wholesale (`set_X`, PUT-like) | `pause`, `resume`, `enable`, `disable`, `lock`, `unlock`, `mute`, `unmute`, `start`, `stop`, `open`, `close`, `assign`, `unassign` |
 | `call` | Invoke a method / service / dispatch / device command | `send`, `dispatch`, `invoke`, `request`, `evaluate`, `run`, `force` |
-| `manage` | Action-dispatch — gateways, plus flat-only top-level tools (see Tool naming) | — |
+| `manage` | Action-dispatch gateway that contains writes (mixed read+write or write-only), plus flat-only top-level tools (see Tool naming) | — |
 | `restore` | Re-apply a prior backup | — |
 | `import` / `export` | Round-trip serialization counterpart | — |
 | `clone` | Duplicate an existing entity | — |
-| `read` / `write` | File-manager domain only — narrow exception | — |
+| `read` / `write` | File-manager **leaf** tools (`hub_read_file`, `hub_write_file`) — narrow exception. `read` is ALSO the verb for pure-read **gateways** (`hub_read_*`, every sub-tool read-only); the noun disambiguates a gateway domain from the `file` leaf | — |
 | `report` | LOCKED to `hub_report_issue` only | — |
 | `reboot` / `shutdown` | EXCEPTIONS — destructive-ops gateway only | — |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,14 +36,14 @@ These rules apply to every MCP tool added or renamed. Cached MCP clients refresh
 
 - **Universal service prefix.** Every MCP tool name begins with `hub_`. Anthropic's verified guidance: prefix-namespacing tools by service has "non-trivial effects on our tool-use evaluations" — *writing-tools-for-agents* (2025-09-11). Example: `hub_list_devices`, `hub_create_room`, `hub_call_device_command`.
 - **Verb-noun order.** After the `hub_` prefix, the name reads verb-noun. Verbs are drawn from the strict vocabulary table below. Nouns are the most natural English for the entity in context (drop redundant qualifiers — e.g., `rule` is preferred over `rm_rule` where context disambiguates).
-- **Gateways and flat-only `manage_` tools.** `manage_` is the verb for gateway tools (e.g., `hub_manage_rooms`, `hub_manage_logs`). It MAY also be used by a **flat-only tool** — one that never sits behind any gateway and is always kept top-level on `tools/list` — even though it is not itself a gateway. The canonical case is a flat tool that action-dispatches a small set (≤4) of verbs on a single noun (current example: `hub_manage_virtual_device` with `action: "create"/"delete"`). Don't introduce more flat `manage_` tools without explicit maintainer sign-off.
+- **Gateway verbs — `manage_` (write-bearing) and `read_` (pure-read).** A gateway's verb encodes whether it can mutate. **`manage_`** names any gateway that contains at least one write tool, whether mixed read+write or write-only (e.g., `hub_manage_rooms`, `hub_manage_code`, `hub_manage_destructive_ops`). **`read_`** names a gateway whose every sub-tool is read-only (e.g., `hub_read_apps_code`, `hub_read_diagnostics`). This lets an AI consumer enable the `hub_read_*` gateways for safe read-only access while gating every write-bearing `hub_manage_*` gateway behind a write permission. `manage_` MAY also be used by a **flat-only tool** — one that never sits behind any gateway and is always kept top-level on `tools/list` — even though it is not itself a gateway. The canonical case is a flat tool that action-dispatches a small set (≤4) of verbs on a single noun (current example: `hub_manage_virtual_device` with `action: "create"/"delete"`). Don't introduce more flat `manage_` tools without explicit maintainer sign-off. A gateway `read_` prefix is distinct from the file-manager **leaf** tools `hub_read_file`/`hub_write_file` (see the verb table) — those keep their own `read`/`write` verbs; the noun (`file` vs a gateway domain) disambiguates.
 - **Multi-gateway membership.** A tool MAY appear under more than one gateway when both gateway domains apply.
-- **Gateway read/write split.** Gateways SHOULD be read-only OR write-only where the domain permits. Mixed-mode gateways are accepted only when splitting genuinely doesn't fit the domain. Pure-mode gateways enable cleaner per-gateway disable in LLM client settings and clearer mental models for AI consumers.
+- **Gateway read/write split.** A read-only tool MUST be reachable from a `hub_read_*` gateway (or be a flat top-level tool) — it may never be unique to a `hub_manage_*` gateway. A `hub_manage_*` gateway MAY be mixed (carry its read tools too, for workflow cohesion) as long as those reads are *also* surfaced in a `hub_read_*` gateway via multi-gateway membership (same tool listed in both; no code duplication). This guarantees an AI consumer can reach every read through a pure-read surface while disabling every write-bearing `manage_` gateway. Pure-read gateways enable cleaner per-gateway disable in LLM client settings and clearer mental models for AI consumers.
 - **Hard rename, no aliases.** Non-conforming tools are renamed in lockstep when the convention requires it. The expectation: MCP clients refresh their cached tool list on server update. No deprecation aliases are shipped.
 
 ### Verb vocabulary
 
-Tools use exactly one verb from the table below. The table is the canonical list — `read`/`write` (file-manager domain), `report` (locked to one tool), and `reboot`/`shutdown` (destructive-ops domain) are narrow exceptions to the otherwise-general verb vocabulary.
+Tools use exactly one verb from the table below. The table is the canonical list — `write` (file-manager leaf tools), `report` (locked to one tool), and `reboot`/`shutdown` (destructive-ops domain) are narrow exceptions to the otherwise-general verb vocabulary. `read` is dual-purpose: the file-manager leaf verb (`hub_read_file`) AND the verb for pure-read **gateways** (`hub_read_*`). `manage` is the verb for write-bearing gateways (see Tool naming).
 
 | Verb | Semantic | Folds in |
 |---|---|---|
@@ -56,11 +56,11 @@ Tools use exactly one verb from the table below. The table is the canonical list
 | `delete` | Write that destroys an entity (no ID = delete all) | `clear`, `remove` |
 | `set` | Write that assigns a value/state (`set_X_<attr>`) or replaces an entity wholesale (`set_X`, PUT-like) | `pause`, `resume`, `enable`, `disable`, `lock`, `unlock`, `mute`, `unmute`, `start`, `stop`, `open`, `close`, `assign`, `unassign` |
 | `call` | Invoke a method / service / dispatch / device command | `send`, `dispatch`, `invoke`, `request`, `evaluate`, `run`, `force` |
-| `manage` | Action-dispatch — gateways, plus flat-only top-level tools (see Tool naming) | — |
+| `manage` | Action-dispatch gateway that contains writes (mixed read+write or write-only), plus flat-only top-level tools (see Tool naming) | — |
 | `restore` | Re-apply a prior backup | — |
 | `import` / `export` | Round-trip serialization counterpart | — |
 | `clone` | Duplicate an existing entity | — |
-| `read` / `write` | File-manager domain only — narrow exception | — |
+| `read` / `write` | File-manager **leaf** tools (`hub_read_file`, `hub_write_file`) — narrow exception. `read` is ALSO the verb for pure-read **gateways** (`hub_read_*`, every sub-tool read-only); the noun disambiguates a gateway domain from the `file` leaf | — |
 | `report` | LOCKED to `hub_report_issue` only | — |
 | `reboot` / `shutdown` | EXCEPTIONS — destructive-ops gateway only | — |
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hubitat MCP Server
 
-A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 89 MCP tools (33 on `tools/list` via category gateways).
+A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 88 MCP tools (30 on `tools/list` via category gateways).
 
 > **BETA SOFTWARE**: This project is ~99% AI-generated ("vibe coded") using Claude. It's a work in progress — contributions and [bug reports](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues) are welcome!
 
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 89 tools total — 20 core tools are always visible, while 69 additional tools are organized behind 13 domain-named gateways to keep the tool list manageable. If your client handles long tool lists well, you can disable the gateways via the **Consolidate tools behind category gateways** setting and every tool is exposed individually instead. (Counts here describe the shipped catalog; the runtime count on `tools/list` varies based on enabled settings.)
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 88 tools total — 11 core tools are always visible, while the rest are organized behind 19 domain-named gateways to keep the tool list manageable. If your client handles long tool lists well, you can disable the gateways via the **Consolidate tools behind category gateways** setting and every tool is exposed individually instead. (Counts here describe the shipped catalog; the runtime count on `tools/list` varies based on enabled settings.)
 
 ## Requirements
 
@@ -221,47 +221,11 @@ For free remote access without a Hubitat Cloud subscription:
 
 ## Features
 
-### MCP Tools (89 total — 33 on tools/list)
+### MCP Tools (88 total — 30 on tools/list)
 
-The server has 89 tools total. To keep the MCP `tools/list` manageable, **20 core tools** are always visible and **69 additional tools** are organized behind **13 domain-named gateways**. The AI sees 33 items on `tools/list` (20 + 13 gateways). Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
+The server has 88 tools total. To keep the MCP `tools/list` manageable, **11 core tools** are always visible and the remaining tools are organized behind **19 domain-named gateways** (7 read-only `hub_read_*` gateways + 12 write-bearing `hub_manage_*` gateways). The AI sees 30 items on `tools/list` (11 + 19 gateways). A tool may appear under more than one gateway — read tools inside a mixed `hub_manage_*` gateway are also surfaced in a pure-read `hub_read_*` gateway. Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
 
-#### Core Tools (20) — Always visible on tools/list
-
-<details>
-<summary><b>Devices</b> (5) — Control and query devices</summary>
-
-| Tool | Description |
-|------|-------------|
-| `hub_list_devices` | List accessible devices (pagination, server-side labelFilter/capabilityFilter, format=ids, field projection; `filter='virtual'` lists only MCP-managed virtual devices) |
-| `hub_get_device` | Full device details: attributes, commands, capabilities |
-| `hub_get_device_attribute` | Get a specific attribute value. Pass `expectedValue` (or `expectedValues`) to block-poll the attribute until it matches or times out — `timeoutMs` in MILLISECONDS (default 5000ms = 5 seconds, max 60000ms). Polling BLOCKS the MCP request; use sparingly and prefer event-driven flows when available. |
-| `hub_call_device_command` | Send a command (on, off, setLevel, etc.) |
-| `hub_list_device_events` | Recent events for a device. Add `hoursBack` for a time window (up to 7 days of device or location event history); omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events. |
-
-</details>
-
-<details>
-<summary><b>Rules</b> (4) — Create and manage automation rules</summary>
-
-| Tool | Description |
-|------|-------------|
-| `hub_get_custom_rule` | Full custom-engine rule details (triggers, conditions, actions). Omit `ruleId` to list all custom-engine rules with status; pass `detailed=true` for comprehensive diagnostics on a specific rule. |
-| `hub_create_custom_rule` | Create a new custom-engine automation rule (separate from native Rule Machine) |
-| `hub_update_custom_rule` | Update custom-engine rule triggers, conditions, actions, or enabled state (`enabled=true/false`) |
-| `hub_create_native_app` | Create a NATIVE classic SmartApp (RM 5.1 by default; `appType` enum extends to Room Lighting / Button Controllers / Basic Rules / etc.). Appears under Apps / Automations like a normally-created app. |
-| `hub_update_native_app` | Modify any classic native app by appId (multiple=true contract automatic, snapshot-before-write) |
-| `hub_delete_native_app` | Delete a classic native app (auto-snapshot to File Manager) |
-
-</details>
-
-<details>
-<summary><b>Device Management</b> (1)</summary>
-
-| Tool | Description |
-|------|-------------|
-| `hub_update_device` | Update device properties (label, room, preferences, etc.) |
-
-</details>
+#### Core Tools (11) — Always visible on tools/list
 
 <details>
 <summary><b>System</b> (5) — Hub modes, HSM, and info</summary>
@@ -306,20 +270,134 @@ The server has 89 tools total. To keep the MCP `tools/list` manageable, **20 cor
 
 </details>
 
-#### Gateway Tools (13) — Each gateway proxies multiple tools
+#### Gateway Tools (19) — Each gateway proxies multiple tools
 
-Call a gateway with no arguments to see full parameter schemas. Call with `tool='<name>'` and `args={...}` to execute a specific tool.
+Call a gateway with no arguments to see full parameter schemas. Call with `tool='<name>'` and `args={...}` to execute a specific tool. Gateways split into 7 read-only `hub_read_*` gateways (every sub-tool is read-only) and 12 write-bearing `hub_manage_*` gateways (mixed read+write or write-only). A tool may be listed in more than one gateway — reads inside a mixed `hub_manage_*` gateway are also surfaced in a `hub_read_*` gateway.
+
+##### Read-only gateways (7)
 
 <details>
-<summary><b>hub_manage_rules</b> (5) — Rule administration</summary>
+<summary><b>hub_read_apps_code</b> (9) — App/driver/library listing, source, backups, and HPM (read-only)</summary>
 
 | Tool | Description |
 |------|-------------|
-| `hub_delete_custom_rule` | Permanently delete a custom-engine rule (auto-backs up first) |
+| `hub_list_apps` | List apps on the hub. `scope='types'` lists installed app types (code); `scope='instances'` enumerates all app instances (built-in + user) with parent/child tree, filterable by builtin/user/disabled/parents/children. |
+| `hub_list_drivers` | List all installed drivers on the hub |
+| `hub_get_source` | Get Groovy source code for an app, driver, or library (`type`: "app", "driver", "library"; `id`). Supports chunked reading via `offset`/`length`. |
+| `hub_list_backups` | List auto-created source code backups |
+| `hub_get_backup` | Get source from a backup |
+| `hub_list_device_dependents` | Find all apps that reference a specific device (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.) |
+| `hub_get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.) — sections, inputs, values. Multi-page apps via `pageName`. Read-only. Hub Admin Read. |
+| `hub_list_app_pages` | List known page names for a multi-page app (HPM, Room Lighting, etc.). Returns curated directory + live primary page. Use before `hub_get_app_config` on multi-page apps to avoid guessing page names. Hub Admin Read. |
+| `hub_list_hpm_packages` | List all packages tracked by HPM — name, version, beta flag, author, and full component inventory (apps, drivers, files with heIDs). Top-level `count` and echoed `hpmAppId`. Auto-discovers HPM's app ID. Pass `includeDrift=true` to also cross-reference HPM-tracked packages against installed apps and drivers (surfacing missing-required components, orphan apps, and orphan drivers under a `drift` key; optional `packageFilter` substring; surfaces `orphanDetection` / `orphanDriverDetection` when registry fetches fail; data-quality warning types: `heid-whitespace-normalized`, `heid-non-scalar-dropped`, `empty-heid`, `skipped-malformed-component` — see `hub_get_tool_guide` for full details). Hub Admin Read. |
+
+`hub_list_device_dependents` requires opt-in **Enable Built-in App Tools** setting. `hub_get_app_config`, `hub_list_app_pages`, and `hub_list_hpm_packages` require Hub Admin Read. HPM itself must be installed on the hub.
+
+</details>
+
+<details>
+<summary><b>hub_read_devices</b> (4) — Query devices (read-only)</summary>
+
+| Tool | Description |
+|------|-------------|
+| `hub_list_devices` | List accessible devices (pagination, server-side labelFilter/capabilityFilter, format=ids, field projection; `filter='virtual'` lists only MCP-managed virtual devices) |
+| `hub_get_device` | Full device details: attributes, commands, capabilities |
+| `hub_get_device_attribute` | Get a specific attribute value. Pass `expectedValue` (or `expectedValues`) to block-poll the attribute until it matches or times out — `timeoutMs` in MILLISECONDS (default 5000ms = 5 seconds, max 60000ms). Polling BLOCKS the MCP request; use sparingly and prefer event-driven flows when available. |
+| `hub_list_device_events` | Recent events for a device. Add `hoursBack` for a time window (up to 7 days of device or location event history); omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events. |
+
+</details>
+
+<details>
+<summary><b>hub_read_diagnostics</b> (9) — Diagnostics, metrics, memory, radio details (read-only)</summary>
+
+| Tool | Description |
+|------|-------------|
+| `hub_get_logs` | Hub log entries (most recent first) with level/source/regex filters, multi-pattern AND/OR, time-window (since/until, max 30d relative -- throws if exceeded; use ISO-8601 for longer ranges), and server-side deviceId/appId scoping. `pattern` matches the message field only; pathological regex like `(.*)*` may hang the matcher. (Device/location event *history* is in `hub_list_device_events` via `hoursBack`.) |
+| `hub_get_performance_stats` | Device/app performance stats (count, % busy, total ms, state size, events, large-state flag) |
+| `hub_get_jobs` | Scheduled jobs, running jobs, and hub actions |
+| `hub_get_debug_logs` | Retrieve MCP debug log entries. Pass `mode='status'` to get logging system status and capacity instead. |
+| `hub_get_metrics` | Retrieve hub metrics with CSV trend history (read-only by default; does not record a new snapshot) |
+| `hub_get_memory_history` | Free OS memory and CPU load history with summary stats (Hub Admin Read) |
+| `hub_get_device_health` | Find stale/offline devices |
+| `hub_get_radio_details` | Radio info — Z-Wave (firmware, devices) or Zigbee (channel, PAN ID, devices). `radio`: "zwave" or "zigbee"; omit for both. |
+| `hub_list_captured_states` | List saved device state snapshots |
+
+Monitoring tools require Hub Admin Read to be enabled.
+
+</details>
+
+<details>
+<summary><b>hub_read_files</b> (2) — Hub File Manager (read-only)</summary>
+
+| Tool | Description |
+|------|-------------|
+| `hub_list_files` | List all files in File Manager |
+| `hub_read_file` | Read a file's contents |
+
+</details>
+
+<details>
+<summary><b>hub_read_rooms</b> (2) — Room listing (read-only)</summary>
+
+| Tool | Description |
+|------|-------------|
+| `hub_list_rooms` | List all rooms with IDs, names, and device counts |
+| `hub_get_room` | Get room details with assigned devices |
+
+</details>
+
+<details>
+<summary><b>hub_read_rules</b> (4) — Rule introspection (read-only)</summary>
+
+| Tool | Description |
+|------|-------------|
+| `hub_get_custom_rule` | Full custom-engine rule details (triggers, conditions, actions). Omit `ruleId` to list all custom-engine rules with status; pass `detailed=true` for comprehensive diagnostics on a specific rule. |
 | `hub_test_custom_rule` | Dry-run a custom-engine rule without executing actions |
-| `hub_export_custom_rule` | Export custom-engine rule to JSON for backup/sharing |
+| `hub_list_rules` | List all Rule Machine rules (RM 4.x + 5.x) via official `hubitat.helper.RMUtils` API |
+| `hub_get_rule_health` | Read-only health check on any installed app — surfaces broken markers, multiple-flag poison, configPage errors. |
+
+</details>
+
+<details>
+<summary><b>hub_read_variables</b> (3) — Hub variable reads (read-only)</summary>
+
+| Tool | Description |
+|------|-------------|
+| `hub_list_variables` | List all hub connector and rule engine variables |
+| `hub_get_variable` | Get a variable value and metadata |
+| `hub_list_variable_changes` | Recent hub-variable changes since the MCP app last started |
+
+</details>
+
+##### Write-bearing gateways (12)
+
+<details>
+<summary><b>hub_manage_custom_rules</b> (8) — Custom rule administration</summary>
+
+| Tool | Description |
+|------|-------------|
+| `hub_get_custom_rule` | Full custom-engine rule details (triggers, conditions, actions). Omit `ruleId` to list all custom-engine rules with status; pass `detailed=true` for comprehensive diagnostics on a specific rule. (Also in `hub_read_rules`.) |
+| `hub_create_custom_rule` | Create a new custom-engine automation rule (separate from native Rule Machine) |
+| `hub_update_custom_rule` | Update custom-engine rule triggers, conditions, actions, or enabled state (`enabled=true/false`) |
+| `hub_delete_custom_rule` | Permanently delete a custom-engine rule (auto-backs up first) |
+| `hub_test_custom_rule` | Dry-run a custom-engine rule without executing actions (also in `hub_read_rules`) |
+| `hub_export_custom_rule` | Export custom-engine rule to JSON and persist it to File Manager via saveAs (write) |
 | `hub_import_custom_rule` | Import custom-engine rule from exported JSON |
 | `hub_clone_custom_rule` | Clone an existing custom-engine rule (starts disabled) |
+
+</details>
+
+<details>
+<summary><b>hub_manage_devices</b> (6) — Control and query devices</summary>
+
+| Tool | Description |
+|------|-------------|
+| `hub_call_device_command` | Send a command (on, off, setLevel, etc.) |
+| `hub_update_device` | Update device properties (label, room, preferences, etc.) |
+| `hub_list_devices` | List accessible devices (pagination, server-side labelFilter/capabilityFilter, format=ids, field projection; `filter='virtual'` lists only MCP-managed virtual devices) (also in `hub_read_devices`) |
+| `hub_get_device` | Full device details: attributes, commands, capabilities (also in `hub_read_devices`) |
+| `hub_get_device_attribute` | Get a specific attribute value. Pass `expectedValue` (or `expectedValues`) to block-poll the attribute until it matches or times out — `timeoutMs` in MILLISECONDS (default 5000ms = 5 seconds, max 60000ms). Polling BLOCKS the MCP request; use sparingly and prefer event-driven flows when available. (also in `hub_read_devices`) |
+| `hub_list_device_events` | Recent events for a device. Add `hoursBack` for a time window (up to 7 days of device or location event history); omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events. (also in `hub_read_devices`) |
 
 </details>
 
@@ -328,14 +406,14 @@ Call a gateway with no arguments to see full parameter schemas. Call with `tool=
 
 | Tool | Description |
 |------|-------------|
-| `hub_list_variables` | List all hub connector and rule engine variables |
-| `hub_get_variable` | Get a variable value and metadata |
+| `hub_list_variables` | List all hub connector and rule engine variables (also in `hub_read_variables`) |
+| `hub_get_variable` | Get a variable value and metadata (also in `hub_read_variables`) |
 | `hub_set_variable` | Set a variable value |
 | `hub_create_variable` | Create a new hub variable |
 | `hub_delete_variable` | Permanently delete a hub variable (DESTRUCTIVE) |
 | `hub_create_connector` | Create a virtual-device connector for a hub variable |
 | `hub_delete_connector` | Remove the connector device for a hub variable |
-| `hub_list_variable_changes` | Recent hub-variable changes since the MCP app last started |
+| `hub_list_variable_changes` | Recent hub-variable changes since the MCP app last started (also in `hub_read_variables`) |
 
 </details>
 
@@ -344,8 +422,8 @@ Call a gateway with no arguments to see full parameter schemas. Call with `tool=
 
 | Tool | Description |
 |------|-------------|
-| `hub_list_rooms` | List all rooms with IDs, names, and device counts |
-| `hub_get_room` | Get room details with assigned devices |
+| `hub_list_rooms` | List all rooms with IDs, names, and device counts (also in `hub_read_rooms`) |
+| `hub_get_room` | Get room details with assigned devices (also in `hub_read_rooms`) |
 | `hub_create_room` | Create a new room (Hub Admin Write + confirm) |
 | `hub_delete_room` | Permanently delete a room (Hub Admin Write + confirm) |
 | `hub_update_room` | Rename a room (Hub Admin Write + confirm) |
@@ -366,20 +444,7 @@ All operations are disruptive. Hub admin tools require Hub Admin Read/Write to b
 </details>
 
 <details>
-<summary><b>hub_manage_code_read</b> (5) — App/driver/library listing, source code, and backups (read-only)</summary>
-
-| Tool | Description |
-|------|-------------|
-| `hub_list_apps` | List all installed apps on the hub |
-| `hub_list_drivers` | List all installed drivers on the hub |
-| `hub_get_source` | Get Groovy source code for an app, driver, or library (`type`: "app", "driver", "library"; `id`). Supports chunked reading via `offset`/`length`. |
-| `hub_list_backups` | List auto-created source code backups |
-| `hub_get_backup` | Get source from a backup |
-
-</details>
-
-<details>
-<summary><b>hub_manage_code_write</b> (8) — Install, update, delete apps/drivers/libraries and restore backups</summary>
+<summary><b>hub_manage_code</b> (8) — Install, update, delete apps/drivers/libraries and restore backups</summary>
 
 | Tool | Description |
 |------|-------------|
@@ -401,10 +466,10 @@ Source code is automatically backed up before any modify/delete operation.
 
 | Tool | Description |
 |------|-------------|
-| `hub_get_logs` | Hub log entries (most recent first) with level/source/regex filters, multi-pattern AND/OR, time-window (since/until, max 30d relative -- throws if exceeded; use ISO-8601 for longer ranges), and server-side deviceId/appId scoping. `pattern` matches the message field only; pathological regex like `(.*)*` may hang the matcher. (Device/location event *history* is in `hub_list_device_events` via `hoursBack`.) |
-| `hub_get_performance_stats` | Device/app performance stats (count, % busy, total ms, state size, events, large-state flag) |
-| `hub_get_jobs` | Scheduled jobs, running jobs, and hub actions |
-| `hub_get_debug_logs` | Retrieve MCP debug log entries. Pass `mode='status'` to get logging system status and capacity instead. |
+| `hub_get_logs` | Hub log entries (most recent first) with level/source/regex filters, multi-pattern AND/OR, time-window (since/until, max 30d relative -- throws if exceeded; use ISO-8601 for longer ranges), and server-side deviceId/appId scoping. `pattern` matches the message field only; pathological regex like `(.*)*` may hang the matcher. (Device/location event *history* is in `hub_list_device_events` via `hoursBack`.) (also in `hub_read_diagnostics`) |
+| `hub_get_performance_stats` | Device/app performance stats (count, % busy, total ms, state size, events, large-state flag) (also in `hub_read_diagnostics`) |
+| `hub_get_jobs` | Scheduled jobs, running jobs, and hub actions (also in `hub_read_diagnostics`) |
+| `hub_get_debug_logs` | Retrieve MCP debug log entries. Pass `mode='status'` to get logging system status and capacity instead. (also in `hub_read_diagnostics`) |
 | `hub_delete_debug_logs` | Clear all MCP debug logs |
 | `hub_set_log_level` | Set MCP log level (debug/info/warn/error) |
 
@@ -417,13 +482,13 @@ Monitoring tools require Hub Admin Read to be enabled.
 
 | Tool | Description |
 |------|-------------|
-| `hub_get_metrics` | Record/retrieve hub metrics with CSV trend history |
-| `hub_get_memory_history` | Free OS memory and CPU load history with summary stats (Hub Admin Read) |
+| `hub_get_metrics` | Retrieve hub metrics with CSV trend history (read-only by default; pass `recordSnapshot=true` to also record a new snapshot). (also in `hub_read_diagnostics`) |
+| `hub_get_memory_history` | Free OS memory and CPU load history with summary stats (Hub Admin Read) (also in `hub_read_diagnostics`) |
 | `hub_call_gc` | Force JVM garbage collection; returns before/after free memory (Hub Admin Read) |
-| `hub_get_device_health` | Find stale/offline devices |
-| `hub_get_radio_details` | Radio info — Z-Wave (firmware, devices) or Zigbee (channel, PAN ID, devices). `radio`: "zwave" or "zigbee"; omit for both. |
+| `hub_get_device_health` | Find stale/offline devices (also in `hub_read_diagnostics`) |
+| `hub_get_radio_details` | Radio info — Z-Wave (firmware, devices) or Zigbee (channel, PAN ID, devices). `radio`: "zwave" or "zigbee"; omit for both. (also in `hub_read_diagnostics`) |
 | `hub_call_zwave_repair` | Z-Wave network repair (5-30 min) |
-| `hub_list_captured_states` | List saved device state snapshots |
+| `hub_list_captured_states` | List saved device state snapshots (also in `hub_read_diagnostics`) |
 | `hub_delete_captured_state` | Delete a captured device state snapshot. Omit `stateId` to delete all snapshots. |
 
 </details>
@@ -433,8 +498,8 @@ Monitoring tools require Hub Admin Read to be enabled.
 
 | Tool | Description |
 |------|-------------|
-| `hub_list_files` | List all files in File Manager |
-| `hub_read_file` | Read a file's contents |
+| `hub_list_files` | List all files in File Manager (also in `hub_read_files`) |
+| `hub_read_file` | Read a file's contents (also in `hub_read_files`) |
 | `hub_write_file` | Create or update a file (auto-backs up existing) |
 | `hub_delete_file` | Delete a file (auto-backs up first) |
 
@@ -443,36 +508,26 @@ Write/delete require Hub Admin Write + confirm.
 </details>
 
 <details>
-<summary><b>hub_manage_installed_apps</b> (4) — Built-in app visibility and configuration</summary>
+<summary><b>hub_manage_rule_machine</b> (5) — Rule Machine interop (RMUtils)</summary>
 
 | Tool | Description |
 |------|-------------|
-| `hub_list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by builtin/user/disabled/parents/children. |
-| `hub_list_device_dependents` | Find all apps that reference a specific device (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.) |
-| `hub_get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.) — sections, inputs, values. Multi-page apps via `pageName`. Read-only. Hub Admin Read. |
-| `hub_list_app_pages` | List known page names for a multi-page app (HPM, Room Lighting, etc.). Returns curated directory + live primary page. Use before `hub_get_app_config` on multi-page apps to avoid guessing page names. Hub Admin Read. |
+| `hub_list_rules` | List all Rule Machine rules (RM 4.x + 5.x) via official `hubitat.helper.RMUtils` API (also in `hub_read_rules`) |
+| `hub_call_rule` | Trigger an RM rule (`action`: "rule"/"actions"/"stop") |
+| `hub_set_rule_paused` | Pause or resume an RM rule (`value=true` pauses, `value=false` resumes; reversible) |
+| `hub_set_rule_private_boolean` | Set an RM rule's private boolean variable |
+| `hub_get_rule_health` | Read-only health check on any installed app — surfaces broken markers, multiple-flag poison, configPage errors. (also in `hub_read_rules`) |
 
-`hub_list_installed_apps` and `hub_list_device_dependents` require opt-in **Enable Built-in App Tools** setting. `hub_get_app_config` and `hub_list_app_pages` require Hub Admin Read.
+Requires opt-in **Enable Built-in App Tools** setting.
 
 </details>
 
 <details>
-<summary><b>hub_manage_hpm</b> (1) — Hubitat Package Manager state introspection (read-only)</summary>
+<summary><b>hub_manage_native_rules_and_apps</b> (11) — Rule Machine interop (RMUtils) + native CRUD on any classic SmartApp (RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.)</summary>
 
 | Tool | Description |
 |------|-------------|
-| `hub_list_hpm_packages` | List all packages tracked by HPM — name, version, beta flag, author, and full component inventory (apps, drivers, files with heIDs). Top-level `count` and echoed `hpmAppId`. Auto-discovers HPM's app ID. Pass `includeDrift=true` to also cross-reference HPM-tracked packages against installed apps and drivers (surfacing missing-required components, orphan apps, and orphan drivers under a `drift` key; optional `packageFilter` substring; surfaces `orphanDetection` / `orphanDriverDetection` when registry fetches fail; data-quality warning types: `heid-whitespace-normalized`, `heid-non-scalar-dropped`, `empty-heid`, `skipped-malformed-component` — see `hub_get_tool_guide` section=hub_manage_hpm for full details). Hub Admin Read. |
-
-Both tools require Hub Admin Read. HPM itself must be installed on the hub.
-
-</details>
-
-<details>
-<summary><b>hub_manage_native_rules</b> (11) — Rule Machine interop (RMUtils) + native CRUD on any classic SmartApp (RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.)</summary>
-
-| Tool | Description |
-|------|-------------|
-| `hub_list_rules` | List all Rule Machine rules (RM 4.x + 5.x) via official `hubitat.helper.RMUtils` API |
+| `hub_list_rules` | List all Rule Machine rules (RM 4.x + 5.x) via official `hubitat.helper.RMUtils` API (also in `hub_read_rules`) |
 | `hub_call_rule` | Trigger an RM rule (`action`: "rule"/"actions"/"stop") |
 | `hub_set_rule_paused` | Pause or resume an RM rule (`value=true` pauses, `value=false` resumes; reversible) |
 | `hub_set_rule_private_boolean` | Set an RM rule's private boolean variable |
@@ -480,9 +535,9 @@ Both tools require Hub Admin Read. HPM itself must be installed on the hub.
 | `hub_update_native_app` | Modify any classic native app by appId (triggers, actions, settings, structured shortcuts). Auto-snapshots before every write. `clearActions` / `replaceActions` commit the delete synchronously via a full selectActions page-form submit (runs RM's trashActs handler in-band), so the actions are gone when the call returns. A thin defensive verify-retry remains: on the rare residual it returns `partial:true, asyncCommitLikely:true` with `stage` + `safeRecovery` -- verify via `hub_get_app_config` rather than rolling back. |
 | `hub_delete_native_app` | Delete a classic native app (auto-snapshot to File Manager before deleting). |
 | `hub_clone_native_app` | Clone an existing classic SmartApp via Hubitat's `appCloner` endpoint. Returns the new `appId`. |
-| `hub_export_native_app` | Export a classic SmartApp to JSON (round-trippable with `hub_import_native_app`). |
+| `hub_export_native_app` | Export a classic SmartApp to JSON and persist it to File Manager (round-trippable with `hub_import_native_app`). |
 | `hub_import_native_app` | Import previously-exported app JSON into a new instance. Returns the new `appId`. |
-| `hub_get_rule_health` | Read-only health check on any installed app — surfaces broken markers, multiple-flag poison, configPage errors. |
+| `hub_get_rule_health` | Read-only health check on any installed app — surfaces broken markers, multiple-flag poison, configPage errors. (also in `hub_read_rules`) |
 
 Requires opt-in **Enable Built-in App Tools** setting. Create/update/delete additionally requires Hub Admin Write.
 
@@ -1669,13 +1724,13 @@ The `tests/` directory contains:
 ./gradlew test
 ```
 
-See [docs/testing.md](docs/testing.md) for the full Spock harness overview, how to add new specs, and the RMUtils mocking recipe for `hub_manage_native_rules` tools.
+See [docs/testing.md](docs/testing.md) for the full Spock harness overview, how to add new specs, and the RMUtils mocking recipe for `hub_manage_native_rules_and_apps` tools.
 
 ## Contributing
 
 Contributions welcome! Fork the repo, create a feature branch, make your changes, and submit a pull request.
 
-**New MCP tools must ship with unit tests** — both golden-path and error-path coverage. Tool handler tests go under `src/test/groovy/server/`; rule-engine tests under `src/test/groovy/rules/`. See [docs/testing.md](docs/testing.md) for the harness overview, the recipe for adding a new tool spec, and the RMUtils mocking pattern for `hub_manage_native_rules`-style tools.
+**New MCP tools must ship with unit tests** — both golden-path and error-path coverage. Tool handler tests go under `src/test/groovy/server/`; rule-engine tests under `src/test/groovy/rules/`. See [docs/testing.md](docs/testing.md) for the harness overview, the recipe for adding a new tool spec, and the RMUtils mocking pattern for `hub_manage_native_rules_and_apps`-style tools.
 
 PRs that add tools without tests will be asked to add them before merge. CI (`./gradlew test`) runs on every PR via `.github/workflows/unit-tests.yml`.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hubitat-mcp-server
-description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 89 tools (33 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver/library management, installed-app visibility, Rule Machine interoperability, native rule CRUD, HPM package state introspection, and Developer Mode self-administration.
+description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 88 tools (30 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver/library management, installed-app visibility, Rule Machine interoperability, native rule CRUD, HPM package state introspection, and Developer Mode self-administration.
 license: MIT
 ---
 
@@ -32,7 +32,7 @@ The Hubitat-runtime code has no external dependencies -- everything runs inside 
 │  │  MCP Rule Server (parent app)             │  │
 │  │  - OAuth endpoint: /apps/api/<id>/mcp     │  │
 │  │  - JSON-RPC 2.0 handler                   │  │
-│  │  - 89 tools (33 on tools/list + gateways)  │  │
+│  │  - 88 tools (30 on tools/list + gateways)  │  │
 │  │  - Device access gate (selectedDevices)   │  │
 │  │  - Hub Admin tools (internal API calls)   │  │
 │  │  - Hub Security cookie auth               │  │
@@ -93,38 +93,52 @@ New code should be placed in the appropriate section. New sections should follow
 
 ### Category Gateway Proxy (v0.8.0+)
 
-The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 89 items to 33. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways.
+The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 88 items to 30. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways. Gateways come in two flavors: `hub_read_<noun>` gateways whose every sub-tool is read-only, and `hub_manage_<noun>` gateways that contain at least one write (mixed read+write or write-only). A tool MAY appear in more than one gateway (multi-membership) — reads are listed in BOTH their mixed `manage_` gateway AND a pure-read `read_` gateway.
 
 **Architecture:**
-- `getGatewayConfig()` — defines 13 gateways, each with a description, tools list, and summaries map
-- `getToolDefinitions()` — returns 20 core tools + 13 gateway tool definitions (client-visible)
-- `getAllToolDefinitions()` — returns all 89 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
+- `getGatewayConfig()` — defines 19 gateways, each with a description, tools list, and summaries map
+- `getToolDefinitions()` — returns 11 core tools + 19 gateway tool definitions (client-visible)
+- `getAllToolDefinitions()` — returns all 88 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
 - `handleGateway(gatewayName, toolName, toolArgs)` — catalog mode (no args → full schemas) or execute mode (tool + args → dispatch)
 
 **Gateway calling convention:**
-1. AI calls `manage_<domain>()` with no args → gets full tool schemas (catalog mode)
-2. AI calls `manage_<domain>(tool="tool_name", args={...})` → executes the proxied tool
+1. AI calls `<gateway>()` with no args → gets full tool schemas (catalog mode)
+2. AI calls `<gateway>(tool="tool_name", args={...})` → executes the proxied tool
 
-**13 gateways (69 proxied tools):**
+**19 gateways (7 read + 12 manage):**
+
+Read gateways (`hub_read_*`, every sub-tool read-only):
 | Gateway | Tools | Domain |
 |---------|-------|--------|
-| `hub_manage_rules` | 5 | Rule delete/test/export/import/clone |
+| `hub_read_apps_code` | 9 | List apps/drivers, get source, backups (list/get), device-in-use-by lookup, app config inspection, page-name directory, HPM package state (read-only) |
+| `hub_read_devices` | 4 | List/get devices, device attributes, device events (read-only) |
+| `hub_read_diagnostics` | 9 | Logs, performance stats, hub jobs, debug logs, metrics, memory history, device health, radio details (zwave/zigbee), captured states (read-only) |
+| `hub_read_files` | 2 | File Manager list + read (read-only) |
+| `hub_read_rooms` | 2 | Room list + get (read-only) |
+| `hub_read_rules` | 4 | Custom-engine rule get/test, native rule list, rule health (read-only) |
+| `hub_read_variables` | 3 | Hub connector and rule engine variable list/get + change history (read-only) |
+
+Manage gateways (`hub_manage_*`, contain at least one write):
+| Gateway | Tools | Domain |
+|---------|-------|--------|
+| `hub_manage_custom_rules` | 8 | Custom-engine rule get/create/update/delete/test/export/import/clone |
 | `hub_manage_variables` | 8 | Hub connector and rule engine variables (CRUD + connector + history) |
 | `hub_manage_rooms` | 5 | Room CRUD |
 | `hub_manage_destructive_ops` | 3 | Hub reboot, shutdown, device deletion (write) |
-| `hub_manage_code_read` | 5 | List apps/drivers, get source (app/driver/library), backups (read-only) |
-| `hub_manage_code_write` | 8 | Install/update apps+drivers+libraries, delete item (app/driver/library), restore backup (write) |
-| `hub_manage_logs` | 6 | Logs, performance stats, hub jobs, debug tools |
-| `hub_manage_diagnostics` | 8 | Diagnostics, state capture, radio details (zwave/zigbee), zwave repair, memory history, GC |
+| `hub_manage_code` | 8 | Install/update apps+drivers+libraries, delete item (app/driver/library), restore backup (write) |
+| `hub_manage_devices` | 6 | Device command/update (write) + list/get devices, attributes, events (reads) |
+| `hub_manage_logs` | 6 | Logs, performance stats, hub jobs, debug tools (read + clear/set-level write) |
+| `hub_manage_diagnostics` | 8 | Diagnostics, state capture/delete, radio details (zwave/zigbee), zwave repair, memory history, metrics, GC |
 | `hub_manage_files` | 4 | File Manager CRUD |
-| `hub_manage_installed_apps` | 4 | Built-in + user app visibility, device-in-use-by lookup, app config inspection, page-name directory |
-| `hub_manage_hpm` | 1 | HPM package state introspection (list tracked packages + optional drift signals) -- read-only, Hub Admin Read |
-| `hub_manage_native_rules` | 11 | Rule Machine interop (RMUtils: list/run/set-paused/boolean) + admin-layer CRUD on any classic SmartApp (create/update/delete/clone/export/hub_import_native_app + hub_get_rule_health — works on RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.) |
+| `hub_manage_native_rules_and_apps` | 11 | Rule Machine interop (RMUtils: list/run/set-paused/boolean) + admin-layer CRUD on any classic SmartApp (create/update/delete/clone/export/hub_import_native_app + hub_get_rule_health — works on RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.) |
+| `hub_manage_rule_machine` | 5 | Rule Machine interop (RMUtils: list/run/set-paused/boolean) + rule health |
 | `hub_manage_mcp` | 1 | Developer Mode self-administration — update MCP rule app's own settings (allowlist-gated, requires `enableDeveloperMode`) |
 
 `hub_update_native_app` `clearActions` / `replaceActions` shortcuts: the trashActs delete commits synchronously via a full selectActions page-form submit (the complete form-action envelope plus serialized page state, mirroring the native UI), which runs RM's `trashActs` submitOnChange handler in-band -- the actions are gone by the time the call returns. A thin defensive verify-retry remains: on the rare residual where verification still sees the actions (stuck `state.editAct`, or an uncommon firmware commit lag) the tool returns `partial:true, asyncCommitLikely:true` with a `stage` discriminator and a `safeRecovery` block. Verify via `hub_get_app_config` rather than rolling back if that fires. See TOOL_GUIDE.md for the full response shape.
 
-**Core tools:** `hub_list_devices` (`filter='virtual'` lists only MCP-managed virtual devices), `hub_get_device`, `hub_get_device_attribute` (pass `expectedValue`/`expectedValues` to block-poll the attribute until it matches or times out; `timeoutMs` in MILLISECONDS, default 5000ms = 5 seconds, max 60000ms; polling BLOCKS the MCP request -- use sparingly, prefer event-driven flows), `hub_call_device_command`, `hub_list_device_events` (add `hoursBack` for a window — up to 7 days of device or location event history; omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events), `hub_get_custom_rule` (omit `ruleId` to list all custom-engine rules; `detailed=true` for comprehensive diagnostics on one rule), `hub_create_custom_rule`, `hub_update_custom_rule` (the MCP custom rule engine — distinct from native Rule Machine; native-RM CRUD (and Room Lighting, Button Controllers, Basic Rules, etc.) is in the `hub_manage_native_rules` gateway via `hub_create_native_app` / `hub_update_native_app` / `hub_delete_native_app` / `hub_get_rule_health`), `hub_update_device`, `hub_manage_virtual_device` (action enum: "create", "delete"), `hub_get_info` (comprehensive: hardware, health — memory, temp, DB size — and MCP stats always available; PII/location data — name, IP, timezone, coordinates, zip — gated behind Hub Admin Read), `hub_list_modes`, `hub_set_mode`, `hub_get_hsm_status`, `hub_set_hsm`, `hub_create_backup`, `hub_get_update_status`, `hub_report_issue`, `hub_get_tool_guide`, `hub_search_tools` (BM25 natural language search across all tools)
+**Flat (top-level) tools (11):** `hub_manage_virtual_device` (action enum: "create", "delete"), `hub_get_info` (comprehensive: hardware, health — memory, temp, DB size — and MCP stats always available; PII/location data — name, IP, timezone, coordinates, zip — gated behind Hub Admin Read), `hub_list_modes`, `hub_set_mode`, `hub_get_hsm_status`, `hub_set_hsm`, `hub_create_backup`, `hub_get_update_status`, `hub_report_issue`, `hub_get_tool_guide`, `hub_search_tools` (BM25 natural language search across all tools).
+
+Device tools (`hub_list_devices` with `filter='virtual'` to list only MCP-managed virtual devices, `hub_get_device`, `hub_get_device_attribute` — pass `expectedValue`/`expectedValues` to block-poll the attribute until it matches or times out; `timeoutMs` in MILLISECONDS, default 5000ms = 5 seconds, max 60000ms; polling BLOCKS the MCP request, use sparingly, prefer event-driven flows — `hub_call_device_command`, `hub_update_device`, and `hub_list_device_events` with `hoursBack` for a window up to 7 days of device or location event history; omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events) live in the `hub_read_devices` / `hub_manage_devices` gateways. The MCP custom rule engine tools (`hub_get_custom_rule` — omit `ruleId` to list all custom-engine rules, `detailed=true` for comprehensive diagnostics on one rule — `hub_create_custom_rule`, `hub_update_custom_rule`) live in the `hub_read_rules` / `hub_manage_custom_rules` gateways; this engine is distinct from native Rule Machine, whose CRUD (and Room Lighting, Button Controllers, Basic Rules, etc.) is in the `hub_manage_native_rules_and_apps` gateway via `hub_create_native_app` / `hub_update_native_app` / `hub_delete_native_app` / `hub_get_rule_health`.
 
 **Safety gates are preserved:** All Hub Admin Read/Write checks live in the handler functions (e.g., `requireHubAdminRead()`, `requireHubAdminWrite(args.confirm)`), not in the dispatch layer. The gateway simply calls `executeTool()`, which calls the handler, which enforces the gate. No safety check is bypassed.
 
@@ -553,7 +567,7 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 | `/hub/fileManager/json` | Lists all files in File Manager (JSON array: name, size, date) |
 | `/hub2/roomsList` | List of rooms as JSON (alternative to `getRooms()` SDK method) |
 | `/logs/past/json` | Hub log buffer as JSON array of tab-delimited strings (chronological order, oldest first — reverse client-side for newest-first). Accepts optional `?type=dev&id=<deviceId>` or `?type=app&id=<appId>` to scope server-side to a single source. |
-| `/hub2/appsList` | All installed apps (built-in + user) as JSON. Keys: `systemAppTypes[]`, `userAppTypes[]`, `apps[]` (instance tree). Each `apps[]` entry has `{key, id, data: {id, name, type, disabled, user, hidden, appTypeId}, parent: bool, child: bool, children: [...]}`. Used by `hub_list_installed_apps`. |
+| `/hub2/appsList` | All installed apps (built-in + user) as JSON. Keys: `systemAppTypes[]`, `userAppTypes[]`, `apps[]` (instance tree). Each `apps[]` entry has `{key, id, data: {id, name, type, disabled, user, hidden, appTypeId}, parent: bool, child: bool, children: [...]}`. Used by `hub_list_apps` (`scope=instances`). |
 | `/device/fullJson/<id>` | Comprehensive device JSON — includes `appsUsing` array (apps referencing this device: `{id, name, label, trueLabel, disabled}`), `appsUsingCount`, `parentApp`, plus device commands/attributes/settings/dashboards. Used by `hub_list_device_dependents`. |
 | `/installedapp/configure/json/<id>[/<pageName>]` | SDK-level config-page serialization for any installed app using `dynamicPage()`. Returns `{app, configPage: {name, title, sections: [{title, input: [...], body: [...]}]}, settings, childApps}`. `app` carries identity (label, name, appType, disabled, parentAppId). Sections hold typed inputs with current values. The Web UI itself consumes this endpoint. Used by `hub_get_app_config`. |
 | `/installedapp/statusJson/<id>` | Raw Groovy `state` map for any installed app. Returns `{id, appState: [{name, value}, ...], appSettings: [...]}`. `appState[].value` shape varies: live hubs typically return the value already parsed as a Map (JsonSlurper recursively decoded the inner JSON); older firmwares or large payloads may leave it as a JSON-encoded String requiring a second parse. The implementation handles both: if value is already a Map, use it directly; if String, parse again. Used by `hub_list_hpm_packages` (including its `includeDrift=true` mode) to read HPM's `state.manifests` package registry. Requires Hub Admin Read. |
@@ -590,7 +604,7 @@ The server implements MCP protocol version `2024-11-05`:
 - **Methods**: `initialize`, `tools/list`, `tools/call`, `ping`
 - **Notifications**: Handled silently (HTTP 204)
 - **Error codes**: `-32700` (parse), `-32600` (invalid request), `-32601` (method not found), `-32602` (invalid params from `IllegalArgumentException`), `-32603` (internal error)
-- **`tools/list` returns the full catalog in one response.** Pagination was tried (page size 50, cursor-based) but removed because many MCP clients — including the Claude.ai connector — don't iterate `nextCursor`, which silently truncated the flat-mode catalog at 50 tools. The full-catalog response is backstopped by the universal response-size guard at `handleMcpRequest` (124,000-byte threshold) that emits a loud `-32603 "Response too large"` envelope if the catalog ever exceeds the hub cap. Stale clients passing a `cursor` get the full catalog and find no `nextCursor`. Opt-in cursor pagination on `tools/call` (`hub_list_devices`, `hub_list_installed_apps`, `hub_list_rules`, etc.) is unaffected.
+- **`tools/list` returns the full catalog in one response.** Pagination was tried (page size 50, cursor-based) but removed because many MCP clients — including the Claude.ai connector — don't iterate `nextCursor`, which silently truncated the flat-mode catalog at 50 tools. The full-catalog response is backstopped by the universal response-size guard at `handleMcpRequest` (124,000-byte threshold) that emits a loud `-32603 "Response too large"` envelope if the catalog ever exceeds the hub cap. Stale clients passing a `cursor` get the full catalog and find no `nextCursor`. Opt-in cursor pagination on `tools/call` (`hub_list_devices`, `hub_list_apps`, `hub_list_rules`, etc.) is unaffected.
 
 ### Common Pitfalls
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -4,13 +4,17 @@ Detailed reference for MCP Rule Server tools. Consult this when tool description
 
 ## Category Gateway Proxy (v0.8.0+)
 
-As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 33 items (20 core + 13 gateways) covering 89 total tools. Use `hub_search_tools` to find any tool by natural language query.
+As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 30 items (11 core + 19 gateways) covering 88 total tools. Use `hub_search_tools` to find any tool by natural language query.
 
 **How to use a gateway:**
 1. Call the gateway with no arguments to see full parameter schemas for all its tools
 2. Call with `tool='<tool_name>'` and `args={...}` to execute a specific tool
 
-**Gateways:** `hub_manage_rules` (5), `hub_manage_variables` (8), `hub_manage_rooms` (5), `hub_manage_destructive_ops` (3), `hub_manage_code_read` (7), `hub_manage_code_write` (10), `hub_manage_logs` (8), `hub_manage_diagnostics` (11), `hub_manage_files` (4), `hub_manage_installed_apps` (4), `hub_manage_hpm` (2), `hub_manage_native_rules` (12), `hub_manage_mcp` (1)
+Gateway verbs encode mutation: **`hub_read_*`** gateways are pure-read (every sub-tool read-only), **`hub_manage_*`** gateways contain at least one write. A read tool may appear in BOTH a `hub_read_*` gateway and a mixed `hub_manage_*` gateway (multi-membership).
+
+**Read gateways:** `hub_read_apps_code` (9), `hub_read_devices` (4), `hub_read_diagnostics` (9), `hub_read_files` (2), `hub_read_rooms` (2), `hub_read_rules` (4), `hub_read_variables` (3)
+
+**Manage gateways:** `hub_manage_code` (8), `hub_manage_custom_rules` (8), `hub_manage_destructive_ops` (3), `hub_manage_devices` (6), `hub_manage_diagnostics` (8), `hub_manage_files` (4), `hub_manage_logs` (6), `hub_manage_mcp` (1), `hub_manage_native_rules_and_apps` (11), `hub_manage_rooms` (5), `hub_manage_rule_machine` (5), `hub_manage_variables` (8)
 
 All safety gates (Hub Admin Read/Write, confirm, backup checks) are preserved — they are enforced in the handler functions, not the dispatch layer.
 
@@ -24,7 +28,7 @@ Default is **ON** (gateways enabled). Existing installations keep the gateway be
 
 ### `tools/list` Returns the Full Catalog in One Response
 
-`tools/list` returns the complete tool catalog in a single response (no pagination). Pagination was tried briefly (page size 50, cursor-based) but removed because many MCP clients — including the Claude.ai connector — do NOT iterate `nextCursor` automatically, which silently truncated the catalog at the first 50 tools. The full-catalog response is backstopped by the universal response-size guard inside `handleMcpRequest` (124,000-byte threshold) that emits a loud `-32603 "Response too large"` envelope if the catalog ever exceeds the hub's 128KB JSON-RPC limit — better to fail loud than silently lose tools. Stale clients that pass a `cursor` param get the full catalog and find no `nextCursor`, so any iteration loop terminates after one call. Opt-in cursor pagination on `tools/call` (`hub_list_devices`, `hub_list_installed_apps`, `hub_list_rules`, etc.) is unaffected — see the next section.
+`tools/list` returns the complete tool catalog in a single response (no pagination). Pagination was tried briefly (page size 50, cursor-based) but removed because many MCP clients — including the Claude.ai connector — do NOT iterate `nextCursor` automatically, which silently truncated the catalog at the first 50 tools. The full-catalog response is backstopped by the universal response-size guard inside `handleMcpRequest` (124,000-byte threshold) that emits a loud `-32603 "Response too large"` envelope if the catalog ever exceeds the hub's 128KB JSON-RPC limit — better to fail loud than silently lose tools. Stale clients that pass a `cursor` param get the full catalog and find no `nextCursor`, so any iteration loop terminates after one call. Opt-in cursor pagination on `tools/call` (`hub_list_devices`, `hub_list_apps`, `hub_list_rules`, etc.) is unaffected — see the next section.
 
 ### `tools/call` Response-Size Guard (v1.3.x+, fail-soft)
 
@@ -36,7 +40,7 @@ Every `tools/call` response is measured before send. If the wire-encoded respons
   "truncated": true,
   "estimatedBytes": 145320,
   "sizeLimitBytes": 120000,
-  "tool": "hub_list_installed_apps",
+  "tool": "hub_list_apps",
   "suggestion": "Set includeHidden=false (the default), narrow via filter ..., or pass cursor to page through the apps list."
 }
 ```
@@ -50,8 +54,7 @@ These tools follow an explicit opt-in convention so pre-`cursor` callers see no 
 | Tool | Page size | Notes |
 |---|---|---|
 | `hub_list_devices` | 50 (when `limit` unset) | Cursor is an alias for the existing `offset`+`limit` shape; `nextCursor` is emitted alongside `nextOffset`. |
-| `hub_list_installed_apps` | 50 | Cursor respects `filter` — pages the filtered set. |
-| `hub_list_apps` | 50 | Catalog of installable apps on the hub. |
+| `hub_list_apps` | 50 | `scope='types'` (default): catalog of installable apps. `scope='instances'`: installed app instances; cursor respects `filter` — pages the filtered set. |
 | `hub_list_drivers` | 50 | Catalog of installable drivers. |
 | `hub_list_hpm_packages` | 25 | Smaller page because each HPM entry carries the full app/driver/file inventory. |
 | `hub_list_rules` | 50 | RM 4.x + 5.x deduplicated rules. |
@@ -129,13 +132,13 @@ All Hub Admin Write tools require these steps:
 - List affected devices to user before proceeding
 - Dashboard layouts and automations referencing room may be affected
 
-**hub_create_app** (via `hub_manage_code_write`)
+**hub_create_app** (via `hub_manage_code`)
 - Accepts `source` (inline Groovy) OR `sourceFile` (filename in File Manager). Provide exactly one.
 - Token-economy tip: upload large source via local CLI first, then pass the filename as `sourceFile`. Avoids re-sending multi-KB source strings on each install attempt.
 - Performs post-install verification: after the hub creates the item, fetches it back to confirm the Groovy compiled cleanly. Returns `success: false` with `appId` populated when the hub reports a compile error or the verify response is empty/unparseable, so the error can be inspected via `hub_get_source` (type=app, id). If the hub returns no item ID at all (no `Location` header), `appId` is `null`. Transient verify-fetch failures keep `success: true` but set `verified: false` plus `verifyError`.
 - Requires Hub Admin Write + confirm + backup <24h.
 
-**hub_create_driver** (via `hub_manage_code_write`)
+**hub_create_driver** (via `hub_manage_code`)
 - Single-driver mode: supply `source` (inline Groovy) OR `sourceFile` (filename in File Manager). Provide exactly one.
 - Bulk mode: supply an `installs` array of objects, each with `source` or `sourceFile`. Cannot combine with single-driver fields.
   - Continue-on-error: errors on individual items do not abort remaining installs. Returns a per-item status array with each item's `driverId`.
@@ -145,13 +148,13 @@ All Hub Admin Write tools require these steps:
 - Performs post-install verification: after the hub creates each item, fetches it back to confirm the Groovy compiled cleanly. Returns `success: false` with `driverId` populated when the hub reports a compile error or the verify response is empty/unparseable, so the error can be inspected via `hub_get_source` (type=driver, id). If the hub returns no item ID at all (no `Location` header), `driverId` is `null`. Transient verify-fetch failures keep `success: true` but set `verified: false` plus `verifyError`.
 - Requires Hub Admin Write + confirm + backup <24h.
 
-**hub_update_app** (via `hub_manage_code_write`)
+**hub_update_app** (via `hub_manage_code`)
 - Supply `appId` + one of `source` / `sourceFile` / `resave`.
 - Self-update guard: applies only when `appId` matches this MCP server's own app instance. Refuses to overwrite that source unless **Enable Developer Mode Tools** is on in the MCP Rule Server app settings (a bad self-update bricks the MCP loop; recovery requires the Hubitat UI or SSH). Every self-update attempt — blocked OR allowed — is audit-logged at WARN under the `hub-admin` component. If the app context is unavailable at call time (rare lifecycle window) the guard fails closed with an ERROR audit log; retry the call.
 - Optional `expectedVersion` (integer): optimistic-lock guard. When supplied and the hub's version differs, the update returns `success: false` + `conflict: true` with both `expectedVersion` and `currentVersion` echoed. Use when an agent's read-modify-write spans turns or runs alongside other agents/tools that could mutate the same app. Backup still happens on conflict (intentional: `backupItemSource` has a 1h cache so the parallel-agent retry costs nothing, and the first caller losing the race still has a recovery point). Stringified integers are coerced; explicit `null` is rejected (omit the field entirely to skip the lock).
 - Requires Hub Admin Write + confirm + backup <24h.
 
-**hub_update_driver** (via `hub_manage_code_write`)
+**hub_update_driver** (via `hub_manage_code`)
 - Single-driver mode (unchanged): supply `driverId` + one of `source` / `sourceFile` / `resave`. Optional `expectedVersion` (integer): same optimistic-lock semantics as `hub_update_app` — conflict envelope carries `driverId` instead of `appId`.
 - Bulk mode: supply an `updates` array of objects, each with `driverId` and one of `sourceFile` / `source` / `resave`, plus optional per-item `expectedVersion`. Cannot combine with single-driver fields (including a top-level `expectedVersion` — put it on each entry instead).
   - Continue-on-error: errors on individual items do not abort remaining updates. Returns a per-item status array. Per-item conflicts (failed lock) carry `conflict: true` + `expectedVersion` + `currentVersion`; per-item thrown errors carry `error` + `errorClass`. Other items in the batch still apply.
@@ -159,7 +162,7 @@ All Hub Admin Write tools require these steps:
   - Practical limit: ~20 drivers per call (each update is a sequential on-hub compilation, ~1-5 seconds each).
   - Token-economy pattern: upload all updated driver files via local CLI (curl -F / PowerShell Invoke-RestMethod), then call bulk `hub_update_driver` once with all `{driverId, sourceFile}` pairs.
 
-**hub_delete_item** (type: app|driver|library, via `hub_manage_code_write`)
+**hub_delete_item** (type: app|driver|library, via `hub_manage_code`)
 - Remove app instances via Hubitat UI first (for apps)
 - Change devices to different driver first (for drivers)
 - Ensure no drivers/apps reference the library via #include before deleting (for libraries)
@@ -200,7 +203,7 @@ All Hub Admin Write tools require these steps:
   "confirm": true
 }
 ```
-Use `hub_manage_code_read(tool="hub_list_drivers")` to see installed drivers and their namespace + name values. The namespace and name must match exactly as registered. If the driver is not found (or any other hub error), the tool surfaces an `IllegalArgumentException` (-32602) pointing to `hub_list_drivers`. If a built-in `deviceType` is not found on the hub, the tool surfaces an isError platform error (firmware gap, not a caller error).
+Use `hub_read_apps_code(tool="hub_list_drivers")` to see installed drivers and their namespace + name values. The namespace and name must match exactly as registered. If the driver is not found (or any other hub error), the tool surfaces an `IllegalArgumentException` (-32602) pointing to `hub_list_drivers`. If a built-in `deviceType` is not found on the hub, the tool surfaces an isError platform error (firmware gap, not a caller error).
 
 **Create response shape** (both modes): `{ success, message, tips, device: { id, name, label, deviceNetworkId, driverNamespace, driverType, typeName, capabilities, commands, attributes } }`. `typeName` is a deprecated alias for `driverType` -- prefer `driverType` in new code.
 
@@ -307,7 +310,7 @@ Offset is in minutes (positive = after, negative = before)
 ## App/Driver/Library Code Management
 
 ### Reading Source Code
-- `hub_get_source` (type=app|driver|library, id; via `hub_manage_code_read`) supports chunked reading for large files
+- `hub_get_source` (type=app|driver|library, id; via `hub_read_apps_code`) supports chunked reading for large files
 - Large files auto-saved to File Manager as `mcp-source-app-{id}.groovy`, `mcp-source-driver-{id}.groovy`, or `mcp-source-library-{id}.groovy`
 - Use this saved file with `sourceFile` parameter in update tools
 
@@ -339,7 +342,7 @@ curl -b cookies.txt -F "uploadFile=@mylib.groovy" -F "folder=/" http://<HUB_IP>/
 ```
 Then call `hub_create_library` or `hub_update_library` with `sourceFile: 'mylib.groovy'`.
 
-Note: `hub_get_source` (type=library; read-only, Hub Admin Read) lives in `hub_manage_code_read` and serves apps, drivers, and libraries via its `type` discriminator. The write operations (`hub_create_library`, `hub_update_library`, `hub_delete_item` with type=library) live in `hub_manage_code_write` (Hub Admin Write).
+Note: `hub_get_source` (type=library; read-only, Hub Admin Read) lives in `hub_read_apps_code` and serves apps, drivers, and libraries via its `type` discriminator. The write operations (`hub_create_library`, `hub_update_library`, `hub_delete_item` with type=library) live in `hub_manage_code` (Hub Admin Write).
 
 ### After Installation
 - Apps: Add via Apps > Add User App in Hubitat web UI
@@ -370,7 +373,7 @@ Note: `hub_get_source` (type=library; read-only, Hub Admin Read) lives in `hub_m
 ### Native RM Rule Backups (Automatic)
 - `update_rm_rule` and `delete_rm_rule` snapshot configure/json + statusJson to File Manager as `mcp-rm-backup-<ruleId>-<timestamp>.json`
 - Snapshots register in the unified `state.itemBackupManifest` with type=`rm-rule`
-- Use `hub_list_backups` to enumerate, `hub_restore_backup` (in `hub_manage_code_read`) with the backupKey to roll back
+- Use `hub_list_backups` (in `hub_read_apps_code`) to enumerate, `hub_restore_backup` (in `hub_manage_code`) with the backupKey to roll back
 - If the rule still exists, settings are replayed in place; if deleted, a fresh empty rule is recreated and the saved settings replayed onto it
 
 ### Hubitat Built-in Rule Redirect
@@ -379,12 +382,12 @@ with "Rule not found", the error message may include a redirect hint if the ID b
 Hubitat built-in rule-like app (Rule Machine, Room Lighting, Basic Rules, Visual Rules Builder).
 
 Example redirect message:
-> "Rule 832 is a Hubitat built-in Rule-5.1 app. Use `hub_manage_installed_apps -> hub_get_app_config(appId=832)` to read its configuration."
+> "Rule 832 is a Hubitat built-in Rule-5.1 app. Use `hub_read_apps_code -> hub_get_app_config(appId=832)` to read its configuration."
 
 - Read verbs (`hub_get_custom_rule`, `hub_export_custom_rule`, `hub_clone_custom_rule`): points to `hub_get_app_config` and notes these tools only handle MCP's own rule engine.
-- Write verbs (`hub_update_custom_rule`): points to `hub_get_app_config` for inspection and `hub_manage_native_rules -> hub_update_native_app` for programmatic modification (requires Built-in App Tools + Hub Admin Write).
-- Delete verb (`hub_delete_custom_rule`): points to `hub_manage_native_rules -> hub_delete_native_app` for programmatic deletion.
-- Test verb (`hub_test_custom_rule`): points to `hub_manage_installed_apps -> hub_get_app_config` for inspection. For Rule Machine rules specifically, the hint also includes a pointer to `hub_manage_native_rules -> hub_call_rule` to trigger them; non-RM rule-likes (Room Lighting, Basic Rules, Visual Rule Builder) receive only the `hub_get_app_config` pointer because `hub_call_rule` routes through `RMUtils.sendAction` and is RM-only.
+- Write verbs (`hub_update_custom_rule`): points to `hub_get_app_config` for inspection and `hub_manage_native_rules_and_apps -> hub_update_native_app` for programmatic modification (requires Built-in App Tools + Hub Admin Write).
+- Delete verb (`hub_delete_custom_rule`): points to `hub_manage_native_rules_and_apps -> hub_delete_native_app` for programmatic deletion.
+- Test verb (`hub_test_custom_rule`): points to `hub_read_apps_code -> hub_get_app_config` for inspection. For Rule Machine rules specifically, the hint also includes a pointer to `hub_manage_native_rules_and_apps -> hub_call_rule` to trigger them; non-RM rule-likes (Room Lighting, Basic Rules, Visual Rule Builder) receive only the `hub_get_app_config` pointer because `hub_call_rule` routes through `RMUtils.sendAction` and is RM-only.
 - The redirect check is best-effort: if the hub appsList call fails, a plain "Rule not found" message is returned with no secondary error.
 - `hub_get_custom_rule` in list mode (ruleId omitted) and `hub_create_custom_rule` are not affected (they do not take a rule id as input).
 
@@ -462,11 +465,11 @@ Files stored locally on hub at `http://<HUB_IP>/local/<filename>`
 
 ## Built-in App Tools
 
-Tools in `hub_manage_installed_apps` and `hub_manage_native_rules` gateways have mixed gate requirements. `hub_list_installed_apps` and `hub_list_device_dependents` require the **Enable Built-in App Tools** toggle (`requireBuiltinApp`). `hub_get_app_config` and `hub_list_app_pages` require **Hub Admin Read** (`requireHubAdminRead`). `hub_list_hpm_packages` (including its `includeDrift=true` mode) requires **Hub Admin Read** only -- no Built-in App Tools toggle needed. `hub_manage_native_rules` tools require the **Enable Built-in App Tools** toggle for reads and **Hub Admin Write** (`requireHubAdminWrite`) for the CRUD path (`hub_create_native_app`, `hub_update_native_app`, `hub_delete_native_app`); Hub Admin Write also enforces a backup-within-24h gate before any write. If the user sees "Built-in App Tools are disabled", "Hub Admin Read is disabled", or "Hub Admin Write is disabled" errors, direct them to the MCP Rule Server app settings page to enable the relevant toggle. Note: Hub Admin Write operations additionally require a hub backup within the last 24 hours -- if the write gate blocks with a backup-age message, use `hub_create_backup` first.
+The installed-apps reads (`hub_list_apps` scope=instances, `hub_list_device_dependents`, `hub_get_app_config`, `hub_list_app_pages`, `hub_list_hpm_packages`) live in the `hub_read_apps_code` gateway; the native-rule CRUD lives in `hub_manage_native_rules_and_apps`. These tools have mixed gate requirements. `hub_list_apps` (scope=instances) and `hub_list_device_dependents` require the **Enable Built-in App Tools** toggle (`requireBuiltinApp`). `hub_get_app_config` and `hub_list_app_pages` require **Hub Admin Read** (`requireHubAdminRead`). `hub_list_hpm_packages` (including its `includeDrift=true` mode) requires **Hub Admin Read** only -- no Built-in App Tools toggle needed. `hub_manage_native_rules_and_apps` tools require the **Enable Built-in App Tools** toggle for reads and **Hub Admin Write** (`requireHubAdminWrite`) for the CRUD path (`hub_create_native_app`, `hub_update_native_app`, `hub_delete_native_app`); Hub Admin Write also enforces a backup-within-24h gate before any write. If the user sees "Built-in App Tools are disabled", "Hub Admin Read is disabled", or "Hub Admin Write is disabled" errors, direct them to the MCP Rule Server app settings page to enable the relevant toggle. Note: Hub Admin Write operations additionally require a hub backup within the last 24 hours -- if the write gate blocks with a backup-age message, use `hub_create_backup` first.
 
-### hub_manage_installed_apps (4 tools)
+### Installed-app reads (in `hub_read_apps_code`)
 
-- **`hub_list_installed_apps`** — enumerate ALL apps on the hub (built-in + user) with parent/child tree
+- **`hub_list_apps` (scope=instances)** — enumerate ALL apps on the hub (built-in + user) with parent/child tree (the former `hub_list_installed_apps`, now folded into `hub_list_apps`; pass `scope='instances'`, default `scope='types'` returns the installable-app catalog)
   - `filter="all"` (default) | `"builtin"` | `"user"` | `"disabled"` | `"parents"` | `"children"`
   - Each entry: `id`, `name`, `type`, `disabled`, `user`, `hidden`, `parentId`, `hasChildren`, `childCount`
   - Built-in apps have `user=false` (Rule Machine, Room Lighting, Groups and Scenes, Mode Manager, HSM, Dashboards, Maker API, etc.)
@@ -480,7 +483,7 @@ Tools in `hub_manage_installed_apps` and `hub_manage_native_rules` gateways have
 
 - **`hub_get_app_config`** — read an installed app's configuration page (Hub Admin Read required)
   - See usage tips above for full details on response shape, pageName navigation, and includeSettings flag
-  - Workflow: `hub_list_installed_apps` or `hub_list_rules` to find an `appId`, then `hub_get_app_config` to inspect it
+  - Workflow: `hub_list_apps` (scope=instances) or `hub_list_rules` to find an `appId`, then `hub_get_app_config` to inspect it
 
 - **`hub_list_app_pages`** — list known page names for a multi-page app (Hub Admin Read required)
   - Returns the primary page (introspected from the hub) plus a curated directory of known sub-pages for well-known app types
@@ -489,7 +492,7 @@ Tools in `hub_manage_installed_apps` and `hub_manage_native_rules` gateways have
   - Use this before `hub_get_app_config` on multi-page apps to avoid guessing page names
   - Args: `appId` (required)
 
-### hub_manage_hpm (1 tool)
+### HPM package introspection — `hub_list_hpm_packages` (in `hub_read_apps_code`)
 
 HPM package state introspection. The tool requires **Hub Admin Read** and HPM itself must be installed on the hub. Auto-discovers HPM's installed-app ID unless `hpmAppId` is supplied explicitly. All `IllegalArgumentException`s raised (multi-instance throw, wrong app type, missing HPM, non-numeric `hpmAppId`) are surfaced by the MCP dispatcher as JSON-RPC error `-32602` "Invalid params" -- the response is a JSON-RPC error, **not** a tool-result map with `success=false`.
 
@@ -521,12 +524,12 @@ HPM package state introspection. The tool requires **Hub Admin Read** and HPM it
   - Top-level `skippedMalformed[]`: manifest URLs whose value was not a Map (symmetric with `hub_list_hpm_packages`)
   - When `packageFilter` matched nothing: `filterMatchedZero=true` plus `availablePackages[]` for filter-spelling sanity check; in this case `packagesChecked == 0` and `summary` reads `"No drift detected across 0 tracked packages."`
   - Limitation: heID-presence-only. HPM stores no source hashes, so post-install edits via `hub_update_app` are not detectable.
-  - Example call: `hub_manage_hpm(tool="hub_list_hpm_packages", args={includeDrift: true, packageFilter: "BOND"})` — checks drift for only packages whose name contains "BOND"
+  - Example call: `hub_read_apps_code(tool="hub_list_hpm_packages", args={includeDrift: true, packageFilter: "BOND"})` — checks drift for only packages whose name contains "BOND"
   - Design note: the base package inventory emits `_warning` inline on each component **because** consumers typically enumerate components per-package; the `includeDrift=true` output emits `dataQualityWarnings[]` as a separate aggregate **because** consumers need to distinguish actionable drift signals from data-quality issues without conflating them in a single `signals[]` count
 
-### hub_manage_native_rules (11 tools)
+### hub_manage_native_rules_and_apps (11 tools)
 
-Two surfaces under one gateway: RMUtils-based runtime control for RM rules (RM-only because RMUtils is RM-only) plus admin-layer CRUD that works uniformly across any classic SmartApp (RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.).
+Two surfaces under one gateway: RMUtils-based runtime control for RM rules (RM-only because RMUtils is RM-only) plus admin-layer CRUD that works uniformly across any classic SmartApp (RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.). The four RMUtils control tools below are ALSO surfaced (alongside `hub_get_rule_health`) in the `hub_manage_rule_machine` gateway; the read-only members (`hub_list_rules`, `hub_get_rule_health`) additionally appear in `hub_read_rules`.
 
 **RMUtils control (4 tools, RM-only):**
 
@@ -551,8 +554,8 @@ If a user asks "create a new RM rule" or "modify this Room Lighting instance":
 7. **`hub_get_rule_health(appId)`** — read-only health check on any installed app. Surfaces broken markers, multiple-flag poison, configPage errors. Use after a destructive operation to confirm the app is still well-formed.
 
 **Cross-references** (live in other gateways but commonly used together):
-- **`hub_get_app_config`** (in `hub_manage_installed_apps`) — read any installed app's current page schema, settings, and child apps. Use BEFORE every `hub_update_native_app` to discover the right input names.
-- **`hub_list_backups`** + **`hub_restore_backup`** (in `hub_manage_code_read` / `hub_manage_code_write`) — enumerate and restore native-app snapshots (`type="rm-rule"` entries). Restore re-applies settings in place if the app exists, or recreates the app and replays settings if it was deleted.
+- **`hub_get_app_config`** (in `hub_read_apps_code`) — read any installed app's current page schema, settings, and child apps. Use BEFORE every `hub_update_native_app` to discover the right input names.
+- **`hub_list_backups`** + **`hub_restore_backup`** (in `hub_read_apps_code` / `hub_manage_code`) — enumerate and restore native-app snapshots (`type="rm-rule"` entries). Restore re-applies settings in place if the app exists, or recreates the app and replays settings if it was deleted.
 
 For Room Lighting / Button Controllers / Basic Rules: `hub_update_native_app` and `hub_delete_native_app` already work today (they take any classic-app appId). `hub_create_native_app` will work for them once their entries are added to `_appTypeRegistry()` — same endpoint family, just need namespace + appName + parentTypeName per type.
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -800,9 +800,9 @@ The `hub_manage_mcp` gateway exposes self-administration tools that let an LLM a
 
 - **`hub_update_mcp_settings`** — update one or more of the MCP rule app's own settings (toggles, log level, tuning params)
   - Args: `settings` (map of `{key: value}`), `confirm=true`
-  - Allowlisted keys (intentionally conservative for v1): `mcpLogLevel`, `debugLogging`, `maxCapturedStates`, `loopGuardMax`, `loopGuardWindowSec`, `enableHubAdminRead`, `enableBuiltinApp`, `enableCustomRuleEngine`
+  - Allowlisted keys (intentionally conservative for v1): `mcpLogLevel`, `debugLogging`, `maxCapturedStates`, `loopGuardMax`, `loopGuardWindowSec`, `enableHubAdminRead`, `enableBuiltinApp`, `enableCustomRuleEngine`, `useGateways`
   - **Excluded** from v1 allowlist: `enableHubAdminWrite` (footgun — would disable own write path mid-session), `enableDeveloperMode` (lockout protection — must remain UI-only to disable), `selectedDevices` (different wire format, separate tool planned)
-  - After changing any `enable*` toggle, MCP clients (Claude Code, etc.) may need to reconnect to refresh the cached tool schema
+  - After changing any `enable*` toggle or `useGateways`, MCP clients (Claude Code, etc.) may need to reconnect to refresh the cached tool schema
   - Gated on: `enableDeveloperMode` + `requireHubAdminWrite` + recent backup
 
 ### hub_manage_variables — `hub_delete_variable`

--- a/agent-skill/hubitat-mcp/SKILL.md
+++ b/agent-skill/hubitat-mcp/SKILL.md
@@ -5,7 +5,7 @@ description: Smart home assistant for Hubitat Elevation hubs via MCP. Use when c
 
 # Hubitat MCP Server - Smart Home Assistant
 
-You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 89 MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, Rule Machine interop, native rule CRUD, library management, HPM package state introspection, and Developer Mode self-administration. The tools are organized as **20 core tools** (always visible) plus **13 domain-named gateways** that proxy 69 additional tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute.
+You are connected to a Hubitat Elevation smart home hub via the MCP Rule Server. You have access to 88 distinct MCP tools for device control, automation rules, room management, hub administration, diagnostics, built-in app visibility, Rule Machine interop, native rule CRUD, library management, HPM package state introspection, and Developer Mode self-administration. The tools are organized as **11 flat core tools** (always visible) plus **19 domain-named gateways** that proxy the remaining tools — call a gateway with no args to see full schemas, or with `tool` and `args` to execute. That makes **30 entries** on `tools/list` in gateway mode (11 flat + 19 gateways). Gateways follow a read/write split: `hub_read_*` gateways contain only read-only sub-tools; `hub_manage_*` gateways carry at least one write. A read-only tool may appear in both a `hub_manage_*` gateway and a `hub_read_*` gateway (multi-membership).
 
 ## Core Principles
 
@@ -20,7 +20,7 @@ All tools in this server follow these conventions. Use the conventions to predic
 
 - Every tool name begins with `hub_`.
 - Tool names follow verb-noun order. The allowed verbs are: `list`, `get`, `search`, `test`, `create`, `update`, `delete`, `set`, `call`, `manage`, `restore`, `import`, `export`, `clone`, plus `read`/`write` for file-manager tools and the destructive-ops exceptions `reboot` / `shutdown`. There is one locked-to-one-tool verb: `report` (used only by `hub_report_issue`).
-- `manage_*` tools are gateways. Call with no args to see the catalog of sub-tools; call with `tool=<name>` and `args={...}` to execute one. There is a narrow exception: a flat tool with a small action enum (e.g. `hub_manage_virtual_device` with `action: "create"/"delete"`) may also use `manage_`.
+- Gateways are named `hub_read_<noun>` or `hub_manage_<noun>`. A `hub_read_*` gateway's every sub-tool is read-only; a `hub_manage_*` gateway contains at least one write (mixed read+write or write-only). Call a gateway with no args to see the catalog of sub-tools; call with `tool=<name>` and `args={...}` to execute one. A read-only tool may be listed in both its mixed `hub_manage_*` gateway and a `hub_read_*` gateway (multi-membership). There is a narrow exception: a flat tool with a small action enum (e.g. `hub_manage_virtual_device` with `action: "create"/"delete"`) may also use `manage_`.
 - Read tools never modify state. Write tools require user confirmation per the safety guide.
 
 ## Device Control
@@ -56,7 +56,7 @@ MCP can create and delete virtual devices (switches, sensors, buttons, dimmers, 
 
 For `action="create"`, provide exactly ONE of (mutually exclusive; supplying both -- including a blank/whitespace `deviceType` alongside `customDriver` -- is an error):
 - `deviceType` -- one of the 15 built-in virtual driver names (see `hub_get_tool_guide` for the full list). Not-found surfaces as an isError platform error (firmware gap).
-- `customDriver={namespace, name}` -- a user-installed driver (HPM or pasted); use `hub_manage_code_read(tool="hub_list_drivers")` to find installed namespace + name values. Not-found surfaces as an input error (-32602) with a `hub_list_drivers` hint.
+- `customDriver={namespace, name}` -- a user-installed driver (HPM or pasted); use `hub_read_apps_code(tool="hub_list_drivers")` to find installed namespace + name values. Not-found surfaces as an input error (-32602) with a `hub_list_drivers` hint.
 
 Create response: `{success, message, tips, device: {id, name, label, deviceNetworkId, driverNamespace, driverType, typeName, capabilities, commands, attributes}}`. `typeName` is a deprecated alias for `driverType` -- prefer `driverType` in new code.
 
@@ -120,20 +120,25 @@ Use `hub_create_custom_rule` with a JSON structure. For the complete rule struct
 
 ### Rule Management
 
-Core tools (always visible):
-- `hub_get_custom_rule` - View rule configuration; omit `ruleId` to list all rules, or pass `detailed=true` for comprehensive diagnostics on a specific rule
-- `hub_update_custom_rule` - Modify triggers, conditions, or actions; also handles enable/disable via `enabled=true/false`
+Custom rules are reached through two gateways. The read-only tools (`hub_get_custom_rule`, `hub_test_custom_rule`) are surfaced in `hub_read_rules` for pure-read access and ALSO in `hub_manage_custom_rules` for workflow cohesion (multi-membership).
 
-Via `hub_manage_rules` gateway:
+Via `hub_read_rules` gateway (read-only):
+- `hub_get_custom_rule` - View rule configuration; omit `ruleId` to list all rules, or pass `detailed=true` for comprehensive diagnostics on a specific rule
 - `hub_test_custom_rule` - Dry-run to see what would happen without executing
-- `hub_export_custom_rule` / `hub_import_custom_rule` / `hub_clone_custom_rule` - Portability operations
+
+Via `hub_manage_custom_rules` gateway (8 tools):
+- `hub_get_custom_rule` - View rule configuration (also in `hub_read_rules`)
+- `hub_create_custom_rule` - Create a rule from a JSON structure
+- `hub_update_custom_rule` - Modify triggers, conditions, or actions; also handles enable/disable via `enabled=true/false`
+- `hub_test_custom_rule` - Dry-run to see what would happen without executing (also in `hub_read_rules`)
+- `hub_export_custom_rule` / `hub_import_custom_rule` / `hub_clone_custom_rule` - Portability operations (`hub_export_custom_rule` persists to File Manager via saveAs, so it is a write)
 - `hub_delete_custom_rule` - Removes a rule (auto-backs up to File Manager first)
 
 Mark test/throwaway rules with `testRule: true` to skip backup on deletion.
 
 ## Room Management
 
-5 tools via `hub_manage_rooms` gateway: `hub_list_rooms`, `hub_get_room`, `hub_create_room`, `hub_delete_room`, `hub_update_room`. Room creation/deletion/renaming requires Hub Admin Write.
+5 tools via `hub_manage_rooms` gateway: `hub_list_rooms`, `hub_get_room`, `hub_create_room`, `hub_delete_room`, `hub_update_room`. Room creation/deletion/renaming requires Hub Admin Write. The read-only pair (`hub_list_rooms`, `hub_get_room`) is also surfaced via the pure-read `hub_read_rooms` gateway (2 tools).
 
 ## Hub Administration
 
@@ -145,11 +150,11 @@ Additional hub admin tools are accessed via gateways:
 
 Destructive write operations (require Hub Admin Write): `hub_reboot`, `hub_shutdown`, `hub_delete_device`
 
-### Via `hub_manage_code_read` gateway (5 tools — read-only)
+### Via `hub_read_apps_code` gateway (9 tools — read-only)
 
-`hub_list_apps`, `hub_list_drivers`, `hub_get_source` (`type`: "app"/"driver"/"library"; `id`; chunked `offset`/`length`), `hub_list_backups`, `hub_get_backup`
+`hub_list_apps` (`scope`: "types"/"instances" — lists installed app types or app instances), `hub_list_drivers`, `hub_get_source` (`type`: "app"/"driver"/"library"; `id`; chunked `offset`/`length`), `hub_list_backups`, `hub_get_backup`, `hub_list_device_dependents`, `hub_get_app_config`, `hub_list_app_pages`, `hub_list_hpm_packages`
 
-### Via `hub_manage_code_write` gateway (8 tools — write operations)
+### Via `hub_manage_code` gateway (8 tools — write operations)
 
 `hub_create_app`, `hub_create_driver`, `hub_update_app`, `hub_update_driver`, `hub_delete_item` (`type`: "app"/"driver"/"library"), `hub_restore_backup`, `hub_create_library`, `hub_update_library`
 
@@ -171,11 +176,13 @@ For complete safety protocols and tool-specific requirements, see [safety-guide.
 - `hub_reboot` - 1-3 min downtime, automations stop
 - `hub_shutdown` - Powers off completely, needs manual restart
 - `hub_delete_device` - No undo, intended for ghost/orphaned devices only
-- `hub_delete_item` (via `hub_manage_code_write`, `type`: "app"/"driver"/"library") - Auto-backs up source first
+- `hub_delete_item` (via `hub_manage_code`, `type`: "app"/"driver"/"library") - Auto-backs up source first
 
 ## Diagnostics and Monitoring
 
-Core tool: `hub_list_device_events` (always visible) - recent events for a device; add `hoursBack` for up to 7 days of device or location event history (omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events)
+`hub_list_device_events` (via `hub_read_devices` / `hub_manage_devices`) - recent events for a device; add `hoursBack` for up to 7 days of device or location event history (omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events)
+
+The pure-read `hub_read_diagnostics` gateway (9 tools) surfaces the read-only diagnostics for safe access: `hub_get_logs`, `hub_get_performance_stats`, `hub_get_jobs`, `hub_get_debug_logs`, `hub_get_metrics`, `hub_get_memory_history`, `hub_get_device_health`, `hub_get_radio_details`, `hub_list_captured_states`. The write-bearing diagnostics live in `hub_manage_logs` and `hub_manage_diagnostics` below (reads multi-membered into both surfaces).
 
 Via `hub_manage_logs` gateway (6 tools):
 - `hub_get_logs` - Hub log entries, most recent first; filter by level/source/pattern (regex) or multi-pattern AND/OR (`patternMode`); time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`, max 30d -- throws if exceeded; use ISO-8601 for longer ranges); or scope server-side to a single `deviceId` / `appId` (mutually exclusive). `pattern` matches the message field only (not source/name). Pathological regex like `(.*)*` may hang the matcher; prefer simple alternation.
@@ -185,7 +192,7 @@ Via `hub_manage_logs` gateway (6 tools):
 - `hub_set_log_level` - Set MCP log level
 
 Via `hub_manage_diagnostics` gateway (8 tools):
-- `hub_get_metrics` - Record/retrieve hub metrics with CSV trend history
+- `hub_get_metrics` - Retrieve hub metrics with CSV trend history (read-only by default; `recordSnapshot` defaults to false — also in `hub_read_diagnostics`)
 - `hub_get_memory_history` - Free OS memory and CPU load history with summary stats (Hub Admin Read)
 - `hub_call_gc` - Force JVM GC; returns before/after free memory (Hub Admin Read)
 - `hub_get_device_health` - Find stale/offline devices; optional ICMP ping for arbitrary IPs
@@ -197,11 +204,11 @@ Via `hub_manage_diagnostics` gateway (8 tools):
 
 ## File Manager
 
-Via `hub_manage_files` gateway: `hub_list_files`, `hub_read_file`, `hub_write_file`, `hub_delete_file`. Write/delete require Hub Admin Write. Files live at `http://<HUB_IP>/local/<filename>`.
+Via `hub_manage_files` gateway (4 tools): `hub_list_files`, `hub_read_file`, `hub_write_file`, `hub_delete_file`. Write/delete require Hub Admin Write. The read-only pair (`hub_list_files`, `hub_read_file`) is also surfaced via the pure-read `hub_read_files` gateway (2 tools). Files live at `http://<HUB_IP>/local/<filename>`.
 
 ## Item Backup System
 
-Source code is automatically backed up before modify/delete operations. Use `hub_list_backups`, `hub_get_backup` (via `hub_manage_code_read` gateway) to view backups, and `hub_restore_backup` (via `hub_manage_code_write` gateway) to restore apps and drivers. For libraries, restore via `hub_update_library` with the backup file.
+Source code is automatically backed up before modify/delete operations. Use `hub_list_backups`, `hub_get_backup` (via `hub_read_apps_code` gateway) to view backups, and `hub_restore_backup` (via `hub_manage_code` gateway) to restore apps and drivers. For libraries, restore via `hub_update_library` with the backup file.
 
 ## System Tools
 
@@ -210,12 +217,17 @@ Core tools (always visible):
 - `hub_list_modes` / `hub_set_mode` - Location modes (Home, Away, Night, etc.)
 - `hub_get_hsm_status` / `hub_set_hsm` - Home Security Monitor
 
-Via `hub_manage_variables` gateway:
-- `hub_list_variables` / `hub_get_variable` / `hub_set_variable` - Hub variables
+Via `hub_manage_variables` gateway (8 tools):
+- `hub_list_variables` / `hub_get_variable` - Read hub variables (also in `hub_read_variables`)
+- `hub_set_variable` / `hub_create_variable` / `hub_delete_variable` - Mutate hub variables
+- `hub_create_connector` / `hub_delete_connector` - Variable connector devices
+- `hub_list_variable_changes` - Variable change history (also in `hub_read_variables`)
+
+The read-only subset (`hub_list_variables`, `hub_get_variable`, `hub_list_variable_changes`) is also surfaced via the pure-read `hub_read_variables` gateway (3 tools).
 
 ## HPM Package Introspection
 
-Via `hub_manage_hpm` gateway (1 tool, Hub Admin Read required):
+Via `hub_read_apps_code` gateway (Hub Admin Read required):
 - `hub_list_hpm_packages` - List all HPM-tracked packages with full component inventory. Data-quality issues (non-scalar heID, empty heID, whitespace-padded heID) emit inline `_warning` on each component **because** consumers enumerate components per-package and need the warning co-located. Pass `includeDrift=true` to also cross-reference HPM state against the hub (results nest under a `drift` key); surfaces `missing-required`, `orphan-app`, `orphan-driver` signals, with data-quality issues kept in a separate `dataQualityWarnings[]` aggregate **because** consumers need to distinguish actionable drift signals from data-quality issues without conflating them in a single `signals[]` count.
 
 ## Performance Tips

--- a/agent-skill/hubitat-mcp/safety-guide.md
+++ b/agent-skill/hubitat-mcp/safety-guide.md
@@ -25,7 +25,7 @@ Always confirm device identity before acting on critical systems.
 
 ## Gateway Calling Convention (v0.8.0+)
 
-Many safety-critical tools are now accessed via gateways (e.g., `hub_manage_destructive_ops`, `hub_manage_code_write`). The gateway does **not** bypass any safety checks — all Hub Admin Read/Write gates, backup requirements, and confirm flags are enforced in the handler functions. When calling a tool through a gateway, the same pre-flight checklists apply.
+Many safety-critical tools are now accessed via gateways (e.g., `hub_manage_destructive_ops`, `hub_manage_code`). The gateway does **not** bypass any safety checks — all Hub Admin Read/Write gates, backup requirements, and confirm flags are enforced in the handler functions. When calling a tool through a gateway, the same pre-flight checklists apply.
 
 Example: To reboot the hub, call `hub_manage_destructive_ops(tool="hub_reboot", args={"confirm": true})` — the same backup and confirmation requirements apply as if `hub_reboot` were called directly.
 

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -1,6 +1,6 @@
 # Tool Reference
 
-Quick reference for all 89 MCP tools. The server exposes **33 items on `tools/list`**: 20 core tools + 13 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute.
+Quick reference for all 88 MCP tools. The server exposes **30 items on `tools/list`**: 11 flat core tools + 19 gateway tools. Each gateway proxies additional tools — call with no args for full schemas, or with `tool` and `args` to execute. A tool MAY appear under more than one gateway (multi-membership); read-only tools inside a mixed `hub_manage_*` gateway are also surfaced under a pure-read `hub_read_*` gateway.
 
 For the most authoritative reference, call `hub_get_tool_guide` via MCP.
 
@@ -10,7 +10,7 @@ All tools in this server follow these conventions. Use the conventions to predic
 
 - Every tool name begins with `hub_`.
 - Tool names follow verb-noun order. The allowed verbs are: `list`, `get`, `search`, `test`, `create`, `update`, `delete`, `set`, `call`, `manage`, `restore`, `import`, `export`, `clone`, plus `read`/`write` for file-manager tools and the destructive-ops exceptions `reboot` / `shutdown`. There is one locked-to-one-tool verb: `report` (used only by `hub_report_issue`).
-- `manage_*` tools are gateways. Call with no args to see the catalog of sub-tools; call with `tool=<name>` and `args={...}` to execute one. There is a narrow exception: a flat tool with a small action enum (e.g. `hub_manage_virtual_device` with `action: "create"/"delete"`) may also use `manage_`.
+- Gateways carry one of two verbs. `hub_read_<noun>` names a gateway whose every sub-tool is read-only; `hub_manage_<noun>` names a gateway that contains at least one write (mixed read+write or write-only). Call any gateway with no args to see the catalog of sub-tools; call with `tool=<name>` and `args={...}` to execute one. There is a narrow exception: a flat tool with a small action enum (e.g. `hub_manage_virtual_device` with `action: "create"/"delete"`) may also use `manage_`. The `read`/`write` file-manager leaf verbs (`hub_read_file`, `hub_write_file`) are distinct from the `hub_read_*` gateway prefix — the noun disambiguates.
 - Per-tool entries below use the names current at the time of writing. Predict shape from the conventions, not the names.
 
 ## Universal response-size guard + opt-in cursor pagination
@@ -19,33 +19,11 @@ Every `tools/call` response is bounded by a 120 KB wire-encoded size guard. Over
 
 Opt-in cursor pagination is wired into the read-only list-returning tools below. All follow the same shape: omit `cursor` for the full list (backward-compatible), pass `cursor: ""` for the first page, iterate `nextCursor` until absent. Non-numeric / out-of-range cursors reject as `-32602`.
 
-**Tools with cursor:** `hub_list_devices` (including `filter='virtual'`), `hub_list_installed_apps`, `hub_list_apps`, `hub_list_drivers`, `hub_list_hpm_packages`, `hub_list_rules`, `hub_get_custom_rule` (list mode, ruleId omitted), `hub_list_variables`, `hub_list_captured_states`, `hub_list_backups`, `hub_list_files`, `hub_list_rooms`, `hub_get_device_health`, `hub_list_device_dependents`, `hub_get_logs`, `hub_get_memory_history`, `hub_get_debug_logs`. See [TOOL_GUIDE.md](../../TOOL_GUIDE.md) for per-tool page sizes.
+**Tools with cursor:** `hub_list_devices` (including `filter='virtual'`), `hub_list_apps` (both `scope=types` and `scope=instances`), `hub_list_drivers`, `hub_list_hpm_packages`, `hub_list_rules`, `hub_get_custom_rule` (list mode, ruleId omitted), `hub_list_variables`, `hub_list_captured_states`, `hub_list_backups`, `hub_list_files`, `hub_list_rooms`, `hub_get_device_health`, `hub_list_device_dependents`, `hub_get_logs`, `hub_get_memory_history`, `hub_get_debug_logs`. See [TOOL_GUIDE.md](../../TOOL_GUIDE.md) for per-tool page sizes.
 
-## Core Tools (20) — Always visible on tools/list
+## Core Tools (11) — Always flat and visible on tools/list
 
-### Device Tools (5)
-
-| Tool | Description | Access Gate |
-|------|-------------|-------------|
-| `hub_list_devices` | List accessible devices. Pagination, `labelFilter` (substring), `capabilityFilter` (exact), `format='ids'` (flat ID array), `fields=[...]` (projection), `filter='virtual'` (only MCP-managed virtual devices, with their states). Use `detailed=false` first, paginate `detailed=true` (limit 20-30). | None |
-| `hub_get_device` | Full device details: attributes, commands, capabilities, room. | None |
-| `hub_get_device_attribute` | Get specific attribute value from a device. Pass `expectedValue` (or any of `expectedValues`; both may be set, OR semantics) to block-poll the attribute until it matches or times out -- `timeoutMs` in MILLISECONDS (default 5000ms = 5 seconds, max 60000ms). Polling BLOCKS the MCP request; use sparingly and prefer event-driven flows. When polling, returns `success`, `finalValue`, `elapsedMs`, `polledCount`, `timedOut`; adds `neverReported: true` if the attribute was null throughout. Use after `hub_call_device_command` to verify a state change in a single round-trip. | None |
-| `hub_call_device_command` | Send a command to a device (on, off, setLevel, etc.). | None |
-| `hub_list_device_events` | Recent events for a device. Default 10, recommended max 50. Add `hoursBack` for a time window (up to 7 days of device or location event history); omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events. | None |
-
-### Rule Tools (4)
-
-| Tool | Description | Access Gate |
-|------|-------------|-------------|
-| `hub_get_custom_rule` | Full rule details (triggers, conditions, actions). Omit `ruleId` to list all rules with status and last-triggered; pass `detailed=true` for comprehensive diagnostics on a specific rule. | None |
-| `hub_create_custom_rule` | Create a new automation rule. | None |
-| `hub_update_custom_rule` | Update rule triggers, conditions, or actions. Also handles enable/disable via `enabled=true/false`. | None |
-
-### Device Management (1)
-
-| Tool | Description | Access Gate |
-|------|-------------|-------------|
-| `hub_update_device` | Update device properties (label, name, room, preferences, enabled). | Varies by property |
+These 11 tools are never behind a gateway. Every other tool is reachable through one or more of the 19 gateways below.
 
 ### Virtual Device Tools (1)
 
@@ -71,27 +49,127 @@ Opt-in cursor pagination is wired into the read-only list-returning tools below.
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
 | `hub_get_tool_guide` | Full tool reference from the MCP server itself. | None |
-| `hub_search_tools` | BM25 natural language search across all 89 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
+| `hub_search_tools` | BM25 natural language search across all 88 tools — returns matching tools ranked by relevance, with gateway attribution so the AI knows how to call each. | None |
 
 ---
 
-## Gateway Tools (13) — Each proxies multiple tools
+## Gateway Tools (19) — Each proxies multiple tools
 
 Call a gateway with no arguments to see full parameter schemas for all its tools. Call with `tool='<name>'` and `args={...}` to execute a specific tool.
 
-### hub_manage_rules (5 tools)
+Seven gateways are pure-read (`hub_read_*`, every sub-tool read-only); twelve carry at least one write (`hub_manage_*`). A read-only tool that lives inside a mixed `hub_manage_*` gateway is also surfaced under a `hub_read_*` gateway (multi-membership; same tool, no duplication).
 
-Rule administration: delete, test, export, import, and clone rules.
+### hub_read_apps_code (9 tools)
+
+Read-only access to apps, drivers, libraries, backups, installed-app inventory, and HPM package state: list, view source, browse backups, inspect configs, and discover page names.
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
+| `hub_list_apps` | List apps. `scope='types'` enumerates installable app types; `scope='instances'` enumerates all installed apps (built-in + user) with parent/child tree, filterable by `all`/`builtin`/`user`/`disabled`/`parents`/`children`. Optional `cursor` opt-in pagination. | Hub Admin Read |
+| `hub_list_drivers` | List installed user drivers. | Hub Admin Read |
+| `hub_get_source` | Get Groovy source code for an app, driver, or library (`type`: "app", "driver", "library"; `id`). Chunked-read support via `offset`/`length`. Large files auto-saved to File Manager. | Hub Admin Read |
+| `hub_list_backups` | List all source code backups. | None |
+| `hub_get_backup` | Retrieve source from a backup. | None |
+| `hub_list_device_dependents` | Given a `deviceId`, list apps referencing it (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.). | Built-in App Read |
+| `hub_get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.). Returns sections/inputs/values; multi-page apps via `pageName`. Workflow: hub_list_apps(scope=instances) or hub_list_rules -> hub_get_app_config with appId; multi-page apps accept pageName (HPM: prefPkgUninstall for full list). Read-only. | Hub Admin Read |
+| `hub_list_app_pages` | List known page names for a multi-page app (HPM, Room Lighting, etc.). Returns curated directory + live primary page. Use before hub_get_app_config on multi-page apps. | Hub Admin Read |
+| `hub_list_hpm_packages` | List all HPM-tracked packages with full component inventory (apps, drivers, files). **Pass `includeDrift=true`** to also cross-reference HPM-tracked state against the hub; results nest under a `drift` key. Requires Hub Admin Read and HPM installed; auto-discovers HPM's installed-app ID unless `hpmAppId` is supplied. See `hub_get_tool_guide` for the full drift response shape. | Hub Admin Read |
+
+### hub_read_devices (4 tools)
+
+Read-only device access: list, view details, read attributes, and recent events.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `hub_list_devices` | List accessible devices. Pagination, `labelFilter` (substring), `capabilityFilter` (exact), `format='ids'` (flat ID array), `fields=[...]` (projection), `filter='virtual'` (only MCP-managed virtual devices, with their states). Use `detailed=false` first, paginate `detailed=true` (limit 20-30). | None |
+| `hub_get_device` | Full device details: attributes, commands, capabilities, room. | None |
+| `hub_get_device_attribute` | Get specific attribute value from a device. Pass `expectedValue` (or any of `expectedValues`; both may be set, OR semantics) to block-poll the attribute until it matches or times out -- `timeoutMs` in MILLISECONDS (default 5000ms = 5 seconds, max 60000ms). Polling BLOCKS the MCP request; use sparingly and prefer event-driven flows. When polling, returns `success`, `finalValue`, `elapsedMs`, `polledCount`, `timedOut`; adds `neverReported: true` if the attribute was null throughout. Use after `hub_call_device_command` to verify a state change in a single round-trip. | None |
+| `hub_list_device_events` | Recent events for a device. Default 10, recommended max 50. Add `hoursBack` for a time window (up to 7 days of device or location event history); omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events. | None |
+
+### hub_read_diagnostics (9 tools)
+
+Read-only diagnostics: metrics, memory/CPU history, scheduled-job-free health checks, radio info, device health, and state-capture inventory.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `hub_get_logs` | Hub log entries, most recent first. Default 100, max 500. Filter by level/source/pattern (regex) or multi-pattern with AND/OR mode; time-window via `since`/`until` (ISO-8601 or relative offset like `'30m'`, max 30d -- throws if exceeded); or scope server-side to a single `deviceId` / `appId`. `pattern` matches the message field only (not source/name). Pathological regex like `(.*)*` may hang the matcher; prefer simple alternation. (Device/location event *history* is in `hub_list_device_events` via `hoursBack`.) | Hub Admin Read |
+| `hub_get_performance_stats` | Device/app performance stats from `/logs`: method call counts, % busy, cumulative total ms, state size, events. Sortable. | Hub Admin Read |
+| `hub_get_jobs` | Scheduled and running jobs on the hub. | Hub Admin Read |
+| `hub_get_debug_logs` | Retrieve MCP debug log entries. Filter by level. Pass `mode='status'` to view logging system statistics instead. | None |
+| `hub_get_metrics` | Retrieve hub metrics with CSV trend history (read-only; `recordSnapshot` defaults to false). | Hub Admin Read |
+| `hub_get_memory_history` | Free OS memory + CPU load history (with Java heap + NIO buffer tracking for leak detection). | Hub Admin Read |
+| `hub_get_device_health` | Find stale/offline devices. Optional `cursor` opt-in pagination over `staleDevices` (page size 100). | Hub Admin Read |
+| `hub_get_radio_details` | Radio info -- Z-Wave (firmware, devices) or Zigbee (channel, PAN ID, devices). `radio`: "zwave" or "zigbee"; omit for both. | Hub Admin Read |
+| `hub_list_captured_states` | List saved device state snapshots. | None |
+
+### hub_read_files (2 tools)
+
+Read-only File Manager access: list and read files stored on the hub.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `hub_list_files` | List all files in File Manager. | None |
+| `hub_read_file` | Read a file (inline for <60KB, URL for larger). | None |
+
+### hub_read_rooms (2 tools)
+
+Read-only room access: list rooms and view room details.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `hub_list_rooms` | List all rooms with device counts. | None |
+| `hub_get_room` | Room details with full device info. Accepts name or ID. | None |
+
+### hub_read_rules (4 tools)
+
+Read-only custom-rule access plus dry-run testing and native-rule listing/health.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `hub_get_custom_rule` | Full rule details (triggers, conditions, actions). Omit `ruleId` to list all rules with status and last-triggered; pass `detailed=true` for comprehensive diagnostics on a specific rule. | None |
+| `hub_test_custom_rule` | Dry-run: see what would happen without executing. | None |
+| `hub_list_rules` | List all Rule Machine rules (RM 4.x + 5.x combined, deduplicated by id). | Built-in App Tools |
+| `hub_get_rule_health` | Read-only health check on any installed app -- surfaces broken markers, multiple-flag poison, configPage errors. | Built-in App Tools |
+
+### hub_read_variables (3 tools)
+
+Read-only variable access: list, get value/metadata, and observe recent changes.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `hub_list_variables` | List all hub variables (with type/connector linkage) and rule-engine variables. | None |
+| `hub_get_variable` | Get a variable's value + metadata (type, deviceId, attribute). | None |
+| `hub_list_variable_changes` | Recent hub-variable changes since the MCP app last started. Filter by name, sinceMs, limit. | None |
+
+### hub_manage_devices (6 tools)
+
+Device control and property edits, plus the read tools (also surfaced under `hub_read_devices`).
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `hub_call_device_command` | Send a command to a device (on, off, setLevel, etc.). | None |
+| `hub_update_device` | Update device properties (label, name, room, preferences, enabled). | Varies by property |
+| `hub_list_devices` | List accessible devices. Pagination, `labelFilter` (substring), `capabilityFilter` (exact), `format='ids'` (flat ID array), `fields=[...]` (projection), `filter='virtual'` (only MCP-managed virtual devices, with their states). Use `detailed=false` first, paginate `detailed=true` (limit 20-30). | None |
+| `hub_get_device` | Full device details: attributes, commands, capabilities, room. | None |
+| `hub_get_device_attribute` | Get specific attribute value from a device. Block-poll via `expectedValue`/`expectedValues` until match or `timeoutMs` (MILLISECONDS, default 5000ms, max 60000ms). Use after `hub_call_device_command` to verify a state change in a single round-trip. | None |
+| `hub_list_device_events` | Recent events for a device. Default 10, recommended max 50. Add `hoursBack` for a time window (up to 7 days of device or location event history); omit `deviceId` for mode/HSM/hub-variable/sendLocationEvent location events. | None |
+
+### hub_manage_custom_rules (8 tools)
+
+Custom-rule administration: get, create, update, delete, test, export, import, and clone MCP-native rules.
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `hub_get_custom_rule` | Full rule details (triggers, conditions, actions). Omit `ruleId` to list all rules with status and last-triggered; pass `detailed=true` for comprehensive diagnostics on a specific rule. | None |
+| `hub_create_custom_rule` | Create a new automation rule. | None |
+| `hub_update_custom_rule` | Update rule triggers, conditions, or actions. Also handles enable/disable via `enabled=true/false`. | None |
 | `hub_delete_custom_rule` | Delete a rule (auto-backs up first). | None |
 | `hub_test_custom_rule` | Dry-run: see what would happen without executing. | None |
-| `hub_export_custom_rule` | Export rule as portable JSON. | None |
+| `hub_export_custom_rule` | Export rule as portable JSON (persists to File Manager via saveAs). | Hub Admin Write |
 | `hub_import_custom_rule` | Import a rule from exported JSON. | None |
 | `hub_clone_custom_rule` | Duplicate an existing rule. | None |
 
-> **Built-in rule redirect:** `hub_get_custom_rule`, `hub_export_custom_rule`, `hub_update_custom_rule`, `hub_delete_custom_rule`, `hub_test_custom_rule`, and `hub_clone_custom_rule` operate only on MCP-native rules. If you pass an id belonging to a Hubitat built-in rule (Rule Machine, Room Lighting, Basic Rules, Visual Rules), the error message includes a redirect hint pointing to `hub_manage_installed_apps -> hub_get_app_config(appId=<id>)` (read) or, for write and delete verbs, the appropriate `hub_manage_native_rules` CRUD tool. The test verb hint includes `hub_call_rule` only for Rule Machine rules; other built-in rule-likes receive `hub_get_app_config` for inspection because `hub_call_rule` is RM-only. This redirect fires only when Built-in App Tools are enabled. See `TOOL_GUIDE.md` "Hubitat Built-in Rule Redirect" for full details.
+> **Built-in rule redirect:** `hub_get_custom_rule`, `hub_export_custom_rule`, `hub_update_custom_rule`, `hub_delete_custom_rule`, `hub_test_custom_rule`, and `hub_clone_custom_rule` operate only on MCP-native rules. If you pass an id belonging to a Hubitat built-in rule (Rule Machine, Room Lighting, Basic Rules, Visual Rules), the error message includes a redirect hint pointing to `hub_read_apps_code -> hub_get_app_config(appId=<id>)` (read) or, for write and delete verbs, the appropriate `hub_manage_native_rules_and_apps` CRUD tool. The test verb hint includes `hub_call_rule` only for Rule Machine rules; other built-in rule-likes receive `hub_get_app_config` for inspection because `hub_call_rule` is RM-only. This redirect fires only when Built-in App Tools are enabled. See `TOOL_GUIDE.md` "Hubitat Built-in Rule Redirect" for full details.
 
 ### hub_manage_variables (8 tools)
 
@@ -130,19 +208,7 @@ Destructive hub operations: reboot, shutdown, and device deletion.
 | `hub_shutdown` | Power off hub (needs manual restart). | Hub Admin Write |
 | `hub_delete_device` | Permanently delete a device. **NO UNDO.** For ghost/orphaned devices only. | Hub Admin Write |
 
-### hub_manage_code_read (5 tools)
-
-Read-only access to hub apps, drivers, and libraries: list, view source, and browse backups.
-
-| Tool | Description | Access Gate |
-|------|-------------|-------------|
-| `hub_list_apps` | List installed user apps. | Hub Admin Read |
-| `hub_list_drivers` | List installed user drivers. | Hub Admin Read |
-| `hub_get_source` | Get Groovy source code for an app, driver, or library (`type`: "app", "driver", "library"; `id`). Chunked-read support via `offset`/`length`. Large files auto-saved to File Manager. | Hub Admin Read |
-| `hub_list_backups` | List all source code backups. | None |
-| `hub_get_backup` | Retrieve source from a backup. | None |
-
-### hub_manage_code_write (8 tools)
+### hub_manage_code (8 tools)
 
 Write operations for apps, drivers, and libraries: install, update, delete, and restore code.
 
@@ -176,7 +242,7 @@ Performance monitoring, health checks, diagnostics, radio info, memory / GC, and
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
-| `hub_get_metrics` | Record/retrieve hub metrics with CSV trend history. | Hub Admin Read |
+| `hub_get_metrics` | Retrieve hub metrics with CSV trend history (read-only; `recordSnapshot` defaults to false). | Hub Admin Read |
 | `hub_get_device_health` | Find stale/offline devices. Optional `cursor` opt-in pagination over `staleDevices` (page size 100). | Hub Admin Read |
 | `hub_get_radio_details` | Radio info -- Z-Wave (firmware, devices) or Zigbee (channel, PAN ID, devices). `radio`: "zwave" or "zigbee"; omit for both. | Hub Admin Read |
 | `hub_get_memory_history` | Free OS memory + CPU load history (with Java heap + NIO buffer tracking for leak detection). | Hub Admin Read |
@@ -196,26 +262,7 @@ Manage hub File Manager: list, read, write, and delete files stored on the hub.
 | `hub_write_file` | Create/update a file (auto-backs up existing). | Hub Admin Write |
 | `hub_delete_file` | Delete a file (auto-backs up first). | Hub Admin Write |
 
-### hub_manage_installed_apps (4 tools)
-
-Read-only visibility into all installed apps (built-in + user): enumerate with parent/child tree, find apps using a specific device, inspect an app's configuration page, discover page names for multi-page apps.
-
-| Tool | Description | Access Gate |
-|------|-------------|-------------|
-| `hub_list_installed_apps` | Enumerate all apps on the hub (built-in + user) with parent/child tree. Filter by `all`/`builtin`/`user`/`disabled`/`parents`/`children`. Optional `cursor` opt-in pagination (page size 50). | Built-in App Read |
-| `hub_list_device_dependents` | Given a `deviceId`, list apps referencing it (Room Lighting, Rule Machine, Groups, Mode Manager, dashboards, Maker API, etc.). | Built-in App Read |
-| `hub_get_app_config` | Read an installed app's configuration page (Rule Machine, Room Lighting, Basic Rules, HPM, etc.). Returns sections/inputs/values; multi-page apps via `pageName`. Workflow: hub_list_installed_apps or hub_list_rules -> hub_get_app_config with appId; multi-page apps accept pageName (HPM: prefPkgUninstall for full list). Read-only. | Hub Admin Read |
-| `hub_list_app_pages` | List known page names for a multi-page app (HPM, Room Lighting, etc.). Returns curated directory + live primary page. Use before hub_get_app_config on multi-page apps. | Hub Admin Read |
-
-### hub_manage_hpm (1 tool)
-
-HPM package state introspection -- read-only. Tracks installed packages, their manifest versions, and (via `includeDrift=true`) per-component drift signals. Requires Hub Admin Read and HPM itself must be installed on the hub. Auto-discovers HPM's installed-app ID unless `hpmAppId` is supplied explicitly. All `IllegalArgumentException`s thrown by this tool surface to the MCP wire as JSON-RPC error `-32602` "Invalid params" (not a `success=false` tool-result map).
-
-| Tool | Description | Access Gate |
-|------|-------------|-------------|
-| `hub_list_hpm_packages` | List all HPM-tracked packages with full component inventory (apps, drivers, files). Each package: `packageName`, `version`, `beta`, `author`, components with `heID` (null if not installed; empty/whitespace-only heID cleared to null + `_warning` e.g. `"empty heID string '' normalized to null"`; whitespace-padded heID normalized to trimmed value + `_warning` recording e.g. `"whitespace-padded heID ' 142 ' normalized to '142'"`, heID remains non-null; non-scalar heID cleared to null + `_warning`). Inline `_warning` per component **because** consumers typically enumerate components per-package and need the warning co-located with the component. Top-level `count` (number of packages returned); `hpmAppId` (echoed, for caching); `skippedMalformed[]` lists URLs skipped due to non-Map manifest value. Per-package `skippedAppCount`, `skippedDriverCount`, `skippedFileCount` (each omitted when 0). When multiple HPM instances are found, throws with a bracketed ID list capped at 10 with `"and N more (total M)"` suffix. When `hpmAppId` is supplied explicitly but points at an app that is not Hubitat Package Manager, throws `IllegalArgumentException` with the actual type disclosed (e.g. `"hpmAppId N is not Hubitat Package Manager (actual type: Simple Automation Rules)"`). **Pass `includeDrift=true`** to also cross-reference HPM-tracked state against the hub; results nest under a `drift` key. Drift signal types: `missing-required` (heID null on required component), `orphan-app` (heID recorded but app code no longer in Apps Code registry), `orphan-driver` (heID recorded but driver code no longer in Drivers Code registry). Optional `packageFilter` substring (narrows the set examined; `packagesChecked` reflects this rather than `count`). Actionable drift is reported via `packagesWithActionableDrift` / `totalDriftSignals`; data-quality issues land in a separate `dataQualityWarnings[]` aggregate (types: `heid-whitespace-normalized`, `heid-non-scalar-dropped`, `empty-heid`, `skipped-malformed-component`). Files are not checked for drift. **Under-count caveats**: when `orphanDetection`/`orphanDriverDetection` is disabled (see each `{enabled, reason?}`), `packagesWithActionableDrift` reflects only `missing-required` signals; and a `required=true` component with non-scalar heID produces `heid-non-scalar-dropped` rather than `missing-required` -- inspect `dataQualityWarnings[]` before treating zero as clean. See `hub_get_tool_guide` section=hub_manage_hpm for the full drift response shape. | Hub Admin Read |
-
-### hub_manage_native_rules (11 tools)
+### hub_manage_native_rules_and_apps (11 tools)
 
 Two surfaces: RMUtils-based runtime control for RM rules (read/trigger/pause-resume) plus admin-layer CRUD that works uniformly across any classic SmartApp (RM, Room Lighting, Button Controllers, Basic Rules, Notifier, etc.). Requires Built-in App Tools enabled; CRUD operations additionally require Hub Admin Write.
 
@@ -229,8 +276,20 @@ Two surfaces: RMUtils-based runtime control for RM rules (read/trigger/pause-res
 | `hub_update_native_app` | Modify any classic native app by appId. Structured shortcuts: addTrigger, addAction, addRequiredExpression, clearActions, replaceActions, patches, etc. Auto-snapshots before writing. clearActions / replaceActions commit the delete synchronously via a full selectActions page-form submit (RM's trashActs handler runs in-band), so the actions are gone when the call returns; a thin defensive verify-retry returns `partial:true, asyncCommitLikely:true` with `stage` + `safeRecovery` on the rare residual -- verify via `hub_get_app_config` rather than rolling back. | Built-in App Tools + Hub Admin Write |
 | `hub_delete_native_app` | Delete a classic native app (auto-snapshot to File Manager before deleting). `force=true` for hard delete. | Built-in App Tools + Hub Admin Write |
 | `hub_clone_native_app` | Clone an existing classic SmartApp via Hubitat's `appCloner` endpoint. Returns the new `appId`. | Built-in App Tools + Hub Admin Write |
-| `hub_export_native_app` | Export a classic SmartApp to JSON, round-trippable with `hub_import_native_app`. Useful for backup, sharing, or export-mutate-import editing of complex rules. | Built-in App Tools |
+| `hub_export_native_app` | Export a classic SmartApp to JSON (persists to File Manager), round-trippable with `hub_import_native_app`. Useful for backup, sharing, or export-mutate-import editing of complex rules. | Built-in App Tools + Hub Admin Write |
 | `hub_import_native_app` | Import previously-exported app JSON into a new instance. Pairs with `hub_export_native_app`. Returns the new `appId`. | Built-in App Tools + Hub Admin Write |
+| `hub_get_rule_health` | Read-only health check on any installed app -- surfaces broken markers, multiple-flag poison, configPage errors. | Built-in App Tools |
+
+### hub_manage_rule_machine (5 tools)
+
+RMUtils-based runtime control for Rule Machine rules: list, trigger, pause/resume, set private boolean, and check health. (CRUD and other classic-app operations live in `hub_manage_native_rules_and_apps`.)
+
+| Tool | Description | Access Gate |
+|------|-------------|-------------|
+| `hub_list_rules` | List all Rule Machine rules (RM 4.x + 5.x combined, deduplicated by id). | Built-in App Tools |
+| `hub_call_rule` | Trigger an existing RM rule. `action`: `rule` (full), `actions` (bypass conditions), or `stop` (cancel in-flight). | Built-in App Tools |
+| `hub_set_rule_paused` | Pause or resume an RM rule (`value=true` pauses, `value=false` resumes; reversible; paused rules don't fire on triggers). | Built-in App Tools |
+| `hub_set_rule_private_boolean` | Set an RM rule's private boolean (true or false only; string values must be lowercase `"true"`/`"false"`). | Built-in App Tools |
 | `hub_get_rule_health` | Read-only health check on any installed app -- surfaces broken markers, multiple-flag poison, configPage errors. | Built-in App Tools |
 
 ### hub_manage_mcp (1 tool)

--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -298,4 +298,4 @@ Developer Mode self-administration: tools that let an LLM agent or CI/CD pipelin
 
 | Tool | Description | Access Gate |
 |------|-------------|-------------|
-| `hub_update_mcp_settings` | Update one or more of the MCP rule app's own settings (toggles, log level, tuning params). Allowlisted: `mcpLogLevel`, `debugLogging`, `maxCapturedStates`, `loopGuardMax`, `loopGuardWindowSec`, `enableHubAdminRead`, `enableBuiltinApp`, `enableCustomRuleEngine`. After flipping any `enable*` toggle, MCP clients may need to reconnect to refresh their cached tool schema. | Developer Mode + Hub Admin Write + recent backup |
+| `hub_update_mcp_settings` | Update one or more of the MCP rule app's own settings (toggles, log level, tuning params). Allowlisted: `mcpLogLevel`, `debugLogging`, `maxCapturedStates`, `loopGuardMax`, `loopGuardWindowSec`, `enableHubAdminRead`, `enableBuiltinApp`, `enableCustomRuleEngine`, `useGateways`. After flipping any `enable*` toggle or `useGateways`, MCP clients may need to reconnect to refresh their cached tool schema. | Developer Mode + Hub Admin Write + recent backup |

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -879,7 +879,7 @@ def _paginateList(List fullList, cursor, int pageSize, String toolName) {
 def getGatewayConfig() {
     return [
         hub_manage_custom_rules: [
-            description: "Legacy MCP custom-rule engine (sandbox rules that fire as installed apps but are NOT visible in Hubitat's RM UI): create, read, update, delete, test, export, import, and clone. For native Rule Machine rules visible in the hub UI use hub_manage_rule_machine / hub_manage_native_rules_and_apps_and_apps instead. Read-only views are also in hub_read_rules.",
+            description: "Legacy MCP custom-rule engine (sandbox rules that fire as installed apps but are NOT visible in Hubitat's RM UI): create, read, update, delete, test, export, import, and clone. For native Rule Machine rules visible in the hub UI use hub_manage_rule_machine / hub_manage_native_rules_and_apps instead. Read-only views are also in hub_read_rules.",
             tools: ["hub_get_custom_rule", "hub_create_custom_rule", "hub_update_custom_rule", "hub_delete_custom_rule", "hub_test_custom_rule", "hub_export_custom_rule", "hub_import_custom_rule", "hub_clone_custom_rule"],
             summaries: [
                 hub_get_custom_rule: "List custom rules (omit ruleId) or get one rule's detail; detailed=true (with ruleId) adds diagnostics. Args: ruleId?, detailed?, cursor?",
@@ -1535,7 +1535,7 @@ def getToolDefinitions() {
         // All 13 of these tools require enableBuiltinApp.
         //   hub_manage_native_rules_and_apps: ALL 12 sub-tools require it → that
         //     gateway empties out and drops entirely.
-        //   hub_manage_installed_apps: hub_list_device_dependents requires it; the
+        //   hub_read_apps_code: hub_list_device_dependents requires it; the
         //     others (hub_list_apps, hub_get_app_config, hub_list_app_pages) only need
         //     Hub Admin Read and stay visible. hub_list_apps stays visible because its
         //     scope='types' path works with Hub Admin Read alone; the Built-in App Tools
@@ -2905,7 +2905,7 @@ pageName: optional — target a specific sub-page whose schema drives the settin
 
 stateAttribute: optional string passed with the button click (e.g., RM uses this for editCond/editAct to identify which trigger/action).
 
-BEFORE EVERY WRITE: a full snapshot (configure/json + statusJson) is saved to File Manager. Response includes backup.backupKey for use with hub_restore_backup (in hub_manage_code_write) if the write goes wrong.
+BEFORE EVERY WRITE: a full snapshot (configure/json + statusJson) is saved to File Manager. Response includes backup.backupKey for use with hub_restore_backup (in hub_manage_code) if the write goes wrong.
 
 Auto-updateRule: main-page settings writes are followed by an implicit updateRule button click so initialize() re-fires. Sub-page writes (pageName=selectTriggers, selectActions, etc.) skip the auto-click so the wizard's stateAttribute (moreCond, editCond, editAct, ...) survives — commit the wizard via its own Done button (RM triggers: hasAll; RM actions: actionDone) and issue a final hub_update_native_app(button='updateRule') to re-initialize.
 
@@ -3386,7 +3386,7 @@ force=false (default): soft delete via /installedapp/delete. Hub refuses if the 
 
 force=true: hard delete via /installedapp/forcedelete/quiet — the same path the hub UI uses internally for its own \"Delete\" buttons. No child safety checks.
 
-BEFORE DELETE: full snapshot saved to File Manager. Response includes backup.backupKey; call hub_restore_backup (in hub_manage_code_write) with that key to recreate the app with all its settings re-applied.
+BEFORE DELETE: full snapshot saved to File Manager. Response includes backup.backupKey; call hub_restore_backup (in hub_manage_code) with that key to recreate the app with all its settings re-applied.
 
 Requires Hub Admin Write + confirm=true + recent hub backup.""",
             inputSchema: [
@@ -3525,14 +3525,7 @@ def executeTool(toolName, args) {
         // get_hub_details merged into hub_get_info
         case "hub_list_apps": return (args?.scope == "types") ? toolListHubApps(args) : toolListInstalledApps(args)
         case "hub_list_drivers": return toolListHubDrivers(args)
-        case "hub_get_radio_details": {
-            def radio = args.radio
-            if (radio != null && !(radio in ["zwave", "zigbee"]))
-                throw new IllegalArgumentException("radio must be 'zwave' or 'zigbee' (or omit for both)")
-            if (radio == "zwave") return toolGetZwaveDetails(args)
-            if (radio == "zigbee") return toolGetZigbeeDetails(args)
-            return [zwave: toolGetZwaveDetails(args), zigbee: toolGetZigbeeDetails(args)]
-        }
+        case "hub_get_radio_details": return toolGetRadioDetails(args)
         // get_hub_health merged into hub_get_info
 
         // Monitoring Tools
@@ -3595,13 +3588,7 @@ def executeTool(toolName, args) {
         case "hub_list_device_dependents": return toolGetDeviceInUseBy(args)
 
         // HPM Package State
-        case "hub_list_hpm_packages": {
-            def listResult = toolListHpmPackages(args)
-            if (args.includeDrift == true && listResult instanceof Map) {
-                listResult = listResult + [drift: toolGetHpmDrift(args)]
-            }
-            return listResult
-        }
+        case "hub_list_hpm_packages": return toolListHpmPackagesWithDrift(args)
 
         // Rule Machine Integration (via RMUtils)
         case "hub_list_rules": return toolListRmRules(args)
@@ -3610,7 +3597,7 @@ def executeTool(toolName, args) {
         case "hub_set_rule_private_boolean": return toolSetRmRuleBoolean(args)
 
         // Native Rule Machine CRUD (hub admin-layer; backups flow through
-        // hub_list_backups (hub_manage_code_read) + hub_restore_backup (hub_manage_code_write))
+        // hub_list_backups (hub_read_apps_code) + hub_restore_backup (hub_manage_code))
         case "hub_create_native_app": return toolCreateNativeApp(args)
         case "hub_update_native_app": return toolUpdateNativeApp(args)
         case "hub_delete_native_app": return toolDeleteNativeApp(args)
@@ -3668,6 +3655,29 @@ def executeTool(toolName, args) {
         default:
             throw new IllegalArgumentException("Unknown tool: ${toolName}")
     }
+}
+
+// Radio-details dispatch helper. Extracted from the executeTool switch so the
+// case body is a plain method call: a bare `{ ... }` block right after a
+// `case X:` label is rejected by the hub's Groovy parser (ambiguous
+// parameterless-closure vs open-block) even though hubitat_ci's parser accepts it.
+def toolGetRadioDetails(args) {
+    def radio = args.radio
+    if (radio != null && !(radio in ["zwave", "zigbee"]))
+        throw new IllegalArgumentException("radio must be 'zwave' or 'zigbee' (or omit for both)")
+    if (radio == "zwave") return toolGetZwaveDetails(args)
+    if (radio == "zigbee") return toolGetZigbeeDetails(args)
+    return [zwave: toolGetZwaveDetails(args), zigbee: toolGetZigbeeDetails(args)]
+}
+
+// HPM-packages dispatch helper (same case-block-extraction reason as above):
+// optionally attaches per-component drift signals when includeDrift=true.
+def toolListHpmPackagesWithDrift(args) {
+    def listResult = toolListHpmPackages(args)
+    if (args.includeDrift == true && listResult instanceof Map) {
+        listResult = listResult + [drift: toolGetHpmDrift(args)]
+    }
+    return listResult
 }
 
 // ==================== DEVICE TOOLS ====================
@@ -4799,11 +4809,11 @@ private String findRuleAppRedirect(ruleId, String verb) {
         // Build verb-appropriate redirect hint.
         if (verb == "read") {
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
-                "Use `hub_manage_installed_apps -> hub_get_app_config(appId=${idStr})` to read its configuration. " +
+                "Use `hub_read_apps_code -> hub_get_app_config(appId=${idStr})` to read its configuration. " +
                 "`hub_get_custom_rule`, `hub_export_custom_rule`, and `hub_clone_custom_rule` only handle MCP's own rule engine, not Hubitat built-in apps."
         } else if (verb == "delete") {
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
-                "Use `hub_manage_installed_apps -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
+                "Use `hub_read_apps_code -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
                 "`hub_delete_custom_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +
                 "Use `hub_manage_native_rules_and_apps -> hub_delete_native_app(appId=${idStr}, confirm=true)` to delete it programmatically " +
                 "(requires Built-in App Tools + Hub Admin Write)."
@@ -4811,13 +4821,13 @@ private String findRuleAppRedirect(ruleId, String verb) {
             // hub_call_rule routes through RMUtils and is RM-only. Point non-RM rule-likes at hub_get_app_config instead.
             if (isRmRule) {
                 return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
-                    "Use `hub_manage_installed_apps -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
+                    "Use `hub_read_apps_code -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
                     "`hub_test_custom_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +
                     "Use `hub_manage_native_rules_and_apps -> hub_call_rule(ruleId=${idStr})` to trigger it " +
                     "(requires Built-in App Tools)."
             } else {
                 return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
-                    "Use `hub_manage_installed_apps -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
+                    "Use `hub_read_apps_code -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
                     "`hub_test_custom_rule` only handles MCP's own rule engine, not Hubitat built-in apps."
             }
         } else {
@@ -4826,7 +4836,7 @@ private String findRuleAppRedirect(ruleId, String verb) {
                 mcpLog("debug", "rules", "findRuleAppRedirect: unrecognized verb '${verb}', defaulting to write-verb message")
             }
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
-                "Use `hub_manage_installed_apps -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
+                "Use `hub_read_apps_code -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
                 "`hub_update_custom_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +
                 "Use `hub_manage_native_rules_and_apps -> hub_update_native_app(appId=${idStr})` to modify it programmatically " +
                 "(requires Built-in App Tools + Hub Admin Write)."
@@ -24930,7 +24940,7 @@ All Hub Admin Write tools require these steps:
 
 Use `customDriver={namespace, name}` instead of `deviceType` to instantiate any user-installed driver:
 - `namespace` and `name` must match exactly as the driver is registered on the hub
-- Use `hub_manage_code_read(tool="hub_list_drivers")` to discover installed driver namespace + name values
+- Use `hub_read_apps_code(tool="hub_list_drivers")` to discover installed driver namespace + name values
 - Mutually exclusive with `deviceType` -- supply exactly one
 - On failure, the tool surfaces an `IllegalArgumentException` with a `hub_list_drivers` hint
 
@@ -25064,9 +25074,9 @@ Files stored at http://<HUB_IP>/local/<filename>
 
         builtin_app_tools: '''## Built-in App Tools
 
-Tools in the hub_manage_installed_apps and hub_manage_native_rules_and_apps gateways have mixed gate requirements. hub_list_apps with scope='instances' and hub_list_device_dependents require the "Enable Built-in App Tools (read + write)" toggle (requireBuiltinApp); hub_list_apps with scope='types' requires only Hub Admin Read. hub_get_app_config and hub_list_app_pages require Hub Admin Read (requireHubAdminRead). The hub_manage_hpm tool (hub_list_hpm_packages, with optional includeDrift) requires Hub Admin Read. All hub_manage_native_rules_and_apps tools require the "Enable Built-in App Tools" toggle; the CRUD tools (hub_create_native_app / hub_update_native_app / hub_delete_native_app) ALSO require Hub Admin Write. If the user sees "Built-in App Tools are disabled" or "Hub Admin Read is disabled" errors, direct them to the MCP Rule Server app settings page.
+Tools in the hub_read_apps_code and hub_manage_native_rules_and_apps gateways have mixed gate requirements. hub_list_apps with scope='instances' and hub_list_device_dependents require the "Enable Built-in App Tools (read + write)" toggle (requireBuiltinApp); hub_list_apps with scope='types' requires only Hub Admin Read. hub_get_app_config and hub_list_app_pages require Hub Admin Read (requireHubAdminRead). The hub_read_apps_code tool (hub_list_hpm_packages, with optional includeDrift) requires Hub Admin Read. All hub_manage_native_rules_and_apps tools require the "Enable Built-in App Tools" toggle; the CRUD tools (hub_create_native_app / hub_update_native_app / hub_delete_native_app) ALSO require Hub Admin Write. If the user sees "Built-in App Tools are disabled" or "Hub Admin Read is disabled" errors, direct them to the MCP Rule Server app settings page.
 
-**hub_manage_installed_apps (4 tools):**
+**hub_read_apps_code (4 tools):**
 
 - **hub_list_apps (scope='instances')** — enumerate ALL running app instances on the hub (built-in + user) with parent/child tree
   - filter="all" (default) | "builtin" | "user" | "disabled" | "parents" | "children"
@@ -25091,7 +25101,7 @@ Tools in the hub_manage_installed_apps and hub_manage_native_rules_and_apps gate
   - Returns curated page directory for known app types (HPM, RM 5.x, Room Lighting, Mode Manager) plus an introspected primary page for unknown app types
   - Cuts the page-name guessing cycle for multi-page apps. Especially useful for HPM which exposes multiple sub-pages (prefPkgUninstall / prefPkgModify / prefPkgInstall / prefPkgMatchUp) for different operations.
 
-**hub_manage_hpm (2 tools) — HPM package state introspection (Hub Admin Read required):**
+**hub_read_apps_code (2 tools) — HPM package state introspection (Hub Admin Read required):**
 
 - **hub_list_hpm_packages** — return all packages tracked by Hubitat Package Manager with full component inventory
   - If hpmAppId is omitted, HPM is auto-discovered by scanning installed apps for type="Hubitat Package Manager"
@@ -25126,9 +25136,9 @@ Native CRUD (hub admin-layer, additionally requires Hub Admin Write):
 - **hub_import_native_app** — re-create a rule/app from a previously-exported JSON via Hubitat's first-party appCloner. Args: jsonContent | fromFile, parentHintAppId, newName (opt), confirm. Returns newAppId. The cloner needs an existing rule under the target parent to seed itself (parentHintAppId).
 - **hub_get_rule_health** — read-only health check on any installed app. Args: appId. Returns ok / configPageError / brokenMarkers / multipleFlagPoison / structuralIssues / issues.
 
-For READING an RM rule's current state, use **hub_get_app_config** in the hub_manage_installed_apps gateway — it works on any installed app including RM rules and returns the same configPage shape that hub_update_native_app expects to see.
+For READING an RM rule's current state, use **hub_get_app_config** in the hub_read_apps_code gateway — it works on any installed app including RM rules and returns the same configPage shape that hub_update_native_app expects to see.
 
-For BACKUP enumeration and restore, use the unified **hub_list_backups** (in hub_manage_code_read) + **hub_restore_backup** (in hub_manage_code_write) — RM rule snapshots have type="rm-rule" in those tools' output and hub_restore_backup auto-dispatches the rule-restore path.
+For BACKUP enumeration and restore, use the unified **hub_list_backups** (in hub_read_apps_code) + **hub_restore_backup** (in hub_manage_code) — RM rule snapshots have type="rm-rule" in those tools' output and hub_restore_backup auto-dispatches the rule-restore path.
 
 **Safety model for native CRUD:**
 1. Every write is preceded by a full snapshot (configure/json + statusJson) saved to File Manager; the response's backup.backupKey is the restore handle.

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -9468,42 +9468,54 @@ def toolGetDeviceHistory(args) {
     def attributeFilter = args.attribute
     def sinceDate = new Date(now() - (hoursBack * 3600000L))
 
-    // Location-scope branch: when deviceId is omitted, fold in
-    // Hubitat's getLocationEventsSince(Date) so callers can pull
-    // mode/HSM/hub-variable/sendLocationEvent history alongside
-    // device history through one tool.
+    // Location-scope branch: when deviceId is omitted, return location history
+    // (mode / HSM / hub-variable / sunrise-sunset / system events). There is NO
+    // Groovy accessor for this -- neither location.eventsSince(Date, Map) nor
+    // getLocationEventsSince(Date) exist on the hub (both NoSuchMethod live). The
+    // hub's own Logs page reads it from /logs/eventsJson (per the hub2 frontend),
+    // so we hit the same endpoint and parse it. Each row is
+    // {name, value, unit, descriptionText, isStateChange, type, date(ISO+offset)}.
     if (!args.deviceId) {
-        def locEvents
+        def rawJson
         try {
-            // Location history comes from the app-context getLocationEventsSince(Date)
-            // helper. The Location object itself has NO eventsSince(Date, Map)
-            // overload, so the old location.eventsSince(...) call always
-            // NoSuchMethod'd and this whole branch returned an error.
-            locEvents = getLocationEventsSince(sinceDate)
-            if (locEvents != null && limit && locEvents.size() > limit) {
-                locEvents = locEvents.take(limit)
-            }
+            rawJson = hubInternalGet("/logs/eventsJson")
         } catch (Exception e) {
-            mcpLog("warn", "monitoring", "getLocationEventsSince failed: ${e.message}")
-            return [error: "Location event history unavailable: ${e.message}", source: "location"]
+            mcpLog("warn", "monitoring", "/logs/eventsJson fetch failed: ${e.message}")
+            return [error: "Location event history fetch failed: ${e.message}", source: "location"]
+        }
+        def rows
+        try {
+            def parsed = new groovy.json.JsonSlurper().parseText(rawJson?.toString() ?: "[]")
+            rows = (parsed instanceof List) ? parsed : []
+        } catch (Exception e) {
+            mcpLog("warn", "monitoring", "/logs/eventsJson parse failed: ${e.message}")
+            return [error: "Location event history parse failed: ${e.message}", source: "location"]
         }
 
-        def locResults = locEvents?.collect { evt ->
-            [
+        def locResults = []
+        for (evt in rows) {
+            if (!(evt instanceof Map)) continue
+            if (attributeFilter && evt.name != attributeFilter) continue
+            // Best-effort hoursBack window: drop events older than sinceDate when the
+            // ISO+offset date parses; keep them if it doesn't (don't silently lose
+            // history). The numeric offset (e.g. -0400) parses via the 'Z' pattern.
+            def evtDate = null
+            try { evtDate = Date.parse("yyyy-MM-dd'T'HH:mm:ss.SSSZ", evt.date?.toString()) }
+            catch (Exception ignored) { evtDate = null }
+            if (evtDate != null && evtDate.before(sinceDate)) continue
+            locResults << [
                 name: evt.name,
                 value: evt.value,
                 unit: evt.unit,
                 description: evt.descriptionText,
-                date: evt.date?.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
+                date: evt.date,
+                type: evt.type,
                 isStateChange: evt.isStateChange
             ]
-        } ?: []
-
-        if (attributeFilter) {
-            locResults = locResults.findAll { it.name == attributeFilter }
+            if (locResults.size() >= limit) break
         }
 
-        mcpLog("info", "monitoring", "Retrieved ${locResults.size()} location history events (${hoursBack}h back)")
+        mcpLog("info", "monitoring", "Retrieved ${locResults.size()} location history events (${hoursBack}h back) from /logs/eventsJson")
         return [
             source: "location",
             hoursBack: hoursBack,
@@ -9512,6 +9524,7 @@ def toolGetDeviceHistory(args) {
             count: locResults.size(),
             sinceTimestamp: sinceDate.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
         ]
+    }
     }
 
     def device = findDevice(args.deviceId)

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -9525,7 +9525,6 @@ def toolGetDeviceHistory(args) {
             sinceTimestamp: sinceDate.format("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
         ]
     }
-    }
 
     def device = findDevice(args.deviceId)
     if (!device) throw new IllegalArgumentException("Device not found: ${args.deviceId}. Device must be selected in MCP Rule Server app settings.")

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -162,7 +162,7 @@ def mainPage() {
                 paragraph "<b>NOTICE: ${existingRuleCount} existing custom MCP rule(s)</b><br>" +
                           "Your ${existingRuleCount} custom MCP rule(s) still fire and work normally. The Custom Rule Engine setting used to be ON by default; it now defaults OFF because the custom MCP rule engine is legacy -- it will continue to receive bug fixes but new feature work goes to native Rule Machine.<br>" +
                           "<b>Current state (toggle OFF):</b>${readonlyNote} Recommended: leave OFF if you have migrated to native Rule Machine. Turn ON only if you actively use your AI to fully manage these rules.<br>" +
-                          "For new rule creation, prefer <code>hub_manage_native_rules</code> hub_create_native_app -- those rules are visible in Hubitat's Rule Machine app list and web UI."
+                          "For new rule creation, prefer <code>hub_manage_native_rules_and_apps</code> hub_create_native_app -- those rules are visible in Hubitat's Rule Machine app list and web UI."
             }
             input "enableCustomRuleEngine", "bool", title: "Enable Custom Rule Engine (legacy)",
                   description: "Controls the legacy MCP-managed rule engine (custom_* tools). OFF + Built-in App Tools ON = read-only mode: hub_get_custom_rule (list/get/diagnostics modes), hub_update_custom_rule(enabled only), hub_test_custom_rule are visible; create/delete/export/import/clone are hidden. OFF + Built-in App Tools OFF = all custom_* tools hidden. ON = all custom_* tools shown (full mode). The native Hubitat Rule Machine (Built-in App Tools toggle) is independent of this. Note: Hubitat firmware upgrades may briefly reset Boolean toggles -- verify this stays OFF after each firmware upgrade if you've migrated to native Rule Machine.",
@@ -698,7 +698,7 @@ def handleToolsList(msg) {
     // Stale clients that pass a `cursor` param get the full catalog regardless;
     // there is no longer a nextCursor in the response, so any iteration loop
     // terminates after one call. Cursor pagination on tools/call (hub_list_devices,
-    // hub_list_installed_apps, hub_list_rules, etc. via _paginateList) is unchanged
+    // hub_list_apps, hub_list_rules, etc. via _paginateList) is unchanged
     // -- that is opt-in and the size guard's "suggestion" hints already point
     // callers at it when needed.
     def all = getToolDefinitions()
@@ -807,8 +807,8 @@ def _responseTooLargeSuggestion(String toolName) {
     switch (toolName) {
         case "hub_list_devices":
             return "Narrow with filter/labelFilter/capabilityFilter, project fields=['id','label',...], pass a smaller limit, or page with offset+limit. format='ids' is the cheapest shape."
-        case "hub_list_installed_apps":
-            return "Set includeHidden=false (the default), narrow via filter (builtin / user / disabled / parents / children), or pass cursor to page through the apps list."
+        case "hub_list_apps":
+            return "For scope='instances': set includeHidden=false (the default), narrow via filter (builtin / user / disabled / parents / children), or pass cursor to page through the apps list."
         case "hub_get_app_config":
             return "Omit includeSettings -- Room Lighting / RM 5.1 apps can have 500-1000 settings keys. For multi-page apps, call hub_list_app_pages then hub_get_app_config with a specific pageName."
         case "hub_get_device_health":
@@ -878,23 +878,29 @@ def _paginateList(List fullList, cursor, int pageSize, String toolName) {
 
 def getGatewayConfig() {
     return [
-        hub_manage_rules: [
-            description: "Rule administration: delete, test, export, import, and clone rules.",
-            tools: ["hub_delete_custom_rule", "hub_test_custom_rule", "hub_export_custom_rule", "hub_import_custom_rule", "hub_clone_custom_rule"],
+        hub_manage_custom_rules: [
+            description: "Legacy MCP custom-rule engine (sandbox rules that fire as installed apps but are NOT visible in Hubitat's RM UI): create, read, update, delete, test, export, import, and clone. For native Rule Machine rules visible in the hub UI use hub_manage_rule_machine / hub_manage_native_rules_and_apps_and_apps instead. Read-only views are also in hub_read_rules.",
+            tools: ["hub_get_custom_rule", "hub_create_custom_rule", "hub_update_custom_rule", "hub_delete_custom_rule", "hub_test_custom_rule", "hub_export_custom_rule", "hub_import_custom_rule", "hub_clone_custom_rule"],
             summaries: [
-                hub_delete_custom_rule: "Permanently delete a rule (auto-backs up first). Args: ruleId",
-                hub_test_custom_rule: "Dry-run a rule without executing actions. Args: ruleId",
-                hub_export_custom_rule: "Export rule to JSON for backup/sharing. Args: ruleId",
-                hub_import_custom_rule: "Import rule from exported JSON. Args: exportData (JSON string)",
-                hub_clone_custom_rule: "Clone an existing rule (starts disabled). Args: ruleId"
+                hub_get_custom_rule: "List custom rules (omit ruleId) or get one rule's detail; detailed=true (with ruleId) adds diagnostics. Args: ruleId?, detailed?, cursor?",
+                hub_create_custom_rule: "Create a new MCP custom (sandbox) rule. Args: name, triggers, actions, conditions?, enabled?",
+                hub_update_custom_rule: "Update a custom rule (enabled toggle, or structural changes when the engine toggle is ON). Args: ruleId, enabled?|triggers?|conditions?|actions?",
+                hub_delete_custom_rule: "Permanently delete a custom rule (auto-backs up first). Args: ruleId, confirm=true",
+                hub_test_custom_rule: "Dry-run a custom rule without executing actions. Args: ruleId",
+                hub_export_custom_rule: "Export a custom rule to JSON and save it to the hub File Manager. Args: ruleId, saveAs? (filename)",
+                hub_import_custom_rule: "Import a custom rule from exported JSON. Args: exportData (JSON string)",
+                hub_clone_custom_rule: "Clone an existing custom rule (starts disabled). Args: ruleId"
             ],
             // BM25 search hints — extra keywords that don't appear in summaries but help discovery
             searchHints: [
-                hub_delete_custom_rule: "remove automation",
-                hub_test_custom_rule: "simulate preview validate check automation",
-                hub_export_custom_rule: "save download share automation",
-                hub_import_custom_rule: "load upload restore automation",
-                hub_clone_custom_rule: "copy duplicate automation"
+                hub_get_custom_rule: "read fetch inspect list show custom mcp sandbox rule automation diagnostics",
+                hub_create_custom_rule: "add new custom mcp sandbox rule automation",
+                hub_update_custom_rule: "modify edit change enable disable custom mcp sandbox rule automation",
+                hub_delete_custom_rule: "remove automation custom mcp sandbox",
+                hub_test_custom_rule: "simulate preview validate check automation custom",
+                hub_export_custom_rule: "save download share automation custom file manager persist",
+                hub_import_custom_rule: "load upload restore automation custom",
+                hub_clone_custom_rule: "copy duplicate automation custom"
             ]
         ],
         hub_manage_variables: [
@@ -956,27 +962,34 @@ def getGatewayConfig() {
                 hub_delete_device: "remove ghost orphan zwave zigbee stuck failed pairing"
             ]
         ],
-        // Option B: hub_manage_code_read split into browse (read) + changes (write)
-        hub_manage_code_read: [
-            description: "Browse installed apps, drivers, and libraries: list, view source code, and view code backups. All operations are read-only. Write operations (install, update, delete) live in the hub_manage_code_write gateway.",
-            tools: ["hub_list_apps", "hub_list_drivers", "hub_get_source", "hub_list_backups", "hub_get_backup"],
+        hub_read_apps_code: [
+            description: "Read-only inspection of installed apps, drivers, libraries, code backups, and HPM packages: list apps (by code type or running instance), list drivers, view Groovy source, browse code backups, inspect an installed app's config/pages, and list HPM-tracked packages. All operations are read-only; writes live in hub_manage_code.",
+            tools: ["hub_list_apps", "hub_list_drivers", "hub_get_source", "hub_list_backups", "hub_get_backup", "hub_list_device_dependents", "hub_get_app_config", "hub_list_app_pages", "hub_list_hpm_packages"],
             summaries: [
-                hub_list_apps: "List all installed apps on the hub",
+                hub_list_apps: "List installed apps. scope='types' (installed app code library) or 'instances' (running apps with parent/child tree). Args: scope, filter?, includeHidden?, cursor?",
                 hub_list_drivers: "List all installed drivers on the hub",
                 hub_get_source: "Get app/driver/library Groovy source with chunked reading. Args: type (app|driver|library), id, offset?, length?",
                 hub_list_backups: "List auto-created source code backups",
-                hub_get_backup: "Get source from a backup. Args: backupId"
+                hub_get_backup: "Get source from a backup. Args: backupId",
+                hub_list_device_dependents: "List all apps that reference a device (Room Lighting, Rule Machine, Groups, etc.). Args: deviceId",
+                hub_get_app_config: "Read an installed app's configuration page (sections, inputs, current values). Works for Rule Machine, Room Lighting, Basic Rules, HPM, etc. Args: appId, pageName?, includeSettings?",
+                hub_list_app_pages: "List known page names for a multi-page app (HPM, Room Lighting, etc.). Args: appId",
+                hub_list_hpm_packages: "List all HPM-tracked packages (name, version, beta flag, apps, drivers, files). includeDrift=true surfaces missing-required/orphan components. Args: hpmAppId?, includeDrift?, packageFilter?"
             ],
             searchHints: [
-                hub_list_apps: "show installed applications integrations",
+                hub_list_apps: "show installed applications integrations apps list code types running instances builtin user parent child tree",
                 hub_list_drivers: "show installed device handlers types",
                 hub_get_source: "view read application driver library groovy code namespace include",
                 hub_list_backups: "show saved previous versions revisions",
-                hub_get_backup: "view read saved previous version revision"
+                hub_get_backup: "view read saved previous version revision",
+                hub_list_device_dependents: "which apps use device reference inUseBy appsUsing dependencies affected by",
+                hub_get_app_config: "read inspect app configuration page settings inputs values rule machine room lighting hpm mode manager",
+                hub_list_app_pages: "page names sub-pages pageName multi-page hpm navigation discover",
+                hub_list_hpm_packages: "package manager HPM tracked installed manifest version inventory community apps drivers drift orphan missing required"
             ]
         ],
-        hub_manage_code_write: [
-            description: "Install, update, and delete hub apps, drivers, and libraries. All operations modify hub code and require Hub Admin Write. Read-only counterparts (hub_get_source, list_*) live in the hub_manage_code_read gateway.",
+        hub_manage_code: [
+            description: "Install, update, and delete hub apps, drivers, and libraries. All operations modify hub code and require Hub Admin Write. Read-only counterparts (hub_get_source, list_*) live in the hub_read_apps_code gateway.",
             tools: ["hub_create_app", "hub_create_driver", "hub_update_app", "hub_update_driver", "hub_delete_item", "hub_restore_backup", "hub_create_library", "hub_update_library"],
             summaries: [
                 hub_create_app: "Install new app. PREFER curl-upload + sourceFile (bypasses agent context); inline source for stubs only. Args: source|sourceFile, confirm=true",
@@ -1060,34 +1073,50 @@ def getGatewayConfig() {
                 hub_delete_file: "remove clean up stored data"
             ]
         ],
-        hub_manage_installed_apps: [
-            description: "Read-only visibility into all installed apps (built-in + user): enumerate apps with parent/child tree, find apps using a device, inspect an app's configuration page, list page names for multi-page apps. Requires Built-in App Tools enabled in MCP app settings (list/device-in-use-by); hub_get_app_config and hub_list_app_pages require Hub Admin Read.",
-            tools: ["hub_list_installed_apps", "hub_list_device_dependents", "hub_get_app_config", "hub_list_app_pages"],
+        hub_read_diagnostics: [
+            description: "Read-only hub health, logs, and diagnostics: system logs, performance stats, scheduled jobs, MCP debug logs, hub metrics, free-memory/CPU history, device health/staleness, Z-Wave/Zigbee radio details, and saved state snapshots. All operations are read-only; the matching writes (gc, Z-Wave repair, clear logs, set log level, delete snapshots) live in hub_manage_logs / hub_manage_diagnostics.",
+            tools: ["hub_get_logs", "hub_get_performance_stats", "hub_get_jobs", "hub_get_debug_logs", "hub_get_metrics", "hub_get_memory_history", "hub_get_device_health", "hub_get_radio_details", "hub_list_captured_states"],
             summaries: [
-                hub_list_installed_apps: "List all installed apps with parent/child tree. Args: filter (all/builtin/user/disabled/parents/children), includeHidden",
-                hub_list_device_dependents: "List all apps that reference a device (Room Lighting, Rule Machine, Groups, etc.). Args: deviceId",
-                hub_get_app_config: "Read an installed app's configuration page (sections, inputs, current values). Works for Rule Machine, Room Lighting, Basic Rules, HPM, etc. Args: appId, pageName (optional), includeSettings (optional)",
-                hub_list_app_pages: "List known page names for a multi-page app (HPM, Room Lighting, etc.). Curated directory + live primary page. Args: appId"
+                hub_get_logs: "Get Hubitat system logs, most recent first. Args: level, source, pattern/patterns, since/until, deviceId|appId, limit",
+                hub_get_performance_stats: "Get device/app performance stats (count, % busy, total ms, state size, events). Args: type, sortBy, limit",
+                hub_get_jobs: "Get scheduled jobs, running jobs, and hub actions",
+                hub_get_debug_logs: "Get MCP internal debug logs (mode='logs') or logging status (mode='status'). Args: mode, level, limit",
+                hub_get_metrics: "Get hub metrics (memory, temp, DB) with CSV trend history. Read-only by default; pass recordSnapshot=true to also append a snapshot to the File Manager. Args: recordSnapshot?, trendPoints?",
+                hub_get_memory_history: "Get free OS memory and CPU load history with summary stats. Args: limit",
+                hub_get_device_health: "Check device staleness, ICMP-ping arbitrary IPs, and/or blink the hub identify-LED. Args: staleHours, includeHealthy, pingHosts, pingCount, identifyHub",
+                hub_get_radio_details: "Z-Wave and/or Zigbee radio info (firmware, channel, PAN/home ID, device count). Args: radio (zwave|zigbee, omit for both)",
+                hub_list_captured_states: "List saved device state snapshots"
             ],
             searchHints: [
-                hub_list_installed_apps: "rule machine room lighting scenes mode manager hsm dashboards groups button controllers native builtin",
-                hub_list_device_dependents: "which apps use device reference inUseBy appsUsing dependencies affected by",
-                hub_get_app_config: "read inspect app configuration page settings inputs values rule machine room lighting hpm mode manager",
-                hub_list_app_pages: "page names sub-pages pageName multi-page hpm prefPkgUninstall prefPkgModify prefOptions navigation discover"
+                hub_get_logs: "errors warnings messages trace syslog output recent latest device app scope regex pattern filter time window since until",
+                hub_get_performance_stats: "slow cpu busy resource usage hog bottleneck",
+                hub_get_jobs: "scheduled cron timer recurring what is running next automation",
+                hub_get_debug_logs: "mcp internal troubleshoot trace logging status buffer capacity level",
+                hub_get_metrics: "temperature database size trending monitoring memory over time snapshot history",
+                hub_get_memory_history: "ram free used leak trending over time java heap nio",
+                hub_get_device_health: "stale offline dead unresponsive battery not reporting ping icmp reachable network ip lan host router identify led blink locate",
+                hub_get_radio_details: "zwave zigbee mesh network frequency firmware channel pan coordinator radio",
+                hub_list_captured_states: "saved snapshot bookmark remember device values"
             ]
         ],
-        hub_manage_hpm: [
-            description: "Hubitat Package Manager (HPM) state introspection -- read-only. Tracks installed packages, their manifest versions, and (with includeDrift=true) per-component drift signals (missing-required, orphan-app, orphan-driver). HPM-managed code lives in the same Apps/Drivers registries as everything else, but its lifecycle is owned by HPM; this gateway surfaces that ownership state for diagnostic and drift-detection purposes without write side-effects. Requires Hub Admin Read.",
-            tools: ["hub_list_hpm_packages"],
+        hub_read_rules: [
+            description: "Read-only inspection of automation rules: list/inspect MCP custom rules (legacy engine) and list native Rule Machine rules + check rule health. All operations are read-only; rule writes live in hub_manage_custom_rules, hub_manage_rule_machine, and hub_manage_native_rules_and_apps.",
+            tools: ["hub_get_custom_rule", "hub_test_custom_rule", "hub_list_rules", "hub_get_rule_health"],
             summaries: [
-                hub_list_hpm_packages: "List all HPM-tracked packages (name, version, beta flag, apps, drivers, files). includeDrift=true also cross-references installed apps/drivers to surface missing-required/orphan components. Args: hpmAppId (optional), includeDrift, packageFilter. Hub Admin Read."
+                hub_get_custom_rule: "List MCP custom rules (omit ruleId) or get one rule's detail; detailed=true (with ruleId) adds diagnostics. Args: ruleId?, detailed?, cursor?",
+                hub_test_custom_rule: "Dry-run an MCP custom rule without executing actions. Args: ruleId",
+                hub_list_rules: "List all native Rule Machine rules (RM 4.x + 5.x) with IDs and labels",
+                hub_get_rule_health: "Inspect a native rule/app for broken state (BROKEN markers, configPage errors, multiple-flag corruption). Args: appId"
             ],
             searchHints: [
-                hub_list_hpm_packages: "package manager HPM tracked installed manifest version inventory dcmeglio community apps drivers drift orphan missing required divergence inconsistency check verify"
+                hub_get_custom_rule: "read fetch inspect list show custom mcp sandbox rule automation diagnostics",
+                hub_test_custom_rule: "simulate preview validate check automation custom dry run",
+                hub_list_rules: "rule machine rules native builtin automation list enumerate",
+                hub_get_rule_health: "broken validate inspect rule health diagnostic broken trigger broken action multiple flag corruption"
             ]
         ],
-        hub_manage_native_rules: [
-            description: "WHEN TO USE: this is the right path for any user who says 'create a rule machine rule,' 'make a Hubitat rule,' or wants the rule visible in Hubitat's Rule Machine app list / web UI. Use this for default rule-creation requests. The custom_* MCP rule engine (separate surface) is only appropriate when the user EXPLICITLY wants a sandbox MCP-managed rule that does not appear in Hubitat's UI -- uncommon outside power-user / testing scenarios. QUICK FLOW for a default rule create: (1) hub_create_native_app(appType='rule_machine', name='...', confirm=true) returns appId. (2) hub_update_native_app(appId=N, addTrigger={capability:'Certain Time (and optional date)', time:'A specific time', atTime:'17:00'}, confirm=true). (3) hub_update_native_app(appId=N, addAction={capability:'log', message:'...'}, confirm=true). Three calls. Each call returns settingsApplied so you can confirm the rule baked. Native rules + apps (RM rules, Room Lighting, Button Controllers, Basic Rules, Notifier, Groups+Scenes, Visual Rules -- any classic SmartApp). Two surfaces: (1) RMUtils-based runtime control for RM rules (list/run/pause/resume/setBoolean -- RM-specific because RMUtils is RM-only); (2) admin-layer CRUD that works uniformly across ALL classic SmartApps via /installedapp/* (create/update/delete by appId). Writes snapshot before every change; restore via the unified hub_list_backups (in hub_manage_code_read) + hub_restore_backup (in hub_manage_code_write) tools. Completely separate from the MCP custom rule engine (custom_* tools). Requires Built-in App Tools enabled; CRUD additionally requires Hub Admin Write. Verification protocol: write operations on RM 5.1 are asynchronous; if a response indicates a hard failure (success: false) or a partial state needing repair (partial: true, or non-empty settingsSkipped), the hub may have applied the change post-response despite the reported status -- verify via hub_get_app_config(appId=N) and inspect persisted settings before retrying.",
+        hub_manage_native_rules_and_apps: [
+            description: "WHEN TO USE: this is the right path for any user who says 'create a rule machine rule,' 'make a Hubitat rule,' or wants the rule visible in Hubitat's Rule Machine app list / web UI. Use this for default rule-creation requests. The custom_* MCP rule engine (separate surface) is only appropriate when the user EXPLICITLY wants a sandbox MCP-managed rule that does not appear in Hubitat's UI -- uncommon outside power-user / testing scenarios. QUICK FLOW for a default rule create: (1) hub_create_native_app(appType='rule_machine', name='...', confirm=true) returns appId. (2) hub_update_native_app(appId=N, addTrigger={capability:'Certain Time (and optional date)', time:'A specific time', atTime:'17:00'}, confirm=true). (3) hub_update_native_app(appId=N, addAction={capability:'log', message:'...'}, confirm=true). Three calls. Each call returns settingsApplied so you can confirm the rule baked. Native rules + apps (RM rules, Room Lighting, Button Controllers, Basic Rules, Notifier, Groups+Scenes, Visual Rules -- any classic SmartApp). Two surfaces: (1) RMUtils-based runtime control for RM rules (list/run/pause/resume/setBoolean -- RM-specific because RMUtils is RM-only); (2) admin-layer CRUD that works uniformly across ALL classic SmartApps via /installedapp/* (create/update/delete by appId). Writes snapshot before every change; restore via the unified hub_list_backups (in hub_read_apps_code) + hub_restore_backup (in hub_manage_code) tools. Completely separate from the MCP custom rule engine (custom_* tools). Requires Built-in App Tools enabled; CRUD additionally requires Hub Admin Write. Verification protocol: write operations on RM 5.1 are asynchronous; if a response indicates a hard failure (success: false) or a partial state needing repair (partial: true, or non-empty settingsSkipped), the hub may have applied the change post-response despite the reported status -- verify via hub_get_app_config(appId=N) and inspect persisted settings before retrying.",
             tools: ["hub_list_rules", "hub_call_rule", "hub_set_rule_paused", "hub_set_rule_private_boolean", "hub_create_native_app", "hub_update_native_app", "hub_delete_native_app", "hub_clone_native_app", "hub_export_native_app", "hub_import_native_app", "hub_get_rule_health"],
             summaries: [
                 hub_list_rules: "List all Rule Machine rules (RM 4.x + 5.x) with IDs and labels (uses RMUtils — RM only)",
@@ -1125,6 +1154,98 @@ def getGatewayConfig() {
             searchHints: [
                 hub_update_mcp_settings: "self-admin developer mode toggle setting log level tuning loopGuard maxCapturedStates enableHubAdminRead enableBuiltinApp enableCustomRuleEngine ci automation"
             ]
+        ],
+        hub_read_devices: [
+            description: "Read-only device inspection: list devices with current states, get one device's full detail, read or block-poll a single attribute, and read device/location event history. All operations are read-only; device commands and updates live in hub_manage_devices.",
+            tools: ["hub_list_devices", "hub_get_device", "hub_get_device_attribute", "hub_list_device_events"],
+            summaries: [
+                hub_list_devices: "List devices with current states. Args: detailed?, filter (enabled/disabled/stale:N/virtual), labelFilter?, capabilityFilter?, format (summary/detailed/ids), fields?, limit?, cursor?",
+                hub_get_device: "Get one device's full detail (capabilities, attributes, commands). Args: deviceId",
+                hub_get_device_attribute: "Read one attribute's value, or block-poll until it reaches expectedValue/expectedValues. Args: deviceId, attribute, expectedValue?, expectedValues?, timeoutMs?, pollIntervalMs?",
+                hub_list_device_events: "Recent device events, a time-windowed history (hoursBack, max 168), or location events (mode/HSM/hub-variable; omit deviceId). Args: deviceId?, hoursBack?, attribute?, limit?"
+            ],
+            searchHints: [
+                hub_list_devices: "show all devices switches lights sensors locks state inventory enumerate",
+                hub_get_device: "device detail capabilities attributes commands info inspect one",
+                hub_get_device_attribute: "read attribute value poll wait until threshold sensor verify state changed inclusion",
+                hub_list_device_events: "device history events timeline recent location mode hsm variable activity"
+            ]
+        ],
+        hub_read_rooms: [
+            description: "Read-only room inspection: list rooms and view a room's assigned devices. All operations are read-only; room create/delete/rename live in hub_manage_rooms.",
+            tools: ["hub_list_rooms", "hub_get_room"],
+            summaries: [
+                hub_list_rooms: "List all rooms with IDs, names, and device counts",
+                hub_get_room: "Get room details with assigned devices. Args: room (name or ID)"
+            ],
+            searchHints: [
+                hub_list_rooms: "show all locations areas groups rooms",
+                hub_get_room: "view location area group room devices"
+            ]
+        ],
+        hub_read_files: [
+            description: "Read-only hub File Manager access: list files and read file content. All operations are read-only; write/delete live in hub_manage_files.",
+            tools: ["hub_list_files", "hub_read_file"],
+            summaries: [
+                hub_list_files: "List files in File Manager (names, sizes, URLs)",
+                hub_read_file: "Read file content. Args: fileName, offset, limit"
+            ],
+            searchHints: [
+                hub_list_files: "show uploaded stored csv json text data files",
+                hub_read_file: "view open contents download stored data file"
+            ]
+        ],
+        hub_read_variables: [
+            description: "Read-only hub-variable inspection: list all variables (with type/connector linkage), get one variable's value + metadata, and watch the recent change timeline. All operations are read-only; variable create/set/delete and connectors live in hub_manage_variables.",
+            tools: ["hub_list_variables", "hub_get_variable", "hub_list_variable_changes"],
+            summaries: [
+                hub_list_variables: "List all hub variables (with type/connector linkage) and rule-engine variables.",
+                hub_get_variable: "Get a variable's value + metadata (type, deviceId, attribute). Args: name",
+                hub_list_variable_changes: "Recent hub-variable changes since the MCP app last started. Args: name?, sinceMs?, limit?"
+            ],
+            searchHints: [
+                hub_list_variables: "show all global state connector variables",
+                hub_get_variable: "read fetch lookup global state variable",
+                hub_list_variable_changes: "watch observe changes events recent variable timeline"
+            ]
+        ],
+        hub_manage_devices: [
+            description: "Control and inspect devices: send commands and update a device, plus read-only inspection (list/get/attribute/events). Device reads are also in hub_read_devices.",
+            tools: ["hub_call_device_command", "hub_update_device", "hub_list_devices", "hub_get_device", "hub_get_device_attribute", "hub_list_device_events"],
+            summaries: [
+                hub_call_device_command: "Send a command to a device (verify state after). Args: deviceId, command, parameters?",
+                hub_update_device: "Update a device's label and/or room assignment. Args: deviceId, label?, room?",
+                hub_list_devices: "List devices with current states. Args: detailed?, filter, labelFilter?, capabilityFilter?, format, fields?, limit?, cursor?",
+                hub_get_device: "Get one device's full detail (capabilities, attributes, commands). Args: deviceId",
+                hub_get_device_attribute: "Read one attribute's value, or block-poll until it reaches expectedValue/expectedValues. Args: deviceId, attribute, expectedValue?, expectedValues?, timeoutMs?, pollIntervalMs?",
+                hub_list_device_events: "Recent device events, a time-windowed history, or location events. Args: deviceId?, hoursBack?, attribute?, limit?"
+            ],
+            searchHints: [
+                hub_call_device_command: "send command control turn on off set level dim lock unlock device run",
+                hub_update_device: "rename relabel move room device edit",
+                hub_list_devices: "show all devices switches lights sensors locks state inventory",
+                hub_get_device: "device detail capabilities attributes commands info inspect one",
+                hub_get_device_attribute: "read attribute value poll wait until threshold sensor verify state changed",
+                hub_list_device_events: "device history events timeline recent location mode hsm variable activity"
+            ]
+        ],
+        hub_manage_rule_machine: [
+            description: "Dedicated Rule Machine gateway: list RM rules, trigger/run them, pause/resume, set the private boolean, and check rule health. RM-only (RMUtils). To CREATE or edit RM rules and other classic apps, use hub_manage_native_rules_and_apps. Read-only views are also in hub_read_rules.",
+            tools: ["hub_list_rules", "hub_call_rule", "hub_set_rule_paused", "hub_set_rule_private_boolean", "hub_get_rule_health"],
+            summaries: [
+                hub_list_rules: "List all Rule Machine rules (RM 4.x + 5.x) with IDs and labels (RMUtils — RM only)",
+                hub_call_rule: "Trigger an RM rule lifecycle verb. Args: ruleId, action (rule/actions/stop/start, default rule)",
+                hub_set_rule_paused: "Pause or resume an RM rule. Args: ruleId, value (true=pause, false=resume)",
+                hub_set_rule_private_boolean: "Set an RM rule's private boolean. Args: ruleId, value (bool)",
+                hub_get_rule_health: "Inspect a rule for broken state (BROKEN markers, configPage errors, multiple-flag corruption). Args: appId"
+            ],
+            searchHints: [
+                hub_list_rules: "rule machine rules native builtin automation list enumerate RM",
+                hub_call_rule: "trigger fire execute run native rule machine rule stop start",
+                hub_set_rule_paused: "pause resume disable enable stop unpause rule machine rule",
+                hub_set_rule_private_boolean: "private boolean flag rule machine rule condition",
+                hub_get_rule_health: "broken validate inspect rule health diagnostic broken trigger multiple flag corruption"
+            ]
         ]
     ]
 }
@@ -1153,8 +1274,8 @@ def getReadOnlyToolNames() {
         // Device introspection
         "hub_list_devices", "hub_get_device", "hub_get_device_attribute", "hub_list_device_events",
         // Custom rule reads (legacy MCP engine) -- test_rule is dry-run, no
-        // actions fire; export is a serialization read.
-        "hub_get_custom_rule", "hub_test_custom_rule", "hub_export_custom_rule",
+        // actions fire. (hub_export_custom_rule now persists to File Manager -> write.)
+        "hub_get_custom_rule", "hub_test_custom_rule",
         // Hub state reads
         "hub_get_info", "hub_list_modes", "hub_get_hsm_status", "hub_get_update_status",
         // Variables (reads)
@@ -1166,6 +1287,9 @@ def getReadOnlyToolNames() {
         "hub_get_logs", "hub_get_performance_stats",
         "hub_get_jobs", "hub_get_memory_history",
         "hub_get_radio_details",
+        // hub_get_metrics is read by default (recordSnapshot defaults false;
+        // pass recordSnapshot=true to also persist a CSV snapshot to File Manager).
+        "hub_get_metrics",
         // hub_get_device_health has an optional identifyHub LED blink, but its
         // primary mode is staleness + ICMP-ping observation; treating as read
         // matches user expectation for a "health check" tool.
@@ -1178,14 +1302,14 @@ def getReadOnlyToolNames() {
         "hub_list_rooms", "hub_get_room",
         // Files (read)
         "hub_list_files", "hub_read_file",
-        // Installed apps (read)
-        "hub_list_installed_apps", "hub_list_device_dependents", "hub_get_app_config",
+        // Installed apps (read) -- instances list folded into hub_list_apps(scope='instances').
+        "hub_list_device_dependents", "hub_get_app_config",
         "hub_list_app_pages",
         // HPM (read)
         "hub_list_hpm_packages",
-        // Native rules (read) -- export is appCloner serialization; hub_get_rule_health
-        // inspects only.
-        "hub_list_rules", "hub_export_native_app", "hub_get_rule_health",
+        // Native rules (read) -- hub_get_rule_health inspects only.
+        // (hub_export_native_app instantiates a cloner app + persists -> write.)
+        "hub_list_rules", "hub_get_rule_health",
         // Meta
         "hub_get_tool_guide", "hub_search_tools"
     ] as Set
@@ -1408,13 +1532,16 @@ def getToolDefinitions() {
     def hideByName = [] as Set
 
     if (!builtinAppOn) {
-        // All 14 of these tools require enableBuiltinApp.
-        //   hub_manage_native_rules: ALL 12 sub-tools require it → that
+        // All 13 of these tools require enableBuiltinApp.
+        //   hub_manage_native_rules_and_apps: ALL 12 sub-tools require it → that
         //     gateway empties out and drops entirely.
-        //   hub_manage_installed_apps: 2/4 sub-tools require it (hub_list_installed_apps,
-        //     hub_list_device_dependents); the other 2 (hub_get_app_config, hub_list_app_pages)
-        //     only need Hub Admin Read and stay visible.
-        ["hub_list_installed_apps", "hub_list_device_dependents", "hub_list_rules", "hub_call_rule", "hub_set_rule_paused", "hub_set_rule_private_boolean", "hub_create_native_app", "hub_update_native_app", "hub_delete_native_app", "hub_clone_native_app", "hub_export_native_app", "hub_import_native_app", "hub_get_rule_health"].each {
+        //   hub_manage_installed_apps: hub_list_device_dependents requires it; the
+        //     others (hub_list_apps, hub_get_app_config, hub_list_app_pages) only need
+        //     Hub Admin Read and stay visible. hub_list_apps stays visible because its
+        //     scope='types' path works with Hub Admin Read alone; the Built-in App Tools
+        //     requirement for scope='instances' is enforced at call time by
+        //     toolListInstalledApps.
+        ["hub_list_device_dependents", "hub_list_rules", "hub_call_rule", "hub_set_rule_paused", "hub_set_rule_private_boolean", "hub_create_native_app", "hub_update_native_app", "hub_delete_native_app", "hub_clone_native_app", "hub_export_native_app", "hub_import_native_app", "hub_get_rule_health"].each {
             hideByName << it
         }
     }
@@ -1606,7 +1733,7 @@ Default: most-recent events for a device (deviceId + optional limit). Add hoursB
         // Rule Management
         [
             name: "hub_get_custom_rule",
-            description: "Read MCP custom-engine automation rules. Omit ruleId to LIST all rules (summaries; supports cursor pagination). Provide ruleId for one rule's full detail. Add detailed=true (requires ruleId) for comprehensive diagnostics (config + execution history + recent logs + errors). NOTE: when the Custom Rule Engine toggle is OFF, this operates read-only -- you can list/inspect existing custom rules, but create/modify/delete are hidden. The custom MCP rule engine is legacy; for new rule work prefer native Rule Machine via hub_manage_native_rules.",
+            description: "Read MCP custom-engine automation rules. Omit ruleId to LIST all rules (summaries; supports cursor pagination). Provide ruleId for one rule's full detail. Add detailed=true (requires ruleId) for comprehensive diagnostics (config + execution history + recent logs + errors). NOTE: when the Custom Rule Engine toggle is OFF, this operates read-only -- you can list/inspect existing custom rules, but create/modify/delete are hidden. The custom MCP rule engine is legacy; for new rule work prefer native Rule Machine via hub_manage_native_rules_and_apps.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -1618,7 +1745,7 @@ Default: most-recent events for a device (deviceId + optional limit). Add hoursB
         ],
         [
             name: "hub_create_custom_rule",
-            description: """*** LEGACY: the custom MCP rule engine is now considered legacy. Existing custom rules continue to fire and this engine will receive bug fixes if reported, but new feature work goes to native Rule Machine. For default rule creation requests ("create a Rule Machine rule," "Hubitat rule," anything the user wants visible in Hubitat's RM app list / web UI), use hub_manage_native_rules hub_create_native_app instead. THIS tool creates MCP-managed sandbox rules that fire as installed apps but are NOT visible in Hubitat's RM UI; only use when explicitly asked for that or for backward compatibility with existing custom_* rules. ***
+            description: """*** LEGACY: the custom MCP rule engine is now considered legacy. Existing custom rules continue to fire and this engine will receive bug fixes if reported, but new feature work goes to native Rule Machine. For default rule creation requests ("create a Rule Machine rule," "Hubitat rule," anything the user wants visible in Hubitat's RM app list / web UI), use hub_manage_native_rules_and_apps hub_create_native_app instead. THIS tool creates MCP-managed sandbox rules that fire as installed apps but are NOT visible in Hubitat's RM UI; only use when explicitly asked for that or for backward compatibility with existing custom_* rules. ***
 
 Create a new automation rule (MCP sandbox engine). Call `hub_get_tool_guide(section='rules')` for structure, syntax, and examples.
 
@@ -1918,11 +2045,12 @@ Verify rule after creation.""",
         // Rule Export/Import/Clone Tools
         [
             name: "hub_export_custom_rule",
-            description: "Export a rule to JSON for backup or sharing. Returns full rule data plus a device manifest listing all referenced devices.",
+            description: "Export a custom rule to JSON and save it to the hub File Manager for backup or sharing. Returns the full rule data plus a device manifest listing all referenced devices, and writes a .json file to the File Manager (pass saveAs for the filename; defaults to a generated name).",
             inputSchema: [
                 type: "object",
                 properties: [
-                    ruleId: [type: "string", description: "Rule ID to export"]
+                    ruleId: [type: "string", description: "Rule ID to export"],
+                    saveAs: [type: "string", description: "File Manager filename to write the export JSON to (\".json\" appended if missing). Omit to use a generated name based on the rule."]
                 ],
                 required: ["ruleId"]
             ]
@@ -1965,11 +2093,24 @@ Verify rule after creation.""",
         // get_hub_details merged into hub_get_info (core tool)
         [
             name: "hub_list_apps",
-            description: "List all installed apps on the hub (not just MCP rules). Requires Hub Admin Read.",
+            description: """List apps on the hub. scope selects what kind of "apps" to return.
+
+scope='instances' (default) — running app INSTANCES (built-in + user) with parent/child tree. Requires Built-in App Tools enabled.
+  Each app entry returns: id, name, type, disabled, user (true=user-installed Groovy app, false=built-in), hidden, parentId (null for top-level), hasChildren, childCount.
+  Use filter to narrow results: 'all' (default), 'builtin' (Hubitat native apps), 'user' (custom Groovy apps), 'disabled' (paused/disabled), 'parents' (apps with children like Rule Machine, Room Lighting, Groups and Scenes), 'children' (individual rules, scenes, etc.).
+  filter, includeHidden, and cursor apply to this mode.
+
+scope='types' — installed app CODE LIBRARY / available app TYPES (the app code installed on the hub, not running instances). Requires Hub Admin Read.
+  filter and includeHidden are ignored in this mode.
+
+Pass cursor (opaque string from a prior call's nextCursor) to page through the list at 50 per page when the full response would exceed the hub's 128KB JSON-RPC cap.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit for unbounded; pass \"\" for the first page, iterate nextCursor (page size 50)."]
+                    scope: [type: "string", enum: ["instances", "types"], description: "What to list. 'instances' (default) = running app instances with parent/child tree (Built-in App Tools). 'types' = installed app code library / available app types (Hub Admin Read).", default: "instances"],
+                    filter: [type: "string", enum: ["all", "builtin", "user", "disabled", "parents", "children"], description: "scope='instances' only: filter apps by category. Default: all"],
+                    includeHidden: [type: "boolean", description: "scope='instances' only: include hidden apps (typically Hubitat internal). Default: false", default: false],
+                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit to get the full list in a single response (subject to the universal 120KB response-size guard -- oversized responses come back as a response_too_large envelope). Pass the nextCursor value from a prior call to fetch the next page (page size 50). Empty string starts at the first page."]
                 ]
             ]
         ],
@@ -2036,11 +2177,11 @@ Verify rule after creation.""",
         ],
         [
             name: "hub_get_metrics",
-            description: "Record and retrieve hub metrics (memory, temp, DB size) with CSV trend history. Use recordSnapshot=false to read without recording. Requires Hub Admin Read.",
+            description: "Retrieve hub metrics (memory, temp, DB size) with CSV trend history. Read-only by default; pass recordSnapshot=true to ALSO append the current snapshot to the performance-history CSV in the hub File Manager (the only write side-effect). Requires Hub Admin Read.",
             inputSchema: [
                 type: "object",
                 properties: [
-                    recordSnapshot: [type: "boolean", description: "Record this snapshot to the performance history CSV. Default: true.", default: true],
+                    recordSnapshot: [type: "boolean", description: "If true, also append this snapshot to the performance-history CSV in the hub File Manager (a write side-effect). Default: false (read-only).", default: false],
                     trendPoints: [type: "integer", description: "Number of recent historical data points to include. Default: 10, max: 50.", default: 10]
                 ]
             ]
@@ -2569,24 +2710,6 @@ Auto-backs up before modifying. Requires Hub Admin Write + confirm + backup <24h
         ],
         // Installed Apps Integration (built-in + user app visibility)
         [
-            name: "hub_list_installed_apps",
-            description: """List all installed apps on the hub (built-in + user) with parent/child tree. Requires Built-in App Tools enabled.
-
-Each app entry returns: id, name, type, disabled, user (true=user-installed Groovy app, false=built-in), hidden, parentId (null for top-level), hasChildren, childCount.
-
-Use filter to narrow results: 'all' (default), 'builtin' (Hubitat native apps), 'user' (custom Groovy apps), 'disabled' (paused/disabled), 'parents' (apps with children like Rule Machine, Room Lighting, Groups and Scenes), 'children' (individual rules, scenes, etc.).
-
-Pass cursor (opaque string from a prior call's nextCursor) to page through the apps list at 50 per page when the full response would exceed the hub's 128KB JSON-RPC cap.""",
-            inputSchema: [
-                type: "object",
-                properties: [
-                    filter: [type: "string", enum: ["all", "builtin", "user", "disabled", "parents", "children"], description: "Filter apps by category. Default: all"],
-                    includeHidden: [type: "boolean", description: "Include hidden apps (typically Hubitat internal). Default: false", default: false],
-                    cursor: [type: "string", description: "Opt-in pagination cursor. Omit to get the full filtered list in a single response (subject to the universal 120KB response-size guard -- oversized responses come back as a response_too_large envelope). Pass the nextCursor value from a prior call to fetch the next page (page size 50). Empty string starts at the first page."]
-                ]
-            ]
-        ],
-        [
             name: "hub_list_device_dependents",
             description: """List all apps that reference a specific device (Room Lighting instances, Rule Machine rules, Groups and Scenes, Mode Manager, dashboards, Maker API, Echo Skill, etc.). Requires Built-in App Tools enabled.
 
@@ -2609,15 +2732,15 @@ Returns: deviceId, deviceName, appsUsing array (each entry: id, name=app type, l
 
 Returns the app's identity (label, type, parent, disabled state) and its current config page: sections, inputs (name, type, title, description, options, current value), and `embeddedActions` — clickable button affordances embedded in paragraph HTML (RM 5.1 wizards expose "Create New Trigger", "Edit Trigger", "Delete Trigger" etc. as `<div class='submitOnChange'>` elements rather than schema inputs; this field surfaces them with their button name + stateAttribute so hub_update_native_app can drive them). Multi-page apps (e.g. RM 5.1) expose sub-pages by name — pass pageName to navigate into them. Read-only; does not modify anything.
 
-Use to: understand what an existing automation actually does, audit rules for best-practice issues, diff two similar apps, generate human-readable summaries, or answer "which app is doing X" after hub_list_installed_apps / hub_list_device_dependents narrows the field.
+Use to: understand what an existing automation actually does, audit rules for best-practice issues, diff two similar apps, generate human-readable summaries, or answer "which app is doing X" after hub_list_apps (scope='instances') / hub_list_device_dependents narrows the field.
 
-Workflow: (1) Get the appId from hub_list_installed_apps (all apps), hub_list_rules (RM rules specifically -- these are Rule-5.x appIds under parent Rule Machine; use this, not hub_get_custom_rule, which only handles MCP-native rules), or hub_list_installed_apps with filter=parents to explore app hierarchy. (2) Call hub_get_app_config with the appId. (3) For multi-page apps, optionally pass pageName -- call hub_list_app_pages first to discover available page names. Common multi-page names: HPM uses prefPkgUninstall (full installed-package list), prefPkgModify (modifiable subset only), prefOptions (main menu / navigation); RM and Room Lighting use a single mainPage (no pageName needed).
+Workflow: (1) Get the appId from hub_list_apps (scope='instances', all apps), hub_list_rules (RM rules specifically -- these are Rule-5.x appIds under parent Rule Machine; use this, not hub_get_custom_rule, which only handles MCP-native rules), or hub_list_apps (scope='instances') with filter=parents to explore app hierarchy. (2) Call hub_get_app_config with the appId. (3) For multi-page apps, optionally pass pageName -- call hub_list_app_pages first to discover available page names. Common multi-page names: HPM uses prefPkgUninstall (full installed-package list), prefPkgModify (modifiable subset only), prefOptions (main menu / navigation); RM and Room Lighting use a single mainPage (no pageName needed).
 
 Requires Hub Admin Read.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    appId: [type: "string", description: "Installed-app ID (decimal). From hub_list_installed_apps, hub_list_rules, or the numeric id in the Hubitat UI URL (/installedapp/configure/<id>)."],
+                    appId: [type: "string", description: "Installed-app ID (decimal). From hub_list_apps (scope='instances'), hub_list_rules, or the numeric id in the Hubitat UI URL (/installedapp/configure/<id>)."],
                     pageName: [type: "string", description: "Optional sub-page name for multi-page apps. Main page is used when omitted. Call hub_list_app_pages to discover available pages. HPM: prefPkgUninstall (full installed-package list), prefPkgModify (modifiable subset), prefOptions (main menu). RM / Room Lighting: mainPage only."],
                     includeSettings: [type: "boolean", description: "Include the raw app-internal settings key-value map. Default false -- large apps can have 500-1000 keys with app-specific encoding (e.g. Room Lighting's dm~<deviceId>~<scene>). Set true only for power-user inspection.", default: false]
                 ],
@@ -2639,7 +2762,7 @@ Requires Hub Admin Read.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    appId: [type: "string", description: "Installed-app ID (decimal). From hub_list_installed_apps, hub_list_rules, or the Hubitat UI URL (/installedapp/configure/<id>)."]
+                    appId: [type: "string", description: "Installed-app ID (decimal). From hub_list_apps (scope='instances'), hub_list_rules, or the Hubitat UI URL (/installedapp/configure/<id>)."]
                 ],
                 required: ["appId"]
             ]
@@ -2804,7 +2927,7 @@ Requires Hub Admin Write + confirm=true + recent hub backup.""",
             inputSchema: [
                 type: "object",
                 properties: [
-                    appId: [type: "integer", description: "Installed-app ID (for RM rules, this is the rule ID; for any other classic app, it's the app's id from hub_list_installed_apps)."],
+                    appId: [type: "integer", description: "Installed-app ID (for RM rules, this is the rule ID; for any other classic app, it's the app's id from hub_list_apps with scope='instances')."],
                     settings: [type: "object", description: "Map {inputName: value}. Use List for multi-device capability inputs — CSV marshaling is automatic."],
                     button: [type: "string", description: "Page-transition button name (e.g. updateRule, editCond, pausRule, refreshActions for RM; analogous buttons for other app types)."],
                     pageName: [type: "string", description: "Optional sub-page for schema introspection + settings POST."],
@@ -3323,7 +3446,7 @@ def executeTool(toolName, args) {
             throw new IllegalArgumentException("${toolName} is not available. Both 'Enable Custom Rule Engine' and 'Enable Built-in App Tools' are OFF. To use the legacy custom-rule tools (hub_*_custom_rule), turn on Custom Rule Engine. To use native Hubitat Rule Machine rules (recommended), turn on Built-in App Tools instead.")
         }
         if (customEngineMode == "readonly" && !customReadonlyTools.contains(toolName)) {
-            throw new IllegalArgumentException("${toolName} is not available in read-only mode. The Custom Rule Engine toggle is OFF. Turn it ON in MCP Rule Server settings to use create/delete/export/import/clone operations. NOTE: the custom MCP rule engine is legacy -- for new rule work prefer hub_manage_native_rules.")
+            throw new IllegalArgumentException("${toolName} is not available in read-only mode. The Custom Rule Engine toggle is OFF. Turn it ON in MCP Rule Server settings to use create/delete/export/import/clone operations. NOTE: the custom MCP rule engine is legacy -- for new rule work prefer hub_manage_native_rules_and_apps.")
         }
     }
     switch (toolName) {
@@ -3400,7 +3523,7 @@ def executeTool(toolName, args) {
 
         // Hub Admin Read Tools
         // get_hub_details merged into hub_get_info
-        case "hub_list_apps": return toolListHubApps(args)
+        case "hub_list_apps": return (args?.scope == "types") ? toolListHubApps(args) : toolListInstalledApps(args)
         case "hub_list_drivers": return toolListHubDrivers(args)
         case "hub_get_radio_details": {
             def radio = args.radio
@@ -3469,7 +3592,6 @@ def executeTool(toolName, args) {
         case "hub_delete_file": return toolDeleteFile(args)
 
         // Installed Apps Integration
-        case "hub_list_installed_apps": return toolListInstalledApps(args)
         case "hub_list_device_dependents": return toolGetDeviceInUseBy(args)
 
         // HPM Package State
@@ -3504,19 +3626,25 @@ def executeTool(toolName, args) {
         case "hub_search_tools": return toolSearchTools(args)
 
         // Category Gateway Proxy Tools
-        case "hub_manage_rules":
-        case "hub_manage_variables":
-        case "hub_manage_rooms":
+        case "hub_read_apps_code":
+        case "hub_read_devices":
+        case "hub_read_diagnostics":
+        case "hub_read_files":
+        case "hub_read_rooms":
+        case "hub_read_rules":
+        case "hub_read_variables":
+        case "hub_manage_code":
+        case "hub_manage_custom_rules":
         case "hub_manage_destructive_ops":
-        case "hub_manage_code_read":
-        case "hub_manage_code_write":
-        case "hub_manage_logs":
+        case "hub_manage_devices":
         case "hub_manage_diagnostics":
         case "hub_manage_files":
-        case "hub_manage_installed_apps":
-        case "hub_manage_hpm":
-        case "hub_manage_native_rules":
+        case "hub_manage_logs":
         case "hub_manage_mcp":
+        case "hub_manage_native_rules_and_apps":
+        case "hub_manage_rooms":
+        case "hub_manage_rule_machine":
+        case "hub_manage_variables":
             // Flat-mode guard: gateways are not advertised on tools/list when useGateways=false,
             // so a gateway-name call here is almost certainly a stale/cached client. Returning
             // the gateway catalog would silently contradict the user's intent — fail loud with
@@ -4315,7 +4443,7 @@ def toolGetRule(ruleId) {
 
     def ruleData = childApp.getRuleData()
     // Inject source marker so callers can distinguish MCP-managed rules from
-    // native RM rules returned by hub_list_rules / hub_manage_native_rules.
+    // native RM rules returned by hub_list_rules / hub_manage_native_rules_and_apps.
     if (ruleData instanceof Map) {
         ruleData = ruleData + [source: "mcp_custom_engine"]
     }
@@ -4439,7 +4567,7 @@ def toolUpdateRule(ruleId, args, String customEngineMode = "full") {
         // Fields in args besides 'enabled' (ruleId is passed as a separate param, not in args)
         def structuralKeys = (args?.keySet() ?: []).findAll { it != "enabled" && it != "ruleId" }
         if (!structuralKeys.isEmpty()) {
-            throw new IllegalArgumentException("In read-only mode (Custom Rule Engine toggle OFF), only the 'enabled' field can be updated. Structural fields provided: ${structuralKeys.sort().join(', ')}. To modify rule structure (triggers/conditions/actions), turn ON the Custom Rule Engine toggle in MCP server settings. The custom rule engine is legacy -- for new rule structure work, use hub_manage_native_rules hub_create_native_app/hub_update_native_app instead.")
+            throw new IllegalArgumentException("In read-only mode (Custom Rule Engine toggle OFF), only the 'enabled' field can be updated. Structural fields provided: ${structuralKeys.sort().join(', ')}. To modify rule structure (triggers/conditions/actions), turn ON the Custom Rule Engine toggle in MCP server settings. The custom rule engine is legacy -- for new rule structure work, use hub_manage_native_rules_and_apps hub_create_native_app/hub_update_native_app instead.")
         }
     }
 
@@ -4677,7 +4805,7 @@ private String findRuleAppRedirect(ruleId, String verb) {
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                 "Use `hub_manage_installed_apps -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
                 "`hub_delete_custom_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +
-                "Use `hub_manage_native_rules -> hub_delete_native_app(appId=${idStr}, confirm=true)` to delete it programmatically " +
+                "Use `hub_manage_native_rules_and_apps -> hub_delete_native_app(appId=${idStr}, confirm=true)` to delete it programmatically " +
                 "(requires Built-in App Tools + Hub Admin Write)."
         } else if (verb == "test") {
             // hub_call_rule routes through RMUtils and is RM-only. Point non-RM rule-likes at hub_get_app_config instead.
@@ -4685,7 +4813,7 @@ private String findRuleAppRedirect(ruleId, String verb) {
                 return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                     "Use `hub_manage_installed_apps -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
                     "`hub_test_custom_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +
-                    "Use `hub_manage_native_rules -> hub_call_rule(ruleId=${idStr})` to trigger it " +
+                    "Use `hub_manage_native_rules_and_apps -> hub_call_rule(ruleId=${idStr})` to trigger it " +
                     "(requires Built-in App Tools)."
             } else {
                 return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
@@ -4700,7 +4828,7 @@ private String findRuleAppRedirect(ruleId, String verb) {
             return "Rule ${idStr} is a Hubitat built-in ${appTypeName} app. " +
                 "Use `hub_manage_installed_apps -> hub_get_app_config(appId=${idStr})` for read-only inspection. " +
                 "`hub_update_custom_rule` only handles MCP's own rule engine, not Hubitat built-in apps. " +
-                "Use `hub_manage_native_rules -> hub_update_native_app(appId=${idStr})` to modify it programmatically " +
+                "Use `hub_manage_native_rules_and_apps -> hub_update_native_app(appId=${idStr})` to modify it programmatically " +
                 "(requires Built-in App Tools + Hub Admin Write)."
         }
     } catch (Exception e) {
@@ -4757,6 +4885,16 @@ def toolExportRule(args) {
     ]
 
     mcpLog("info", "server", "Exported rule '${ruleData.name}' (ID: ${args.ruleId}) with ${deviceManifest.size()} device references", args.ruleId)
+
+    // hub_export_custom_rule ALWAYS persists the export JSON to the hub File Manager --
+    // that write side-effect is why it is classified a write tool. saveAs sets the filename.
+    def exportFileName = (args.saveAs ?: "mcp-rule-export-${args.ruleId}-${ruleData.name}").toString()
+        .replaceAll(/[^A-Za-z0-9._-]/, "_")
+    if (!exportFileName.toLowerCase().endsWith(".json")) exportFileName += ".json"
+    def jsonContent = groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(exportData))
+    uploadHubFile(exportFileName, jsonContent.getBytes("UTF-8"))
+    exportData.savedToFile = exportFileName
+    mcpLog("info", "server", "Saved rule export to File Manager: ${exportFileName}", args.ruleId)
 
     return exportData
 }
@@ -5264,7 +5402,7 @@ private String _validateHubVarType(String type) {
  * Discovery is two-stage because /hub2/appsList omits hidden system apps
  * on at least some firmware versions (verified on 2.5.0.126: Hub Variables
  * is reachable at /installedapp/configure/json/<id> but not listed in
- * /hub2/appsList -- same gap that hides it from hub_list_installed_apps):
+ * /hub2/appsList -- same gap that hides it from hub_list_apps (scope='instances')):
  *   1. Walk /hub2/appsList (cheap, single GET) -- catches hubs that DO
  *      list it.
  *   2. If miss, fall back to scanning installed-app config endpoints up
@@ -9537,7 +9675,7 @@ def toolGetHubJobs(args) {
 def toolGetHubPerformance(args) {
     requireHubAdminRead()
 
-    def recordSnapshot = args.recordSnapshot != false
+    def recordSnapshot = args.recordSnapshot == true
     def trendPoints = Math.min(args.trendPoints ?: 10, 50)
 
     // Gather current metrics
@@ -13031,7 +13169,7 @@ def toolListInstalledApps(args) {
             }
         }
 
-        def paged = _paginateList(filtered, cursor, 50, "hub_list_installed_apps")
+        def paged = _paginateList(filtered, cursor, 50, "hub_list_apps")
         def result = [
             apps: paged.page,
             count: paged.page.size(),
@@ -13049,7 +13187,7 @@ def toolListInstalledApps(args) {
         // Programmer error -- e.g. validFilters / switch drift on the filter whitelist.
         // Don't reframe as a transport failure; surface so the drift gets fixed instead
         // of swallowed under a misleading "hub blip" note.
-        mcpLog("error", "installed-apps", "hub_list_installed_apps internal invariant violated: ${e.message}")
+        mcpLog("error", "installed-apps", "hub_list_apps internal invariant violated: ${e.message}")
         throw e
     } catch (Exception e) {
         // The Built-in-App-Tools gate has already passed by the time we reach here, so
@@ -13057,7 +13195,7 @@ def toolListInstalledApps(args) {
         // (network blip, firmware change to /hub2/appsList) or the flatten/filter pipeline
         // (unexpected shape in a child entry). The error message itself will usually
         // distinguish the two.
-        mcpLog("error", "installed-apps", "hub_list_installed_apps failed: ${e.message}")
+        mcpLog("error", "installed-apps", "hub_list_apps failed: ${e.message}")
         return [success: false, error: "Failed to list installed apps: ${e.message}", note: "Hub transport error or unexpected /hub2/appsList response shape -- retry; if persistent, inspect the raw response for firmware-side drift."]
     }
 }
@@ -14269,7 +14407,7 @@ private Integer normalizeRuleId(def ruleId) {
  *   - rule_machine: namespace=hubitat appName=Rule-5.1 parentType="Rule Machine"
  *
  * Sources for additional entries (per #120 scope expansion notes —
- * confirm namespace+appName via hub_list_installed_apps before enabling):
+ * confirm namespace+appName via hub_list_apps (scope='instances') before enabling):
  *   - button_controller (parent),  Button Controller-5.1, parentType="Button Controllers"
  *   - button_rule (under controller), Button Rule-5.1, parentType=<a specific Button Controller>
  *   - basic_rule, parentType="Basic Rules"
@@ -14280,7 +14418,7 @@ private Integer normalizeRuleId(def ruleId) {
  *
  * Update + delete already work on these today — call hub_update_native_app /
  * hub_delete_native_app with the appId of any existing classic-app instance
- * (read appId via hub_list_installed_apps + hub_get_app_config).
+ * (read appId via hub_list_apps (scope='instances') + hub_get_app_config).
  */
 private Map _appTypeRegistry() {
     return [
@@ -20598,7 +20736,7 @@ def toolCreateNativeApp(args) {
             "The hub rejected namespace='${reg.namespace}' + appName='${reg.appName}' " +
             "(parent app id ${parentId}). Most likely the _appTypeRegistry entry has the " +
             "wrong child appName for this hub's installed parent. To verify the actual " +
-            "child appName, call hub_list_installed_apps and inspect the children of " +
+            "child appName, call hub_list_apps (scope='instances') and inspect the children of " +
             "parentTypeName='${reg.parentTypeName}' — the children's `type` field is the " +
             "child appName the hub expects. Underlying error: ${createExc.message}")
     }
@@ -24005,7 +24143,7 @@ def toolCloneNativeApp(args) {
 
     String note = newAppId
         ? "Cloned source ${sourceAppId} -> new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use hub_update_native_app to further customize."
-        : "Clone fired but no new child appeared under parent ${parentAppId}. Re-check via hub_list_installed_apps shortly."
+        : "Clone fired but no new child appeared under parent ${parentAppId}. Re-check via hub_list_apps (scope='instances') shortly."
     def result = [
         success: newAppId != null,
         sourceAppId: sourceAppId,
@@ -24256,7 +24394,7 @@ def toolImportNativeApp(args) {
 
     String note = newAppId
         ? "Imported '${originalLabel ?: 'app'}' as new app ${newAppId}${newName ? " (renamed to '${newName}')" : ""}. Use hub_update_native_app to further customize."
-        : "Import fired but no new child appeared under parent ${parentAppId}. Re-check via hub_list_installed_apps shortly."
+        : "Import fired but no new child appeared under parent ${parentAppId}. Re-check via hub_list_apps (scope='instances') shortly."
     def result = [
         success: newAppId != null,
         clonerAppId: clonerAppId,
@@ -24926,11 +25064,11 @@ Files stored at http://<HUB_IP>/local/<filename>
 
         builtin_app_tools: '''## Built-in App Tools
 
-Tools in the hub_manage_installed_apps and hub_manage_native_rules gateways have mixed gate requirements. hub_list_installed_apps and hub_list_device_dependents require the "Enable Built-in App Tools (read + write)" toggle (requireBuiltinApp). hub_get_app_config and hub_list_app_pages require Hub Admin Read (requireHubAdminRead). The hub_manage_hpm tool (hub_list_hpm_packages, with optional includeDrift) requires Hub Admin Read. All hub_manage_native_rules tools require the "Enable Built-in App Tools" toggle; the CRUD tools (hub_create_native_app / hub_update_native_app / hub_delete_native_app) ALSO require Hub Admin Write. If the user sees "Built-in App Tools are disabled" or "Hub Admin Read is disabled" errors, direct them to the MCP Rule Server app settings page.
+Tools in the hub_manage_installed_apps and hub_manage_native_rules_and_apps gateways have mixed gate requirements. hub_list_apps with scope='instances' and hub_list_device_dependents require the "Enable Built-in App Tools (read + write)" toggle (requireBuiltinApp); hub_list_apps with scope='types' requires only Hub Admin Read. hub_get_app_config and hub_list_app_pages require Hub Admin Read (requireHubAdminRead). The hub_manage_hpm tool (hub_list_hpm_packages, with optional includeDrift) requires Hub Admin Read. All hub_manage_native_rules_and_apps tools require the "Enable Built-in App Tools" toggle; the CRUD tools (hub_create_native_app / hub_update_native_app / hub_delete_native_app) ALSO require Hub Admin Write. If the user sees "Built-in App Tools are disabled" or "Hub Admin Read is disabled" errors, direct them to the MCP Rule Server app settings page.
 
 **hub_manage_installed_apps (4 tools):**
 
-- **hub_list_installed_apps** — enumerate ALL apps on the hub (built-in + user) with parent/child tree
+- **hub_list_apps (scope='instances')** — enumerate ALL running app instances on the hub (built-in + user) with parent/child tree
   - filter="all" (default) | "builtin" | "user" | "disabled" | "parents" | "children"
   - Each entry: id, name, type, disabled, user, hidden, parentId, hasChildren, childCount
   - Built-in apps have user=false (Rule Machine, Room Lighting, Groups and Scenes, Mode Manager, HSM, Dashboards, Maker API, etc.)
@@ -24946,7 +25084,7 @@ Tools in the hub_manage_installed_apps and hub_manage_native_rules gateways have
   - Returns app identity (label, type, disabled), config page sections/inputs/values, and child apps
   - Multi-page apps expose sub-pages via pageName. For HPM: use pageName="prefPkgUninstall" for the FULL installed-package list; pageName="prefPkgModify" returns only the subset with optional components; pageName="prefOptions" is the main-menu navigation (no package data). RM 5.x and Room Lighting use a single mainPage (no pageName needed). Call hub_list_app_pages first to discover available page names for any multi-page app.
   - includeSettings=true adds the raw internal settings map (large apps: 500-1000 keys with app-specific encoding)
-  - Workflow: hub_list_installed_apps (or hub_list_rules for RM rules specifically -- note that hub_get_custom_rule handles only MCP-native rules, not Hubitat's built-in Rule Machine) to find appId, then hub_get_app_config to inspect. For multi-page apps, consider hub_list_app_pages first.
+  - Workflow: hub_list_apps (scope='instances'; or hub_list_rules for RM rules specifically -- note that hub_get_custom_rule handles only MCP-native rules, not Hubitat's built-in Rule Machine) to find appId, then hub_get_app_config to inspect. For multi-page apps, consider hub_list_app_pages first.
 
 - **hub_list_app_pages** — discover what pageNames a given app accepts (Hub Admin Read required)
   - Input: appId
@@ -24968,7 +25106,7 @@ Tools in the hub_manage_installed_apps and hub_manage_native_rules gateways have
   - Data-quality warning types in dataQualityWarnings[]: heid-whitespace-normalized (padded heID normalized; component KEPT), heid-non-scalar-dropped (non-scalar heID; component DROPPED), empty-heid, skipped-malformed-component
   - Limitation: heID-presence-only; HPM stores no source hashes so post-install edits via hub_update_app are not detectable
 
-**hub_manage_native_rules (12 tools) — read, trigger, AND full CRUD on native RM rules:**
+**hub_manage_native_rules_and_apps (12 tools) — read, trigger, AND full CRUD on native RM rules:**
 
 RMUtils-based control surface (Built-in App Tools gate only):
 - **hub_list_rules** — enumerate Rule Machine rules (RM 4.x + 5.x combined, deduplicated by id)

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -970,7 +970,7 @@ def getGatewayConfig() {
                 hub_list_drivers: "List all installed drivers on the hub",
                 hub_get_source: "Get app/driver/library Groovy source with chunked reading. Args: type (app|driver|library), id, offset?, length?",
                 hub_list_backups: "List auto-created source code backups",
-                hub_get_backup: "Get source from a backup. Args: backupId",
+                hub_get_backup: "Get source from a backup. Args: backupKey",
                 hub_list_device_dependents: "List all apps that reference a device (Room Lighting, Rule Machine, Groups, etc.). Args: deviceId",
                 hub_get_app_config: "Read an installed app's configuration page (sections, inputs, current values). Works for Rule Machine, Room Lighting, Basic Rules, HPM, etc. Args: appId, pageName?, includeSettings?",
                 hub_list_app_pages: "List known page names for a multi-page app (HPM, Room Lighting, etc.). Args: appId",
@@ -997,7 +997,7 @@ def getGatewayConfig() {
                 hub_update_app: "Modify existing app code (CRITICAL). PREFER curl-upload + sourceFile. Args: appId, source|sourceFile|resave, confirm=true",
                 hub_update_driver: "Modify existing driver code (CRITICAL). For 1 driver: driverId+source|sourceFile|resave. For >1 drivers: USE BULK (single round-trip: updates=[{driverId,sourceFile},...]). PREFER sourceFile + curl-upload over inline. confirm=true",
                 hub_delete_item: "Permanently delete an app/driver/library (DESTRUCTIVE, auto-backs up). Args: type (app|driver|library), id, confirm=true",
-                hub_restore_backup: "Restore app/driver to backed-up version. Args: backupId, confirm=true",
+                hub_restore_backup: "Restore app/driver to backed-up version. Args: backupKey, confirm=true",
                 hub_create_library: "Install new Groovy library (#include namespace.Name). PREFER curl-upload + sourceFile (bypasses agent context); inline source for stubs only. Args: source|sourceFile, confirm=true",
                 hub_update_library: "Modify existing library code. PREFER curl-upload + sourceFile. Args: libraryId, source|sourceFile|resave, confirm=true"
             ],
@@ -1126,8 +1126,8 @@ def getGatewayConfig() {
                 hub_create_native_app: "Create a new empty native automation app (RM rule by default; expand via _appTypeRegistry for Room Lighting / Button Controllers / etc.). Args: appType (default rule_machine), name, confirm. Returns appId — use hub_update_native_app next to populate.",
                 hub_update_native_app: "Modify any classic native app: write settings (multiple=true contract automatic), click a page-transition button, or use a high-level structured shortcut (addTrigger / addAction / addRequiredExpression / addTriggers / addActions / replaceActions / removeAction / clearActions / moveAction / removeTrigger / modifyTrigger / walkStep). Auto-backs-up first. Args: appId, settings|button|<shortcut>, pageName (opt), stateAttribute (opt), confirm",
                 hub_delete_native_app: "Delete any classic native app (soft by default, force=true for hard). Auto-backs-up first. Args: appId, force (opt), confirm",
-                hub_clone_native_app: "Clone an existing rule/app via Hubitat's first-party appCloner. Cheaper than rebuilding from scratch via the wizard. Args: sourceAppId, newName (opt), confirm. Returns newAppId.",
-                hub_export_native_app: "Export a rule/app to its canonical JSON shape via Hubitat's first-party appCloner. Args: sourceAppId, saveAs (opt File Manager filename). Returns the JSON content (and writes to File Manager if saveAs given).",
+                hub_clone_native_app: "Clone an existing rule/app via Hubitat's first-party appCloner. Cheaper than rebuilding from scratch via the wizard. Args: appId (alias sourceAppId), newName (opt), confirm. Returns newAppId.",
+                hub_export_native_app: "Export a rule/app to its canonical JSON shape via Hubitat's first-party appCloner. Args: appId (alias sourceAppId), saveAs (opt File Manager filename). Returns the JSON content (and writes to File Manager if saveAs given).",
                 hub_import_native_app: "Create a new rule/app from a previously-exported JSON via Hubitat's first-party appCloner. Args: jsonContent | fromFile, parentHintAppId (existing rule under the target parent — used to seed the cloner), newName (opt), confirm. Returns newAppId.",
                 hub_get_rule_health: "Inspect a rule for broken state (label *BROKEN*, **Broken Trigger** markers, configPage errors, multiple-flag corruption). Args: appId. Returns {ok, issues, ...}. Auto-attached to hub_update_native_app responses too."
             ],
@@ -3315,11 +3315,12 @@ On failure, wizardStuck: true means the wizard could not be auto-cancelled -- ca
             inputSchema: [
                 type: "object",
                 properties: [
-                    sourceAppId: [type: "integer", description: "Installed-app ID of the rule/app to clone."],
+                    sourceAppId: [type: "integer", description: "Installed-app ID of the rule/app to clone. (alias: appId)"],
+                    appId: [type: "integer", description: "Alias for sourceAppId."],
                     newName: [type: "string", description: "Label for the new cloned app. If omitted, the cloner default ('<source-label> clone') is kept."],
                     confirm: [type: "boolean", description: "Must be true."]
                 ],
-                required: ["sourceAppId", "confirm"]
+                required: ["confirm"]
             ]
         ],
         [
@@ -3328,10 +3329,10 @@ On failure, wizardStuck: true means the wizard could not be auto-cancelled -- ca
             inputSchema: [
                 type: "object",
                 properties: [
-                    sourceAppId: [type: "integer", description: "Installed-app ID of the rule/app to export."],
+                    sourceAppId: [type: "integer", description: "Installed-app ID of the rule/app to export. (alias: appId)"],
+                    appId: [type: "integer", description: "Alias for sourceAppId."],
                     saveAs: [type: "string", description: "Optional File Manager filename (.json or .txt). When provided, the export is also written to /local/<saveAs>."]
-                ],
-                required: ["sourceAppId"]
+                ]
             ]
         ],
         [
@@ -9474,10 +9475,17 @@ def toolGetDeviceHistory(args) {
     if (!args.deviceId) {
         def locEvents
         try {
-            locEvents = location.eventsSince(sinceDate, [max: limit])
+            // Location history comes from the app-context getLocationEventsSince(Date)
+            // helper. The Location object itself has NO eventsSince(Date, Map)
+            // overload, so the old location.eventsSince(...) call always
+            // NoSuchMethod'd and this whole branch returned an error.
+            locEvents = getLocationEventsSince(sinceDate)
+            if (locEvents != null && limit && locEvents.size() > limit) {
+                locEvents = locEvents.take(limit)
+            }
         } catch (Exception e) {
-            mcpLog("warn", "monitoring", "location.eventsSince failed: ${e.message}")
-            return [error: "location.eventsSince not supported or failed: ${e.message}", source: "location"]
+            mcpLog("warn", "monitoring", "getLocationEventsSince failed: ${e.message}")
+            return [error: "Location event history unavailable: ${e.message}", source: "location"]
         }
 
         def locResults = locEvents?.collect { evt ->
@@ -24094,8 +24102,9 @@ private Integer _appClonerDiscoverNewChild(Integer parentAppId, Set<String> preC
 def toolCloneNativeApp(args) {
     requireBuiltinApp()
     requireHubAdminWrite(args?.confirm as Boolean)
-    if (args?.sourceAppId == null) throw new IllegalArgumentException("sourceAppId is required")
-    def sourceAppId = normalizeRuleId(args.sourceAppId)
+    def _srcRaw = (args?.sourceAppId != null) ? args.sourceAppId : args?.appId
+    if (_srcRaw == null) throw new IllegalArgumentException("sourceAppId (or appId) is required")
+    def sourceAppId = normalizeRuleId(_srcRaw)
     def newName = args?.newName?.toString()?.trim()
 
     def sourceCfg
@@ -24184,8 +24193,9 @@ def toolCloneNativeApp(args) {
  */
 def toolExportNativeApp(args) {
     requireBuiltinApp()
-    if (args?.sourceAppId == null) throw new IllegalArgumentException("sourceAppId is required")
-    def sourceAppId = normalizeRuleId(args.sourceAppId)
+    def _srcRaw = (args?.sourceAppId != null) ? args.sourceAppId : args?.appId
+    if (_srcRaw == null) throw new IllegalArgumentException("sourceAppId (or appId) is required")
+    def sourceAppId = normalizeRuleId(_srcRaw)
     def saveAs = args?.saveAs?.toString()?.trim()
 
     def sourceCfg

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1152,7 +1152,7 @@ def getGatewayConfig() {
                 hub_update_mcp_settings: "Update one or more of the MCP rule app's own settings (toggles, log level, tuning params). Args: settings (map of key→value), confirm=true. Allowlist-gated."
             ],
             searchHints: [
-                hub_update_mcp_settings: "self-admin developer mode toggle setting log level tuning loopGuard maxCapturedStates enableHubAdminRead enableBuiltinApp enableCustomRuleEngine ci automation"
+                hub_update_mcp_settings: "self-admin developer mode toggle setting log level tuning loopGuard maxCapturedStates enableHubAdminRead enableBuiltinApp enableCustomRuleEngine useGateways gateway mode consolidate flat tools ci automation"
             ]
         ],
         hub_read_devices: [
@@ -1939,7 +1939,7 @@ Verify rule after creation.""",
         ],
         [
             name: "hub_update_mcp_settings",
-            description: "Update one or more of the MCP rule app's own settings (toggles, log levels, tuning parameters). First tool under the Developer Mode self-administration surface — additional Developer Mode tools (device-access management, true Hub Variables namespace support, artifact cleanup) are planned as follow-ups under the same `enableDeveloperMode` gate.\n\nGated on `enableDeveloperMode` + requireHubAdminWrite + recent backup. Every successful write is logged at WARN level for audit.\n\nAllowlisted settings (intentionally conservative for v1): mcpLogLevel, debugLogging, maxCapturedStates, loopGuardMax, loopGuardWindowSec, enableHubAdminRead, enableBuiltinApp, enableCustomRuleEngine.\n\nExcluded from v1 allowlist (require future explicit security-model discussion): enableHubAdminWrite (footgun: would disable own write path mid-session), enableDeveloperMode (lockout protection — must remain UI-only to disable), selectedDevices (different wire format, will get its own tool).\n\nAfter changing any enable* toggle, MCP clients (Claude Code, etc.) may need to restart their connection to refresh the cached tool schema.",
+            description: "Update one or more of the MCP rule app's own settings (toggles, log levels, tuning parameters). First tool under the Developer Mode self-administration surface — additional Developer Mode tools (device-access management, true Hub Variables namespace support, artifact cleanup) are planned as follow-ups under the same `enableDeveloperMode` gate.\n\nGated on `enableDeveloperMode` + requireHubAdminWrite + recent backup. Every successful write is logged at WARN level for audit.\n\nAllowlisted settings (intentionally conservative for v1): mcpLogLevel, debugLogging, maxCapturedStates, loopGuardMax, loopGuardWindowSec, enableHubAdminRead, enableBuiltinApp, enableCustomRuleEngine, useGateways.\n\nExcluded from v1 allowlist (require future explicit security-model discussion): enableHubAdminWrite (footgun: would disable own write path mid-session), enableDeveloperMode (lockout protection — must remain UI-only to disable), selectedDevices (different wire format, will get its own tool).\n\nAfter changing any enable* toggle or useGateways, MCP clients (Claude Code, etc.) may need to restart their connection to refresh the cached tool schema.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -5936,6 +5936,9 @@ def toolUpdateMcpSettings(args) {
 
     // Allowlist of settings that can be modified via this tool, with their Hubitat input
     // type (matches the input "<key>", "<type>", ... declarations in the mainPage section).
+    // useGateways is allowlisted: it only reshapes tools/list (gateway vs flat) — same class
+    // as enableBuiltinApp/enableCustomRuleEngine, no write-path or lockout risk; clients must
+    // reconnect afterward to pick up the new tool surface.
     // Excluded:
     //   enableHubAdminWrite  — would footgun: could disable own write path mid-session
     //   enableDeveloperMode  — lockout protection (must remain UI-only to disable)
@@ -5948,7 +5951,8 @@ def toolUpdateMcpSettings(args) {
         "loopGuardWindowSec":     "number",
         "enableHubAdminRead":     "bool",
         "enableBuiltinApp":       "bool",
-        "enableCustomRuleEngine": "bool"
+        "enableCustomRuleEngine": "bool",
+        "useGateways":            "bool"
     ]
 
     // Validate, coerce, and stage each update. Validation is fully atomic — every key
@@ -6007,7 +6011,7 @@ def toolUpdateMcpSettings(args) {
     return [
         success: true,
         updated: updates,
-        message: "Updated ${updateCount} ${settingWord}. MCP clients (Claude Code, etc.) may need to reconnect to refresh cached tool schemas if you toggled an enable* flag."
+        message: "Updated ${updateCount} ${settingWord}. MCP clients (Claude Code, etc.) may need to reconnect to refresh cached tool schemas if you toggled an enable* flag or useGateways."
     ]
 }
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1037,7 +1037,7 @@ def getGatewayConfig() {
             description: "Health monitoring, diagnostics, and radio details: hub metrics, memory history, garbage collection, device health, radio info, Z-Wave repair, and state snapshots. (Custom-rule diagnostics: use hub_get_custom_rule with detailed=true.)",
             tools: ["hub_get_metrics", "hub_get_memory_history", "hub_call_gc", "hub_get_device_health", "hub_get_radio_details", "hub_call_zwave_repair", "hub_list_captured_states", "hub_delete_captured_state"],
             summaries: [
-                hub_get_metrics: "Record/retrieve hub metrics (memory, temp, DB) with CSV trend history. Args: recordSnapshot, trendPoints",
+                hub_get_metrics: "Get hub metrics (memory, temp, DB) with CSV trend history. Read-only by default; recordSnapshot=true also persists a snapshot. Args: recordSnapshot, trendPoints",
                 hub_get_memory_history: "Get free OS memory and CPU load history. Returns most recent entries with summary stats. Args: limit (default 100, 0 for all). Requires Hub Admin Read",
                 hub_call_gc: "Force JVM garbage collection to reclaim memory. Returns before/after free memory. Requires Hub Admin Read",
                 hub_get_device_health: "Check device staleness, ICMP-ping arbitrary IPs (router, NAS, server), and/or blink the hub identify-LED. Args: staleHours, includeHealthy, pingHosts (max 5 IPv4), pingCount (1-5), identifyHub",
@@ -1532,8 +1532,8 @@ def getToolDefinitions() {
     def hideByName = [] as Set
 
     if (!builtinAppOn) {
-        // All 13 of these tools require enableBuiltinApp.
-        //   hub_manage_native_rules_and_apps: ALL 12 sub-tools require it → that
+        // All 12 of these tools require enableBuiltinApp.
+        //   hub_manage_native_rules_and_apps: ALL 11 of its sub-tools require it → that
         //     gateway empties out and drops entirely.
         //   hub_read_apps_code: hub_list_device_dependents requires it; the
         //     others (hub_list_apps, hub_get_app_config, hub_list_app_pages) only need
@@ -1547,7 +1547,7 @@ def getToolDefinitions() {
     }
     if (customEngineMode == "off") {
         // Both toggles off: hide all custom_* tools everywhere they could appear
-        // (base tools in flat mode, sub-tools of hub_manage_rules and hub_manage_diagnostics
+        // (base tools in flat mode, sub-tools of hub_manage_custom_rules and hub_read_rules
         // in gateway mode).
         ["hub_get_custom_rule", "hub_create_custom_rule", "hub_update_custom_rule", "hub_delete_custom_rule", "hub_test_custom_rule", "hub_export_custom_rule", "hub_import_custom_rule", "hub_clone_custom_rule"].each {
             hideByName << it
@@ -24723,6 +24723,17 @@ def toolSearchTools(args) {
         if (score > 0) ranked << [index: idx, score: score]
     }
     ranked.sort { -it.score }
+    // Dedup by tool name: a tool listed in more than one gateway (multi-gateway
+    // membership) yields one corpus entry per membership and would otherwise
+    // occupy several result slots for the same tool. Keep the highest-scoring
+    // entry per tool (ranked is already sorted by descending score).
+    def seenSearchNames = [] as Set
+    ranked = ranked.findAll { r ->
+        def nm = visibleCorpus[r.index].name
+        if (seenSearchNames.contains(nm)) return false
+        seenSearchNames << nm
+        return true
+    }
     if (ranked.size() > maxResults) ranked = ranked.take(maxResults)
 
     def results = ranked.collect { r ->

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -5738,6 +5738,13 @@ def toolRemoveConnector(args) {
     }
 
     def deviceId = existing.deviceId
+    // Known Hubitat platform bug (confirmed 2026-06-02, fw 2.5.0.143, via Hubitat's
+    // own UI "Remove Device"): removing a variable-connector child makes Hubitat's
+    // BUILT-IN "Variable Connectors" parent driver recurse in childRemoved() and log
+    // a java.lang.StackOverflowError (the child's uninstalled() fires ~10x first).
+    // NOT ours -- the official Remove Device button triggers the identical crash, and
+    // the device is removed either way. We surface it in the response `note` so the
+    // logged error isn't mistaken for a hub_delete_connector failure.
     def res = toolDeleteDevice([deviceId: deviceId.toString(), confirm: true])
     if (res?.success != true) {
         throw new IllegalStateException(
@@ -5764,7 +5771,8 @@ def toolRemoveConnector(args) {
         name: name,
         deviceId: deviceId,
         deviceDeleted: true,
-        message: "Connector for '${name}' (deviceId=${deviceId}) removed. Variable itself is unchanged."
+        message: "Connector for '${name}' (deviceId=${deviceId}) removed. Variable itself is unchanged.",
+        note: "A java.lang.StackOverflowError from Hubitat's built-in 'Variable Connectors' driver (childRemoved) may appear in the hub log during this removal. It is a known Hubitat platform bug -- the same crash occurs via the UI's Remove Device button -- and is harmless: the connector is removed regardless."
     ]
 }
 

--- a/src/test/groovy/server/GatewayToggleSpec.groovy
+++ b/src/test/groovy/server/GatewayToggleSpec.groovy
@@ -25,9 +25,14 @@ class GatewayToggleSpec extends ToolSpecBase {
         !names.contains('hub_list_files')
         !names.contains('hub_get_logs')
 
-        and: 'core tools still appear'
-        names.contains('hub_list_devices')
-        names.contains('hub_get_device')
+        and: 'device + custom-rule tools are now proxied behind gateways, NOT top-level'
+        !names.contains('hub_list_devices')
+        !names.contains('hub_get_device')
+        !names.contains('hub_get_custom_rule')
+
+        and: 'flat (always top-level) tools still appear'
+        names.contains('hub_get_info')
+        names.contains('hub_get_hsm_status')
         names.contains('hub_search_tools')
     }
 
@@ -59,8 +64,8 @@ class GatewayToggleSpec extends ToolSpecBase {
         !names.contains('hub_manage_files')
         !names.contains('hub_manage_logs')
         !names.contains('hub_manage_diagnostics')
-        !names.contains('hub_manage_rules')
-        !names.contains('hub_manage_native_rules')
+        !names.contains('hub_manage_custom_rules')
+        !names.contains('hub_manage_native_rules_and_apps')
         !names.contains('hub_manage_mcp')
 
         and: 'every previously-proxied sub-tool is now top-level'
@@ -144,7 +149,7 @@ class GatewayToggleSpec extends ToolSpecBase {
             'hub_get_radio_details', 'hub_call_zwave_repair',
             'hub_list_captured_states', 'hub_delete_captured_state',
             'hub_list_files', 'hub_read_file', 'hub_write_file', 'hub_delete_file',
-            'hub_list_installed_apps', 'hub_list_device_dependents', 'hub_get_app_config', 'hub_list_app_pages',
+            'hub_list_device_dependents', 'hub_get_app_config', 'hub_list_app_pages',
             'hub_list_rules', 'hub_call_rule', 'hub_set_rule_paused', 'hub_set_rule_private_boolean',
             'hub_create_native_app', 'hub_update_native_app', 'hub_delete_native_app', 'hub_get_rule_health',
             'hub_update_mcp_settings'
@@ -210,11 +215,12 @@ class GatewayToggleSpec extends ToolSpecBase {
         then: 'built-in-app tools are removed from the flat catalog, not just from gateway entries'
         !names.contains('hub_list_rules')
         !names.contains('hub_create_native_app')
-        !names.contains('hub_list_installed_apps')
+        !names.contains('hub_list_device_dependents')
         !names.contains('hub_get_rule_health')
 
         and: 'tools that do not depend on enableBuiltinApp are still present'
         names.contains('hub_get_app_config')
+        names.contains('hub_list_apps')
         names.contains('hub_list_devices')
     }
 
@@ -255,7 +261,7 @@ class GatewayToggleSpec extends ToolSpecBase {
 
         when:
         def tools = script.getToolDefinitions()
-        def rulesAdmin = tools.find { it.name == 'hub_manage_rules' }
+        def rulesAdmin = tools.find { it.name == 'hub_manage_custom_rules' }
 
         then: 'gateway entry still appears (hub_test_custom_rule remains visible)'
         rulesAdmin != null
@@ -286,8 +292,8 @@ class GatewayToggleSpec extends ToolSpecBase {
         settingsMap.enableBuiltinApp = false
         settingsMap.enableCustomRuleEngine = false
 
-        when: 'every sub-tool of hub_manage_native_rules is hidden by enableBuiltinApp=false'
-        def result = script.executeTool('hub_manage_native_rules', [tool: 'hub_list_rules', args: [:]])
+        when: 'every sub-tool of hub_manage_native_rules_and_apps is hidden by enableBuiltinApp=false'
+        def result = script.executeTool('hub_manage_native_rules_and_apps', [tool: 'hub_list_rules', args: [:]])
 
         then: 'guard fires, hint does not name any of the hidden sub-tools'
         result.isError == true

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -73,13 +73,16 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         response.id == 2
         response.result.tools instanceof List
 
-        and: 'at least these well-known entries are in the catalog by name (non-gatewayed base tools + a gateway)'
+        and: 'at least these well-known entries are in the catalog by name (flat top-level tools + a gateway)'
         def names = response.result.tools*.name as Set
-        // hub_list_devices + hub_get_device are base tools (not behind a gateway) — getToolDefinitions
-        // at hubitat-mcp-server.groovy:717-744 folds gatewayed tools under a gateway entry
-        // instead of listing them individually.
-        names.contains('hub_list_devices')
-        names.contains('hub_get_device')
+        // hub_get_info + hub_get_hsm_status are flat (always top-level) tools — getToolDefinitions
+        // at hubitat-mcp-server.groovy folds gatewayed tools (device + custom-rule tools included)
+        // under a gateway entry instead of listing them individually, so device tools are NOT
+        // top-level in gateway mode.
+        names.contains('hub_get_info')
+        names.contains('hub_get_hsm_status')
+        // device tools now live behind the hub_read_devices / hub_manage_devices gateways.
+        !names.contains('hub_list_devices')
         // hub_manage_rooms is a gateway, so it appears by its gateway name, not its sub-tool names.
         names.contains('hub_manage_rooms')
 
@@ -111,9 +114,9 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         // A regression in applyDescriptionTransform / JsonOutput that stripped
         // the `annotations` key would silently undo the Read/Write split.
         response.result.tools.every { it.annotations?.readOnlyHint instanceof Boolean }
-        def listDevices = response.result.tools.find { it.name == 'hub_list_devices' }
-        listDevices.annotations.readOnlyHint == true
-        listDevices.annotations.containsKey('destructiveHint') == false
+        def getInfo = response.result.tools.find { it.name == 'hub_get_info' }
+        getInfo.annotations.readOnlyHint == true
+        getInfo.annotations.containsKey('destructiveHint') == false
         def manageDestructive = response.result.tools.find { it.name == 'hub_manage_destructive_ops' }
         manageDestructive.annotations.readOnlyHint == false
         manageDestructive.annotations.destructiveHint == true
@@ -144,7 +147,7 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         // loud -32603 envelope if the catalog exceeds the hub's 124,000-byte
         // cap -- avoids that footgun. Any client that DOES iterate nextCursor
         // simply finds none and terminates after one call. Note: cursor
-        // pagination on tools/call (hub_list_devices, hub_list_installed_apps, etc.
+        // pagination on tools/call (hub_list_devices, hub_list_apps, etc.
         // via _paginateList) is unchanged -- that is opt-in and remains.
         !response.result.containsKey('nextCursor')
 
@@ -159,7 +162,7 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
 
         and: 'feature-toggle-gated tools also surface (proves the envelope returns the full flat catalog, not just the cores)'
         names.contains('hub_list_rules')
-        names.contains('hub_list_installed_apps')
+        names.contains('hub_list_apps')
         names.contains('hub_create_custom_rule')
 
         and: 'no duplicate tool names in the response'
@@ -298,7 +301,7 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         given: 'a stubbed sub-tool (hub_get_app_config) that returns a huge config'
         settingsMap.enableBuiltinApp = true
         settingsMap.enableHubAdminRead = true
-        // useGateways=true so hub_manage_installed_apps actually dispatches (PR #187/#191's
+        // useGateways=true so hub_read_apps_code actually dispatches (PR #187/#191's
         // flat-mode matrix would otherwise short-circuit gateway calls with isError).
         settingsMap.useGateways = true
         // Build a hub_get_app_config response large enough to trip the wire-byte guard once
@@ -310,10 +313,10 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
             config: [logLevel: 'debug', maxEntries: 1000]
         ]
         settingsMap.mcpLogLevel = 'debug'
-        // Gateway-routed call: name=hub_manage_installed_apps, args carries tool+args.
+        // Gateway-routed call: name=hub_read_apps_code, args carries tool+args.
         mcpDriver.pushBody([
             jsonrpc: '2.0', id: 200, method: 'tools/call',
-            params: [name: 'hub_manage_installed_apps', arguments: [tool: 'hub_get_app_config', args: [appId: '99', includeSettings: true]]]
+            params: [name: 'hub_read_apps_code', arguments: [tool: 'hub_get_app_config', args: [appId: '99', includeSettings: true]]]
         ])
 
         when:
@@ -330,7 +333,7 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         and: 'debug-log details surface the gateway/sub-tool split for an operator running hub_get_debug_logs'
         def warn = (stateMap.debugLogs?.entries ?: []).find { it.message?.contains('response too large') }
         warn.details.tool == 'hub_get_app_config'
-        warn.details.gateway == 'hub_manage_installed_apps'
+        warn.details.gateway == 'hub_read_apps_code'
     }
 
     def "non-gateway caller passing a stray `tool` arg does NOT route the suggestion to the wrong tool"() {
@@ -421,7 +424,7 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         where:
         toolName              | expectedFragment
         'hub_list_devices'        | 'filter'
-        'hub_list_installed_apps' | 'cursor'
+        'hub_list_apps'           | 'cursor'
         'hub_get_app_config'      | 'includeSettings'
         'hub_get_device_health' | 'includeHealthy'
         'hub_get_memory_history'  | 'limit'

--- a/src/test/groovy/server/McpToolAnnotationsSpec.groovy
+++ b/src/test/groovy/server/McpToolAnnotationsSpec.groovy
@@ -147,7 +147,8 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         def tools = script.getToolDefinitions()
 
         then: 'gateways whose every sub-tool is in getReadOnlyToolNames()'
-        ['hub_read_apps_code'].each { gwName ->
+        ['hub_read_apps_code', 'hub_read_devices', 'hub_read_diagnostics', 'hub_read_files',
+         'hub_read_rooms', 'hub_read_rules', 'hub_read_variables'].each { gwName ->
             def gw = tools.find { it.name == gwName }
             assert gw != null : "${gwName} missing from gateway-mode catalog"
             assert gw.annotations.readOnlyHint == true : "${gwName} should be read-only"
@@ -171,10 +172,12 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
             'hub_manage_rooms',              // create/delete/rename + others
             'hub_manage_destructive_ops',// reboot/shutdown/hub_delete_device
             'hub_manage_code',          // install/update/delete code
+            'hub_manage_devices',            // hub_call_device_command, hub_update_device
             'hub_manage_logs',               // hub_delete_debug_logs, hub_set_log_level
             'hub_manage_diagnostics',        // hub_call_zwave_repair, hub_delete_captured_state
             'hub_manage_files',              // hub_write_file, hub_delete_file
             'hub_manage_native_rules_and_apps', // create/update/delete/run native rules
+            'hub_manage_rule_machine',       // hub_call_rule, set_rule_paused, set_rule_private_boolean
             'hub_manage_mcp'            // hub_update_mcp_settings
         ]
         writeGateways.each { gwName ->

--- a/src/test/groovy/server/McpToolAnnotationsSpec.groovy
+++ b/src/test/groovy/server/McpToolAnnotationsSpec.groovy
@@ -73,19 +73,19 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         // Sample from each category in getReadOnlyToolNames() -- full set lives in source.
         name << [
             'hub_list_devices', 'hub_get_device', 'hub_get_device_attribute',
-            'hub_get_custom_rule', 'hub_test_custom_rule', 'hub_export_custom_rule',
+            'hub_get_custom_rule', 'hub_test_custom_rule',
             'hub_get_info', 'hub_list_modes', 'hub_get_hsm_status',
             'hub_list_variables', 'hub_get_variable', 'hub_list_variable_changes',
             'hub_list_captured_states',
             'hub_get_debug_logs', 'hub_report_issue',
             'hub_get_logs', 'hub_list_device_events', 'hub_get_performance_stats',
-            'hub_get_radio_details', 'hub_get_device_health',
+            'hub_get_radio_details', 'hub_get_device_health', 'hub_get_metrics',
             'hub_list_apps', 'hub_get_source', 'hub_list_backups', 'hub_get_backup',
             'hub_list_rooms', 'hub_get_room',
             'hub_list_files', 'hub_read_file',
-            'hub_list_installed_apps', 'hub_get_app_config',
+            'hub_get_app_config',
             'hub_list_hpm_packages',
-            'hub_list_rules', 'hub_export_native_app', 'hub_get_rule_health',
+            'hub_list_rules', 'hub_get_rule_health',
             'hub_get_tool_guide'
         ]
     }
@@ -114,7 +114,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         name << [
             'hub_call_device_command',
             'hub_create_custom_rule', 'hub_update_custom_rule', 'hub_delete_custom_rule',
-            'hub_import_custom_rule', 'hub_clone_custom_rule',
+            'hub_import_custom_rule', 'hub_clone_custom_rule', 'hub_export_custom_rule',
             'hub_set_mode',
             'hub_set_variable', 'hub_create_variable', 'hub_delete_variable',
             'hub_create_connector', 'hub_delete_connector',
@@ -122,7 +122,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
             'hub_update_mcp_settings',
             'hub_delete_captured_state',
             'hub_delete_debug_logs',
-            'hub_create_backup', 'hub_call_gc', 'hub_get_metrics',
+            'hub_create_backup', 'hub_call_gc',
             'hub_reboot', 'hub_shutdown', 'hub_call_zwave_repair', 'hub_delete_device',
             'hub_manage_virtual_device', 'hub_update_device',
             'hub_create_room', 'hub_delete_room', 'hub_update_room',
@@ -133,7 +133,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
             'hub_write_file', 'hub_delete_file',
             'hub_call_rule', 'hub_set_rule_paused', 'hub_set_rule_private_boolean',
             'hub_create_native_app', 'hub_update_native_app', 'hub_clone_native_app',
-            'hub_import_native_app', 'hub_delete_native_app'
+            'hub_import_native_app', 'hub_delete_native_app', 'hub_export_native_app'
         ]
     }
 
@@ -147,7 +147,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         def tools = script.getToolDefinitions()
 
         then: 'gateways whose every sub-tool is in getReadOnlyToolNames()'
-        ['hub_manage_code_read', 'hub_manage_installed_apps', 'hub_manage_hpm'].each { gwName ->
+        ['hub_read_apps_code'].each { gwName ->
             def gw = tools.find { it.name == gwName }
             assert gw != null : "${gwName} missing from gateway-mode catalog"
             assert gw.annotations.readOnlyHint == true : "${gwName} should be read-only"
@@ -166,15 +166,15 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
 
         then: 'every gateway with at least one write sub-tool is write+destructive'
         def writeGateways = [
-            'hub_manage_rules',        // hub_delete_custom_rule + others
+            'hub_manage_custom_rules', // hub_delete_custom_rule + others
             'hub_manage_variables',      // set/create/delete + others
             'hub_manage_rooms',              // create/delete/rename + others
             'hub_manage_destructive_ops',// reboot/shutdown/hub_delete_device
-            'hub_manage_code_write',    // install/update/delete code
+            'hub_manage_code',          // install/update/delete code
             'hub_manage_logs',               // hub_delete_debug_logs, hub_set_log_level
             'hub_manage_diagnostics',        // hub_call_zwave_repair, hub_delete_captured_state
             'hub_manage_files',              // hub_write_file, hub_delete_file
-            'hub_manage_native_rules', // create/update/delete/run native rules
+            'hub_manage_native_rules_and_apps', // create/update/delete/run native rules
             'hub_manage_mcp'            // hub_update_mcp_settings
         ]
         writeGateways.each { gwName ->
@@ -306,23 +306,23 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
 
         def expectedReadOnly = [
             'hub_list_devices', 'hub_get_device', 'hub_get_device_attribute', 'hub_list_device_events',
-            'hub_get_custom_rule', 'hub_test_custom_rule', 'hub_export_custom_rule',
+            'hub_get_custom_rule', 'hub_test_custom_rule',
             'hub_get_info', 'hub_list_modes', 'hub_get_hsm_status', 'hub_get_update_status',
             'hub_list_variables', 'hub_get_variable', 'hub_list_variable_changes',
             'hub_list_captured_states',
             'hub_get_debug_logs', 'hub_report_issue',
             'hub_get_logs', 'hub_get_performance_stats',
             'hub_get_jobs', 'hub_get_memory_history',
-            'hub_get_radio_details', 'hub_get_device_health',
+            'hub_get_radio_details', 'hub_get_device_health', 'hub_get_metrics',
             'hub_list_apps', 'hub_list_drivers',
             'hub_get_source',
             'hub_list_backups', 'hub_get_backup',
             'hub_list_rooms', 'hub_get_room',
             'hub_list_files', 'hub_read_file',
-            'hub_list_installed_apps', 'hub_list_device_dependents', 'hub_get_app_config',
+            'hub_list_device_dependents', 'hub_get_app_config',
             'hub_list_app_pages',
             'hub_list_hpm_packages',
-            'hub_list_rules', 'hub_export_native_app', 'hub_get_rule_health',
+            'hub_list_rules', 'hub_get_rule_health',
             'hub_get_tool_guide'
             // hub_search_tools is in getReadOnlyToolNames() but suppressed in flat mode.
         ] as Set
@@ -330,7 +330,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         def expectedWrites = [
             'hub_call_device_command',
             'hub_create_custom_rule', 'hub_update_custom_rule', 'hub_delete_custom_rule',
-            'hub_import_custom_rule', 'hub_clone_custom_rule',
+            'hub_import_custom_rule', 'hub_clone_custom_rule', 'hub_export_custom_rule',
             'hub_set_mode',
             'hub_set_variable', 'hub_create_variable', 'hub_delete_variable',
             'hub_create_connector', 'hub_delete_connector',
@@ -340,7 +340,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
             'hub_delete_debug_logs', 'hub_set_log_level',
             'hub_create_backup',
             'hub_reboot', 'hub_shutdown', 'hub_call_zwave_repair', 'hub_delete_device',
-            'hub_call_gc', 'hub_get_metrics',
+            'hub_call_gc',
             'hub_manage_virtual_device', 'hub_update_device',
             'hub_create_room', 'hub_delete_room', 'hub_update_room',
             'hub_create_app', 'hub_create_driver', 'hub_update_app', 'hub_update_driver',
@@ -350,7 +350,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
             'hub_write_file', 'hub_delete_file',
             'hub_call_rule', 'hub_set_rule_paused', 'hub_set_rule_private_boolean',
             'hub_create_native_app', 'hub_update_native_app', 'hub_clone_native_app',
-            'hub_import_native_app', 'hub_delete_native_app'
+            'hub_import_native_app', 'hub_delete_native_app', 'hub_export_native_app'
         ] as Set
 
         then:

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -5,7 +5,7 @@ import support.TestChildApp
 import support.ToolSpecBase
 
 /**
- * Spec for the hub_manage_code_write gateway tools in hubitat-mcp-server.groovy:
+ * Spec for the hub_manage_code gateway tools in hubitat-mcp-server.groovy:
  *
  * - toolInstallApp          -> hub_create_app         (source|sourceFile; post-install verification)
  * - toolInstallDriver       -> hub_create_driver      (source|sourceFile; bulk installs[]; post-install verification)

--- a/src/test/groovy/server/ToolAppsDriversSpec.groovy
+++ b/src/test/groovy/server/ToolAppsDriversSpec.groovy
@@ -3,7 +3,7 @@ package server
 import support.ToolSpecBase
 
 /**
- * Spec for the hub_manage_code_read gateway tools in hubitat-mcp-server.groovy:
+ * Spec for the hub_read_apps_code gateway tools in hubitat-mcp-server.groovy:
  *
  * - toolListHubApps       -> hub_list_apps
  * - toolListHubDrivers    -> hub_list_drivers
@@ -50,7 +50,7 @@ class ToolAppsDriversSpec extends ToolSpecBase {
         settingsMap.useGateways = useGateways
 
         when:
-        def response = mcpDriver.callTool('hub_list_apps', [:])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'types'])
 
         then:
         response.error.code == -32602
@@ -86,7 +86,7 @@ class ToolAppsDriversSpec extends ToolSpecBase {
         }
 
         when:
-        def response = mcpDriver.callTool('hub_list_apps', [:])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'types'])
 
         then:
         response.error == null
@@ -122,7 +122,7 @@ class ToolAppsDriversSpec extends ToolSpecBase {
         hubGet.register('/hub2/userAppTypes') { params -> '<html>not json</html>' }
 
         when:
-        def response = mcpDriver.callTool('hub_list_apps', [:])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'types'])
 
         then:
         response.error == null
@@ -162,7 +162,7 @@ class ToolAppsDriversSpec extends ToolSpecBase {
         }
 
         when:
-        def response = mcpDriver.callTool('hub_list_apps', [:])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'types'])
 
         then:
         response.error == null

--- a/src/test/groovy/server/ToolGenerateBugReportSpec.groovy
+++ b/src/test/groovy/server/ToolGenerateBugReportSpec.groovy
@@ -249,13 +249,13 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         when:
         def result = script.toolGenerateBugReport(baseArgs([
             title       : longTitle,
-            failingTool : 'hub_manage_native_rules',
+            failingTool : 'hub_manage_native_rules_and_apps',
         ]))
 
         then:
         result.suggestedTitle.length() == 140
         result.suggestedTitle.endsWith('...')
-        result.suggestedTitle.startsWith('[bug] hub_manage_native_rules:')
+        result.suggestedTitle.startsWith('[bug] hub_manage_native_rules_and_apps:')
     }
 
     def "suggested title left untouched when under 140 chars"() {
@@ -279,13 +279,13 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         long anchor = 1_700_000_000_000L
         seedLogs([
             logEntry(timestamp: anchor - 500_000, level: 'error', details: [tool: 'other_tool'],                       message: 'unrelated_old_log'),
-            logEntry(timestamp: anchor,           level: 'error', details: [tool: 'hub_manage_native_rules'],     message: 'the_real_failure'),
-            logEntry(timestamp: anchor + 5_000,   level: 'warn',  details: [tool: 'hub_manage_native_rules'],     message: 'followup_warn'),
+            logEntry(timestamp: anchor,           level: 'error', details: [tool: 'hub_manage_native_rules_and_apps'],     message: 'the_real_failure'),
+            logEntry(timestamp: anchor + 5_000,   level: 'warn',  details: [tool: 'hub_manage_native_rules_and_apps'],     message: 'followup_warn'),
             logEntry(timestamp: anchor + 10_000,  level: 'error', details: [tool: 'different_tool'],                   message: 'noise_after'),
         ])
 
         when:
-        def result = script.toolGenerateBugReport(baseArgs([failingTool: 'hub_manage_native_rules']))
+        def result = script.toolGenerateBugReport(baseArgs([failingTool: 'hub_manage_native_rules_and_apps']))
 
         then:
         result.logs.scoped == true
@@ -388,7 +388,7 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         seedLogs([])
 
         when:
-        def result = script.toolGenerateBugReport(baseArgs([failingTool: 'hub_manage_native_rules']))
+        def result = script.toolGenerateBugReport(baseArgs([failingTool: 'hub_manage_native_rules_and_apps']))
 
         then: 'anchor is null (empty buffer), so fallback path is the unscoped lastN (which is also empty)'
         result.success == true
@@ -403,13 +403,13 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         sharedLocation.hub = new TestHub()
         long anchor = 1_700_000_000_000L
         seedLogs([
-            logEntry(timestamp: anchor,         level: 'error', details: [tool: 'hub_manage_native_rules'], message: 'real_failure'),
+            logEntry(timestamp: anchor,         level: 'error', details: [tool: 'hub_manage_native_rules_and_apps'], message: 'real_failure'),
             logEntry(timestamp: anchor + 5_000, level: 'error', details: [tool: 'different_tool'],               message: 'noise_after_real'),
         ])
 
         when:
         def result = script.toolGenerateBugReport(baseArgs([
-            failingTool                : 'hub_manage_native_rules',
+            failingTool                : 'hub_manage_native_rules_and_apps',
             includeUnrelatedRecentLogs : true,
         ]))
 
@@ -528,12 +528,12 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         given:
         sharedLocation.hub = new TestHub()
         seedLogs([
-            logEntry(timestamp: 1_700_000_000_000L, level: 'error', details: [tool: 'hub_manage_native_rules'], message: 'secret_message_in_log'),
+            logEntry(timestamp: 1_700_000_000_000L, level: 'error', details: [tool: 'hub_manage_native_rules_and_apps'], message: 'secret_message_in_log'),
         ])
 
         when:
         def result = script.toolGenerateBugReport(baseArgs([
-            failingTool : 'hub_manage_native_rules',
+            failingTool : 'hub_manage_native_rules_and_apps',
             privacyMode : 'public',
         ]))
 
@@ -550,12 +550,12 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         given:
         sharedLocation.hub = new TestHub()
         seedLogs([
-            logEntry(timestamp: 1_700_000_000_000L, level: 'error', details: [tool: 'hub_manage_native_rules'], message: 'shown_anyway_in_public_mode'),
+            logEntry(timestamp: 1_700_000_000_000L, level: 'error', details: [tool: 'hub_manage_native_rules_and_apps'], message: 'shown_anyway_in_public_mode'),
         ])
 
         when:
         def result = script.toolGenerateBugReport(baseArgs([
-            failingTool    : 'hub_manage_native_rules',
+            failingTool    : 'hub_manage_native_rules_and_apps',
             privacyMode    : 'public',
             includeRawLogs : true,
         ]))
@@ -636,13 +636,13 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         long anchor = 1_700_000_000_000L
         seedLogs([
             logEntry(timestamp: anchor - 500_000, level: 'error', details: [tool: 'other_tool'],                       message: 'unrelated_old_log'),
-            logEntry(timestamp: anchor,           level: 'error', details: [tool: 'hub_manage_native_rules'],     message: 'the_real_failure'),
-            logEntry(timestamp: anchor + 5_000,   level: 'warn',  details: [tool: 'hub_manage_native_rules'],     message: 'followup_warn'),
+            logEntry(timestamp: anchor,           level: 'error', details: [tool: 'hub_manage_native_rules_and_apps'],     message: 'the_real_failure'),
+            logEntry(timestamp: anchor + 5_000,   level: 'warn',  details: [tool: 'hub_manage_native_rules_and_apps'],     message: 'followup_warn'),
             logEntry(timestamp: anchor + 10_000,  level: 'error', details: [tool: 'different_tool'],                   message: 'noise_after'),
         ])
 
         when:
-        def response = mcpDriver.callTool('hub_report_issue', baseArgs([failingTool: 'hub_manage_native_rules']))
+        def response = mcpDriver.callTool('hub_report_issue', baseArgs([failingTool: 'hub_manage_native_rules_and_apps']))
 
         then:
         response.error == null
@@ -667,12 +667,12 @@ class ToolGenerateBugReportSpec extends ToolSpecBase {
         settingsMap.useGateways = useGateways
         sharedLocation.hub = new TestHub()
         seedLogs([
-            logEntry(timestamp: 1_700_000_000_000L, level: 'error', details: [tool: 'hub_manage_native_rules'], message: 'secret_message_in_log'),
+            logEntry(timestamp: 1_700_000_000_000L, level: 'error', details: [tool: 'hub_manage_native_rules_and_apps'], message: 'secret_message_in_log'),
         ])
 
         when:
         def response = mcpDriver.callTool('hub_report_issue', baseArgs([
-            failingTool : 'hub_manage_native_rules',
+            failingTool : 'hub_manage_native_rules_and_apps',
             privacyMode : 'public',
         ]))
 

--- a/src/test/groovy/server/ToolGetAppConfigSpec.groovy
+++ b/src/test/groovy/server/ToolGetAppConfigSpec.groovy
@@ -5,7 +5,7 @@ import support.ToolSpecBase
 
 /**
  * Spec for toolGetAppConfig (hubitat-mcp-server.groovy approx line 6232).
- * Gateway tool under hub_manage_installed_apps — executeTool() dispatches via case "hub_get_app_config".
+ * Gateway tool under hub_read_apps_code — executeTool() dispatches via case "hub_get_app_config".
  *
  * Covers:
  *  - Hub Admin Read gate (throws when disabled)

--- a/src/test/groovy/server/ToolGetDeviceInUseBySpec.groovy
+++ b/src/test/groovy/server/ToolGetDeviceInUseBySpec.groovy
@@ -5,7 +5,7 @@ import support.ToolSpecBase
 
 /**
  * Spec for toolGetDeviceInUseBy (hubitat-mcp-server.groovy approx line 7573).
- * Gateway: hub_manage_installed_apps -> hub_list_device_dependents.
+ * Gateway: hub_read_apps_code -> hub_list_device_dependents.
  *
  * Critical: PR-79-review fix tightened deviceId validation -- findDevice()
  * is called before any HTTP request, so unknown IDs throw
@@ -365,7 +365,7 @@ class ToolGetDeviceInUseBySpec extends ToolSpecBase {
         hubGet.register('/device/fullJson/10') { params -> responseJson }
 
         when:
-        def result = script.handleGateway('hub_manage_installed_apps', 'hub_list_device_dependents', [deviceId: '10'])
+        def result = script.handleGateway('hub_read_apps_code', 'hub_list_device_dependents', [deviceId: '10'])
 
         then:
         result.deviceId == '10'

--- a/src/test/groovy/server/ToolHpmReadonlySpec.groovy
+++ b/src/test/groovy/server/ToolHpmReadonlySpec.groovy
@@ -5,7 +5,7 @@ import support.ToolSpecBase
 
 /**
  * Spec for toolListHpmPackages and toolGetHpmDrift.
- * Gateway: hub_manage_hpm -> hub_list_hpm_packages (drift folds in via includeDrift=true,
+ * Gateway: hub_read_apps_code -> hub_list_hpm_packages (drift folds in via includeDrift=true,
  * which attaches the toolGetHpmDrift result under a `drift` key on the list response).
  *
  * HPM stores its tracked packages in state.manifests. The /installedapp/statusJson
@@ -66,7 +66,8 @@ class ToolHpmReadonlySpec extends ToolSpecBase {
     /**
      * /hub2/userAppTypes response: flat JSON array of code definitions.
      * Each entry has at minimum an id field. This is the Apps Code registry
-     * (what hub_list_apps uses), not the installed-instances tree in appsList.
+     * (what hub_list_apps with scope:"types" uses), not the installed-instances
+     * tree in appsList (hub_list_apps with scope:"instances").
      * Child-app templates appear here even with zero running instances.
      */
     private static String makeUserAppTypes(List<String> ids = []) {
@@ -2819,7 +2820,7 @@ class ToolHpmReadonlySpec extends ToolSpecBase {
     // Coverage gap: gateway dispatch regression
     // -------------------------------------------------------------------------
 
-    def "gateway dispatch: hub_manage_hpm(tool='hub_list_hpm_packages') produces same shape as direct toolListHpmPackages call"() {
+    def "gateway dispatch: hub_read_apps_code(tool='hub_list_hpm_packages') produces same shape as direct toolListHpmPackages call"() {
         given:
         settingsMap.useGateways = true  // gateway-name dispatch requires gateway mode on
         settingsMap.enableHubAdminRead = true
@@ -2828,7 +2829,7 @@ class ToolHpmReadonlySpec extends ToolSpecBase {
 
         when:
         def direct  = script.toolListHpmPackages([hpmAppId: "37"])
-        def gateway = script.executeTool('hub_manage_hpm', [tool: 'hub_list_hpm_packages', args: [hpmAppId: "37"]])
+        def gateway = script.executeTool('hub_read_apps_code', [tool: 'hub_list_hpm_packages', args: [hpmAppId: "37"]])
 
         then: 'both paths return success=true with deep structural equality'
         direct.success == true
@@ -2836,7 +2837,7 @@ class ToolHpmReadonlySpec extends ToolSpecBase {
         gateway == direct
     }
 
-    def "gateway dispatch: hub_manage_hpm(tool='hub_list_hpm_packages', includeDrift=true) nests drift block matching direct toolGetHpmDrift call"() {
+    def "gateway dispatch: hub_read_apps_code(tool='hub_list_hpm_packages', includeDrift=true) nests drift block matching direct toolGetHpmDrift call"() {
         given:
         settingsMap.useGateways = true  // gateway-name dispatch requires gateway mode on
         settingsMap.enableHubAdminRead = true
@@ -2858,7 +2859,7 @@ class ToolHpmReadonlySpec extends ToolSpecBase {
         // toolGetHpmDrift result under a `drift` key. The gateway's nested drift block must
         // deep-equal the direct toolGetHpmDrift call.
         def direct  = script.toolGetHpmDrift([hpmAppId: "37"])
-        def gateway = script.executeTool('hub_manage_hpm', [tool: 'hub_list_hpm_packages', args: [hpmAppId: "37", includeDrift: true]])
+        def gateway = script.executeTool('hub_read_apps_code', [tool: 'hub_list_hpm_packages', args: [hpmAppId: "37", includeDrift: true]])
 
         then: 'both paths return success=true; gateway nests the drift block under a `drift` key'
         direct.success == true
@@ -3000,7 +3001,7 @@ class ToolHpmReadonlySpec extends ToolSpecBase {
     // Parallel coverage exercising callTool() so the JSON-RPC envelope, gateway
     // routing toggles, and error mapping (IAE -> -32602, generic -> isError) are
     // verified end-to-end alongside the direct-call golden paths above. The
-    // direct-call tests (above) and the existing hub_manage_hpm gateway-shape tests
+    // direct-call tests (above) and the existing hub_read_apps_code gateway-shape tests
     // (line ~2821) already pin tool-result deep structure; these tests add the
     // missing JSON-RPC envelope + render(Map) pipeline coverage by routing the
     // same scenarios through mcpDriver.callTool().

--- a/src/test/groovy/server/ToolLibraryCodeSpec.groovy
+++ b/src/test/groovy/server/ToolLibraryCodeSpec.groovy
@@ -3,8 +3,8 @@ package server
 import support.ToolSpecBase
 
 /**
- * Spec for the library management tools in the hub_manage_code_read
- * (hub_get_source) and hub_manage_code_write (create/update/delete) gateways:
+ * Spec for the library management tools in the hub_read_apps_code
+ * (hub_get_source) and hub_manage_code (create/update/delete) gateways:
  *
  * - toolGetLibrarySource   -> hub_get_source (type:library)
  * - toolInstallLibrary     -> hub_create_library

--- a/src/test/groovy/server/ToolListAppPagesSpec.groovy
+++ b/src/test/groovy/server/ToolListAppPagesSpec.groovy
@@ -5,7 +5,7 @@ import support.ToolSpecBase
 
 /**
  * Spec for toolListAppPages (hubitat-mcp-server.groovy).
- * Gateway tool under hub_manage_installed_apps -- executeTool() dispatches via case "hub_list_app_pages".
+ * Gateway tool under hub_read_apps_code -- executeTool() dispatches via case "hub_list_app_pages".
  *
  * Covers:
  *  - Hub Admin Read gate (throws when disabled)

--- a/src/test/groovy/server/ToolListInstalledAppsSpec.groovy
+++ b/src/test/groovy/server/ToolListInstalledAppsSpec.groovy
@@ -5,7 +5,8 @@ import support.ToolSpecBase
 
 /**
  * Spec for toolListInstalledApps (hubitat-mcp-server.groovy approx line 7483).
- * Gateway: hub_manage_installed_apps -> hub_list_installed_apps.
+ * Tool: hub_list_apps with scope:"instances" (the merged-in former hub_list_installed_apps).
+ * Gateway: hub_read_apps_code -> hub_list_apps.
  *
  * Covers: gate-throw, golden path flattening with parentId wiring, the
  * includeHidden promotion logic, each filter value, invalid filter rejection,
@@ -34,13 +35,13 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch returns -32602 envelope when Built-in App Read is disabled (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch returns -32602 envelope when Built-in App Read is disabled (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = false
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [:])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances'])
 
         then:
         response.error.code == -32602
@@ -92,7 +93,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch flattens 2-level tree with parentId wiring (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch flattens 2-level tree with parentId wiring (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
@@ -110,7 +111,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         hubGet.register('/hub2/appsList') { params -> treeJson }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [filter: 'all'])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances', filter: 'all'])
 
         then:
         response.error == null
@@ -151,7 +152,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch filter=builtin returns only non-user apps (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch filter=builtin returns only non-user apps (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
@@ -164,7 +165,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         hubGet.register('/hub2/appsList') { params -> treeJson }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [filter: 'builtin'])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances', filter: 'builtin'])
 
         then:
         response.error == null
@@ -198,7 +199,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch filter=user returns only user apps (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch filter=user returns only user apps (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
@@ -211,7 +212,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         hubGet.register('/hub2/appsList') { params -> treeJson }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [filter: 'user'])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances', filter: 'user'])
 
         then:
         response.error == null
@@ -245,7 +246,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch filter=disabled returns only disabled apps (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch filter=disabled returns only disabled apps (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
@@ -258,7 +259,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         hubGet.register('/hub2/appsList') { params -> treeJson }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [filter: 'disabled'])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances', filter: 'disabled'])
 
         then:
         response.error == null
@@ -296,7 +297,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch filter=parents returns only apps with children (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch filter=parents returns only apps with children (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
@@ -313,7 +314,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         hubGet.register('/hub2/appsList') { params -> treeJson }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [filter: 'parents'])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances', filter: 'parents'])
 
         then:
         response.error == null
@@ -351,7 +352,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch filter=children returns only apps with parentId (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch filter=children returns only apps with parentId (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
@@ -368,7 +369,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         hubGet.register('/hub2/appsList') { params -> treeJson }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [filter: 'children'])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances', filter: 'children'])
 
         then:
         response.error == null
@@ -411,7 +412,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch excludes hidden parent and promotes child to root (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch excludes hidden parent and promotes child to root (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
@@ -428,7 +429,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         hubGet.register('/hub2/appsList') { params -> treeJson }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [filter: 'all'])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances', filter: 'all'])
 
         then:
         response.error == null
@@ -472,7 +473,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch promotes grandchildren past hidden middle ancestor (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch promotes grandchildren past hidden middle ancestor (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
@@ -490,7 +491,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [:])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances'])
 
         then:
         response.error == null
@@ -532,7 +533,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch includeHidden=true includes hidden parent (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch includeHidden=true includes hidden parent (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
@@ -549,7 +550,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         hubGet.register('/hub2/appsList') { params -> treeJson }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [filter: 'all', includeHidden: true])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances', filter: 'all', includeHidden: true])
 
         then:
         response.error == null
@@ -577,13 +578,13 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch returns -32602 envelope for invalid filter (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch returns -32602 envelope for invalid filter (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [filter: 'bogus'])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances', filter: 'bogus'])
 
         then:
         response.error.code == -32602
@@ -607,14 +608,14 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch returns success=false envelope when hub body is empty (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch returns success=false envelope when hub body is empty (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { params -> '' }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [:])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances'])
 
         then:
         response.error == null
@@ -641,14 +642,14 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_list_installed_apps via dispatch returns success=false envelope when hub body is non-JSON (useGateways=#useGateways)"() {
+    def "hub_list_apps scope=instances via dispatch returns success=false envelope when hub body is non-JSON (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableBuiltinApp = true
         hubGet.register('/hub2/appsList') { params -> 'not json at all' }
 
         when:
-        def response = mcpDriver.callTool('hub_list_installed_apps', [:])
+        def response = mcpDriver.callTool('hub_list_apps', [scope: 'instances'])
 
         then:
         response.error == null
@@ -751,7 +752,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         then:
         def ex = thrown(IllegalArgumentException)
         ex.message.toLowerCase().contains('cursor')
-        ex.message.contains('hub_list_installed_apps')
+        ex.message.contains('hub_list_apps')
     }
 
     def "negative cursor is rejected as out of range (matches PR #180 contract)"() {
@@ -862,7 +863,7 @@ class ToolListInstalledAppsSpec extends ToolSpecBase {
         }
 
         when:
-        def result = script.handleGateway('hub_manage_installed_apps', 'hub_list_installed_apps', [filter: 'all'])
+        def result = script.handleGateway('hub_read_apps_code', 'hub_list_apps', [scope: 'instances', filter: 'all'])
 
         then:
         result.apps instanceof List

--- a/src/test/groovy/server/ToolListRmRulesSpec.groovy
+++ b/src/test/groovy/server/ToolListRmRulesSpec.groovy
@@ -5,7 +5,7 @@ import support.ToolSpecBase
 
 /**
  * Spec for toolListRmRules (hubitat-mcp-server.groovy approx line 7644).
- * Gateway: hub_manage_native_rules -> hub_list_rules.
+ * Gateway: hub_manage_native_rules_and_apps -> hub_list_rules.
  *
  * Covers: gate-throw, RM 5.x Map shape with Integer key coercion, RM 4.x
  * explicit-fields shape, dedup when same id in both, the "both-absent quiet
@@ -669,7 +669,7 @@ class ToolListRmRulesSpec extends ToolSpecBase {
         rmUtils.stubRuleList5 = [[10: 'Test Rule']]
 
         when:
-        def result = script.handleGateway('hub_manage_native_rules', 'hub_list_rules', [:])
+        def result = script.handleGateway('hub_manage_native_rules_and_apps', 'hub_list_rules', [:])
 
         then:
         result.rules instanceof List

--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -89,8 +89,8 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
             uploaded[fileName] = new String(content, 'UTF-8')
         }
 
-        when:
-        def result = script.toolGetHubPerformance([:])
+        when: 'recordSnapshot=true exercises the CSV-recording path (default is read-only now)'
+        def result = script.toolGetHubPerformance([recordSnapshot: true])
 
         then:
         result.current.freeMemoryKB == '123456'
@@ -118,8 +118,8 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         script.metaClass.downloadHubFile = { String fileName -> null }
         script.metaClass.uploadHubFile = { String fileName, byte[] content -> }
 
-        when:
-        def response = mcpDriver.callTool('hub_get_metrics', [:])
+        when: 'recordSnapshot=true exercises the CSV-recording dispatch path (default is read-only now)'
+        def response = mcpDriver.callTool('hub_get_metrics', [recordSnapshot: true])
 
         then:
         response.error == null
@@ -128,6 +128,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         inner.current.freeMemoryKB == '123456'
         inner.current.internalTempC == '45.5'
         inner.current.uptimeFormatted == '2d 0h 0m'
+        inner.trendPointsAvailable == 1
 
         where:
         useGateways << [true, false]
@@ -506,7 +507,7 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         page1.staleDevices.size() == 100
         page1.nextCursor == '100'
 
-        and: 'top-level total mirrors hub_list_installed_apps so paginating clients read the same shape across tools'
+        and: 'top-level total mirrors hub_list_apps so paginating clients read the same shape across tools'
         page1.total == 150
 
         when: 'second page (cursor=100)'

--- a/src/test/groovy/server/ToolManageLogsSpec.groovy
+++ b/src/test/groovy/server/ToolManageLogsSpec.groovy
@@ -255,28 +255,21 @@ class ToolManageLogsSpec extends ToolSpecBase {
 
     // -------- toolGetDeviceHistory --------
 
-    def "hub_list_device_events returns location events when deviceId is omitted"() {
-        given: 'location.eventsSince stubbed to return mode + HSM + hub-variable events'
-        def fixedDate = new Date(1234567880000L)
-        def capturedSince = null
-        def capturedOpts = null
-        sharedLocation.metaClass.eventsSince = { Date since, Map opts ->
-            capturedSince = since
-            capturedOpts = opts
-            [
-                [name: 'mode',        value: 'Night',  unit: null, descriptionText: 'Mode changed to Night', date: fixedDate, isStateChange: true],
-                [name: 'hsmStatus',   value: 'armedAway', unit: null, descriptionText: 'HSM armed away',     date: fixedDate, isStateChange: true],
-                [name: 'guestCount',  value: '3',     unit: null, descriptionText: 'hub variable updated',   date: fixedDate, isStateChange: true]
-            ]
+    def "hub_list_device_events returns location events when deviceId is omitted (reads /logs/eventsJson)"() {
+        given: '/logs/eventsJson stubbed with mode + HSM + hub-variable rows (real wire shape)'
+        hubGet.register('/logs/eventsJson') { params ->
+            '''[
+              {"name":"mode","value":"Night","unit":null,"descriptionText":"Mode changed to Night","isStateChange":true,"type":"API","date":"2026-06-02T20:19:00.073-0400"},
+              {"name":"hsmStatus","value":"armedAway","unit":null,"descriptionText":"HSM armed away","isStateChange":true,"type":"API","date":"2026-06-02T20:18:00.000-0400"},
+              {"name":"variable:guestCount","value":"3","unit":null,"descriptionText":"hub variable updated","isStateChange":true,"type":"HUB_VARIABLE_SET","date":"2026-06-02T20:17:00.000-0400"}
+            ]'''
         }
 
         when:
         def result = script.toolGetDeviceHistory([hoursBack: 6, limit: 25])
 
-        then: 'location.eventsSince receives the hoursBack-derived sinceDate and opts.max'
-        capturedSince != null
-        capturedSince.time == 1234567890000L - (6 * 3600000L)
-        capturedOpts == [max: 25]
+        then: 'it reads the same endpoint the hub Logs page uses'
+        hubGet.calls.any { it.path == '/logs/eventsJson' }
 
         and:
         result.source == 'location'
@@ -284,22 +277,19 @@ class ToolManageLogsSpec extends ToolSpecBase {
         !result.containsKey('deviceId')
         result.hoursBack == 6
         result.count == 3
-        result.events*.name == ['mode', 'hsmStatus', 'guestCount']
+        result.events*.name == ['mode', 'hsmStatus', 'variable:guestCount']
         result.events[0].value == 'Night'
-
-        cleanup:
-        sharedLocation.metaClass = null
+        result.events[0].description == 'Mode changed to Night'
     }
 
     def "hub_list_device_events applies attribute filter to location events"() {
         given:
-        def fixedDate = new Date(1234567880000L)
-        sharedLocation.metaClass.eventsSince = { Date since, Map opts ->
-            [
-                [name: 'mode',      value: 'Night',  date: fixedDate, isStateChange: true],
-                [name: 'hsmStatus', value: 'armedAway', date: fixedDate, isStateChange: true],
-                [name: 'mode',      value: 'Day',   date: fixedDate, isStateChange: true]
-            ]
+        hubGet.register('/logs/eventsJson') { params ->
+            '''[
+              {"name":"mode","value":"Night","descriptionText":"m1","isStateChange":true,"type":"API","date":"2026-06-02T20:19:00.000-0400"},
+              {"name":"hsmStatus","value":"armedAway","descriptionText":"h1","isStateChange":true,"type":"API","date":"2026-06-02T20:18:00.000-0400"},
+              {"name":"mode","value":"Day","descriptionText":"m2","isStateChange":true,"type":"API","date":"2026-06-02T20:17:00.000-0400"}
+            ]'''
         }
 
         when:
@@ -310,14 +300,11 @@ class ToolManageLogsSpec extends ToolSpecBase {
         result.attributeFilter == 'mode'
         result.count == 2
         result.events.every { it.name == 'mode' }
-
-        cleanup:
-        sharedLocation.metaClass = null
     }
 
-    def "hub_list_device_events returns an error map when location.eventsSince throws"() {
+    def "hub_list_device_events returns an error map when /logs/eventsJson fetch fails"() {
         given:
-        sharedLocation.metaClass.eventsSince = { Date since, Map opts ->
+        hubGet.register('/logs/eventsJson') { params ->
             throw new RuntimeException('location event store unavailable')
         }
 
@@ -328,9 +315,6 @@ class ToolManageLogsSpec extends ToolSpecBase {
         result.source == 'location'
         result.error.contains('failed')
         result.error.contains('location event store unavailable')
-
-        cleanup:
-        sharedLocation.metaClass = null
     }
 
     def "hub_list_device_events throws when device is not found"() {

--- a/src/test/groovy/server/ToolPauseRmRuleSpec.groovy
+++ b/src/test/groovy/server/ToolPauseRmRuleSpec.groovy
@@ -6,7 +6,7 @@ import support.ToolSpecBase
 /**
  * Spec for toolSetRulePaused with value=true (the pause half of the merged
  * verb-pair tool; former pause_rm_rule).
- * Gateway: hub_manage_native_rules -> hub_set_rule_paused.
+ * Gateway: hub_manage_native_rules_and_apps -> hub_set_rule_paused.
  *
  * Covers: gate-throw, missing ruleId, golden-path pauseRule dispatch,
  * and String ruleId coercion.
@@ -184,7 +184,7 @@ class ToolPauseRmRuleSpec extends ToolSpecBase {
         settingsMap.enableBuiltinApp = true
 
         when:
-        def result = script.handleGateway('hub_manage_native_rules', 'hub_set_rule_paused', [ruleId: 500, value: true])
+        def result = script.handleGateway('hub_manage_native_rules_and_apps', 'hub_set_rule_paused', [ruleId: 500, value: true])
 
         then:
         result.success == true

--- a/src/test/groovy/server/ToolResumeRmRuleSpec.groovy
+++ b/src/test/groovy/server/ToolResumeRmRuleSpec.groovy
@@ -5,7 +5,7 @@ import support.ToolSpecBase
 
 /**
  * Spec for toolSetRulePaused resume path (value:false).
- * Gateway: hub_manage_native_rules -> hub_set_rule_paused.
+ * Gateway: hub_manage_native_rules_and_apps -> hub_set_rule_paused.
  *
  * Covers: gate-throw, missing ruleId, golden-path resumeRule dispatch,
  * and String ruleId coercion.
@@ -183,7 +183,7 @@ class ToolResumeRmRuleSpec extends ToolSpecBase {
         settingsMap.enableBuiltinApp = true
 
         when:
-        def result = script.handleGateway('hub_manage_native_rules', 'hub_set_rule_paused', [ruleId: 700, value: false])
+        def result = script.handleGateway('hub_manage_native_rules_and_apps', 'hub_set_rule_paused', [ruleId: 700, value: false])
 
         then:
         result.success == true

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -12,9 +12,9 @@ import spock.lang.Shared
  *   toolUpdateRmRule          -> update_rm_rule
  *   toolDeleteRmRule          -> delete_rm_rule
  *
- * Reading is via the existing hub_get_app_config (hub_manage_installed_apps gateway).
+ * Reading is via the existing hub_get_app_config (hub_read_apps_code gateway).
  * Backup enumeration + restore is via the existing hub_list_backups +
- * hub_restore_backup (hub_manage_code_read gateway) — rule snapshots use
+ * hub_restore_backup (hub_read_apps_code gateway) — rule snapshots use
  * type="rm-rule" and hub_restore_backup dispatches them through the private
  * _rmRestoreFromBackup helper. The cross-tool restore path is exercised
  * here too to guard the dispatch + replay shape.
@@ -4191,7 +4191,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == true
@@ -4207,7 +4207,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == false
@@ -4248,7 +4248,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == false
@@ -4272,7 +4272,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == false
@@ -4291,7 +4291,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == false
@@ -4310,7 +4310,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == false
@@ -4331,7 +4331,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == false
@@ -4355,7 +4355,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == true
@@ -4378,7 +4378,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == true
@@ -4397,7 +4397,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100, settings) }
 
         when:
-        def result = script.handleGateway("hub_manage_native_rules", "hub_get_rule_health", [appId: 100])
+        def result = script.handleGateway("hub_manage_native_rules_and_apps", "hub_get_rule_health", [appId: 100])
 
         then:
         result.ok == true
@@ -5133,7 +5133,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
         // All 8 custom_* renames split across dispatch paths:
         //   - executeTool top-level switch: every custom_* has a case there
-        //   - hub_manage_rules gateway:    delete/test/export/import/clone
+        //   - hub_manage_custom_rules gateway:    delete/test/export/import/clone
         // (list + diagnostics folded into hub_get_custom_rule; diagnostics now
         //  ride hub_get_custom_rule with detailed=true, not a hub_manage_diagnostics
         //  sub-tool.)
@@ -5155,11 +5155,11 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             catch (Exception ignored) { return null }
         }
 
-        // hub_manage_rules gateway lists 5 tools — verify gateway routes them.
+        // hub_manage_custom_rules gateway lists 5 tools — verify gateway routes them.
         def rulesAdminTools = ["hub_delete_custom_rule", "hub_test_custom_rule",
                                "hub_export_custom_rule", "hub_import_custom_rule", "hub_clone_custom_rule"]
         def rulesAdminErrors = rulesAdminTools.collect { name ->
-            try { script.handleGateway("hub_manage_rules", name, [:]); return null }
+            try { script.handleGateway("hub_manage_custom_rules", name, [:]); return null }
             catch (IllegalArgumentException e) { return e.message }
             catch (Exception ignored) { return null }
         }
@@ -5167,8 +5167,8 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         then: "no top-level dispatch returns 'Unknown tool: custom_*' for any of the 8 renames"
         topLevelErrors.every { msg -> msg == null || !msg.contains("Unknown tool") }
 
-        and: "no hub_manage_rules gateway dispatch returns 'Unknown tool ... in hub_manage_rules'"
-        rulesAdminErrors.every { msg -> msg == null || !(msg.contains("Unknown tool") && msg.contains("hub_manage_rules")) }
+        and: "no hub_manage_custom_rules gateway dispatch returns 'Unknown tool ... in hub_manage_custom_rules'"
+        rulesAdminErrors.every { msg -> msg == null || !(msg.contains("Unknown tool") && msg.contains("hub_manage_custom_rules")) }
     }
 
     // ---------- addTrigger/addAction discover mode ----------
@@ -9767,7 +9767,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
     def "hub_get_custom_rule (list mode) includes source: mcp_custom_engine on every rule"() {
         // The source marker lets LLMs distinguish MCP-managed rules from
-        // native RM rules (hub_list_rules / hub_manage_native_rules).
+        // native RM rules (hub_list_rules / hub_manage_native_rules_and_apps).
         given:
         settingsMap.enableCustomRuleEngine = true
         def app1 = new support.TestChildApp(id: 11L, label: "Rule One")
@@ -9833,7 +9833,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         def ex = thrown(IllegalArgumentException)
         ex.message.contains("read-only mode")
         ex.message.contains("triggers")
-        ex.message.contains("hub_manage_native_rules")
+        ex.message.contains("hub_manage_native_rules_and_apps")
     }
 
     // ---------- runCommand parameter slot-allocation fix ----------
@@ -10168,7 +10168,7 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         then: "write tool blocked with read-only mode message"
         def ex = thrown(IllegalArgumentException)
         ex.message.contains("read-only mode")
-        ex.message.contains("hub_manage_native_rules")
+        ex.message.contains("hub_manage_native_rules_and_apps")
     }
 
     def "hub_search_tools filters write custom_* tools in readonly mode"() {

--- a/src/test/groovy/server/ToolRulesAdminSpec.groovy
+++ b/src/test/groovy/server/ToolRulesAdminSpec.groovy
@@ -5,7 +5,7 @@ import support.TestDevice
 import support.ToolSpecBase
 
 /**
- * Spec for the hub_manage_rules gateway tools in hubitat-mcp-server.groovy:
+ * Spec for the hub_manage_custom_rules gateway tools in hubitat-mcp-server.groovy:
  *
  * - toolDeleteRule -> delete_rule
  * - toolTestRule   -> test_rule
@@ -70,6 +70,10 @@ class ToolRulesAdminSpec extends ToolSpecBase {
         ]
         childAppsList << childApp
 
+        and: 'hub_export_custom_rule now always persists the export to File Manager — capture the write'
+        def savedName = null
+        script.metaClass.uploadHubFile = { String name, byte[] content -> savedName = name }
+
         when:
         def result = script.toolExportRule([ruleId: '7'])
 
@@ -82,9 +86,16 @@ class ToolRulesAdminSpec extends ToolSpecBase {
         result.rule.actions[0].type == 'delay'
         result.deviceManifest == []
         result.exportedAt != null
+
+        and: 'the export was written to the hub File Manager and reported back'
+        savedName != null
+        result.savedToFile == savedName
     }
 
     def "export_rule throws when ruleId is missing"() {
+        given:
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+
         when:
         script.toolExportRule([:])
 
@@ -94,6 +105,9 @@ class ToolRulesAdminSpec extends ToolSpecBase {
     }
 
     def "export_rule throws when rule id is unknown"() {
+        given:
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+
         when:
         script.toolExportRule([ruleId: '404'])
 
@@ -208,6 +222,9 @@ class ToolRulesAdminSpec extends ToolSpecBase {
         def cloned = new TestChildApp(id: 6L, label: 'Copy of Original Rule')
         mockChildAppForCreate = cloned
 
+        and: 'clone exports internally, which now persists to File Manager'
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+
         when:
         def result = script.toolCloneRule([ruleId: '5'])
 
@@ -247,6 +264,9 @@ class ToolRulesAdminSpec extends ToolSpecBase {
 
         and:
         mockChildAppForCreate = new TestChildApp(id: 21L, label: 'Morning Backup Check')
+
+        and: 'clone exports internally, which now persists to File Manager'
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
 
         when:
         def result = script.toolCloneRule([ruleId: '20', name: '  Morning Backup Check  '])
@@ -367,7 +387,7 @@ class ToolRulesAdminSpec extends ToolSpecBase {
     // Parallel coverage exercising callTool() so the JSON-RPC envelope, gateway
     // routing toggles, and error mapping (IAE -> -32602, generic -> isError) are
     // verified end-to-end alongside the direct-call golden paths above. The
-    // tools live under the hub_manage_rules gateway; their dispatch names are
+    // tools live under the hub_manage_custom_rules gateway; their dispatch names are
     // custom_* (hub_test_custom_rule, hub_export_custom_rule, hub_import_custom_rule,
     // hub_clone_custom_rule, hub_delete_custom_rule) per the gateway config at
     // hubitat-mcp-server.groovy:761.
@@ -430,6 +450,8 @@ class ToolRulesAdminSpec extends ToolSpecBase {
             localVariables: [:]
         ]
         childAppsList << childApp
+        // hub_export_custom_rule now always persists the export to File Manager.
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
 
         when:
         def response = mcpDriver.callTool('hub_export_custom_rule', [ruleId: '7'])
@@ -441,6 +463,7 @@ class ToolRulesAdminSpec extends ToolSpecBase {
         inner.exportVersion == '1.0'
         inner.rule.name == 'Sunset Lights'
         inner.deviceManifest == []
+        inner.savedToFile != null
 
         where:
         useGateways << [true, false]
@@ -451,6 +474,7 @@ class ToolRulesAdminSpec extends ToolSpecBase {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableCustomRuleEngine = true
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
 
         when:
         def response = mcpDriver.callTool('hub_export_custom_rule', [:])
@@ -468,6 +492,7 @@ class ToolRulesAdminSpec extends ToolSpecBase {
         given:
         settingsMap.useGateways = useGateways
         settingsMap.enableCustomRuleEngine = true
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
 
         when:
         def response = mcpDriver.callTool('hub_export_custom_rule', [ruleId: '404'])
@@ -565,6 +590,8 @@ class ToolRulesAdminSpec extends ToolSpecBase {
         childAppsList << source
         def cloned = new TestChildApp(id: 6L, label: 'Copy of Original Rule')
         mockChildAppForCreate = cloned
+        // clone exports internally, which now persists to File Manager
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
 
         when:
         def response = mcpDriver.callTool('hub_clone_custom_rule', [ruleId: '5'])

--- a/src/test/groovy/server/ToolRunRmRuleSpec.groovy
+++ b/src/test/groovy/server/ToolRunRmRuleSpec.groovy
@@ -6,7 +6,7 @@ import support.ToolSpecBase
 
 /**
  * Spec for toolRunRmRule (hubitat-mcp-server.groovy approx line 7788).
- * Gateway: hub_manage_native_rules -> hub_call_rule.
+ * Gateway: hub_manage_native_rules_and_apps -> hub_call_rule.
  *
  * Covers: gate-throw, missing ruleId, action-to-rmAction mapping (rule/actions
  * via RMUtils; stop/start via the stopRule button toggle because RMUtils has
@@ -484,7 +484,7 @@ class ToolRunRmRuleSpec extends ToolSpecBase {
         settingsMap.enableBuiltinApp = true
 
         when:
-        def result = script.handleGateway('hub_manage_native_rules', 'hub_call_rule', [ruleId: 300, action: 'rule'])
+        def result = script.handleGateway('hub_manage_native_rules_and_apps', 'hub_call_rule', [ruleId: 300, action: 'rule'])
 
         then:
         result.success == true

--- a/src/test/groovy/server/ToolSetRmRuleBooleanSpec.groovy
+++ b/src/test/groovy/server/ToolSetRmRuleBooleanSpec.groovy
@@ -5,7 +5,7 @@ import support.ToolSpecBase
 
 /**
  * Spec for toolSetRmRuleBoolean (hubitat-mcp-server.groovy approx line 7837).
- * Gateway: hub_manage_native_rules -> hub_set_rule_private_boolean.
+ * Gateway: hub_manage_native_rules_and_apps -> hub_set_rule_private_boolean.
  *
  * Load-bearing: strict coercion policy. Accepts ONLY Boolean true/false OR
  * the lowercase strings "true"/"false". All other truthy-looking values
@@ -363,7 +363,7 @@ class ToolSetRmRuleBooleanSpec extends ToolSpecBase {
         settingsMap.enableBuiltinApp = true
 
         when:
-        def result = script.handleGateway('hub_manage_native_rules', 'hub_set_rule_private_boolean', [ruleId: 900, value: true])
+        def result = script.handleGateway('hub_manage_native_rules_and_apps', 'hub_set_rule_private_boolean', [ruleId: 900, value: true])
 
         then:
         result.success == true

--- a/src/test/groovy/server/ToolUpdateMcpSettingsSpec.groovy
+++ b/src/test/groovy/server/ToolUpdateMcpSettingsSpec.groovy
@@ -276,6 +276,42 @@ class ToolUpdateMcpSettingsSpec extends ToolSpecBase {
         sharedAppStub.settingsStore['maxCapturedStates'] == [type: 'number', value: 50]
     }
 
+    // -------- Golden path: useGateways (gateway-mode self-switch) --------
+
+    def "writes useGateways toggle — gateway-mode self-switch is allowlisted (dev-mode gated)"() {
+        given:
+        enableDeveloperModeAndAdminWrite()
+
+        when: 'the agent switches the server into gateway mode via its own self-admin tool'
+        def result = script.toolUpdateMcpSettings([
+            settings: [useGateways: true],
+            confirm: true
+        ])
+
+        then:
+        result.success == true
+        result.updated == [useGateways: true]
+        sharedAppStub.settingsStore['useGateways'] == [type: 'bool', value: true]
+
+        and: 'message still steers the client to reconnect — the tools/list shape just changed'
+        result.message.contains('reconnect')
+    }
+
+    def "coerces useGateways string 'false' to native false — turning gateway mode OFF must not stay truthy"() {
+        given: 'a CI/curl client sends the string "false" to flatten the tool surface'
+        enableDeveloperModeAndAdminWrite()
+
+        when:
+        def result = script.toolUpdateMcpSettings([
+            settings: [useGateways: 'false'],
+            confirm: true
+        ])
+
+        then: 'string "false" coerces to native false, not Groovy-truthy "false"'
+        result.success == true
+        sharedAppStub.settingsStore['useGateways'] == [type: 'bool', value: false]
+    }
+
     // -------- Golden path: mcpLogLevel delegates to toolSetLogLevel --------
 
     def "mcpLogLevel updates state.debugLogs.config AND settings (via toolSetLogLevel delegation)"() {

--- a/src/test/groovy/server/UpdateNativeAppSchemaTrimSpec.groovy
+++ b/src/test/groovy/server/UpdateNativeAppSchemaTrimSpec.groovy
@@ -109,7 +109,7 @@ class UpdateNativeAppSchemaTrimSpec extends ToolSpecBase {
 
         and: 'gateway-catalog response from handleGateway (no toolName) -- this is where gateway-mode callers see full descriptions'
         settingsMap.useGateways = true
-        def gatewayResp = script.handleGateway('hub_manage_native_rules', null, [:])
+        def gatewayResp = script.handleGateway('hub_manage_native_rules_and_apps', null, [:])
         def gwUpdateNative = gatewayResp.tools.find { it.name == 'hub_update_native_app' }
         def gwBytes = JsonOutput.toJson(gwUpdateNative).getBytes('UTF-8').length
 
@@ -150,7 +150,7 @@ class UpdateNativeAppSchemaTrimSpec extends ToolSpecBase {
         enableEveryToggle()
 
         when: 'gateway-catalog disclosure (caller invokes the gateway with no toolName)'
-        def gatewayResp = script.handleGateway('hub_manage_native_rules', null, [:])
+        def gatewayResp = script.handleGateway('hub_manage_native_rules_and_apps', null, [:])
         def updateNative = gatewayResp.tools.find { it.name == 'hub_update_native_app' }
         def addTrigger = updateNative.inputSchema.properties.addTrigger.description
         def addAction = updateNative.inputSchema.properties.addAction.description
@@ -516,7 +516,7 @@ class UpdateNativeAppSchemaTrimSpec extends ToolSpecBase {
         enableEveryToggle()
 
         when:
-        def result = script.handleGateway('hub_manage_native_rules', 'hub_update_native_app', [:])
+        def result = script.handleGateway('hub_manage_native_rules_and_apps', 'hub_update_native_app', [:])
 
         then: 'pre-validation surfaces a structured error envelope'
         result instanceof Map

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -2656,6 +2656,18 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 
 **Expected**: Both calls return success. The `message` field on each response contains "MCP clients ... may need to reconnect to refresh cached tool schemas". AI surfaces this hint to the user explaining that tools/list won't reflect the toggle until the client reconnects.
 
+### T223b — hub_update_mcp_settings flips useGateways (gateway-mode self-switch)
+
+```json
+{
+  "setup_prompt": "Developer Mode is enabled, Hub Admin Write is enabled, recent backup exists. Note whether the server is currently in gateway mode or flat mode (useGateways).",
+  "test_prompt": "Use hub_update_mcp_settings to flip useGateways to the OPPOSITE of its current value. Report the response message, then explain what the user must do for the new tool surface to take effect.",
+  "teardown_prompt": "Use hub_update_mcp_settings to set useGateways back to its original value, then reconnect (/mcp refresh) so the tool list matches the server again."
+}
+```
+
+**Expected**: AI calls `hub_manage_mcp(tool='hub_update_mcp_settings', args={settings:{useGateways:<flipped>}, confirm:true})`. The key is **accepted** (NOT rejected as outside the allowlist — this is the regression guard for the dev-mode gateway self-switch), result `{success:true, updated:{useGateways:<flipped>}, message:"...may need to reconnect to refresh cached tool schemas if you toggled an enable* flag or useGateways."}`. The WARN `[developer-mode]` audit line fires. AI explains the client must reconnect (`/mcp refresh`) before tools/list reflects the new gateway-vs-flat surface. Teardown restores the original value.
+
 ### T224 — hub_delete_variable removes a stale rule_engine variable
 
 ```json

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -530,7 +530,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 
 **Expected v0.8.0**: Calls `hub_get_info` directly (core tool — includes hardware, health, MCP stats; PII gated behind Hub Admin Read).
 
-### T36 — Discover hub_get_radio_details for Z-Wave (hub_manage_diagnostics)
+### T36 — Discover hub_get_radio_details for Z-Wave (hub_read_diagnostics)
 
 ```json
 {
@@ -538,9 +538,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_diagnostics` → `hub_get_radio_details` with `radio=zwave`.
+**Expected v0.8.0**: Discovers `hub_read_diagnostics` → `hub_get_radio_details` with `radio=zwave` (also reachable via `hub_manage_diagnostics` — multi-membership).
 
-### T37 — Discover hub_get_radio_details for Zigbee (hub_manage_diagnostics)
+### T37 — Discover hub_get_radio_details for Zigbee (hub_read_diagnostics)
 
 ```json
 {
@@ -548,7 +548,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_diagnostics` → `hub_get_radio_details` with `radio=zigbee`.
+**Expected v0.8.0**: Discovers `hub_read_diagnostics` → `hub_get_radio_details` with `radio=zigbee` (also reachable via `hub_manage_diagnostics` — multi-membership).
 
 ### T38 — Discover hub_get_info for health (core)
 
@@ -683,7 +683,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 
 **Expected v0.8.0**: Discovers `hub_read_devices` → `hub_list_device_events` (windowed: pass `hoursBack`).
 
-### T49 — Discover hub_get_metrics (hub_manage_diagnostics)
+### T49 — Discover hub_get_metrics (hub_read_diagnostics)
 
 ```json
 {
@@ -691,9 +691,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_diagnostics` → `hub_get_metrics`.
+**Expected v0.8.0**: Discovers `hub_read_diagnostics` → `hub_get_metrics` (the pure-read gateway; `hub_manage_diagnostics` also exposes it via multi-membership, so a read-only client still reaches it).
 
-### T50 — Discover hub_get_device_health (hub_manage_diagnostics)
+### T50 — Discover hub_get_device_health (hub_read_diagnostics)
 
 ```json
 {
@@ -701,7 +701,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_diagnostics` → `hub_get_device_health`.
+**Expected v0.8.0**: Discovers `hub_read_diagnostics` → `hub_get_device_health` (also in `hub_manage_diagnostics` via multi-membership).
 
 ### T51 — Discover hub_get_debug_logs (hub_manage_logs)
 
@@ -746,7 +746,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 
 **Expected v0.8.0**: Discovers `hub_manage_logs` → `hub_set_log_level` and → `hub_get_debug_logs` (mode='status').
 
-### T55 — Discover hub_list_captured_states (hub_manage_diagnostics)
+### T55 — Discover hub_list_captured_states (hub_read_diagnostics)
 
 ```json
 {
@@ -754,7 +754,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_diagnostics` → `hub_list_captured_states`.
+**Expected v0.8.0**: Discovers `hub_read_diagnostics` → `hub_list_captured_states` (also in `hub_manage_diagnostics` via multi-membership).
 
 ### T56 — Discover hub_list_files (hub_manage_files)
 
@@ -1051,7 +1051,7 @@ Complex scenarios spanning multiple tools and gateways.
 }
 ```
 
-**Expected**: Split across `hub_manage_diagnostics` (hub_get_metrics, hub_get_device_health) and `hub_manage_logs` (hub_get_logs, hub_get_debug_logs).
+**Expected**: All four are reads available from `hub_read_diagnostics` (hub_get_metrics, hub_get_device_health, hub_get_logs, hub_get_debug_logs) — a read-only client gets the whole report from the pure-read gateway; the write-bearing `hub_manage_diagnostics` / `hub_manage_logs` also expose them.
 
 ### T84 — Cross-gateway workflow
 
@@ -1140,7 +1140,7 @@ These test correct routing when the request is ambiguous.
 }
 ```
 
-**Expected**: `hub_get_metrics` (in `hub_manage_diagnostics`), not `hub_get_info` (core). Performance metrics = diagnostics gateway.
+**Expected**: `hub_get_metrics` (in `hub_read_diagnostics`, also `hub_manage_diagnostics`), not `hub_get_info` (core). Performance metrics = diagnostics gateway.
 
 ### T95 — User references wrong gateway domain
 
@@ -1150,7 +1150,7 @@ These test correct routing when the request is ambiguous.
 }
 ```
 
-**Expected**: `hub_get_device_health` is in `hub_manage_diagnostics`. AI should find the right gateway despite the misdirection.
+**Expected**: `hub_get_device_health` is in `hub_read_diagnostics` (and `hub_manage_diagnostics`). AI should find the right gateway despite the misdirection.
 
 ### T96 — Same-name artifact ambiguity
 
@@ -2022,7 +2022,7 @@ These tests cover the same tool capabilities as earlier sections, but use **pure
 }
 ```
 
-**Expected**: `hub_get_metrics` (via `hub_manage_diagnostics`).
+**Expected**: `hub_get_metrics` (via `hub_read_diagnostics`, also `hub_manage_diagnostics`).
 **Equivalent to**: T49
 
 #### T278 — Dead or unresponsive devices

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -1,10 +1,10 @@
 # Bot Acceptance Test (BAT) Suite — v2
 
-Updated for the installed-apps + Rule Machine interop + native CRUD + library management + HPM package state architecture, then the issue #105 PR1A hub_ rename + consolidation (20 core + 13 gateways = 33 on tools/list, 69 proxied, 89 total).
+Updated for the installed-apps + Rule Machine interop + native CRUD + library management + HPM package state architecture, then the issue #105 PR1A hub_ rename + consolidation, then the PR1B 19-gateway read/write split (11 flat core + 19 gateways = 30 on tools/list, 88 total distinct tools).
 
 Comprehensive test scenarios for the Hubitat MCP Rule Server. Modeled after ha-mcp's BAT framework.
 
-> **Supplement**: see [`tests/BAT-rm-native-crud.md`](./BAT-rm-native-crud.md) for the native-RM CRUD suite (T300-T399) -- acceptance gate for the `hub_manage_native_rules` CRUD tools (`hub_create_native_app`, `hub_update_native_app`, `hub_delete_native_app`, `hub_get_rule_health`). Those tools are shipped; all scenarios in that file should pass against the current codebase.
+> **Supplement**: see [`tests/BAT-rm-native-crud.md`](./BAT-rm-native-crud.md) for the native-RM CRUD suite (T300-T399) -- acceptance gate for the `hub_manage_native_rules_and_apps` CRUD tools (`hub_create_native_app`, `hub_update_native_app`, `hub_delete_native_app`, `hub_get_rule_health`). Those tools are shipped; all scenarios in that file should pass against the current codebase.
 
 Each test is a JSON scenario with optional `setup_prompt`, required `test_prompt`, and optional `teardown_prompt`. Run each prompt in the same AI session (setup → test → teardown). Each TEST SCENARIO starts a fresh session.
 
@@ -48,7 +48,7 @@ Each test is a JSON scenario with optional `setup_prompt`, required `test_prompt
 
 ## Section 1: Core Tool Tests
 
-These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0.8.0 (21 core tools). Every AI should find and use them without difficulty.
+These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0.8.0 (11 flat core tools). Every AI should find and use them without difficulty.
 
 ### T01 — hub_list_devices (basic)
 
@@ -367,7 +367,7 @@ These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0
 
 ```json
 {
-  "setup_prompt": "Use hub_manage_code_read(tool='hub_list_drivers') to find any installed custom driver. If none are installed, skip this test and say 'no custom drivers available'.",
+  "setup_prompt": "Use hub_read_apps_code(tool='hub_list_drivers') to find any installed custom driver. If none are installed, skip this test and say 'no custom drivers available'.",
   "test_prompt": "Create a virtual device using the first available custom driver (use its namespace and name), label it 'BAT Custom Driver Success Test' (include confirm=true). Then delete it.",
   "teardown_prompt": "Delete the virtual device 'BAT Custom Driver Success Test' if it still exists."
 }
@@ -383,7 +383,7 @@ These ask the AI to do something that requires a **proxied tool** (behind a gate
 
 On v0.7.7 these tools are directly available — this section tests whether v0.8.0 gateway descriptions provide enough information for discovery.
 
-### T20 — Discover hub_export_custom_rule (hub_manage_rules)
+### T20 — Discover hub_export_custom_rule (hub_manage_custom_rules)
 
 ```json
 {
@@ -394,9 +394,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 ```
 
 **Expected v0.7.7**: Calls `export_rule` directly *(pre-custom_ rename; tool no longer exists on v0.8.0+)*.
-**Expected v0.8.0+**: Finds `hub_manage_rules` → `hub_export_custom_rule`.
+**Expected v0.8.0+**: Finds `hub_manage_custom_rules` → `hub_export_custom_rule`.
 
-### T21 — Discover hub_clone_custom_rule (hub_manage_rules)
+### T21 — Discover hub_clone_custom_rule (hub_manage_custom_rules)
 
 ```json
 {
@@ -406,9 +406,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_rules` → `hub_clone_custom_rule`.
+**Expected v0.8.0**: Discovers `hub_manage_custom_rules` → `hub_clone_custom_rule`.
 
-### T22 — Discover hub_test_custom_rule (hub_manage_rules)
+### T22 — Discover hub_test_custom_rule (hub_manage_custom_rules)
 
 ```json
 {
@@ -418,9 +418,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_rules` → `hub_test_custom_rule`.
+**Expected v0.8.0**: Discovers `hub_manage_custom_rules` → `hub_test_custom_rule`.
 
-### T23 — Discover hub_import_custom_rule round-trip (hub_manage_rules)
+### T23 — Discover hub_import_custom_rule round-trip (hub_manage_custom_rules)
 
 ```json
 {
@@ -430,7 +430,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_rules` → `hub_import_custom_rule`.
+**Expected v0.8.0**: Discovers `hub_manage_custom_rules` → `hub_import_custom_rule`.
 
 ### T24 — Discover hub_list_variables (hub_manage_variables)
 
@@ -580,7 +580,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 
 **Expected v0.8.0**: Calls `hub_create_backup` directly (promoted to core in v0.8.0).
 
-### T41 — Discover hub_list_apps (hub_manage_code_read)
+### T41 — Discover hub_list_apps (hub_read_apps_code)
 
 ```json
 {
@@ -588,9 +588,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_code_read` → `hub_list_apps`.
+**Expected v0.8.0**: Discovers `hub_read_apps_code` → `hub_list_apps`.
 
-### T42 — Discover hub_list_drivers (hub_manage_code_read)
+### T42 — Discover hub_list_drivers (hub_read_apps_code)
 
 ```json
 {
@@ -598,9 +598,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_code_read` → `hub_list_drivers`.
+**Expected v0.8.0**: Discovers `hub_read_apps_code` → `hub_list_drivers`.
 
-### T43 — Discover hub_get_source for an app (hub_manage_code_read)
+### T43 — Discover hub_get_source for an app (hub_read_apps_code)
 
 ```json
 {
@@ -608,9 +608,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_code_read` → `hub_list_apps` then → `hub_get_source` with `type=app`.
+**Expected v0.8.0**: Discovers `hub_read_apps_code` → `hub_list_apps` then → `hub_get_source` with `type=app`.
 
-### T44 — Discover hub_get_source for a driver (hub_manage_code_read)
+### T44 — Discover hub_get_source for a driver (hub_read_apps_code)
 
 ```json
 {
@@ -618,9 +618,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_code_read` → `hub_list_drivers` then → `hub_get_source` with `type=driver`.
+**Expected v0.8.0**: Discovers `hub_read_apps_code` → `hub_list_drivers` then → `hub_get_source` with `type=driver`.
 
-### T45 — Discover hub_list_backups (hub_manage_code_read)
+### T45 — Discover hub_list_backups (hub_read_apps_code)
 
 ```json
 {
@@ -628,9 +628,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_code_read` → `hub_list_backups`.
+**Expected v0.8.0**: Discovers `hub_read_apps_code` → `hub_list_backups`.
 
-### T46 — Discover hub_get_backup (hub_manage_code_read)
+### T46 — Discover hub_get_backup (hub_read_apps_code)
 
 ```json
 {
@@ -639,7 +639,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_code_read` → `hub_get_backup`.
+**Expected v0.8.0**: Discovers `hub_read_apps_code` → `hub_get_backup`.
 
 ### T47 — Discover hub_get_logs (hub_manage_logs)
 
@@ -671,7 +671,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 
 **Expected**: Calls `hub_manage_logs` -> `hub_get_logs` with `patterns=['timeout', 'device']` and `patternMode='all'` (AND semantics) plus `since='2h'`. Demonstrates AND-mode multi-pattern filtering -- higher-value than OR-mode because it narrows results more precisely.
 
-### T48 — Discover hub_list_device_events windowed (hub_manage_logs)
+### T48 — Discover hub_list_device_events windowed (hub_read_devices)
 
 ```json
 {
@@ -681,7 +681,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_logs` → `hub_list_device_events` (windowed: pass `hoursBack`).
+**Expected v0.8.0**: Discovers `hub_read_devices` → `hub_list_device_events` (windowed: pass `hoursBack`).
 
 ### T49 — Discover hub_get_metrics (hub_manage_diagnostics)
 
@@ -713,7 +713,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 
 **Expected v0.8.0**: Discovers `hub_manage_logs` → `hub_get_debug_logs`.
 
-### T52 — Discover hub_report_issue (hub_manage_diagnostics)
+### T52 — Discover hub_report_issue (core)
 
 ```json
 {
@@ -721,9 +721,9 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_diagnostics` → `hub_report_issue`.
+**Expected v0.8.0**: Calls `hub_report_issue` directly (flat core tool).
 
-### T53 — Discover hub_get_custom_rule diagnostics (hub_manage_diagnostics)
+### T53 — Discover hub_get_custom_rule diagnostics (hub_read_rules)
 
 ```json
 {
@@ -733,7 +733,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 }
 ```
 
-**Expected v0.8.0**: Discovers `hub_manage_diagnostics` → `hub_get_custom_rule` (diagnostics: `detailed=true`).
+**Expected v0.8.0**: Discovers `hub_read_rules` → `hub_get_custom_rule` (diagnostics: `detailed=true`).
 
 ### T54 — Discover hub_set_log_level (hub_manage_logs)
 
@@ -854,7 +854,7 @@ These test gateway-specific behaviors: catalog mode, skip-catalog optimization, 
 }
 ```
 
-**Expected**: AI recognizes `hub_export_custom_rule` is behind `hub_manage_rules` and routes correctly. Does NOT report "tool not found."
+**Expected**: AI recognizes `hub_export_custom_rule` is behind `hub_manage_custom_rules` and routes correctly. Does NOT report "tool not found."
 
 ### T65 — Wrong gateway for tool (error handling)
 
@@ -1016,12 +1016,12 @@ Complex scenarios spanning multiple tools and gateways.
 ```
 
 **Expected tools (v0.8.0)**:
-1. `hub_create_custom_rule` (core)
-2. `hub_get_custom_rule` (core)
-3. `hub_manage_rules(tool=hub_test_custom_rule)` (gateway)
-4. `hub_update_custom_rule` with `enabled=false` (core)
-5. `hub_manage_rules(tool=hub_export_custom_rule)` (gateway)
-6. `hub_manage_rules(tool=hub_delete_custom_rule)` (gateway)
+1. `hub_manage_custom_rules(tool=hub_create_custom_rule)` (gateway)
+2. `hub_manage_custom_rules(tool=hub_get_custom_rule)` (gateway)
+3. `hub_manage_custom_rules(tool=hub_test_custom_rule)` (gateway)
+4. `hub_manage_custom_rules(tool=hub_update_custom_rule)` with `enabled=false` (gateway)
+5. `hub_manage_custom_rules(tool=hub_export_custom_rule)` (gateway)
+6. `hub_manage_custom_rules(tool=hub_delete_custom_rule)` (gateway)
 
 ### T81 — Virtual device workflow
 
@@ -1061,7 +1061,7 @@ Complex scenarios spanning multiple tools and gateways.
 }
 ```
 
-**Expected (v0.8.0)**: Uses 5 gateways plus core: `hub_manage_rooms` (hub_list_rooms), core (`hub_list_devices(filter='virtual')`), `hub_manage_variables` (hub_list_variables), `hub_manage_files` (hub_list_files), `hub_manage_code_read` (hub_list_backups), core (`hub_get_info`), `hub_manage_diagnostics` (hub_get_device_health).
+**Expected (v0.8.0)**: Uses gateways plus core: `hub_manage_rooms` (hub_list_rooms), `hub_read_devices` (`hub_list_devices(filter='virtual')`), `hub_manage_variables` (hub_list_variables), `hub_manage_files` (hub_list_files), `hub_read_apps_code` (hub_list_backups), core (`hub_get_info`), `hub_manage_diagnostics` (hub_get_device_health).
 
 ### T85 — Rule with virtual device end-to-end
 
@@ -1072,7 +1072,7 @@ Complex scenarios spanning multiple tools and gateways.
 }
 ```
 
-**Expected**: Core tools (`hub_manage_virtual_device` x2, `hub_create_custom_rule`, `hub_get_custom_rule`) and `hub_manage_rules` (`hub_test_custom_rule`).
+**Expected**: `hub_manage_virtual_device` x2 (flat core) plus `hub_manage_custom_rules` (`hub_create_custom_rule`, `hub_get_custom_rule`, `hub_test_custom_rule`).
 
 ### T86 — Variable round-trip workflow
 
@@ -1276,10 +1276,10 @@ Per Finding #4 (shipped in commit `95654ad`), `success` and `partial` are orthog
 ```
 
 **Expected**:
-- Agent calls `hub_manage_native_rules(tool=hub_create_native_app)` to create the rule, then `hub_manage_native_rules(tool=hub_update_native_app, args={addAction: ...})`.
+- Agent calls `hub_manage_native_rules_and_apps(tool=hub_create_native_app)` to create the rule, then `hub_manage_native_rules_and_apps(tool=hub_update_native_app, args={addAction: ...})`.
 - The response returns `{success: true, partial: true, ...}` (empirically observed for Switch actions).
 - Agent does NOT panic, does NOT call `removeAction`, does NOT retry the `addAction` (which would create a duplicate).
-- Agent calls `hub_manage_installed_apps(tool=hub_get_app_config, args={appId: ..., includeSettings: true})` OR `hub_manage_native_rules(tool=hub_update_native_app, args={walkStep: {page: "mainPage", operation: "introspect"}})` to verify the action rendered correctly in the rule.
+- Agent calls `hub_read_apps_code(tool=hub_get_app_config, args={appId: ..., includeSettings: true})` OR `hub_manage_native_rules_and_apps(tool=hub_update_native_app, args={walkStep: {page: "mainPage", operation: "introspect"}})` to verify the action rendered correctly in the rule.
 - Agent reports the action was added successfully, noting the partial flag was cosmetic.
 
 **What an agent must NOT do**:
@@ -1294,7 +1294,7 @@ Per Finding #4 (shipped in commit `95654ad`), `success` and `partial` are orthog
 
 ## Section 8: Comparison/Regression Tests
 
-Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (21 + 10 gateways) to compare.
+Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (11 flat + 19 gateways) to compare.
 
 ### T110 — Tool count verification
 
@@ -1304,7 +1304,7 @@ Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (21 + 10 gate
 }
 ```
 
-**v0.7.7**: 74 tools listed. **v0.8.0**: 31 items (21 core + 10 gateways). Compare token usage, completeness.
+**v0.7.7**: 74 tools listed. **v0.8.0**: 30 items (11 flat core + 19 gateways). Compare token usage, completeness.
 
 ### T111 — Simple device control (baseline)
 
@@ -1338,7 +1338,7 @@ Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (21 + 10 gate
 }
 ```
 
-**v0.7.7**: Calls `export_rule` directly *(pre-custom_ rename)*. **v0.8.0+**: Via `hub_manage_rules(tool=hub_export_custom_rule)`. Compare extra turns for discovery.
+**v0.7.7**: Calls `export_rule` directly *(pre-custom_ rename)*. **v0.8.0+**: Via `hub_manage_custom_rules(tool=hub_export_custom_rule)`. Compare extra turns for discovery.
 
 ### T114 — Hub logs (moved to gateway in v0.8.0)
 
@@ -1359,7 +1359,7 @@ Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (21 + 10 gate
 }
 ```
 
-**v0.7.7**: `delete_rule` directly *(pre-custom_ rename)*. **v0.8.0+**: Via `hub_manage_rules(tool=hub_delete_custom_rule)`. Did AI try direct call first and fail?
+**v0.7.7**: `delete_rule` directly *(pre-custom_ rename)*. **v0.8.0+**: Via `hub_manage_custom_rules(tool=hub_delete_custom_rule)`. Did AI try direct call first and fail?
 
 ### T116 — Multi-tool hub status (regression baseline)
 
@@ -1375,7 +1375,7 @@ Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (21 + 10 gate
 
 ## Section 9: Stress Tests
 
-### T120 — Many-gateway stress (7 of 13 gateways)
+### T120 — Many-gateway stress (7 of 19 gateways)
 
 ```json
 {
@@ -1385,7 +1385,7 @@ Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (21 + 10 gate
 }
 ```
 
-**Expected**: 10 calls across core tools and gateways (hub_manage_rooms, hub_manage_variables, hub_get_info (core), hub_create_backup (core), hub_manage_files, hub_manage_code_read, hub_manage_diagnostics, hub_manage_logs, hub_get_update_status (core), hub_manage_rules). Excluded: `hub_manage_code_write` (all tools destructive), `hub_manage_destructive_ops` (destructive ops), `hub_manage_hpm` (separate T600-T602 scenarios), `hub_manage_installed_apps` (separate T205 scenarios), `hub_manage_native_rules` (separate T200-series scenarios), `hub_manage_mcp` (separate T102 scenarios). All 7 exercised gateways should succeed.
+**Expected**: 10 calls across core tools and gateways (hub_manage_rooms, hub_manage_variables, hub_get_info (core), hub_create_backup (core), hub_manage_files, hub_read_apps_code (hub_list_apps scope=instances), hub_manage_diagnostics, hub_manage_logs, hub_get_update_status (core), hub_manage_custom_rules). Excluded: `hub_manage_code` (all write tools destructive), `hub_manage_destructive_ops` (destructive ops), `hub_manage_native_rules_and_apps` (separate T200-series scenarios), `hub_manage_mcp` (separate T102 scenarios). All 7 exercised gateways should succeed.
 
 ### T121 — Rapid rule create-delete cycles
 
@@ -2244,12 +2244,12 @@ These operations are too destructive for automated testing. Test manually with e
 | Shutdown hub | `hub_shutdown` | hub_manage_destructive_ops | Requires physical restart |
 | Z-Wave repair | `hub_call_zwave_repair` | hub_manage_diagnostics | 5-30 min, devices unresponsive |
 | Delete real device | `hub_delete_device` | hub_manage_destructive_ops | Permanent, no undo |
-| Install app | `hub_create_app` | hub_manage_code_write | Modifies hub code |
-| Install driver | `hub_create_driver` | hub_manage_code_write | Modifies hub code |
-| Update app code | `hub_update_app` | hub_manage_code_write | Modifies production code |
-| Update driver code | `hub_update_driver` | hub_manage_code_write | Modifies production code |
-| Delete app/driver/library | `hub_delete_item` (type: app\|driver\|library) | hub_manage_code_write | Permanent code removal |
-| Restore item backup | `hub_restore_backup` | hub_manage_code_write | Overwrites current code |
+| Install app | `hub_create_app` | hub_manage_code | Modifies hub code |
+| Install driver | `hub_create_driver` | hub_manage_code | Modifies hub code |
+| Update app code | `hub_update_app` | hub_manage_code | Modifies production code |
+| Update driver code | `hub_update_driver` | hub_manage_code | Modifies production code |
+| Delete app/driver/library | `hub_delete_item` (type: app\|driver\|library) | hub_manage_code | Permanent code removal |
+| Restore item backup | `hub_restore_backup` | hub_manage_code | Overwrites current code |
 | Set HSM | `hub_set_hsm` | core | Changes security system state |
 | Set Mode | `hub_set_mode` | core | Changes hub mode (may trigger automations) |
 
@@ -2287,7 +2287,7 @@ These operations are too destructive for automated testing. Test manually with e
 
 | Section | Tests | Purpose |
 |---------|-------|---------|
-| 1. Core Tools | T01-T19f | 20 core tools work directly |
+| 1. Core Tools | T01-T19f | 11 flat core tools work directly |
 | 2. Gateway Discovery | T20-T31, T35-T59 | LLM finds all proxied tools without hints |
 | 3. Gateway Behavior | T60-T65 | Catalog mode, skip-catalog, errors |
 | 4. Natural Language | T70-T79 | Casual prompts route correctly |
@@ -2301,21 +2301,24 @@ These operations are too destructive for automated testing. Test manually with e
 | 13. Driver Code Lifecycle | T400-T406 | hub_create_driver (single + bulk), hub_update_driver (bulk), delete |
 | 14. Library Management | T500-T508 | Library CRUD: install, update, delete, hub_get_source |
 
-### Architecture (post installed-apps + RM interop + Developer Mode)
+### Architecture (post installed-apps + RM interop + Developer Mode + PR1B read/write split)
 
 | Component | Count |
 |-----------|-------|
-| Core tools on `tools/list` | 20 |
-| Gateways on `tools/list` | 13 |
-| Total visible on `tools/list` | 33 |
-| Tools proxied behind gateways | 69 |
-| Total tools in codebase | 89 |
+| Flat core tools on `tools/list` | 11 |
+| Gateways on `tools/list` | 19 |
+| Total visible on `tools/list` | 30 |
+| Total distinct tools in codebase | 88 |
 
-**13 Gateways**: `hub_manage_rules` (5), `hub_manage_variables` (8), `hub_manage_rooms` (5), `hub_manage_destructive_ops` (3), `hub_manage_code_read` (5), `hub_manage_code_write` (8), `hub_manage_logs` (6), `hub_manage_diagnostics` (8), `hub_manage_files` (4), `hub_manage_installed_apps` (4), `hub_manage_hpm` (1), `hub_manage_native_rules` (11), `hub_manage_mcp` (1)
+**7 read gateways**: `hub_read_apps_code` (9), `hub_read_devices` (4), `hub_read_diagnostics` (9), `hub_read_files` (2), `hub_read_rooms` (2), `hub_read_rules` (4), `hub_read_variables` (3)
+
+**12 manage gateways**: `hub_manage_code` (8), `hub_manage_custom_rules` (8), `hub_manage_destructive_ops` (3), `hub_manage_devices` (6), `hub_manage_diagnostics` (8), `hub_manage_files` (4), `hub_manage_logs` (6), `hub_manage_mcp` (1), `hub_manage_native_rules_and_apps` (11), `hub_manage_rooms` (5), `hub_manage_rule_machine` (5), `hub_manage_variables` (8)
+
+**11 flat core tools**: `hub_manage_virtual_device`, `hub_get_tool_guide`, `hub_report_issue`, `hub_search_tools`, `hub_get_info`, `hub_list_modes`, `hub_set_mode`, `hub_get_hsm_status`, `hub_set_hsm`, `hub_get_update_status`, `hub_create_backup`
 
 ### Tool Coverage (non-destructive tools only)
 
-All 89 tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
+All 88 distinct tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
 
 Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
 
@@ -2325,7 +2328,7 @@ Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests 
 
 ## Section 11: Built-in App Integration Tests
 
-Tools in this section have mixed gate requirements. `hub_list_installed_apps` and `hub_list_device_dependents` require the `Enable Built-in App Tools` toggle (`requireBuiltinApp`). `hub_get_app_config` and `hub_list_app_pages` require Hub Admin Read (`requireHubAdminRead`). `hub_manage_native_rules` tools require `Enable Built-in App Tools`; CRUD tools additionally require Hub Admin Write. Tests assume at least one Rule Machine rule and at least one Room Lighting or other multi-app configuration exists on the hub.
+Tools in this section have mixed gate requirements. `hub_list_apps` (scope=instances) and `hub_list_device_dependents` require the `Enable Built-in App Tools` toggle (`requireBuiltinApp`). `hub_get_app_config` and `hub_list_app_pages` require Hub Admin Read (`requireHubAdminRead`). `hub_manage_native_rules_and_apps` tools require `Enable Built-in App Tools`; CRUD tools additionally require Hub Admin Write. Tests assume at least one Rule Machine rule and at least one Room Lighting or other multi-app configuration exists on the hub.
 
 ### Safety Rules for Section 11
 
@@ -2341,7 +2344,7 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 }
 ```
 
-**Expected**: Calls `hub_manage_installed_apps` with `tool='hub_list_installed_apps'` (via gateway). Returns list with at least one entry; each entry has id, name, type, disabled, user, parentId, hasChildren. AI reports the count.
+**Expected**: Calls `hub_read_apps_code` with `tool='hub_list_apps', args={scope:'instances'}` (via gateway). Returns list with at least one entry; each entry has id, name, type, disabled, user, parentId, hasChildren. AI reports the count.
 
 ### T201 — List only built-in apps
 
@@ -2351,7 +2354,7 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 }
 ```
 
-**Expected**: Calls `hub_list_installed_apps` with `filter='builtin'`. Returns apps where `user` is false. AI doesn't show user-installed apps like Ecobee or Awair.
+**Expected**: Calls `hub_list_apps` with `scope='instances', filter='builtin'`. Returns apps where `user` is false. AI doesn't show user-installed apps like Ecobee or Awair.
 
 ### T202 — List Rule Machine rules
 
@@ -2361,7 +2364,7 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 }
 ```
 
-**Expected**: Calls `hub_manage_native_rules.hub_list_rules`. Returns list with ids and labels. AI reports count. If Rule Machine is not installed, AI gracefully reports "none found" or equivalent.
+**Expected**: Calls `hub_manage_native_rules_and_apps.hub_list_rules`. Returns list with ids and labels. AI reports count. If Rule Machine is not installed, AI gracefully reports "none found" or equivalent.
 
 ### T203 — Find apps using a device
 
@@ -2384,17 +2387,17 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 
 **Expected**: Tool returns `{success: false}` or similar error. AI reports device not found — does NOT fabricate results.
 
-### T205 — Gateway catalog discovery (hub_manage_installed_apps)
+### T205 — Gateway catalog discovery (hub_read_apps_code)
 
 ```json
 {
-  "test_prompt": "What can the hub_manage_installed_apps gateway do?"
+  "test_prompt": "What can the hub_read_apps_code gateway do?"
 }
 ```
 
-**Expected**: AI calls `hub_manage_installed_apps` with no args, sees catalog of 4 tools (`hub_list_installed_apps`, `hub_list_device_dependents`, `hub_get_app_config`, `hub_list_app_pages`) with full parameter schemas.
+**Expected**: AI calls `hub_read_apps_code` with no args, sees catalog of 9 tools (`hub_list_apps`, `hub_list_drivers`, `hub_get_source`, `hub_list_backups`, `hub_get_backup`, `hub_list_device_dependents`, `hub_get_app_config`, `hub_list_app_pages`, `hub_list_hpm_packages`) with full parameter schemas. The installed-apps listing is reached via `hub_list_apps` with `scope='instances'`.
 
-### T206 — Gateway catalog discovery (hub_manage_native_rules)
+### T206 — Gateway catalog discovery (hub_manage_native_rules_and_apps)
 
 ```json
 {
@@ -2402,9 +2405,9 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 }
 ```
 
-**Expected**: AI calls `hub_manage_native_rules` with no args, sees 12 tools. AI describes them (list/run/pause/resume/set_boolean + create/update/delete/clone/export/hub_import_native_app + hub_get_rule_health).
+**Expected**: AI calls `hub_manage_native_rules_and_apps` with no args, sees 11 tools. AI describes them (list/run/pause/set_boolean + create/update/delete/clone/export/hub_import_native_app + hub_get_rule_health).
 
-### T207 — AI uses native RM rule creation via hub_manage_native_rules
+### T207 — AI uses native RM rule creation via hub_manage_native_rules_and_apps
 
 ```json
 {
@@ -2412,7 +2415,7 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 }
 ```
 
-**Expected**: AI calls `hub_manage_native_rules.hub_create_native_app` (appType=rule_machine) to create the rule, then `hub_update_native_app` to add the motion trigger and switch action. Returns the new appId. Does NOT fall back to `hub_create_custom_rule` (that creates an MCP-engine rule, not a native RM rule).
+**Expected**: AI calls `hub_manage_native_rules_and_apps.hub_create_native_app` (appType=rule_machine) to create the rule, then `hub_update_native_app` to add the motion trigger and switch action. Returns the new appId. Does NOT fall back to `hub_create_custom_rule` (that creates an MCP-engine rule, not a native RM rule).
 
 ### T208 — AI correctly refuses Room Lighting creation
 
@@ -2422,7 +2425,7 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 }
 ```
 
-**Expected**: AI attempts `hub_manage_native_rules.hub_create_native_app` for Room Lighting. Since Room Lighting is not yet in the `_appTypeRegistry`, the tool returns an error listing supported appTypes. AI relays the error and suggests using the native UI. Does not fabricate a fake result.
+**Expected**: AI attempts `hub_manage_native_rules_and_apps.hub_create_native_app` for Room Lighting. Since Room Lighting is not yet in the `_appTypeRegistry`, the tool returns an error listing supported appTypes. AI relays the error and suggests using the native UI. Does not fabricate a fake result.
 
 ### T209 — Pause and resume an RM rule (reversible)
 
@@ -2472,7 +2475,7 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 }
 ```
 
-**Expected**: Calls `hub_list_installed_apps` with `filter='disabled'`. AI reports the count and names.
+**Expected**: Calls `hub_list_apps` with `scope='instances', filter='disabled'`. AI reports the count and names.
 
 ### T211 — Built-in App Tools feature flag disabled
 
@@ -2485,34 +2488,34 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 
 **Expected**: `hub_list_rules` returns `IllegalArgumentException: Built-in App Tools are disabled...`. AI reports the feature flag requirement and points user to the MCP app settings page.
 
-### T212 — Read an installed app's config page (hub_get_app_config — hub_manage_installed_apps gateway)
+### T212 — Read an installed app's config page (hub_get_app_config — hub_read_apps_code gateway)
 
 ```json
 {
-  "setup_prompt": "Hub Admin Read is enabled. Use hub_list_installed_apps to find any Rule Machine rule and note its app ID.",
+  "setup_prompt": "Hub Admin Read is enabled. Use hub_list_apps (scope=instances) to find any Rule Machine rule and note its app ID.",
   "test_prompt": "Show me the configuration of that Rule Machine rule — what conditions and actions does it have?",
   "teardown_prompt": "No teardown needed — hub_get_app_config is read-only."
 }
 ```
 
-**Expected**: AI first calls `hub_list_installed_apps` (or `hub_list_rules`) to discover a Rule Machine app ID, then calls `hub_manage_installed_apps(tool='hub_get_app_config', args={appId: <discovered_id>})`. Returns `app` (label, type), `page` (sections with inputs showing configured triggers, conditions, actions). AI summarizes the rule's behavior from the structured response. Tool is accessed via the `hub_manage_installed_apps` gateway.
+**Expected**: AI first calls `hub_list_apps` (scope=instances, or `hub_list_rules`) to discover a Rule Machine app ID, then calls `hub_read_apps_code(tool='hub_get_app_config', args={appId: <discovered_id>})`. Returns `app` (label, type), `page` (sections with inputs showing configured triggers, conditions, actions). AI summarizes the rule's behavior from the structured response. Tool is accessed via the `hub_read_apps_code` gateway.
 
 ### T213 — hub_get_app_config multi-page (HPM full package list)
 
 ```json
 {
-  "setup_prompt": "Use hub_list_installed_apps to find the Hubitat Package Manager app ID.",
+  "setup_prompt": "Use hub_list_apps (scope=instances) to find the Hubitat Package Manager app ID.",
   "test_prompt": "Use hub_get_app_config to list ALL packages installed via Hubitat Package Manager."
 }
 ```
 
-**Expected**: AI calls `hub_list_installed_apps` to discover the HPM app ID, then calls `hub_get_app_config(appId=<discovered_id>, pageName='prefPkgUninstall')`. Returns the full installed-package enum. AI extracts and lists package names. Note: `pageName='prefPkgModify'` returns only the modifiable subset (those with optional components) -- the correct page for the FULL list is `prefPkgUninstall`.
+**Expected**: AI calls `hub_list_apps` (scope=instances) to discover the HPM app ID, then calls `hub_get_app_config(appId=<discovered_id>, pageName='prefPkgUninstall')`. Returns the full installed-package enum. AI extracts and lists package names. Note: `pageName='prefPkgModify'` returns only the modifiable subset (those with optional components) -- the correct page for the FULL list is `prefPkgUninstall`.
 
 ### T214 — hub_get_app_config with includeSettings=true (power user)
 
 ```json
 {
-  "setup_prompt": "Use hub_list_rules or hub_list_installed_apps to find an existing Rule Machine rule and note its app ID.",
+  "setup_prompt": "Use hub_list_rules or hub_list_apps (scope=instances) to find an existing Rule Machine rule and note its app ID.",
   "test_prompt": "Get the raw settings map for that Rule Machine rule — include all internal keys."
 }
 ```
@@ -2544,12 +2547,12 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 
 ```json
 {
-  "setup_prompt": "Hub Admin Read is enabled. Use hub_list_installed_apps to find the Hubitat Package Manager app and note its app ID.",
+  "setup_prompt": "Hub Admin Read is enabled. Use hub_list_apps (scope=instances) to find the Hubitat Package Manager app and note its app ID.",
   "test_prompt": "I want to inspect HPM's configuration but I don't know the page names. Use hub_list_app_pages to discover what pages are available for the HPM app you just found."
 }
 ```
 
-**Expected**: AI uses the HPM app ID discovered in setup, then calls `hub_manage_installed_apps(tool='hub_list_app_pages', args={appId: <discovered_id>})`. Returns a `pages` list including at least `prefOptions`, `prefPkgUninstall`, `prefPkgModify`, `prefPkgInstall`, `prefPkgMatchUp`. AI lists the available page names and explains their roles (e.g. prefPkgUninstall = full installed-package list). Tool is accessed via the `hub_manage_installed_apps` gateway.
+**Expected**: AI uses the HPM app ID discovered in setup, then calls `hub_read_apps_code(tool='hub_list_app_pages', args={appId: <discovered_id>})`. Returns a `pages` list including at least `prefOptions`, `prefPkgUninstall`, `prefPkgModify`, `prefPkgInstall`, `prefPkgMatchUp`. AI lists the available page names and explains their roles (e.g. prefPkgUninstall = full installed-package list). Tool is accessed via the `hub_read_apps_code` gateway.
 
 ### T218 — hub_list_app_pages for Rule Machine rule (single-page confirmation)
 
@@ -2560,25 +2563,25 @@ Tools in this section have mixed gate requirements. `hub_list_installed_apps` an
 }
 ```
 
-**Expected**: AI uses the Rule Machine app ID discovered in setup, then calls `hub_manage_installed_apps(tool='hub_list_app_pages', args={appId: <discovered_id>})`. Returns a `pages` list with a single entry `{name: 'mainPage', role: 'primary'}` plus a `note` confirming rules are single-page. AI explains there is only one page (mainPage) and no sub-pages are available.
+**Expected**: AI uses the Rule Machine app ID discovered in setup, then calls `hub_read_apps_code(tool='hub_list_app_pages', args={appId: <discovered_id>})`. Returns a `pages` list with a single entry `{name: 'mainPage', role: 'primary'}` plus a `note` confirming rules are single-page. AI explains there is only one page (mainPage) and no sub-pages are available.
 
 ### T219 — hub_get_custom_rule on a Rule Machine rule ID (redirect hint)
 
 ```json
 {
-  "setup_prompt": "Built-in App Tools is enabled. Use hub_list_rules or hub_list_installed_apps to find an existing Rule Machine rule and note its app ID (not an MCP rule ID).",
+  "setup_prompt": "Built-in App Tools is enabled. Use hub_list_rules or hub_list_apps (scope=instances) to find an existing Rule Machine rule and note its app ID (not an MCP rule ID).",
   "test_prompt": "Call hub_get_custom_rule with the Rule Machine app ID you just found and tell me what error message you receive.",
   "teardown_prompt": "No teardown needed."
 }
 ```
 
 **Expected**: `hub_get_custom_rule` throws `IllegalArgumentException` containing both "Rule not found: <id>" and a redirect hint like:
-> "Rule <id> is a Hubitat built-in Rule-5.1 app. Use `hub_manage_installed_apps -> hub_get_app_config(appId=<id>)` to read its configuration."
+> "Rule <id> is a Hubitat built-in Rule-5.1 app. Use `hub_read_apps_code -> hub_get_app_config(appId=<id>)` to read its configuration."
 
 AI should:
 1. Report the full error including the redirect hint
 2. Recognize that `hub_get_custom_rule` only handles MCP's own rule engine
-3. Follow the hint by calling `hub_manage_installed_apps(tool='hub_get_app_config', args={appId: <id>})` to read the rule's configuration
+3. Follow the hint by calling `hub_read_apps_code(tool='hub_get_app_config', args={appId: <id>})` to read the rule's configuration
 
 This scenario validates that an agent landing on the wrong tool is efficiently redirected to the correct one in a single round-trip rather than wasting 3-4 tool calls.
 
@@ -2688,7 +2691,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 
 ---
 
-## Section 13: Driver Code Lifecycle Tests (hub_manage_code_write)
+## Section 13: Driver Code Lifecycle Tests (hub_manage_code)
 
 All tests below require Hub Admin Write enabled and a recent backup. Tests are excluded from the auto-exercise sweep (destructive to hub code). Test artifacts use the `BAT_` name prefix per BAT convention so they can be identified and cleaned up independently.
 
@@ -2776,7 +2779,7 @@ All tests below require Hub Admin Write enabled and a recent backup. Tests are e
 
 ## Section 14: Library Management Tests
 
-Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with type=library) live in the `hub_manage_code_write` gateway and require Hub Admin Write + confirm + a hub backup within the last 24 hours. `hub_get_source` with type=library (read-only) lives in the `hub_manage_code_read` gateway and requires Hub Admin Read only. Tests use the `BAT_` prefix and clean up after themselves.
+Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with type=library) live in the `hub_manage_code` gateway and require Hub Admin Write + confirm + a hub backup within the last 24 hours. `hub_get_source` with type=library (read-only) lives in the `hub_read_apps_code` gateway and requires Hub Admin Read only. Tests use the `BAT_` prefix and clean up after themselves.
 
 **Pre-flight (manual one-time):**
 1. Enable **Hub Admin Read Tools** and **Hub Admin Write Tools** in MCP Rule Server settings.
@@ -2789,11 +2792,11 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 ```json
 {
   "setup_prompt": "Check Hubitat web UI (FOR DEVELOPERS > Libraries code) for an installed library ID, or install a test library first using hub_create_library.",
-  "test_prompt": "Get the source of the first library returned by hub2/userLibraries. Use hub_manage_code_read -> hub_get_source with type=library."
+  "test_prompt": "Get the source of the first library returned by hub2/userLibraries. Use hub_read_apps_code -> hub_get_source with type=library."
 }
 ```
 
-**Expected**: AI calls `hub_manage_code_read(tool='hub_get_source', args={type:'library', id:'<id>'})`. Result includes `success: true`, `source` (non-empty string), `version`, `name`, `namespace`, `totalLength`. If total length exceeds 64KB, `sourceFile` and `sourceFileHint` fields are present.
+**Expected**: AI calls `hub_read_apps_code(tool='hub_get_source', args={type:'library', id:'<id>'})`. Result includes `success: true`, `source` (non-empty string), `version`, `name`, `namespace`, `totalLength`. If total length exceeds 64KB, `sourceFile` and `sourceFileHint` fields are present.
 
 ### T501 — hub_create_library installs new library from inline source
 
@@ -2805,7 +2808,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 }
 ```
 
-**Expected**: AI calls `hub_manage_code_write(tool='hub_create_library', args={source:'library(...) { } def batHelper() { return "bat_ok" }', confirm:true})`. Result: `{success:true, libraryId:'<id>', version:<positive integer>, sourceMode:'source', message:'Library installed successfully'}`. No `verifyWarning` or `verifyError` field if verification succeeds. `verified: true`.
+**Expected**: AI calls `hub_manage_code(tool='hub_create_library', args={source:'library(...) { } def batHelper() { return "bat_ok" }', confirm:true})`. Result: `{success:true, libraryId:'<id>', version:<positive integer>, sourceMode:'source', message:'Library installed successfully'}`. No `verifyWarning` or `verifyError` field if verification succeeds. `verified: true`.
 
 ### T502 — hub_update_library updates existing library source
 
@@ -2817,7 +2820,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 }
 ```
 
-**Expected**: AI finds the library ID, calls `hub_manage_code_write(tool='hub_update_library', args={libraryId:'<id>', source:'<updated source with v2Method>', confirm:true})`. Result: `{success:true, previousVersion:<N>, newVersion:<N+1>, sourceMode:'source'}` where `newVersion > previousVersion` (both positive integers). Pre-update backup appears in `hub_list_backups` as a `library_<id>` key.
+**Expected**: AI finds the library ID, calls `hub_manage_code(tool='hub_update_library', args={libraryId:'<id>', source:'<updated source with v2Method>', confirm:true})`. Result: `{success:true, previousVersion:<N>, newVersion:<N+1>, sourceMode:'source'}` where `newVersion > previousVersion` (both positive integers). Pre-update backup appears in `hub_list_backups` as a `library_<id>` key.
 
 ### T503 — hub_update_library resave mode recompiles without external source
 
@@ -2829,7 +2832,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 }
 ```
 
-**Expected**: AI calls `hub_manage_code_write(tool='hub_update_library', args={libraryId:'<id>', resave:true, confirm:true})`. Result: `{success:true, sourceMode:'resave', note:'...no cloud round-trip...'}`. `newVersion` is a positive integer greater than `previousVersion`.
+**Expected**: AI calls `hub_manage_code(tool='hub_update_library', args={libraryId:'<id>', resave:true, confirm:true})`. Result: `{success:true, sourceMode:'resave', note:'...no cloud round-trip...'}`. `newVersion` is a positive integer greater than `previousVersion`.
 
 ### T504 — hub_delete_item (type=library) deletes and auto-backs up source
 
@@ -2841,7 +2844,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 }
 ```
 
-**Expected**: AI calls `hub_manage_code_write(tool='hub_delete_item', args={type:'library', id:'<id>', confirm:true})`. Result: `{success:true, backupFile:'mcp-backup-library-<id>.groovy', restoreHint:...}`. Backup file appears in `hub_list_backups`. Subsequent `hub_get_source` (type=library) for the same ID returns `success:false` with "not found".
+**Expected**: AI calls `hub_manage_code(tool='hub_delete_item', args={type:'library', id:'<id>', confirm:true})`. Result: `{success:true, backupFile:'mcp-backup-library-<id>.groovy', restoreHint:...}`. Backup file appears in `hub_list_backups`. Subsequent `hub_get_source` (type=library) for the same ID returns `success:false` with "not found".
 
 ### T505 — hub_create_library refuses without confirm flag
 
@@ -2862,7 +2865,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 }
 ```
 
-**Expected**: AI calls `hub_manage_code_read(tool='hub_get_source', args={type:'library', id:'999999'})`. Result: `{success:false, error:'...not found...'}` or similar. AI reports the error clearly and suggests using hub2/userLibraries or the Hubitat web UI (FOR DEVELOPERS > Libraries code) to find valid library IDs.
+**Expected**: AI calls `hub_read_apps_code(tool='hub_get_source', args={type:'library', id:'999999'})`. Result: `{success:false, error:'...not found...'}` or similar. AI reports the error clearly and suggests using hub2/userLibraries or the Hubitat web UI (FOR DEVELOPERS > Libraries code) to find valid library IDs.
 
 ### T507 — hub_update_library sourceFile mode reads from File Manager
 
@@ -2874,7 +2877,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 }
 ```
 
-**Expected**: AI calls `hub_manage_code_write(tool='hub_update_library', args={libraryId:'<id>', sourceFile:'bat-lib-update.groovy', confirm:true})`. Result: `{success:true, sourceMode:'sourceFile', note:'...File Manager...'}`.
+**Expected**: AI calls `hub_manage_code(tool='hub_update_library', args={libraryId:'<id>', sourceFile:'bat-lib-update.groovy', confirm:true})`. Result: `{success:true, sourceMode:'sourceFile', note:'...File Manager...'}`.
 
 ### T508 — hub_delete_item (type=library) proceeds with warning when backup fails
 
@@ -2886,11 +2889,11 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 
 ## Section 15: HPM Package State Tests
 
-Tools in this section require **Hub Admin Read** and HPM itself must be installed on the hub. Both tools live in the `hub_manage_hpm` gateway. Tests assume at least one package has been installed via HPM.
+Tools in this section require **Hub Admin Read** and HPM itself must be installed on the hub. `hub_list_hpm_packages` lives in the `hub_read_apps_code` gateway. Tests assume at least one package has been installed via HPM.
 
 **Pre-flight (manual one-time):**
 1. Enable **Hub Admin Read Tools** in MCP Rule Server settings.
-2. Verify HPM is installed (`hub_list_installed_apps` should show "Hubitat Package Manager").
+2. Verify HPM is installed (`hub_list_apps` with scope=instances should show "Hubitat Package Manager").
 
 ### T600 — hub_list_hpm_packages: enumerate all HPM-tracked packages
 
@@ -2902,7 +2905,7 @@ Tools in this section require **Hub Admin Read** and HPM itself must be installe
 }
 ```
 
-**Expected**: AI calls `hub_manage_hpm(tool='hub_list_hpm_packages')` (hpmAppId auto-discovered). Returns `success=true`, `count` (number of packages), and `packages` array. Each entry has `packageName`, `version`, `beta`, `author`, `apps`, `drivers`, `files`. AI summarizes the count and names, and flags any beta packages.
+**Expected**: AI calls `hub_read_apps_code(tool='hub_list_hpm_packages')` (hpmAppId auto-discovered). Returns `success=true`, `count` (number of packages), and `packages` array. Each entry has `packageName`, `version`, `beta`, `author`, `apps`, `drivers`, `files`. AI summarizes the count and names, and flags any beta packages.
 
 **Failure modes**: AI calls `hub_get_app_config` with `pageName='prefPkgUninstall'` instead (works but slower and returns the page-rendered enum/option list rather than structured package records). `hub_list_hpm_packages` is the right tool for programmatic enumeration.
 
@@ -2916,17 +2919,17 @@ Tools in this section require **Hub Admin Read** and HPM itself must be installe
 }
 ```
 
-**Expected**: AI calls `hub_manage_hpm(tool='hub_list_hpm_packages', args={includeDrift:true})`. Returns `success=true` with the drift payload nested under a `drift` key containing: `summary` sentence, drift-signals array (may be empty), `packagesWithActionableDrift`, `totalDriftSignals`, `orphanDetection`, `orphanDriverDetection`, and `limitations` note. AI interprets the summary and describes any drift signals found (type, packageName, componentName). If no drift, AI confirms the packages are clean and mentions the heID-presence-only detection limitation. Response may also include `dataQualityWarnings[]` and `skippedMalformed[]` if manifest data quality issues exist. Per-package fields when emitted: `skippedAppCount`, `skippedDriverCount` (files are not iterated in drift -- no `skippedFileCount` on drift entries). Response-level fields when filter matches nothing: `filterMatchedZero=true`, `availablePackages[]`. When either detection system was disabled, `summary` includes a `"(partial: ...)"` suffix naming which detection field was disabled.
+**Expected**: AI calls `hub_read_apps_code(tool='hub_list_hpm_packages', args={includeDrift:true})`. Returns `success=true` with the drift payload nested under a `drift` key containing: `summary` sentence, drift-signals array (may be empty), `packagesWithActionableDrift`, `totalDriftSignals`, `orphanDetection`, `orphanDriverDetection`, and `limitations` note. AI interprets the summary and describes any drift signals found (type, packageName, componentName). If no drift, AI confirms the packages are clean and mentions the heID-presence-only detection limitation. Response may also include `dataQualityWarnings[]` and `skippedMalformed[]` if manifest data quality issues exist. Per-package fields when emitted: `skippedAppCount`, `skippedDriverCount` (files are not iterated in drift -- no `skippedFileCount` on drift entries). Response-level fields when filter matches nothing: `filterMatchedZero=true`, `availablePackages[]`. When either detection system was disabled, `summary` includes a `"(partial: ...)"` suffix naming which detection field was disabled.
 
-### T602 — hub_manage_hpm gateway catalog discovery
+### T602 — hub_read_apps_code catalog discovery (hub_list_hpm_packages)
 
 ```json
 {
-  "test_prompt": "What can the hub_manage_hpm gateway do?"
+  "test_prompt": "What HPM package tools does the hub_read_apps_code gateway expose?"
 }
 ```
 
-**Expected**: AI calls `hub_manage_hpm` with no args, sees the catalog containing `hub_list_hpm_packages` (with its `includeDrift` parameter for drift detection) and full parameter schema. AI describes the tool and its Hub Admin Read requirement.
+**Expected**: AI calls `hub_read_apps_code` with no args, finds `hub_list_hpm_packages` in the catalog (with its `includeDrift` parameter for drift detection) and full parameter schema. AI describes the tool and its Hub Admin Read requirement.
 
 ### T603 — hub_list_hpm_packages (includeDrift): data-quality-only entry does not inflate summary drift count
 
@@ -2944,13 +2947,13 @@ Tools in this section require **Hub Admin Read** and HPM itself must be installe
 
 ```json
 {
-  "setup_prompt": "Hub Admin Read is enabled. HPM is installed. Use hub_list_installed_apps to find an app that is NOT Hubitat Package Manager (e.g. the MCP Rule Server itself) and note its appId.",
+  "setup_prompt": "Hub Admin Read is enabled. HPM is installed. Use hub_list_apps (scope=instances) to find an app that is NOT Hubitat Package Manager (e.g. the MCP Rule Server itself) and note its appId.",
   "test_prompt": "Call hub_list_hpm_packages with includeDrift=true and the non-HPM appId you just found as hpmAppId. Then call hub_list_hpm_packages again with the same non-HPM appId but includeDrift omitted. Confirm both calls reject it with a descriptive error naming the actual app type.",
   "teardown_prompt": "No teardown needed."
 }
 ```
 
-**Expected**: `hub_list_hpm_packages` rejects the call on both the drift path (`includeDrift=true`) and the plain enumeration path. Internally, `_hpmAssertAppIsHpm` throws `IllegalArgumentException` with a message that includes both the supplied ID and the actual app type (e.g. `"hpmAppId <id> is not Hubitat Package Manager (actual type: MCP Rule Server) -- verify the ID or omit hpmAppId to use auto-discovery"`). The MCP protocol surfaces this as a JSON-RPC error response (`-32602` invalid params), not as a tool-result Map with `success=false` and not as a raw exception. The error message contains the supplied id and the `actual type:` string. AI explains the rejection and suggests either omitting `hpmAppId` (to let the tool auto-discover HPM) or supplying the correct HPM instance ID from `hub_list_installed_apps`. The same validator runs on both paths, so the error shape is identical.
+**Expected**: `hub_list_hpm_packages` rejects the call on both the drift path (`includeDrift=true`) and the plain enumeration path. Internally, `_hpmAssertAppIsHpm` throws `IllegalArgumentException` with a message that includes both the supplied ID and the actual app type (e.g. `"hpmAppId <id> is not Hubitat Package Manager (actual type: MCP Rule Server) -- verify the ID or omit hpmAppId to use auto-discovery"`). The MCP protocol surfaces this as a JSON-RPC error response (`-32602` invalid params), not as a tool-result Map with `success=false` and not as a raw exception. The error message contains the supplied id and the `actual type:` string. AI explains the rejection and suggests either omitting `hpmAppId` (to let the tool auto-discover HPM) or supplying the correct HPM instance ID from `hub_list_apps` (scope=instances). The same validator runs on both paths, so the error shape is identical.
 
 **Failure modes**: AI passes the wrong ID silently and returns an empty result (would indicate missing validation). AI reports a generic "tool failed" without extracting the `actual type` field from the error message. AI only tests one of the two paths (drift vs plain enumeration) instead of both.
 
@@ -2958,13 +2961,13 @@ Tools in this section require **Hub Admin Read** and HPM itself must be installe
 
 ```json
 {
-  "setup_prompt": "Hub Admin Read is enabled. HPM is installed. Use hub_list_installed_apps to find an app that is NOT Hubitat Package Manager (e.g. Simple Automation Rules or a user-installed app) and note its appId.",
+  "setup_prompt": "Hub Admin Read is enabled. HPM is installed. Use hub_list_apps (scope=instances) to find an app that is NOT Hubitat Package Manager (e.g. Simple Automation Rules or a user-installed app) and note its appId.",
   "test_prompt": "Call hub_list_hpm_packages with the non-HPM appId as hpmAppId. Confirm the tool rejects it with a descriptive error that names the supplied ID and the actual app type.",
   "teardown_prompt": "No teardown needed."
 }
 ```
 
-**Expected**: `hub_manage_hpm(tool='hub_list_hpm_packages', args={hpmAppId: '<non-hpm-id>'})` is rejected. Internally, the tool throws `IllegalArgumentException` containing the supplied id and `"actual type: <AppTypeName>"`. The MCP protocol surfaces this as a JSON-RPC error response (`-32602` invalid params), not as a tool-result Map with `success=false` and not as a raw exception. AI surfaces this as a clear rejection with guidance to omit `hpmAppId` for auto-discovery.
+**Expected**: `hub_read_apps_code(tool='hub_list_hpm_packages', args={hpmAppId: '<non-hpm-id>'})` is rejected. Internally, the tool throws `IllegalArgumentException` containing the supplied id and `"actual type: <AppTypeName>"`. The MCP protocol surfaces this as a JSON-RPC error response (`-32602` invalid params), not as a tool-result Map with `success=false` and not as a raw exception. AI surfaces this as a clear rejection with guidance to omit `hpmAppId` for auto-discovery.
 
 **Failure modes**: Tool returns an empty packages list without an error (validation skipped). Error message is present but missing the actual type name.
 
@@ -2972,13 +2975,13 @@ Tools in this section require **Hub Admin Read** and HPM itself must be installe
 
 ```json
 {
-  "setup_prompt": "Disable the 'Consolidate tools behind category gateways' setting in the MCP app preferences so tools/list returns the flat catalog (100+ entries). Note the original value so it can be restored.",
-  "test_prompt": "Invoke the MCP method tools/list with no params. Confirm the response contains a 'tools' array with every flat-mode tool present (hub_list_devices, hub_list_rooms, hub_list_files, hub_list_rules, hub_list_installed_apps, hub_create_custom_rule -- all should appear) AND no 'nextCursor' field. Then invoke tools/list again with cursor='not-a-number' and confirm the response still returns the full catalog with no error and no nextCursor (cursor is silently ignored after the pagination removal).",
+  "setup_prompt": "Disable the 'Consolidate tools behind category gateways' setting in the MCP app preferences so tools/list returns the flat catalog (~88 entries). Note the original value so it can be restored.",
+  "test_prompt": "Invoke the MCP method tools/list with no params. Confirm the response contains a 'tools' array with every flat-mode tool present (hub_list_devices, hub_list_rooms, hub_list_files, hub_list_rules, hub_list_apps, hub_create_custom_rule -- all should appear) AND no 'nextCursor' field. Then invoke tools/list again with cursor='not-a-number' and confirm the response still returns the full catalog with no error and no nextCursor (cursor is silently ignored after the pagination removal).",
   "teardown_prompt": "Re-enable the 'Consolidate tools behind category gateways' setting if it was originally on."
 }
 ```
 
-**Expected**: First call returns a single `tools` array containing the full flat-mode catalog (~100+ tools) with NO `nextCursor` field. Every flat-mode tool name appears exactly once. The cursor-with-bad-value follow-up call returns the same full catalog: cursor is now a no-op on `tools/list` (it stays opt-in only on `tools/call` paginated tools).
+**Expected**: First call returns a single `tools` array containing the full flat-mode catalog (~88 tools) with NO `nextCursor` field. Every flat-mode tool name appears exactly once. The cursor-with-bad-value follow-up call returns the same full catalog: cursor is now a no-op on `tools/list` (it stays opt-in only on `tools/call` paginated tools).
 
 **Failure modes**: Response carries a `nextCursor` (pagination was re-introduced or never removed — silent client truncation regression). Tool count substantially less than the expected flat-mode catalog (size-guard hit `-32603` because the catalog grew past the 124,000-byte cap — needs more `[[FLAT_TRIM]]` wraps). Stale `-32602` errors on cursor values (cursor handling not fully removed). Duplicate tool names in the response (catalog assembly regression).
 
@@ -3405,7 +3408,7 @@ Tools in this section require **Hub Admin Read** and HPM itself must be installe
 
 Key differences from the original BAT.md (which targets the pre-v0.8.0 architecture):
 
-1. **Architecture**: 18 core + 8 gateways (26 total) → **23 core + 13 gateways (36 on tools/list, 103 total)** post installed-apps + RM interop + native CRUD + hub_list_app_pages + poll_until_attribute + library management + HPM package state (was 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
+1. **Architecture**: 18 core + 8 gateways (26 total) → **11 flat core + 19 gateways (30 on tools/list, 88 total distinct tools)** post installed-apps + RM interop + native CRUD + hub_list_app_pages + poll_until_attribute + library management + HPM package state + the PR1B read/write gateway split (was 23 core + 13 gateways / 36 total / 103 tools before PR1B; 21 core + 9 gateways / 30 total / 69 tools at v0.8.0)
 2. **Merged tools**: `enable_rule`/`disable_rule` → `hub_update_custom_rule` (enabled=true/false); `create_virtual_device`/`delete_virtual_device` → `hub_manage_virtual_device` (action enum)
 3. **Promoted to core**: `hub_create_backup`, `hub_get_update_status`, `hub_report_issue`
 4. **Dissolved gateway**: `manage_hub_info` — radio details moved to `hub_manage_diagnostics`, other tools merged into `hub_get_info` (core) or promoted
@@ -3416,6 +3419,7 @@ Key differences from the original BAT.md (which targets the pre-v0.8.0 architect
 9. **Excluded tests expanded**: 10 → 13 (separate rows for each app/driver operation, added gateway column)
 10. **Corrected test count**: 159 → 172 (was undercounted in v1); addAction capability completeness adds T607/T608/T609/T610 (176 total); walker parity adds T611 (177 total); Between two times coverage adds T612 (178 total); singular deviceId normalization adds T613 (179 total); paired-tool singular-deviceId coverage adds T614 (addTrigger.condition) + T615 (addAction expression) (181 total); subExpression rejection on addAction adds T616 (182 total -- T616 previously covered recursive subExpression normalization, which production now rejects at the doActPage pre-pass; T616 was rewritten to pin the rejection path); reveal-fallback sentinel adds T617 (183 total); compareToDevice fallback adds T618 (184 total); Between two times sunrise/sunset adds T619 (185 total); Variable compareToVariable on the walker pages adds T620, compareToDevice missing-comparator reject adds T621, and Custom-Attribute '*changed*' cosmetic-partial filter adds T622 (188 total); periodic-frequency completeness adds T623/T624/T625/T626/T627 (the five newly-supported frequencies: Seconds/Minutes/Weekly/Monthly/Yearly -- Monthly by-day and Yearly nth-weekday) + T628 (Cron field-name fix) + T629 (count-enum validation rejection) + T630 (Monthly nth-weekday mode) + T631 (Monthly dayOfMonth/weekOfMonth mutual-exclusivity rejection) + T632 (two periodic triggers in one rule -- no sub-page collision) (198 total). Note: `Total: 227 test scenarios` in the header above counts ALL scenarios including the NL (T501-T565 range), built-in-app integration (T801-T821 range), library management (T901-T909 range), and the unnumbered walker/normalization sub-scenarios. The cumulative T-numbered tally in this item (ending at 198) reflects only sequentially-numbered tests in the explicit-coverage section.
 11. **Spec-only coverage by necessity**: the trailing-updateRule failure paths on `addTrigger`, `addRequiredExpression`, `addLocalVariable`, `addTriggers`/`addActions` (bulk), `patches`, and the action-mutation/trigger-mutation dispatchers (`removeAction`, `clearActions`, `replaceActions`, `moveAction`, `removeTrigger`, `modifyTrigger`) -- response slots `updateRuleFailed`, `subscriptionsNotLive` / `expressionNotLive` / `variableNotLive` / `patchesNotLive`, `updateRuleError`, and the recovery `repairHints` line -- are covered exclusively by Spock specs in `src/test/groovy/server/ToolRmNativeCrudSpec.groovy` (the single-path failure/SUCCESS pairs for `addTrigger` / `addRequiredExpression` / `addLocalVariable`, the three-row `@Unroll` failure/SUCCESS pairs for the bulk path covering `addTriggers`-only / `addActions`-only / both, and the corresponding patches and action-mutation envelope specs). The defensive `asyncCommitLikely` path on `clearActions` / `replaceActions` -- response slots `asyncCommitLikely`, `stage`, `actionsRequestedForRemoval`, `actionsStillPresent`, `pendingActionsToAdd`, `clearActionsResult`, `safeRecovery` -- is also spec-only: with the synchronous full-form trashActs submit the delete commits in-band, so this rare residual path (stuck `state.editAct` or a firmware commit lag still showing the actions present after the verify-retry) is not reproducible from an agent prompt against a live hub. Live-hub BAT coverage was considered but skipped: deterministically forcing the trailing `_rmClickAppButton(updateRule)` to throw against a real hub requires hub-side disruption (firmware downgrade / network partition mid-call / hub-config corruption) that is not realistically scriptable from an agent prompt. The Spock specs exercise the production response-shape contract directly via stub injection and constitute the regression gate.
+12. **PR1B read/write gateway split**: the 13-gateway flat-core layout was restructured into **19 gateways (7 `hub_read_*` pure-read + 12 `hub_manage_*` write-bearing) + 11 flat core tools** (30 on tools/list). Gateway renames: `hub_manage_rules` → `hub_manage_custom_rules`, `hub_manage_code_write` → `hub_manage_code`, `hub_manage_native_rules` → `hub_manage_native_rules_and_apps`. Removed gateways (read tools folded into `hub_read_apps_code`): `hub_manage_code_read`, `hub_manage_installed_apps`, `hub_manage_hpm`. `hub_list_installed_apps` merged into `hub_list_apps` (scope=types|instances). New pure-read gateways added: `hub_read_apps_code`, `hub_read_devices`, `hub_read_diagnostics`, `hub_read_files`, `hub_read_rooms`, `hub_read_rules`, `hub_read_variables`. Reads listed in a mixed `hub_manage_*` gateway are also surfaced in their `hub_read_*` gateway (multi-membership). Tool-behavior flips: `hub_export_custom_rule` and `hub_export_native_app` are now WRITES (they persist via saveAs); `hub_get_metrics` is now a READ (recordSnapshot default false). The previously-flat custom-rule and device tools (`hub_get_custom_rule`, `hub_create_custom_rule`, `hub_update_custom_rule`, `hub_list_devices`, `hub_get_device`, etc.) are now folded into gateways. `hub_report_issue` remains a flat core tool.
 
 ---
 
@@ -3430,9 +3434,9 @@ These are not BAT scenarios (they run autonomously, not via AI session prompts),
 The wizard probe systematically tests RM 5.1 wizard sub-flow sequences that have historically produced "**Broken Condition**" markers, silent setting rejections, or mis-labeled action rows when wizard accumulator state leaks across operations.
 
 For each probe:
-1. Creates a fresh RM rule via `hub_manage_native_rules hub_create_native_app`
+1. Creates a fresh RM rule via `hub_manage_native_rules_and_apps hub_create_native_app`
 2. Executes a sequence of `hub_update_native_app` calls (addTrigger, addRequiredExpression, addAction, etc.)
-3. Snapshots the rule's `mainPage` render via `hub_manage_installed_apps hub_get_app_config` after each step
+3. Snapshots the rule's `mainPage` render via `hub_read_apps_code hub_get_app_config` after each step
 4. Evaluates expectations against the final render (e.g. `Broken Condition` must NOT be present)
 5. Deletes the test rule in a `try/finally` block regardless of outcome
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -112,6 +112,7 @@ class HubitatMcpClient:
 
         last_exc: Optional[Exception] = None
         data: Optional[dict] = None
+        resp = None
         for attempt in range(3):
             resp = None
             try:
@@ -157,6 +158,9 @@ class HubitatMcpClient:
                 raise McpError(f"JSON decode failed on {method}{snippet}") from last_exc
             raise last_exc if last_exc else McpError(f"transport failure on {method}")
 
+        # Reaching here means the loop broke on a successful decode (the for-else
+        # above always raises on exhaustion), so data is a dict.
+        assert data is not None
         self._log(f"<< {json.dumps(data)[:500]}")
 
         if "error" in data:
@@ -407,7 +411,7 @@ class TestRunner:
     def test_tools_list(self) -> None:
         result = self.client.list_tools()
         tools = result.get("tools", [])
-        assert len(tools) == 33, f"Expected 33 tools (20 core + 13 gateways), got {len(tools)}"
+        assert len(tools) == 30, f"Expected 30 tools (11 core + 19 gateways), got {len(tools)}"
 
     @test("infrastructure")
     def test_health_endpoint(self) -> None:
@@ -1073,8 +1077,6 @@ class TestRunner:
     @test("developer_mode")
     def test_t220_update_mcp_settings_boolean_flip(self) -> None:
         """T220: hub_update_mcp_settings flips a boolean setting end-to-end."""
-        # Capture initial value so we can restore.
-        info = self.client.call_tool("hub_get_info")
         # debugLogging isn't surfaced in hub_get_info; just round-trip through
         # hub_update_mcp_settings — true → false → true and assert success each time.
         for value in (True, False, True):
@@ -1369,7 +1371,7 @@ class TestRunner:
     # Cleanup
     # -----------------------------------------------------------------------
 
-    def cleanup(self, artifacts_only: bool = False) -> None:
+    def cleanup(self) -> None:
         """Three-layer cleanup:
         1. Delete tracked artifacts (device DNIs, rule IDs, variables)
         2. Sweep for any BAT_E2E_ virtual devices

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -1928,23 +1928,32 @@ def _run_envelope_parity_self_test() -> int:
 
 
 def check_read_write_split(src_override: str | None = None) -> list[dict]:
-    """Enforce the gateway read/write-split invariant: a read-only tool MUST be
-    reachable from a hub_read_* gateway OR be a flat top-level tool. It may NEVER
-    be reachable ONLY through a hub_manage_* gateway.
+    """Enforce BOTH directions of the gateway read/write-split invariant
+    (AGENTS.md "Gateway read/write split" -- a hard CI failure):
 
-    AGENTS.md "Gateway read/write split" designates this a hard CI failure.
+      (A) No stranded read. Every tool in getReadOnlyToolNames() MUST be
+          reachable from a hub_read_* gateway OR be a flat top-level tool. It may
+          NEVER be reachable ONLY through a hub_manage_* gateway.
+          -> rule "read-write-split-stranded-read".
+      (B) No write in a read gateway. Every tool inside a hub_read_* gateway MUST
+          be in getReadOnlyToolNames() (read-only). A single write flips the
+          gateway's rolled-up readOnlyHint to write+destructive
+          (annotationsForGateway), mislabeling the whole read surface.
+          -> rule "read-write-split-write-in-read-gateway".
+
     Rationale: clients route read-only browsing through the hub_read_* gateways
-    and surface those tools under readOnlyHint=true. A read-only tool that lives
-    ONLY inside a hub_manage_* gateway is (a) invisible on the read-browse
-    surface and (b) inherits that write gateway's write+destructive annotation --
-    a read mislabeled as a write and hidden from the read path. Multi-gateway
-    membership is fine: a read MAY co-live in a hub_manage_* gateway as long as
-    it is ALSO in a hub_read_* gateway (or is flat).
+    and surface those tools under readOnlyHint=true. A read that lives ONLY inside
+    a hub_manage_* gateway is invisible on the read-browse surface AND inherits
+    the write annotation -- a read mislabeled as a write and hidden from the read
+    path. Multi-gateway membership is fine: a read MAY co-live in a hub_manage_*
+    gateway as long as it is ALSO in a hub_read_* gateway (or is flat).
 
-    The read gateways are derived by the `hub_read_` name prefix (NOT a hard-coded
-    list) so adding/removing a read gateway needs no lint edit. Ships with
-    must-catch + must-not-catch self-test fixtures (READ_WRITE_SPLIT_SELF_TEST_CASES)
-    so the guard provably fires and can never silently no-op.
+    Both directions derive the read gateways by the `hub_read_` name prefix (NOT a
+    hard-coded list), so an Nth read gateway is covered automatically -- unlike
+    McpToolAnnotationsSpec's gateway-rollup assertion, which hard-codes its read
+    gateway names. Ships with must-catch + must-not-catch self-test fixtures
+    (READ_WRITE_SPLIT_SELF_TEST_CASES) so the guard provably fires and can never
+    silently no-op.
 
     src_override lets the self-test drive this with synthetic corpora.
     """
@@ -1977,12 +1986,14 @@ def check_read_write_split(src_override: str | None = None) -> list[dict]:
             "changed? The read/write-split guard cannot run until the parser is updated.",
         )
     gateway_tools: dict[str, list[str]] = {}
+    gateway_pos: dict[str, int] = {}  # absolute src offset of each gateway, for line numbers
     for m in re.finditer(
         r"^\s+([a-z_]+):\s*\[\s*description:\s*\".*?\".*?\btools:\s*\[([^\]]+)\]",
         gw_match.group(1), re.MULTILINE | re.DOTALL,
     ):
         no_comments = re.sub(r"//[^\n]*", "", m.group(2))
         gateway_tools[m.group(1)] = [t.strip().strip("\"'") for t in no_comments.split(",") if t.strip()]
+        gateway_pos[m.group(1)] = gw_match.start(1) + m.start()
     if not gateway_tools:
         return _fail(
             "read-write-split-no-gateway-config",
@@ -2050,6 +2061,34 @@ def check_read_write_split(src_override: str | None = None) -> list[dict]:
             ),
             "source": "",
         })
+
+    # 6. Mirror invariant (B): a hub_read_* gateway must contain ONLY read-only
+    #    tools. Derived by prefix so an Nth read gateway is covered too (the Spock
+    #    rollup hard-codes its read-gateway names; this does not).
+    for name in sorted(gateway_tools):
+        if not name.startswith("hub_read_"):
+            continue
+        for tool in gateway_tools[name]:
+            if tool in read_only:
+                continue
+            g_abs = gateway_pos.get(name, ro_match.start())
+            idx = src.find(f'"{tool}"', g_abs)
+            line_no = (src[:idx].count("\n") + 1) if idx != -1 else (src[:g_abs].count("\n") + 1)
+            findings.append({
+                "file": rel,
+                "line": line_no,
+                "severity": "error",
+                "rule": "read-write-split-write-in-read-gateway",
+                "message": (
+                    f"Tool '{tool}' is in read gateway '{name}' but is NOT in getReadOnlyToolNames() "
+                    f"(i.e. it is treated as a write). A hub_read_* gateway must contain only "
+                    f"read-only tools -- a single write flips the gateway's rolled-up readOnlyHint to "
+                    f"write+destructive (annotationsForGateway), mislabeling the entire read surface. "
+                    f"Fix: move '{tool}' to the appropriate hub_manage_* gateway, or -- if it is "
+                    f"genuinely read-only -- add it to getReadOnlyToolNames()."
+                ),
+                "source": "",
+            })
     return findings
 
 
@@ -2132,6 +2171,25 @@ READ_WRITE_SPLIT_SELF_TEST_CASES = [
         "no getGatewayConfig() in source -- flags extractor guard (must-catch)",
         'def getReadOnlyToolNames() {\n    return [ "hub_get_device" ] as Set\n}\n',
         {"read-write-split-no-gateway-config"},
+    ),
+    # --- Mirror invariant (B): no write tool inside a hub_read_* gateway ---
+    (
+        "write tool inside a hub_read_* gateway -- flags write-in-read (must-catch)",
+        _build_read_write_split_corpus(
+            {"hub_read_devices": ["hub_get_device", "hub_update_device"]},
+            ["hub_get_device"],
+            ["hub_get_device", "hub_update_device"],
+        ),
+        {"read-write-split-write-in-read-gateway"},
+    ),
+    (
+        "only read-only tools inside a hub_read_* gateway -- no finding (must-not-catch)",
+        _build_read_write_split_corpus(
+            {"hub_read_files": ["hub_list_files", "hub_read_file"]},
+            ["hub_list_files", "hub_read_file"],
+            ["hub_list_files", "hub_read_file"],
+        ),
+        set(),
     ),
 ]
 
@@ -2605,7 +2663,11 @@ COUNT_SELF_TEST_CASES = [
     (
         "proxied in bare `N proxied` (not paren-prefix, named fixture)",
         "Summary: 23 core + 13 gateways, 80 proxied, 103 total tools.",
-        {"proxied": 79}, ["proxied"],
+        # Override the other counts the sentence mentions to their literal in-text
+        # values so ONLY `proxied` drifts (80 vs 79); otherwise the live core /
+        # gateways / total counts -- which changed after PR1B's gateway reshape --
+        # also fire and the fixture stops isolating the proxied pattern.
+        {"proxied": 79, "core": 23, "gateways": 13, "total": 103}, ["proxied"],
     ),
     (
         "total in `N total` punctuation-bounded (named fixture)",
@@ -2956,14 +3018,39 @@ def run_self_test() -> int:
             "Groovy source."
         )
     else:
-        derived = canonical["core"] + sum(canonical["per_gateway"].values())
-        if derived != canonical["total"]:
+        # Self-consistency of the count breakdown. NOTE: sum(per_gateway.values())
+        # is NOT used as `core + sum == total` anymore -- since PR1B introduced
+        # multi-gateway membership (a read listed in both its hub_read_* and a
+        # hub_manage_* gateway), the per-gateway sum DOUBLE-COUNTS those reads and
+        # exceeds the DISTINCT proxied count. The canonical relationship is on the
+        # distinct count: total == core + distinct_proxied (and core is derived as
+        # total - distinct_proxied, so this also guards a future core-formula change).
+        sum_with_dups = sum(canonical["per_gateway"].values())
+        if canonical["core"] < 0:
             failures += 1
             print(
                 f"SELF-TEST FAIL [tool-count extractor]\n"
-                f"  derived total {derived} != reported total "
-                f"{canonical['total']} — internal inconsistency in "
-                "_extract_canonical_counts()"
+                f"  core {canonical['core']} is negative — distinct proxied "
+                f"({canonical['proxied']}) exceeds total ({canonical['total']}); "
+                "_extract_canonical_counts() is inconsistent."
+            )
+        if canonical["core"] + canonical["proxied"] != canonical["total"]:
+            failures += 1
+            print(
+                f"SELF-TEST FAIL [tool-count extractor]\n"
+                f"  core ({canonical['core']}) + distinct proxied "
+                f"({canonical['proxied']}) != total ({canonical['total']}) — "
+                "internal inconsistency in _extract_canonical_counts()."
+            )
+        # Multi-membership means the per-gateway sum must be >= the distinct
+        # proxied count; sum < distinct would mean a gateway tool went uncounted.
+        if sum_with_dups < canonical["proxied"]:
+            failures += 1
+            print(
+                f"SELF-TEST FAIL [tool-count extractor]\n"
+                f"  per-gateway sum ({sum_with_dups}) < distinct proxied "
+                f"({canonical['proxied']}) — a gateway tool is uncounted; "
+                "_extract_canonical_counts() is inconsistent."
             )
         # Compare the raw list length against the de-duplicated set size.
         # `total` is intentionally len(list); `tool_names` is set(list).

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -144,6 +144,20 @@ RULES = [
         "message": "GroovyShell blocked in Hubitat sandbox",
         "severity": "error",
     },
+    {
+        # The hub runs Groovy 2.4 (antlr2 parser), which rejects a bare `{ ... }`
+        # block immediately after a `case X:` label as an ambiguous
+        # parameterless-closure-vs-open-block. hubitat_ci's Groovy 3.0 (Parrot)
+        # parser accepts it, so the Spock suite compiles clean while the real hub
+        # refuses to save the app ("Ambiguous expression could be either a
+        # parameterless closure expression or an isolated open code block").
+        # Extract the case body into a helper method (or drop the wrapping braces
+        # and declare no locals) so dispatch cases stay plain statements.
+        "id": "SANDBOX-014",
+        "pattern": r"\bcase\b[^:]*:\s*\{",
+        "message": "Bare '{ }' block right after 'case X:' is rejected by the hub's Groovy 2.4 parser (ambiguous closure vs open block) even though hubitat_ci's Groovy 3.0 accepts it -- extract the case body to a method or remove the braces",
+        "severity": "error",
+    },
 ]
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -24,9 +24,9 @@ from pathlib import Path
 # (rather than strict) keeps a single mis-encoded character from masking
 # whatever the lint was actually trying to report.
 if hasattr(sys.stdout, "reconfigure"):
-    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
 if hasattr(sys.stderr, "reconfigure"):
-    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -715,7 +715,11 @@ def _extract_canonical_counts() -> dict | None:
     tool_names: set[str] = set(raw_name_list)
     total = len(raw_name_list)
 
-    proxied = sum(per_gateway.values())
+    # Count DISTINCT proxied tools, not the sum of per-gateway tool counts:
+    # a tool may belong to more than one gateway (multi-gateway membership --
+    # reads are listed in both their mixed manage_ gateway and a read_ gateway),
+    # so sum(per_gateway.values()) over-counts and would drive `core` negative.
+    proxied = len(proxied_names)
     core = total - proxied
     gateways = len(per_gateway)
     tools_list = core + gateways

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -1927,6 +1927,247 @@ def _run_envelope_parity_self_test() -> int:
     return failures
 
 
+def check_read_write_split(src_override: str | None = None) -> list[dict]:
+    """Enforce the gateway read/write-split invariant: a read-only tool MUST be
+    reachable from a hub_read_* gateway OR be a flat top-level tool. It may NEVER
+    be reachable ONLY through a hub_manage_* gateway.
+
+    AGENTS.md "Gateway read/write split" designates this a hard CI failure.
+    Rationale: clients route read-only browsing through the hub_read_* gateways
+    and surface those tools under readOnlyHint=true. A read-only tool that lives
+    ONLY inside a hub_manage_* gateway is (a) invisible on the read-browse
+    surface and (b) inherits that write gateway's write+destructive annotation --
+    a read mislabeled as a write and hidden from the read path. Multi-gateway
+    membership is fine: a read MAY co-live in a hub_manage_* gateway as long as
+    it is ALSO in a hub_read_* gateway (or is flat).
+
+    The read gateways are derived by the `hub_read_` name prefix (NOT a hard-coded
+    list) so adding/removing a read gateway needs no lint edit. Ships with
+    must-catch + must-not-catch self-test fixtures (READ_WRITE_SPLIT_SELF_TEST_CASES)
+    so the guard provably fires and can never silently no-op.
+
+    src_override lets the self-test drive this with synthetic corpora.
+    """
+    findings: list[dict] = []
+    server = REPO_ROOT / "hubitat-mcp-server.groovy"
+    if src_override is not None:
+        src = src_override
+    else:
+        if not server.exists():
+            return findings
+        src = server.read_text(encoding="utf-8", errors="replace")
+
+    rel = str(server.relative_to(REPO_ROOT))
+
+    def _fail(rule: str, message: str) -> list[dict]:
+        findings.append({
+            "file": rel, "line": 1, "severity": "error",
+            "rule": rule, "message": message, "source": "",
+        })
+        return findings
+
+    # 1. getGatewayConfig() -> {gateway_name: [tool, ...]}. Same two-stage anchor
+    #    _extract_canonical_counts() uses, but we keep the full tool LISTS (not
+    #    just counts) and the gateway names (to split hub_read_ vs hub_manage_).
+    gw_match = re.search(r"^def getGatewayConfig\(\) \{(.*?)^}", src, re.DOTALL | re.MULTILINE)
+    if not gw_match:
+        return _fail(
+            "read-write-split-no-gateway-config",
+            "Could not locate getGatewayConfig() return literal -- has the function shape "
+            "changed? The read/write-split guard cannot run until the parser is updated.",
+        )
+    gateway_tools: dict[str, list[str]] = {}
+    for m in re.finditer(
+        r"^\s+([a-z_]+):\s*\[\s*description:\s*\".*?\".*?\btools:\s*\[([^\]]+)\]",
+        gw_match.group(1), re.MULTILINE | re.DOTALL,
+    ):
+        no_comments = re.sub(r"//[^\n]*", "", m.group(2))
+        gateway_tools[m.group(1)] = [t.strip().strip("\"'") for t in no_comments.split(",") if t.strip()]
+    if not gateway_tools:
+        return _fail(
+            "read-write-split-no-gateway-config",
+            "getGatewayConfig() parsed but yielded zero gateways -- parser/source shape mismatch.",
+        )
+
+    # 2. getReadOnlyToolNames() -> the read-only tool set (the source of truth
+    #    that feeds the readOnlyHint annotations).
+    ro_match = re.search(r"^def getReadOnlyToolNames\(\) \{(.*?)^}", src, re.DOTALL | re.MULTILINE)
+    if not ro_match:
+        return _fail(
+            "read-write-split-no-readonly-list",
+            "Could not locate getReadOnlyToolNames() return literal -- has the function shape changed?",
+        )
+    read_only = set(re.findall(r'"([a-z_]+)"', re.sub(r"//[^\n]*", "", ro_match.group(1))))
+    if not read_only:
+        return _fail(
+            "read-write-split-no-readonly-list",
+            "getReadOnlyToolNames() parsed but yielded zero tool names -- parser/source shape mismatch.",
+        )
+
+    # 3. Flat (top-level) tools = every getAllToolDefinitions() tool that no
+    #    gateway proxies. A read-only tool that is flat satisfies the invariant.
+    all_match = re.search(r"^def getAllToolDefinitions\(\) \{(.*?)^}", src, re.DOTALL | re.MULTILINE)
+    if not all_match:
+        return _fail(
+            "read-write-split-no-tool-definitions",
+            "Could not locate getAllToolDefinitions() return literal -- has the function shape changed?",
+        )
+    all_tool_names = set(re.findall(r"^\s*name:\s*['\"]([a-z_]+)['\"]", all_match.group(1), re.MULTILINE))
+    proxied: set[str] = set()
+    for tools in gateway_tools.values():
+        proxied.update(tools)
+    flat_tools = all_tool_names - proxied
+
+    # 4. Read-gateway reach: every tool surfaced by a gateway whose name carries
+    #    the hub_read_ prefix (derived, not hard-coded).
+    read_gateway_tools: set[str] = set()
+    for name, tools in gateway_tools.items():
+        if name.startswith("hub_read_"):
+            read_gateway_tools.update(tools)
+
+    # 5. The invariant. A read-only tool is stranded iff it is neither flat nor in
+    #    any hub_read_* gateway -- i.e. reachable ONLY through hub_manage_*.
+    ro_body_start = ro_match.start(1)
+    for tool in sorted(read_only):
+        if tool in read_gateway_tools or tool in flat_tools:
+            continue
+        holders = sorted(n for n, ts in gateway_tools.items() if tool in ts)
+        where = f"only via hub_manage_* gateway(s) {holders}" if holders else "by no gateway at all (and it is not flat)"
+        idx = src.find(f'"{tool}"', ro_body_start)
+        line_no = (src[:idx].count("\n") + 1) if idx != -1 else (src[:ro_match.start()].count("\n") + 1)
+        findings.append({
+            "file": rel,
+            "line": line_no,
+            "severity": "error",
+            "rule": "read-write-split-stranded-read",
+            "message": (
+                f"Read-only tool '{tool}' is reachable {where}; it is in NO hub_read_* gateway and is "
+                f"not a flat top-level tool. AGENTS.md 'Gateway read/write split' makes this a hard "
+                f"failure: a read-only tool MUST be in a hub_read_* gateway (multi-gateway membership "
+                f"alongside a hub_manage_* gateway is fine) or be flat. Fix: add '{tool}' to the "
+                f"matching hub_read_* gateway's tools[] list, or -- if it is actually a write -- remove "
+                f"it from getReadOnlyToolNames()."
+            ),
+            "source": "",
+        })
+    return findings
+
+
+def _build_read_write_split_corpus(gateways: dict, read_only: list, all_tools: list) -> str:
+    """Construct a minimal Groovy corpus satisfying check_read_write_split's three
+    extractors (getGatewayConfig / getReadOnlyToolNames / getAllToolDefinitions)
+    so self-test fixtures can drive the REAL check. `gateways` maps gateway-name
+    -> list of proxied tool names."""
+    lines = ["def getGatewayConfig() {", "    return ["]
+    for name, tools in gateways.items():
+        csv = ", ".join(f'"{t}"' for t in tools)
+        lines += [
+            f"        {name}: [",
+            f'            description: "{name} facade",',
+            f"            tools: [{csv}]",
+            "        ],",
+        ]
+    lines += ["    ]", "}", "", "def getReadOnlyToolNames() {", "    return ["]
+    lines.append("        " + ", ".join(f'"{t}"' for t in read_only))
+    lines += ["    ] as Set", "}", "", "def getAllToolDefinitions() {", "    return ["]
+    for t in all_tools:
+        lines += ["        [", f'            name: "{t}"', "        ],"]
+    lines += ["    ]", "}"]
+    return "\n".join(lines) + "\n"
+
+
+# Self-test fixtures for check_read_write_split. Drive the real check with
+# synthetic Groovy corpora to cover must-catch + must-not-catch cases
+# (PIPELINE.md Rule 13) so the guard provably fires and never silently no-ops.
+READ_WRITE_SPLIT_SELF_TEST_CASES = [
+    # (description, groovy source, expected_rule_codes)
+    (
+        "read surfaced by a hub_read_* gateway -- no finding (must-not-catch)",
+        _build_read_write_split_corpus(
+            {"hub_read_devices": ["hub_get_device"],
+             "hub_manage_devices": ["hub_get_device", "hub_update_device"]},
+            ["hub_get_device"],
+            ["hub_get_device", "hub_update_device"],
+        ),
+        set(),
+    ),
+    (
+        "read is flat (proxied by no gateway) -- no finding (must-not-catch)",
+        _build_read_write_split_corpus(
+            {"hub_manage_devices": ["hub_update_device"]},
+            ["hub_get_info"],
+            ["hub_get_info", "hub_update_device"],
+        ),
+        set(),
+    ),
+    (
+        "read in BOTH a read and a manage gateway -- multi-membership OK (must-not-catch)",
+        _build_read_write_split_corpus(
+            {"hub_read_rules": ["hub_get_custom_rule"],
+             "hub_manage_custom_rules": ["hub_get_custom_rule", "hub_delete_custom_rule"]},
+            ["hub_get_custom_rule"],
+            ["hub_get_custom_rule", "hub_delete_custom_rule"],
+        ),
+        set(),
+    ),
+    (
+        "read reachable ONLY through a hub_manage_* gateway -- flags stranded (must-catch)",
+        _build_read_write_split_corpus(
+            {"hub_manage_logs": ["hub_get_logs", "hub_delete_debug_logs"]},
+            ["hub_get_logs"],
+            ["hub_get_logs", "hub_delete_debug_logs"],
+        ),
+        {"read-write-split-stranded-read"},
+    ),
+    (
+        "read in no gateway at all and not flat -- flags stranded, empty holders (must-catch)",
+        _build_read_write_split_corpus(
+            {"hub_manage_logs": ["hub_delete_debug_logs"]},
+            ["hub_ghost_read"],
+            ["hub_delete_debug_logs"],
+        ),
+        {"read-write-split-stranded-read"},
+    ),
+    (
+        "no getGatewayConfig() in source -- flags extractor guard (must-catch)",
+        'def getReadOnlyToolNames() {\n    return [ "hub_get_device" ] as Set\n}\n',
+        {"read-write-split-no-gateway-config"},
+    ),
+]
+
+
+def _run_read_write_split_self_test() -> int:
+    """Drive check_read_write_split with synthetic corpora and verify dispatch
+    correctness + finding-dict shape correctness."""
+    failures = 0
+    for i, (desc, src, expected_codes) in enumerate(READ_WRITE_SPLIT_SELF_TEST_CASES, start=1):
+        findings = check_read_write_split(src_override=src)
+        shape_ok = True
+        for f in findings:
+            try:
+                _ = format_finding(f)
+            except KeyError as ke:
+                failures += 1
+                shape_ok = False
+                print(
+                    f"READ-WRITE-SPLIT-SELF-TEST FAIL [{i}] {desc}\n"
+                    f"  finding dict missing required key for format_finding: {ke}\n"
+                    f"  finding keys present: {sorted(f.keys())}"
+                )
+        if not shape_ok:
+            continue
+        actual_codes = {f["rule"] for f in findings}
+        if actual_codes != expected_codes:
+            failures += 1
+            print(
+                f"READ-WRITE-SPLIT-SELF-TEST FAIL [{i}] {desc}\n"
+                f"  expected codes: {sorted(expected_codes)}\n"
+                f"  actual codes:   {sorted(actual_codes)}\n"
+                f"  all findings: {findings!r}"
+            )
+    return failures
+
+
 def format_finding(f: dict) -> str:
     """Format a single finding for human-readable output."""
     severity = f["severity"].upper()
@@ -2790,6 +3031,13 @@ def run_self_test() -> int:
     envelope_parity_failures = _run_envelope_parity_self_test()
     failures += envelope_parity_failures
 
+    # Read/write-split must-catch / must-not-catch fixtures (PIPELINE.md Rule 13):
+    # the guard that a read-only tool is never stranded behind only a hub_manage_*
+    # gateway ships with positive + negative fixtures so a regression in the
+    # dispatch logic surfaces here rather than silently weakening the lint.
+    read_write_split_failures = _run_read_write_split_self_test()
+    failures += read_write_split_failures
+
     if failures:
         print(f"--- {failures} self-test failure(s) ---")
         return 1
@@ -2799,13 +3047,15 @@ def run_self_test() -> int:
         + len(TOOL_GUIDE_ANCHOR_SELF_TEST_CASES)
         + len(DISCRETE_EVENT_CAPS_SELF_TEST_CASES)
         + len(ENVELOPE_PARITY_SELF_TEST_CASES)
+        + len(READ_WRITE_SPLIT_SELF_TEST_CASES)
     )
     print(
         f"Self-test: {total_cases} case(s) passed "
         f"({len(SELF_TEST_CASES)} sandbox, {len(COUNT_SELF_TEST_CASES)} count, "
         f"{len(TOOL_GUIDE_ANCHOR_SELF_TEST_CASES)} tool-guide-anchor, "
         f"{len(DISCRETE_EVENT_CAPS_SELF_TEST_CASES)} discrete-event-caps, "
-        f"{len(ENVELOPE_PARITY_SELF_TEST_CASES)} envelope-parity)."
+        f"{len(ENVELOPE_PARITY_SELF_TEST_CASES)} envelope-parity, "
+        f"{len(READ_WRITE_SPLIT_SELF_TEST_CASES)} read-write-split)."
     )
     return 0
 
@@ -2850,6 +3100,13 @@ def main() -> int:
     # the dedicated slots into the return shape" class -- callers cannot detect
     # the not-live state without log-grep otherwise.
     all_findings.extend(check_trailing_updaterule_envelope_parity())
+
+    # Enforce the gateway read/write-split invariant: a read-only tool must be
+    # reachable from a hub_read_* gateway or be flat -- NEVER stranded behind only
+    # a hub_manage_* gateway (AGENTS.md "Gateway read/write split"). Catches the
+    # "a read got added to a manage gateway but never surfaced on the read side"
+    # class, which mislabels the read as a write and hides it from the read path.
+    all_findings.extend(check_read_write_split())
 
     # Sort by file, then line
     all_findings.sort(key=lambda f: (f["file"], f["line"]))

--- a/tests/test_sandbox_lint.py
+++ b/tests/test_sandbox_lint.py
@@ -74,15 +74,14 @@ def test_read_write_split_self_test_case(desc, src, expected_codes):
     )
 
 
-def test_read_write_split_real_source_has_no_stranded_reads():
-    """The real shipped source must satisfy the invariant: zero stranded reads.
-    Guards against a future edit that adds a read-only tool to a hub_manage_*
-    gateway without also surfacing it in a hub_read_* gateway (or flat)."""
+def test_read_write_split_real_source_clean():
+    """The real shipped source must satisfy BOTH directions of the invariant:
+    no read stranded behind only a hub_manage_* gateway, and no write tool inside
+    a hub_read_* gateway. Guards against a future edit that mis-gates a tool."""
     findings = sl.check_read_write_split()
-    stranded = [f for f in findings if f["rule"] == "read-write-split-stranded-read"]
-    assert stranded == [], (
-        "read-only tool(s) stranded behind only a hub_manage_* gateway:\n  "
-        + "\n  ".join(f["message"] for f in stranded)
+    assert findings == [], (
+        "read/write-split violation(s) in the shipped source:\n  "
+        + "\n  ".join(f"[{f['rule']}] {f['message']}" for f in findings)
     )
 
 

--- a/tests/test_sandbox_lint.py
+++ b/tests/test_sandbox_lint.py
@@ -53,6 +53,40 @@ def test_self_test_case(desc, source, expected):
 
 
 # ---------------------------------------------------------------------------
+# check_read_write_split — read/write-split invariant (AGENTS.md hard rule)
+# ---------------------------------------------------------------------------
+# A read-only tool must be reachable from a hub_read_* gateway OR be flat; it
+# may NEVER be stranded behind only a hub_manage_* gateway. The main lint
+# (sandbox-lint.yml) enforces the invariant on the real source. These tests run
+# the must-catch / must-not-catch fixtures through the REAL check in pytest (CI)
+# so the guard can never silently no-op -- the `--self-test` runner is dev-only
+# and not wired into any CI job.
+
+@pytest.mark.parametrize("desc,src,expected_codes", sl.READ_WRITE_SPLIT_SELF_TEST_CASES)
+def test_read_write_split_self_test_case(desc, src, expected_codes):
+    """Each READ_WRITE_SPLIT_SELF_TEST_CASES entry: the guard reports exactly the
+    declared rule codes (empty set = must-not-catch, a code = must-catch)."""
+    findings = sl.check_read_write_split(src_override=src)
+    actual_codes = {f["rule"] for f in findings}
+    assert actual_codes == set(expected_codes), (
+        f"[{desc}] expected codes {sorted(set(expected_codes))}, "
+        f"got {sorted(actual_codes)}\n  findings: {findings!r}"
+    )
+
+
+def test_read_write_split_real_source_has_no_stranded_reads():
+    """The real shipped source must satisfy the invariant: zero stranded reads.
+    Guards against a future edit that adds a read-only tool to a hub_manage_*
+    gateway without also surfacing it in a hub_read_* gateway (or flat)."""
+    findings = sl.check_read_write_split()
+    stranded = [f for f in findings if f["rule"] == "read-write-split-stranded-read"]
+    assert stranded == [], (
+        "read-only tool(s) stranded behind only a hub_manage_* gateway:\n  "
+        + "\n  ".join(f["message"] for f in stranded)
+    )
+
+
+# ---------------------------------------------------------------------------
 # strip_comments_and_strings — additional direct coverage
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Reorganizes the MCP gateway surface from 13 mixed gateways into **19** — **7 pure-read `hub_read_*`** + **12 write-bearing `hub_manage_*`** — so an AI consumer can enable read-only access and gate writes separately. Reads are multi-listed (in both their mixed `manage_` gateway and a `read_` gateway), so **no read is locked behind a write gateway**.
- `tools/list` goes 33 → 30 (11 flat core tools + 19 gateways); 88 total distinct tools.
- **Part of #105** (PR1B). Completes #207, first step of #137, part of #113.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- **New read-only gateways:** `hub_read_apps_code`, `hub_read_devices`, `hub_read_diagnostics`, `hub_read_files`, `hub_read_rooms`, `hub_read_rules`, `hub_read_variables`.
- **Renames:** `hub_manage_rules`→`hub_manage_custom_rules`, `hub_manage_code_write`→`hub_manage_code`, `hub_manage_native_rules`→`hub_manage_native_rules_and_apps`.
- **New:** dedicated `hub_manage_rule_machine` (RM-only tools) + `hub_manage_devices`; device tools and custom-rule get/create/update moved off the flat surface into gateways (11 flat core tools remain).
- **Merged away** (reads folded into `hub_read_apps_code`): `hub_manage_code_read`, `hub_manage_installed_apps`, `hub_manage_hpm`.
- **`hub_list_installed_apps` merged into `hub_list_apps(scope=types|instances)`** — Closes #207 (its `list_virtual_devices` half shipped in PR1A).
- **Behavior:** `hub_export_custom_rule` now persists the export to the File Manager (it's a write); `hub_export_native_app` reclassified read→write; `hub_get_metrics` read-only by default (`recordSnapshot` defaults false).
- **AGENTS.md/CLAUDE.md:** `read_` added as a gateway verb for pure-read gateways (distinct from the file-manager `read`/`write` leaf tools).
- **Developer Mode:** `useGateways` added to the `hub_update_mcp_settings` allowlist — an agent in Developer Mode can switch gateway/flat mode without editing the app settings UI (same self-admin class as `enableBuiltinApp`/`enableCustomRuleEngine`).
- **Part of #105** (PR1B). First step of **#137** (dedicated RM gateway). Part of **#113** — the read/write *separation*; the 2-tier toggle collapse + per-tool runtime filter land as a **separate follow-up PR** for separate review.

## Release Notes

- **Tool gateways reorganized into read/write groups.** The MCP tool surface is now **19 gateways — 7 read-only (`hub_read_*`) + 12 write-bearing (`hub_manage_*`)** — up from 13 mixed gateways. Enable a `hub_read_*` gateway in your LLM client for safe read-only queries and gate the write gateways separately. `tools/list` now shows **30 entries (11 always-visible core tools + 19 gateways), covering 88 tools total**.
- **New read-only gateways:** `hub_read_apps_code`, `hub_read_devices`, `hub_read_diagnostics`, `hub_read_files`, `hub_read_rooms`, `hub_read_rules`, `hub_read_variables`. Every read tool is reachable from a read-only gateway (or stays flat) — never locked behind a write gateway.
- **New** dedicated **Rule Machine** gateway (`hub_manage_rule_machine`) and **device** gateways (`hub_read_devices` / `hub_manage_devices`).
- **Renamed gateways/tools** (cached MCP clients refresh automatically; no deprecation aliases): `hub_manage_rules`→`hub_manage_custom_rules`, `hub_manage_code_write`→`hub_manage_code`, `hub_manage_native_rules`→`hub_manage_native_rules_and_apps`; `hub_list_installed_apps` folded into `hub_list_apps(scope='instances')`.
- `hub_export_custom_rule` now **saves the exported rule JSON to the hub File Manager** (it's now a write).
- `hub_get_metrics` **no longer records a history snapshot by default** — pass `recordSnapshot=true` to record one.
- **Switch the tool surface between gateway and flat mode from the agent (Developer Mode).** `useGateways` is now adjustable via `hub_update_mcp_settings`, so an AI agent or CI/CD pipeline running in Developer Mode can consolidate tools behind gateways or expose them flat without editing the app settings page. Like the `enable*` toggles, the client must reconnect afterward to pick up the new tool surface.

## Testing

- `python tests/sandbox_lint.py` — **passes clean** (counts 88 / 30 / 11 / 19 all reconcile).
- All specs **compile**. First full `./gradlew test` ran 2998 tests with 10 failures, all from the 3 expected semantic deltas (device tools now gatewayed, `get_metrics` default flip, `export_custom_rule` persist) — **now fixed** in the 4 affected specs.
- ⚠️ The full suite was **not re-run to green locally** — the 7GB dev box OOM'd the test JVM. **Relying on CI** for the authoritative full-suite run; any residuals will be fixed with targeted local runs.

## Checklist

- [ ] **Unit tests added for any new MCP tools** (n/a — no new tools; existing specs updated for the reorg)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (**CI to confirm** — local box OOM)
- [x] Live-hub BAT tests updated (`tests/BAT-v2.md`)
- [x] Documentation updated
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules


