### PR TITLE
ci: add additive Groovy 2.5 Spock runtime lane (issues #227, #230)

### DIFF
--- a/.github/workflows/groovy2x-spock.yml
+++ b/.github/workflows/groovy2x-spock.yml
@@ -1,0 +1,53 @@
+name: Groovy 2.5 Spock (additive)
+
+# Additive lane (issue #230). Hubitat's hub runtime is Groovy 2.4.x; the root Unit Tests lane runs
+# the same Spock corpus under Groovy 3.0 (eighty20results/hubitat_ci), so a 3.0-green can hide
+# 2.x-vs-3.0 RUNTIME-behaviour divergence. The sibling Groovy 2.4 Parse Check lane catches only
+# load-time/syntax failures; this lane runs the EXISTING src/test/groovy specs against a Groovy 2.5
+# runtime via joelwetzel/hubitat_ci (the biocomp-API fork, closest viable to the hub's 2.4).
+#
+# Fully standalone: a separate build under ci/groovy2x-spock/ that never touches the root
+# build.gradle or the existing 3.0 unit-test lane. The shared spec corpus is referenced read-only.
+#
+# ALLOW-FAILURE: continue-on-error keeps this lane informational until the 2.5 corpus is fully green.
+# It is NOT the repo ruleset's required `test` check, so it never blocks merge.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '*.groovy'
+      - 'src/test/groovy/**'
+      - 'src/main/groovy/**'
+      - 'ci/groovy2x-spock/**'
+      - '.github/workflows/groovy2x-spock.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  groovy2x-spock:
+    name: groovy2x-spock (allow-failure)
+    runs-on: ubuntu-latest
+    # Informational lane — a 2.5 spec failure must not fail the workflow or gate merge.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          # 17 for the Gradle 9 daemon; 11 for the test toolchain (Groovy 2.5.x is
+          # unhappy on JDK 17/21). Both are auto-detected by the toolchain resolver.
+          java-version: |
+            11
+            17
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Run the existing Spock specs under Groovy 2.5 (joelwetzel/hubitat_ci)
+        run: ./gradlew -p ci/groovy2x-spock test --console=plain
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: groovy2x-spock-report
+          path: |
+            ci/groovy2x-spock/build/reports/tests/test/
+            ci/groovy2x-spock/build/test-results/test/

--- a/.github/workflows/groovy2x-spock.yml
+++ b/.github/workflows/groovy2x-spock.yml
@@ -42,7 +42,8 @@ jobs:
             17
       - uses: gradle/actions/setup-gradle@v6
       - name: Run the existing Spock specs under Groovy 2.5 (joelwetzel/hubitat_ci)
-        run: ./gradlew -p ci/groovy2x-spock test --console=plain
+        # -PharnessStrictMetaClass=true also exercises the harness metaClass dual-wipe under 2.5.
+        run: ./gradlew -p ci/groovy2x-spock test -PharnessStrictMetaClass=true --console=plain
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v7

--- a/ci/groovy2x-spock/build.gradle
+++ b/ci/groovy2x-spock/build.gradle
@@ -49,8 +49,9 @@ dependencies {
     implementation 'org.codehaus.groovy:groovy-all:2.5.23'
     testImplementation 'org.codehaus.groovy:groovy-all:2.5.23'
     testImplementation 'org.spockframework:spock-core:2.3-groovy-2.5'
-    // joelwetzel/hubitat_ci pinned by commit SHA (no release tags). Tracked alongside the root
-    // lane's eighty20results pin by .github/workflows/hubitat-ci-version-check.yml.
+    // joelwetzel/hubitat_ci pinned by commit SHA (the fork cuts no release tags). This is a MANUAL
+    // pin: the existing .github/workflows/hubitat-ci-version-check.yml only tracks the root build's
+    // eighty20results tag, not this SHA, so bump it by hand when adopting fork fixes.
     testImplementation 'com.github.joelwetzel:hubitat_ci:a62a351eed'
     // Spock needs a class-gen backend (byte-buddy or cglib) to Mock/Spy non-interface types
     // (TestDevice, TestChildApp); neither is transitive on the groovy-2.5 variant.
@@ -108,7 +109,9 @@ def forkCoupledSpecs = [
 // Copy the LIVE spec corpus into the build dir, minus the files the lane overrides or drops, so the
 // originals stay byte-untouched ("referenced read-only, written once" — issue #230) and the lane
 // always runs the same evolving specs. Sync prunes deleted specs automatically.
-def importedSpecsDir = layout.buildDirectory.dir('imported-specs').get().asFile
+// Lazy Provider<Directory> — Sync.into and srcDirs both accept it, so we avoid eagerly resolving
+// the build dir at configuration time (keeps configuration-cache compatibility).
+def importedSpecsDir = layout.buildDirectory.dir('imported-specs')
 def importSpecs = tasks.register('importSpecs', Sync) {
     from("${repoRoot}/src/test/groovy") {
         (laneScaffoldOverrides + forkCoupledSpecs).each { exclude it }
@@ -136,8 +139,18 @@ test {
     // the forked test JVM must run from the repo root, not this isolated project dir.
     workingDir = repoRoot
     // Keep specs single-threaded. RMUtilsMock / NetworkUtilsMock inject static metaclass methods on
-    // hubitat.helper.RMUtils / .NetworkUtils — concurrent install/uninstall would race.
+    // hubitat.helper.RMUtils / .NetworkUtils — concurrent install/uninstall would race. (The
+    // CURRENT_FEATURE static hand-off in the lane HarnessSpec/RuleHarnessSpec also depends on this.)
     maxParallelForks = 1
+    // Forward the same harness-debug flags the root build does, so this lane can exercise the
+    // metaClass dual-wipe (HarnessSpec.checkMetaClassClean) and the gateway-toggle path under
+    // Groovy 2.5 too. The workflow runs this lane with -PharnessStrictMetaClass=true.
+    if (project.hasProperty('harnessStrictMetaClass')) {
+        systemProperty 'harnessStrictMetaClass', project.harnessStrictMetaClass
+    }
+    if (project.hasProperty('harness.useGateways')) {
+        systemProperty 'harness.useGateways', project.getProperty('harness.useGateways')
+    }
     // Silence Groovy 2.5.23's reflective access under JDK 11+. Groovy 2.5's CachedClass /
     // CachedConstructor reflects into these java.base packages on init; without the opens the run is
     // noisy (and some reach throws). Drop this block if the lane ever moves to Groovy 3+.

--- a/ci/groovy2x-spock/build.gradle
+++ b/ci/groovy2x-spock/build.gradle
@@ -1,0 +1,163 @@
+// Additive Groovy 2.5 Spock runtime lane (issue #230).
+//
+// Hubitat's hub runtime is Groovy 2.4.x; the root test lane runs the same specs under Groovy 3.0
+// (eighty20results/hubitat_ci). A 3.0-green can therefore hide 2.x-vs-3.0 RUNTIME-behaviour
+// divergence (the sibling ci/groovy24-parse lane only catches load-time/syntax). This lane runs
+// the EXISTING src/test/groovy spec corpus against a Groovy 2.5 runtime via joelwetzel/hubitat_ci
+// (the biocomp-API fork the repo used before migrating to eighty20results), so spec behaviour is
+// exercised on a hub-closer Groovy.
+//
+// Fully standalone: a separate build under ci/groovy2x-spock/ that never touches the root
+// build.gradle or the existing 3.0 unit-test lane. The shared src/test/groovy/support scaffold is
+// referenced read-only; where joelwetzel's API diverges from eighty20results, this lane carries its
+// own scaffold variant under ci/groovy2x-spock/scaffold/ (see below) — never by editing support/.
+//
+// Run locally:  ./gradlew -p ci/groovy2x-spock test
+plugins {
+    id 'groovy'
+}
+
+repositories {
+    mavenCentral()
+    // joelwetzel/hubitat_ci — actively-maintained fork of biocomp/hubitat_ci that retains biocomp's
+    // public API exactly and stays on Groovy 2.5 (closest viable to the hub's Groovy 2.4; Spock has
+    // no -groovy-2.4 binding). Consumed via JitPack by commit SHA (the fork cuts no release tags).
+    // biocomp itself is unusable here: its JitPack publish emits build:unspecified and every tag
+    // errors; eighty20results (the root lane's fork) is Groovy 3.0. JitPack build for a62a351eed is
+    // verified green.
+    maven {
+        url = 'https://jitpack.io'
+        content {
+            includeGroup 'com.github.joelwetzel'
+        }
+        // Force POM-only resolution: JitPack republishes Gradle Module Metadata
+        // (.module) with an empty dependency list, which would strip hubitat_ci's
+        // transitive classpath entirely. mavenPom() makes Gradle read the full
+        // <dependencies> block. Same treatment the root build gives its JitPack fork.
+        metadataSources {
+            mavenPom()
+        }
+    }
+}
+
+def repoRoot = projectDir.parentFile.parentFile
+
+dependencies {
+    // groovy-all stays on 2.5 — matches joelwetzel's compiled-against Groovy and is closest to the
+    // hub's runtime Groovy 2.4. `implementation` so the main-source-set helper stubs
+    // (hubitat.helper.*) compile.
+    implementation 'org.codehaus.groovy:groovy-all:2.5.23'
+    testImplementation 'org.codehaus.groovy:groovy-all:2.5.23'
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-2.5'
+    // joelwetzel/hubitat_ci pinned by commit SHA (no release tags). Tracked alongside the root
+    // lane's eighty20results pin by .github/workflows/hubitat-ci-version-check.yml.
+    testImplementation 'com.github.joelwetzel:hubitat_ci:a62a351eed'
+    // Spock needs a class-gen backend (byte-buddy or cglib) to Mock/Spy non-interface types
+    // (TestDevice, TestChildApp); neither is transitive on the groovy-2.5 variant.
+    testImplementation 'net.bytebuddy:byte-buddy:1.18.8'
+    // hubitat_ci's public bytecode carries compile- and runtime-time references to these
+    // (HttpResponseDecorator in BaseExecutor via the AppExecutor @Delegate chain; quartz +
+    // chromecast reached the same way). The root build mirrors the identical set for the same
+    // reason; pin the versions so the lane classpath doesn't drift from the fork's compiled-against.
+    testImplementation 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
+    testImplementation 'org.quartz-scheduler:quartz:2.5.2'
+    testImplementation 'su.litvak.chromecast:api-v2:0.11.1'
+
+    // Security pin: commons-collections 3.2.x carries the InvokeTransformer deserialization RCE
+    // (CVE-2015-7501, CVE-2015-6420). 3.2.2 is a drop-in patch on the same line. Reaches the test
+    // classpath transitively only (hubitat_ci -> http-builder -> json-lib -> commons-collections)
+    // and is never shipped. Mirrors the root build's constraint.
+    constraints {
+        testImplementation('commons-collections:commons-collections:3.2.2') {
+            because 'CVE-2015-7501/-6420 — drop-in security patch on a test-only transitive'
+        }
+    }
+}
+
+// Pin the toolchain to JDK 11 — Groovy 2.5.x is unhappy on JDK 17/21 (sun.* encapsulation), same
+// constraint the root build and the parse lane carry.
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+// Two harness bases carry eighty20results' child-app/parent re-architecture (reflective
+// childAppFactory/childAppAccessor fields, childAppResolver, setParent). joelwetzel retains
+// biocomp's @Delegate->AppExecutor wiring, so the lane supplies its own variant of each under
+// scaffold/; the root copies are not imported. (The PassThrough classloader IS kept — joelwetzel
+// doesn't remap hubitat.helper.*, but the sandbox still needs PassThrough to resolve those names
+// from the parent so RMUtilsMock's metaclass injection has class identity and NetworkUtils is
+// visible.)
+def laneScaffoldOverrides = [
+    'support/HarnessSpec.groovy',
+    'rules/RuleHarnessSpec.groovy',
+]
+// Specs that hardcode eighty20results-only sandbox API, so they are not fork-portable:
+//   - ToolManageVirtualDeviceSpec reflects the private `childDeviceFactory` field to intercept
+//     addChildDevice.
+//   - RMUtilsSandboxInterceptionSpec passes the `childAppResolver:` option to sandbox.run() (which
+//     joelwetzel rejects). It is a scaffold self-test for the RMUtils sandbox path; under joelwetzel
+//     that path is proven instead by the RM tool specs (ToolListRmRulesSpec et al.) passing.
+// The Groovy 3.0 lane covers both.
+def forkCoupledSpecs = [
+    'server/ToolManageVirtualDeviceSpec.groovy',
+    'support/RMUtilsSandboxInterceptionSpec.groovy',
+]
+
+// Copy the LIVE spec corpus into the build dir, minus the files the lane overrides or drops, so the
+// originals stay byte-untouched ("referenced read-only, written once" — issue #230) and the lane
+// always runs the same evolving specs. Sync prunes deleted specs automatically.
+def importedSpecsDir = layout.buildDirectory.dir('imported-specs').get().asFile
+def importSpecs = tasks.register('importSpecs', Sync) {
+    from("${repoRoot}/src/test/groovy") {
+        (laneScaffoldOverrides + forkCoupledSpecs).each { exclude it }
+    }
+    into importedSpecsDir
+}
+
+sourceSets {
+    main {
+        groovy { srcDirs = ["${repoRoot}/src/main/groovy"] }
+    }
+    test {
+        groovy {
+            srcDirs = [importedSpecsDir, "${projectDir}/scaffold"]
+        }
+        resources { srcDirs = ["${repoRoot}/src/test/resources"] }
+    }
+}
+
+tasks.named('compileTestGroovy') { dependsOn importSpecs }
+
+test {
+    useJUnitPlatform()
+    // The sandbox loads `new File('hubitat-mcp-server.groovy')` / rule.groovy by RELATIVE path, so
+    // the forked test JVM must run from the repo root, not this isolated project dir.
+    workingDir = repoRoot
+    // Keep specs single-threaded. RMUtilsMock / NetworkUtilsMock inject static metaclass methods on
+    // hubitat.helper.RMUtils / .NetworkUtils — concurrent install/uninstall would race.
+    maxParallelForks = 1
+    // Silence Groovy 2.5.23's reflective access under JDK 11+. Groovy 2.5's CachedClass /
+    // CachedConstructor reflects into these java.base packages on init; without the opens the run is
+    // noisy (and some reach throws). Drop this block if the lane ever moves to Groovy 3+.
+    jvmArgs '--add-opens=java.base/java.lang=ALL-UNNAMED',
+            '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
+            '--add-opens=java.base/java.io=ALL-UNNAMED',
+            '--add-opens=java.base/java.math=ALL-UNNAMED',
+            '--add-opens=java.base/java.net=ALL-UNNAMED',
+            '--add-opens=java.base/java.nio=ALL-UNNAMED',
+            '--add-opens=java.base/java.text=ALL-UNNAMED',
+            '--add-opens=java.base/java.time=ALL-UNNAMED',
+            '--add-opens=java.base/java.util=ALL-UNNAMED',
+            '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
+            '--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED',
+            '--add-opens=java.base/java.util.regex=ALL-UNNAMED',
+            '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
+            '--add-opens=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED'
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        exceptionFormat = 'full'
+    }
+}

--- a/ci/groovy2x-spock/scaffold/rules/RuleHarnessSpec.groovy
+++ b/ci/groovy2x-spock/scaffold/rules/RuleHarnessSpec.groovy
@@ -1,0 +1,217 @@
+package rules
+
+import me.biocomp.hubitat_ci.api.app_api.AppExecutor
+import me.biocomp.hubitat_ci.app.HubitatAppSandbox
+import me.biocomp.hubitat_ci.app.HubitatAppScript
+import me.biocomp.hubitat_ci.validation.Flags
+import spock.lang.Shared
+import spock.lang.Specification
+import support.PassThroughAppValidator
+import support.PermissiveLog
+import support.SubscriptionRecorder
+import support.TestChildApp
+import support.TestLocation
+
+/**
+ * groovy2x-spock lane variant of {@code rules.RuleHarnessSpec} (issue #230).
+ *
+ * Loads hubitat-mcp-rule.groovy under joelwetzel/hubitat_ci on Groovy 2.5,
+ * caching the compiled script per JVM exactly like the root variant. The
+ * only fork-specific differences:
+ *
+ *  - {@code sandbox.run()} + {@link PassThroughAppValidator}, same as the root
+ *    lane — the PassThrough classloader forces {@code hubitat.helper.*} to
+ *    resolve from the parent stubs (class identity for any helper the rule
+ *    file touches). {@code DontValidateSubscriptions} is kept so the rule
+ *    engine can {@code subscribe(...)} plain TestDevice POJOs.
+ *  - {@code parent} resolves through the AppExecutor mock's
+ *    {@code getParent()} (biocomp routes the script's {@code parent} property
+ *    via its {@code @Delegate} to AppExecutor — no {@code @CompileStatic}
+ *    getProperty override, so {@code setParent} reflection is not needed).
+ *
+ * Every recorder stub (runIn, schedule, subscribe, httpGet/httpPost, sunrise-sunset)
+ * and the dual metaClass wipe match the root variant and run against the same specs.
+ */
+abstract class RuleHarnessSpec extends Specification {
+    private static HubitatAppScript SHARED_SCRIPT
+    private static final Object COMPILE_LOCK = new Object()
+    private static final java.lang.reflect.Field API_FIELD = {
+        def f = HubitatAppScript.getDeclaredField('api')
+        f.accessible = true
+        f
+    }()
+
+    // The currently-running feature instance, so the @Shared AppExecutor
+    // mock's getParent() stub can read this feature's `parent` without
+    // rebuilding the mock. Specs run sequentially (maxParallelForks=1).
+    private static RuleHarnessSpec CURRENT_FEATURE
+
+    @Shared protected AppExecutor appExecutor
+    @Shared protected script
+    @Shared private PermissiveLog sharedLog = new PermissiveLog()
+
+    @Shared protected final Map stateMap = [:]
+    @Shared protected final Map atomicStateMap = [:]
+    // Must be non-empty at compile() time — see HarnessSpec.
+    @Shared protected final Map settingsMap = [_harness: true]
+    @Shared protected final TestLocation testLocation = new TestLocation()
+
+    // Call recorders for AppExecutor methods the rule engine dispatches
+    // through @Delegate. Spock interaction verification on a @Shared mock from
+    // given:/then: doesn't fire reliably — stubs live in setupSpec and tests
+    // assert on these lists. All cleared in setup().
+    @Shared protected final List<List<Object>> runInCalls = []
+    @Shared protected final List<List<Object>> runOnceCalls = []
+    @Shared protected final List<List<Object>> scheduleCalls = []
+    @Shared protected int unscheduleAllCount = 0
+    @Shared protected final List<String> unscheduleCalls = []
+    @Shared protected int unsubscribeCount = 0
+    @Shared protected final List<Map> sendLocationEventCalls = []
+    @Shared protected final List<List<Object>> httpGetCalls = []
+    @Shared protected final List<List<Object>> httpPostCalls = []
+    @Shared protected final SubscriptionRecorder subscriptions = new SubscriptionRecorder()
+
+    @Shared protected Boolean stubTimeOfDayResult = false
+    @Shared protected Map<String, Date> stubSunriseSunset = null
+    @Shared protected Throwable stubHttpGetException = null
+
+    // Per-feature backing field — read by the @Shared mock's getParent() stub
+    // via CURRENT_FEATURE at invocation time.
+    private Object _parent
+
+    /** Assigning `parent = foo` in a given: block routes through here. */
+    void setParent(Object p) { _parent = p }
+
+    Object getParent() { _parent }
+
+    def setupSpec() {
+        appExecutor = buildAppExecutorMock()
+        synchronized (COMPILE_LOCK) {
+            if (SHARED_SCRIPT == null) {
+                compileSharedScript()
+            } else {
+                rebindApi(appExecutor)
+            }
+        }
+        script = SHARED_SCRIPT
+    }
+
+    private void rebindApi(AppExecutor mock) {
+        try {
+            API_FIELD.set(SHARED_SCRIPT, mock)
+        } catch (Throwable t) {
+            throw new IllegalStateException(
+                "Failed to rebind AppExecutor on cached SHARED_SCRIPT for " +
+                "${this.class.simpleName}. A joelwetzel/hubitat_ci upgrade may have " +
+                "changed HubitatAppScript.api field shape; see this lane's HarnessSpec " +
+                "for the rebind contract.", t)
+        }
+    }
+
+    private AppExecutor buildAppExecutorMock() {
+        def mock = Mock(AppExecutor) {
+            _ * getState() >> stateMap
+            _ * getAtomicState() >> atomicStateMap
+            _ * getApp() >> new TestChildApp(id: 1L, label: 'TestRuleApp')
+            _ * getLocation() >> testLocation
+            // biocomp routes the script's `parent` property through @Delegate
+            // to AppExecutor.getParent(); read the running feature's value.
+            _ * getParent() >> { CURRENT_FEATURE?.getParent() }
+            _ * now() >> 1234567890000L
+            _ * getLog() >> sharedLog
+            _ * getSettings() >> settingsMap
+        }
+        mock.runIn(*_) >> { args -> runInCalls << (args as List) }
+        mock.runOnce(*_) >> { args -> runOnceCalls << (args as List) }
+        mock.schedule(*_) >> { args -> scheduleCalls << (args as List) }
+        mock.unsubscribe() >> { unsubscribeCount++ }
+        mock.unschedule() >> { unscheduleAllCount++ }
+        mock.unschedule(_ as String) >> { args -> unscheduleCalls << (args[0] as String) }
+        mock.sendLocationEvent(_) >> { args -> sendLocationEventCalls << (args[0] as Map) }
+        mock.httpGet(_, _) >> { args ->
+            httpGetCalls << (args as List)
+            if (stubHttpGetException) throw stubHttpGetException
+        }
+        mock.httpPost(_, _) >> { args -> httpPostCalls << (args as List) }
+        mock.subscribe(_, _ as String, _ as String) >> { args ->
+            subscriptions.record(args[0], args[1] as String, args[2] as String)
+        }
+        mock.subscribe(*_) >> { args ->
+            if (args.size() == 3 && args[1] instanceof String && args[2] instanceof String) {
+                return
+            }
+            throw new IllegalStateException(
+                "Unstubbed subscribe() overload — ${args.size()} args: ${args}. " +
+                "Extend SubscriptionRecorder + the RuleHarnessSpec subscribe stubs " +
+                "if a new overload is in production use. See " +
+                "src/test/groovy/support/SubscriptionRecorder.groovy.")
+        }
+        mock.timeOfDayIsBetween(_, _, _) >> { args -> stubTimeOfDayResult }
+        mock.timeOfDayIsBetween(_, _, _, _) >> { args -> stubTimeOfDayResult }
+        mock.getSunriseAndSunset(_) >> { args -> stubSunriseSunset }
+        mock.getSunriseAndSunset() >> { stubSunriseSunset }
+        return mock
+    }
+
+    private void compileSharedScript() {
+        def sandbox = new HubitatAppSandbox(new File('hubitat-mcp-rule.groovy'))
+        // run() + PassThroughAppValidator (not compile(), which discards the
+        // validator) — keeps helper class-identity consistent with the server
+        // harness. DontRunScript replaces what compile() would add;
+        // DontValidateSubscriptions lets the rule engine subscribe() plain
+        // TestDevice POJOs (the validator otherwise demands a DeviceWrapper).
+        def validator = new PassThroughAppValidator([
+            Flags.DontValidatePreferences,
+            Flags.DontValidateDefinition,
+            Flags.DontRestrictGroovy,
+            Flags.DontRunScript,
+            Flags.DontValidateSubscriptions
+        ])
+        SHARED_SCRIPT = sandbox.run(
+            api: appExecutor,
+            userSettingValues: settingsMap,
+            validator: validator
+        )
+    }
+
+    def setup() {
+        CURRENT_FEATURE = this
+        stateMap.clear()
+        atomicStateMap.clear()
+        settingsMap.clear()
+        settingsMap._harness = true
+        testLocation.setMode('Home')
+        testLocation.modeSetCalls.clear()
+        testLocation.sunrise = null
+        testLocation.sunset = null
+        testLocation.hsmStatus = null
+        appExecutor.getApp().settingsStore.clear()
+        runInCalls.clear()
+        runOnceCalls.clear()
+        scheduleCalls.clear()
+        unscheduleAllCount = 0
+        unscheduleCalls.clear()
+        unsubscribeCount = 0
+        sendLocationEventCalls.clear()
+        httpGetCalls.clear()
+        httpPostCalls.clear()
+        subscriptions.reset()
+        stubTimeOfDayResult = false
+        stubSunriseSunset = null
+        stubHttpGetException = null
+        _parent = null
+        // Drop per-test metaClass writes from the previous feature before
+        // re-installing hooks. Both wipes matter when SHARED_SCRIPT is reused
+        // across spec classes; see support.HarnessSpec.setup().
+        GroovySystem.metaClassRegistry.removeMetaClass(script.getClass())
+        script.setMetaClass(null)
+        support.HarnessSpec.checkMetaClassClean(script, 'RuleHarnessSpec')
+        wireOverrides()
+    }
+
+    protected void wireOverrides() {
+        // All runtime shims (state, atomicState, parent, log, now) route
+        // through the AppExecutor mock. Subclasses override to add
+        // script-method overrides that can't be stubbed via the mock.
+    }
+}

--- a/ci/groovy2x-spock/scaffold/rules/RuleHarnessSpec.groovy
+++ b/ci/groovy2x-spock/scaffold/rules/RuleHarnessSpec.groovy
@@ -41,9 +41,13 @@ abstract class RuleHarnessSpec extends Specification {
         f
     }()
 
-    // The currently-running feature instance, so the @Shared AppExecutor
-    // mock's getParent() stub can read this feature's `parent` without
-    // rebuilding the mock. Specs run sequentially (maxParallelForks=1).
+    // The currently-running feature instance, so the @Shared AppExecutor mock's
+    // getParent() stub can read this feature's `parent` without rebuilding the
+    // mock. setup() points it at the active feature; cleanup() nulls it so a
+    // stale parent can't leak across the spec-class boundary (the gap before the
+    // next class's setup()) — this is what replaces the root harness's defensive
+    // setParent(null) in setupSpec. The static hand-off is only safe because
+    // specs run sequentially (maxParallelForks=1).
     private static RuleHarnessSpec CURRENT_FEATURE
 
     @Shared protected AppExecutor appExecutor
@@ -52,7 +56,7 @@ abstract class RuleHarnessSpec extends Specification {
 
     @Shared protected final Map stateMap = [:]
     @Shared protected final Map atomicStateMap = [:]
-    // Must be non-empty at compile() time — see HarnessSpec.
+    // Must be non-empty at sandbox.run() time — see HarnessSpec.
     @Shared protected final Map settingsMap = [_harness: true]
     @Shared protected final TestLocation testLocation = new TestLocation()
 
@@ -207,6 +211,13 @@ abstract class RuleHarnessSpec extends Specification {
         script.setMetaClass(null)
         support.HarnessSpec.checkMetaClassClean(script, 'RuleHarnessSpec')
         wireOverrides()
+    }
+
+    def cleanup() {
+        // Release the per-feature instance so the getParent() stub can't read a
+        // stale parent in the gap before the next spec class's setup(), and the
+        // static doesn't pin the last spec for the JVM's lifetime.
+        CURRENT_FEATURE = null
     }
 
     protected void wireOverrides() {

--- a/ci/groovy2x-spock/scaffold/rules/RuleParentWiringSpec.groovy
+++ b/ci/groovy2x-spock/scaffold/rules/RuleParentWiringSpec.groovy
@@ -1,0 +1,31 @@
+package rules
+
+/**
+ * Lane self-test (issue #230). Proves a `parent` assigned in a given: block is
+ * visible as `script.parent` through joelwetzel's `@Delegate` to
+ * AppExecutor.getParent() under Groovy 2.5.
+ *
+ * The root (eighty20results) harness can't intercept `parent` via the mock — it
+ * propagates through `script.setParent()` reflection because eighty20results'
+ * HubitatAppScript overrides getProperty("parent"). This lane relies on the
+ * opposite (biocomp routes the property through `@Delegate`, so the getParent()
+ * stub is enough). That is the single load-bearing behavioural difference of the
+ * rule lane, so assert it directly: a wrong assumption would otherwise let
+ * `parent == null` branches pass silently.
+ */
+class RuleParentWiringSpec extends RuleHarnessSpec {
+
+    def "parent assigned in given: is visible as script.parent via the AppExecutor @Delegate"() {
+        given:
+        def stubParent = new Object()
+        parent = stubParent
+
+        expect:
+        script.getParent().is(stubParent)
+    }
+
+    def "parent defaults to null on entry to each feature"() {
+        expect:
+        script.getParent() == null
+    }
+}

--- a/ci/groovy2x-spock/scaffold/support/HarnessSpec.groovy
+++ b/ci/groovy2x-spock/scaffold/support/HarnessSpec.groovy
@@ -146,6 +146,13 @@ abstract class HarnessSpec extends Specification {
             }
             cf.mockChildAppForCreate
         }
+        // deleteChildApp routes via @Delegate to AppExecutor too. Mirror the
+        // root harness's childAppAccessor 'delete' op: drop the matching child
+        // from the shared list so delete_rule specs see it removed.
+        mock.deleteChildApp(_) >> { args ->
+            SHARED_CHILD_APPS_LIST.removeAll { it.id?.toString() == args[0]?.toString() }
+            return null
+        }
         return mock
     }
 

--- a/ci/groovy2x-spock/scaffold/support/HarnessSpec.groovy
+++ b/ci/groovy2x-spock/scaffold/support/HarnessSpec.groovy
@@ -25,10 +25,10 @@ import spock.lang.Specification
  *    validator (its precedence trap), so {@code run()} with
  *    {@code DontRunScript} in the validator flags is required. No
  *    {@code childAppResolver} is passed — joelwetzel/biocomp doesn't need one.
- *  - {@code getChildApps()} / {@code addChildApp(...)} are stubbed on the
- *    AppExecutor mock. biocomp's HubitatAppScript routes both through its
- *    {@code @Delegate} to AppExecutor (no concrete-method/private-factory
- *    interception, so eighty20results' reflective childAppFactory /
+ *  - {@code getChildApps()} / {@code addChildApp(...)} / {@code deleteChildApp(...)}
+ *    are stubbed on the AppExecutor mock. biocomp's HubitatAppScript routes all
+ *    of them through its {@code @Delegate} to AppExecutor (no concrete-method/
+ *    private-factory interception, so eighty20results' reflective childAppFactory /
  *    childAppAccessor replacement does not apply and {@code childAppResolver}
  *    is not required).
  *
@@ -49,7 +49,7 @@ abstract class HarnessSpec extends Specification {
     private static final PermissiveLog SHARED_LOG = new PermissiveLog()
     private static final Map SHARED_STATE_MAP = [:]
     private static final Map SHARED_ATOMIC_STATE_MAP = [:]
-    // Must be non-empty at compile() time — HubitatCI's readUserSettingValues
+    // Must be non-empty at sandbox.run() time — HubitatCI's readUserSettingValues
     // does a Groovy truthy check on the passed map and silently swaps in a
     // fresh empty Map when it's empty, breaking the shared reference specs
     // rely on to mutate settings from given: blocks. setup() restores the
@@ -63,8 +63,10 @@ abstract class HarnessSpec extends Specification {
     // The currently-running feature instance. The @Shared AppExecutor mock's
     // addChildApp stub (built once in setupSpec) reads mockChildAppForCreate
     // off this so the per-feature value is visible without rebuilding the
-    // mock. Specs run sequentially (maxParallelForks=1), so this is always
-    // the active feature.
+    // mock. setup() points it at the active feature; cleanup() nulls it so it
+    // neither leaks the last instance for the JVM's lifetime nor lets a stale
+    // feature's fixture be read across the spec-class boundary. The static
+    // hand-off is only safe because specs run sequentially (maxParallelForks=1).
     private static HarnessSpec CURRENT_FEATURE
 
     // Records parent-app unsubscribe() calls. A `1 * appExecutor.unsubscribe()`
@@ -205,6 +207,13 @@ abstract class HarnessSpec extends Specification {
         script.setMetaClass(null)
         checkMetaClassClean(script, 'HarnessSpec')
         wireScriptOverrides()
+    }
+
+    def cleanup() {
+        // Release the per-feature instance: prevents the static from pinning the
+        // last spec for the JVM's lifetime and stops a stale feature's fixture
+        // from being read in the gap before the next spec class's setup() runs.
+        CURRENT_FEATURE = null
     }
 
     /**

--- a/ci/groovy2x-spock/scaffold/support/HarnessSpec.groovy
+++ b/ci/groovy2x-spock/scaffold/support/HarnessSpec.groovy
@@ -1,0 +1,260 @@
+package support
+
+import me.biocomp.hubitat_ci.api.app_api.AppExecutor
+import me.biocomp.hubitat_ci.app.HubitatAppSandbox
+import me.biocomp.hubitat_ci.app.HubitatAppScript
+import me.biocomp.hubitat_ci.validation.Flags
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * groovy2x-spock lane variant of {@code support.HarnessSpec} (issue #230).
+ *
+ * Identical contract and per-JVM script caching to the root (Groovy 3.0 /
+ * eighty20results) HarnessSpec, but wired for joelwetzel/hubitat_ci on
+ * Groovy 2.5. The only differences from the shared variant are the
+ * fork-specific child-app plumbing:
+ *
+ *  - {@code sandbox.run()} + {@link PassThroughAppValidator}, same as the root
+ *    lane. joelwetzel does NOT remap {@code hubitat.helper.*}, but the sandbox
+ *    still needs the PassThrough classloader to force those names to resolve
+ *    from the PARENT classloader (the main-source-set stubs) — otherwise
+ *    {@code RMUtilsMock}'s static-metaclass injection lands on a different
+ *    class instance than the one the sandbox loads, and {@code NetworkUtils}
+ *    isn't visible at all (NCDFE). {@code compile()} would discard the
+ *    validator (its precedence trap), so {@code run()} with
+ *    {@code DontRunScript} in the validator flags is required. No
+ *    {@code childAppResolver} is passed — joelwetzel/biocomp doesn't need one.
+ *  - {@code getChildApps()} / {@code addChildApp(...)} are stubbed on the
+ *    AppExecutor mock. biocomp's HubitatAppScript routes both through its
+ *    {@code @Delegate} to AppExecutor (no concrete-method/private-factory
+ *    interception, so eighty20results' reflective childAppFactory /
+ *    childAppAccessor replacement does not apply and {@code childAppResolver}
+ *    is not required).
+ *
+ * Everything else — the shared-script cache, per-spec AppExecutor rebind via
+ * the {@code api} field, the {@code request} injection through
+ * {@code injectedMappingHandlerData}, the {@code hubInternalGet} metaClass
+ * shim, and the dual metaClass wipe + strict check — is the same mechanism
+ * as the root variant and is exercised against the same specs.
+ */
+abstract class HarnessSpec extends Specification {
+    private static HubitatAppScript SHARED_SCRIPT
+    private static final Object COMPILE_LOCK = new Object()
+    private static final java.lang.reflect.Field API_FIELD = {
+        def f = HubitatAppScript.getDeclaredField('api')
+        f.accessible = true
+        f
+    }()
+    private static final PermissiveLog SHARED_LOG = new PermissiveLog()
+    private static final Map SHARED_STATE_MAP = [:]
+    private static final Map SHARED_ATOMIC_STATE_MAP = [:]
+    // Must be non-empty at compile() time — HubitatCI's readUserSettingValues
+    // does a Groovy truthy check on the passed map and silently swaps in a
+    // fresh empty Map when it's empty, breaking the shared reference specs
+    // rely on to mutate settings from given: blocks. setup() restores the
+    // seed entry after clearing.
+    private static final Map SHARED_SETTINGS_MAP = [selectedDevices: []]
+    private static final List SHARED_CHILD_DEVICES_LIST = []
+    private static final List SHARED_CHILD_APPS_LIST = []
+    private static final HubInternalGetMock SHARED_HUB_GET = new HubInternalGetMock()
+    private static final McpRequestDriver SHARED_MCP_DRIVER = new McpRequestDriver()
+
+    // The currently-running feature instance. The @Shared AppExecutor mock's
+    // addChildApp stub (built once in setupSpec) reads mockChildAppForCreate
+    // off this so the per-feature value is visible without rebuilding the
+    // mock. Specs run sequentially (maxParallelForks=1), so this is always
+    // the active feature.
+    private static HarnessSpec CURRENT_FEATURE
+
+    // Records parent-app unsubscribe() calls. A `1 * appExecutor.unsubscribe()`
+    // cardinality check from a then-block doesn't fire reliably on the @Shared
+    // AppExecutor mock, so route the call through this counter and assert on
+    // it; lifecycle specs reset it in given: with .set(0).
+    protected static final java.util.concurrent.atomic.AtomicInteger UNSUBSCRIBE_CALL_COUNT = new java.util.concurrent.atomic.AtomicInteger(0)
+
+    @Shared protected AppExecutor appExecutor
+    @Shared protected script
+    @Shared protected final Map stateMap = SHARED_STATE_MAP
+    @Shared protected final Map atomicStateMap = SHARED_ATOMIC_STATE_MAP
+    @Shared protected final Map settingsMap = SHARED_SETTINGS_MAP
+    @Shared protected final List childDevicesList = SHARED_CHILD_DEVICES_LIST
+    @Shared protected final List childAppsList = SHARED_CHILD_APPS_LIST
+    @Shared protected final HubInternalGetMock hubGet = SHARED_HUB_GET
+    @Shared protected final McpRequestDriver mcpDriver = SHARED_MCP_DRIVER
+
+    // Per-test fixture — specs assign in given: blocks to drive addChildApp's
+    // return value. Read by the @Shared mock's addChildApp stub via
+    // CURRENT_FEATURE at invocation time.
+    protected def mockChildAppForCreate
+
+    def setupSpec() {
+        appExecutor = buildAppExecutorMock()
+        synchronized (COMPILE_LOCK) {
+            if (SHARED_SCRIPT == null) {
+                compileSharedScript()
+            } else {
+                rebindApi(appExecutor)
+            }
+        }
+        script = SHARED_SCRIPT
+    }
+
+    private void rebindApi(AppExecutor mock) {
+        try {
+            API_FIELD.set(SHARED_SCRIPT, mock)
+        } catch (Throwable t) {
+            throw new IllegalStateException(
+                "Failed to rebind AppExecutor on cached SHARED_SCRIPT for " +
+                "${this.class.simpleName}. A joelwetzel/hubitat_ci upgrade may have " +
+                "changed HubitatAppScript.api field shape; see this lane's HarnessSpec " +
+                "for the rebind contract.", t)
+        }
+    }
+
+    private AppExecutor buildAppExecutorMock() {
+        def mock = Mock(AppExecutor) {
+            _ * getState() >> SHARED_STATE_MAP
+            _ * getAtomicState() >> SHARED_ATOMIC_STATE_MAP
+            _ * getChildDevices() >> SHARED_CHILD_DEVICES_LIST
+            // biocomp routes getChildApps()/addChildApp() through the script's
+            // @Delegate to AppExecutor (unlike eighty20results, which defines
+            // concrete methods over private factory closures). Stub both here.
+            _ * getChildApps() >> SHARED_CHILD_APPS_LIST
+            _ * now() >> 1234567890000L
+            _ * getLog() >> SHARED_LOG
+            _ * getSettings() >> SHARED_SETTINGS_MAP
+        }
+        mock.render(_) >> { args -> SHARED_MCP_DRIVER.captureRender(args[0] as Map) }
+        mock.render() >> {
+            throw new IllegalStateException(
+                "No-arg render() is not wired into McpRequestDriver. If a new " +
+                "handler path needs it, extend the driver to capture the no-arg " +
+                "call and relax this stub. See ci/groovy2x-spock/scaffold/support/HarnessSpec.groovy.")
+        }
+        mock.unsubscribe() >> { UNSUBSCRIBE_CALL_COUNT.incrementAndGet() }
+        // addChildApp routes via @Delegate to AppExecutor under joelwetzel. *_
+        // covers the 3-arg and 4-arg(props) overloads production code uses.
+        // Read the running feature's fixture so the value set in a spec's
+        // given: block is honoured.
+        mock.addChildApp(*_) >> { args ->
+            def cf = CURRENT_FEATURE
+            if (cf?.mockChildAppForCreate == null) {
+                throw new IllegalStateException(
+                    "Spec invoked addChildApp(${args}) but mockChildAppForCreate was " +
+                    "not assigned. Set `mockChildAppForCreate = new TestChildApp(...)` in given:.")
+            }
+            cf.mockChildAppForCreate
+        }
+        return mock
+    }
+
+    private void compileSharedScript() {
+        def sandbox = new HubitatAppSandbox(new File('hubitat-mcp-server.groovy'))
+        // PassThroughAppValidator swaps in a classloader that resolves
+        // hubitat.helper.{RMUtils,NetworkUtils} from the parent (the
+        // main-source stubs), so RMUtilsMock's static-metaclass injection
+        // reaches sandbox-loaded calls and NetworkUtils resolves. Must use
+        // run() (not compile(), which discards the validator). DontRunScript
+        // replaces what compile() would have added; DontValidatePreferences
+        // sidesteps the multi-page form. No childAppResolver under joelwetzel.
+        def validator = new PassThroughAppValidator([
+            Flags.DontValidatePreferences,
+            Flags.DontValidateDefinition,
+            Flags.DontRestrictGroovy,
+            Flags.DontRunScript
+        ])
+        SHARED_SCRIPT = sandbox.run(
+            api: appExecutor,
+            userSettingValues: SHARED_SETTINGS_MAP,
+            validator: validator
+        )
+        SHARED_MCP_DRIVER.boundScript = SHARED_SCRIPT
+    }
+
+    def setup() {
+        CURRENT_FEATURE = this
+        stateMap.clear()
+        atomicStateMap.clear()
+        settingsMap.clear()
+        settingsMap.selectedDevices = []
+        // CI matrix dispatch-mode dimension: when set, forces useGateways
+        // default per-test. Tests that explicitly pin useGateways in given:
+        // still win.
+        def defaultGateways = System.getProperty('harness.useGateways')
+        if (defaultGateways != null) {
+            settingsMap.useGateways = (defaultGateways == 'true')
+        }
+        childDevicesList.clear()
+        childAppsList.clear()
+        hubGet.reset()
+        mcpDriver.reset()
+        // Drop per-test metaClass writes from previous features before
+        // re-installing the standard hooks. Both wipes matter when
+        // SHARED_SCRIPT is reused across spec classes: removeMetaClass(class)
+        // clears the class-level ExpandoMetaClass; setMetaClass(null) clears
+        // the per-instance one.
+        GroovySystem.metaClassRegistry.removeMetaClass(script.getClass())
+        script.setMetaClass(null)
+        checkMetaClassClean(script, 'HarnessSpec')
+        wireScriptOverrides()
+    }
+
+    /**
+     * Strict-mode invariant check: after both metaClass wipes, before any
+     * harness re-installs, the script's metaClass should have no per-instance
+     * ExpandoMetaClass entries left over from prior tests. Off by default;
+     * enable with {@code -PharnessStrictMetaClass=true}. Static so
+     * {@code StrictMetaClassCheckSpec} can exercise the failure path directly.
+     */
+    static void checkMetaClassClean(Object scriptInstance, String specName) {
+        if (System.getProperty('harnessStrictMetaClass') != 'true') return
+        def mc = scriptInstance.getMetaClass()
+        while (mc instanceof groovy.lang.DelegatingMetaClass) {
+            mc = mc.getAdaptee()
+        }
+        if (mc instanceof ExpandoMetaClass) {
+            // fall through to expando-entry inspection
+        } else if (mc instanceof groovy.lang.MetaClassImpl) {
+            return
+        } else {
+            throw new IllegalStateException(
+                "Unexpected metaClass type ${mc.getClass().name} after dual wipe in ${specName}.setup(). " +
+                "checkMetaClassClean only knows how to introspect ExpandoMetaClass and the default " +
+                "MetaClassImpl. Extend the helper for the new shape, or strict-mode silently no-ops.")
+        }
+        def methods = mc.expandoMethods
+        def props = mc.expandoProperties
+        if (!methods.isEmpty() || !props.isEmpty()) {
+            throw new IllegalStateException(
+                "Per-instance metaClass not clean after dual wipe in ${specName}.setup(). " +
+                "Surviving expando methods=${methods*.name}, expando properties=${props*.name}. " +
+                "Some override escaped both removeMetaClass(class) and setMetaClass(null). Extend setup().")
+        }
+    }
+
+    protected void wireScriptOverrides() {
+        def hubGetRef = hubGet
+        // `request` resolution inside the script: HubitatAppScript reads the
+        // name "request" from its private injectedMappingHandlerData map, so
+        // install the McpRequestDriver's stable proxy directly into that field.
+        // The proxy reads driver state at each getJSON() access, so tests can
+        // call pushBody from their given: block without re-running this wire.
+        def injectedField = me.biocomp.hubitat_ci.app.HubitatAppScript
+            .getDeclaredField('injectedMappingHandlerData')
+        injectedField.accessible = true
+        Map injectedMap = injectedField.get(script) as Map
+        if (injectedMap == null) {
+            injectedMap = [:]
+            injectedField.set(script, injectedMap)
+        }
+        injectedMap['request'] = mcpDriver.scriptRequest
+        // hubInternalGet has no declaration on HubitatAppScript — pure dynamic
+        // Groovy resolved through metaClass, so the per-instance write here
+        // intercepts cleanly. The captured hubGetRef is the @Shared
+        // HubInternalGetMock whose maps reset between tests.
+        script.metaClass.hubInternalGet = { String p, Map pp = [:], Integer t = 30 ->
+            hubGetRef.call(p, pp)
+        }
+    }
+}

--- a/ci/groovy2x-spock/scaffold/support/LaneChildAppWiringSpec.groovy
+++ b/ci/groovy2x-spock/scaffold/support/LaneChildAppWiringSpec.groovy
@@ -1,0 +1,45 @@
+package support
+
+/**
+ * Lane self-test (issue #230). Proves the joelwetzel `@Delegate`→AppExecutor
+ * child-app routing this lane relies on actually flows through the AppExecutor
+ * mock under Groovy 2.5.
+ *
+ * The root (eighty20results) harness intercepts getChildApps/addChildApp/
+ * deleteChildApp by reflectively replacing private childAppFactory/
+ * childAppAccessor closures; this lane stubs them on the mock instead, and the
+ * whole corpus's correctness rests on biocomp routing those calls through its
+ * `@Delegate`. Rather than leave that as an unverified comment, assert it
+ * directly — if a future joelwetzel bump stops delegating one of these, this
+ * spec fails loudly instead of letting tool specs pass against a no-op stub.
+ */
+class LaneChildAppWiringSpec extends HarnessSpec {
+
+    def "getChildApps() routes through the AppExecutor mock to the fixture list"() {
+        given:
+        childAppsList << new TestChildApp(id: 42L, label: 'Probe')
+
+        expect:
+        script.getChildApps()*.id == [42L]
+    }
+
+    def "addChildApp(...) routes through the mock and returns the spec fixture"() {
+        given:
+        mockChildAppForCreate = new TestChildApp(id: 99L, label: 'Created')
+
+        expect:
+        script.addChildApp('ns', 'name', 'label').is(mockChildAppForCreate)
+    }
+
+    def "deleteChildApp(id) routes through the mock and removes the matching child"() {
+        given:
+        childAppsList << new TestChildApp(id: 7L, label: 'Doomed')
+        childAppsList << new TestChildApp(id: 8L, label: 'Survivor')
+
+        when:
+        script.deleteChildApp(7L)
+
+        then:
+        childAppsList*.id == [8L]
+    }
+}

--- a/ci/groovy2x-spock/settings.gradle
+++ b/ci/groovy2x-spock/settings.gradle
@@ -1,0 +1,4 @@
+// Standalone build, isolated from the root project on purpose (issue #230). Keeps the additive
+// Groovy 2.5 Spock runtime lane fully separate from the root build.gradle / Groovy 3.0 test lane,
+// exactly like the sibling ci/groovy24-parse parse lane.
+rootProject.name = 'groovy2x-spock'

--- a/docs/groovy2x-spock-lane.md
+++ b/docs/groovy2x-spock-lane.md
@@ -1,0 +1,102 @@
+# Additive Groovy 2.5 Spock lane (issues #227 + #230)
+
+Canonical design note for the `ci/groovy2x-spock/` CI lane. Pairs with
+[#227](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues/227) (parser divergence)
+and [#230](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues/230) (runtime divergence).
+
+## The problem: CI Groovy ≠ hub Groovy
+
+Hubitat Elevation runs **Groovy 2.4.x** (antlr2 parser). The unit-test harness runs **Groovy 3.0**
+(`eighty20results/hubitat_ci` + `spock-core:2.3-groovy-3.0`). Groovy 3.0's Parrot parser and runtime
+are more permissive than the hub's, so code can be fully green in CI yet fail on a real hub. Two
+distinct failure classes:
+
+- **Load-time / syntax** (issue #227) — e.g. a bare `{ ... }` block after a `case X:` label compiles
+  under Parrot but is rejected by the hub's antlr2 parser. Already gated by the **Groovy 2.4 Parse
+  Check** lane (`ci/groovy24-parse/`, shipped in PR2a), which parses the two production `.groovy`
+  files under stock Groovy 2.4.21.
+- **Runtime behaviour** (issue #230) — 2.x-vs-3.0 differences that only surface when the code *runs*
+  (coercions, GDK method differences, default-parameter and metaclass dispatch). The parse lane
+  cannot see these.
+
+This lane closes the runtime gap, and reinforces the parse gap: running the specs under Groovy 2.5
+compiles and loads the production files through the sandbox under the 2.5 (default antlr2) grammar,
+so it is a strict superset of the parse concern.
+
+## The three lanes (all additive, none replace each other)
+
+| Lane | Groovy | hubitat_ci fork | Catches | Gating |
+|---|---|---|---|---|
+| Unit Tests (`unit-tests.yml`) | 3.0 | eighty20results | full behaviour on 3.0 | **required** (`test`) |
+| Groovy 2.4 Parse (`groovy24-parse.yml`) | 2.4.21 | none (parse only) | load-time/syntax (#227) | required-adjacent |
+| **Groovy 2.5 Spock (`groovy2x-spock.yml`)** | 2.5 | joelwetzel | **runtime divergence (#230)** + parse | **allow-failure** |
+
+## Why joelwetzel/hubitat_ci on Groovy 2.5
+
+The hub is Groovy 2.4, but there is no `spock-core:*-groovy-2.4` for Spock 2.x; **Groovy 2.5 is the
+closest viable runtime** (it still defaults to the antlr2 parser, unlike 3.0's Parrot). Fork survey
+(local git history + a fresh web/JitPack audit):
+
+- **joelwetzel/hubitat_ci** — fork of biocomp, retains biocomp's public API exactly, stays on Groovy
+  2.5. Consumed via JitPack by commit SHA (`com.github.joelwetzel:hubitat_ci:a62a351eed`); JitPack
+  build for that SHA is verified green. This is the harness the repo itself used before migrating to
+  eighty20results, so the configuration is proven in-repo.
+- **biocomp/hubitat_ci** (original) — correct target stack but JitPack publish is broken for every
+  tag (artifact lands at `build:unspecified`); not on Maven Central. Unusable as-is.
+- **eighty20results/hubitat_ci** — the root lane's fork; Groovy 3.0, wrong runtime for this lane.
+
+`spock-core:2.3-groovy-2.5` is the **same Spock version (2.3)** the root lane uses, just the
+Groovy-2.5 binding — so the existing Spock 2.x spec corpus compiles unchanged (no JUnit4 down-port,
+no `@TempDir` rewrite). The only real differences are the Groovy 2.5-vs-3.0 language/runtime and the
+joelwetzel-vs-eighty20results harness API.
+
+## Architecture: additive, zero-touch (issue #230 hard requirement)
+
+Everything new lives under `ci/groovy2x-spock/`. The root `build.gradle`, `src/test/groovy/support/`
+scaffold, and all existing workflows stay **byte-untouched**.
+
+- **Isolated Gradle build** (`ci/groovy2x-spock/build.gradle`, own `settings.gradle`) — joelwetzel +
+  `groovy-all:2.5.23` + `spock-core:2.3-groovy-2.5` + the same transitive mirrors the root build
+  needs (`http-builder`, `quartz`, `chromecast`), JDK 11 toolchain, and the Groovy-2.5 `--add-opens`
+  block (which eighty20results dropped because Groovy 3 is module-aware).
+- **Live specs, referenced read-only** — an `importSpecs` `Sync` task copies the entire
+  `src/test/groovy` corpus into the lane's build dir at build time (originals never edited;
+  "written once" per #230), so the lane always runs the same evolving specs.
+- **Lane-local scaffold variant** (`ci/groovy2x-spock/scaffold/`) — only the two harness bases whose
+  fork API diverges: `support/HarnessSpec.groovy` and `rules/RuleHarnessSpec.groovy`. joelwetzel uses
+  biocomp's `@Delegate`→`AppExecutor` wiring for `getChildApps`/`addChildApp`/`getParent`, so these
+  wire through the AppExecutor mock instead of eighty20results' reflective
+  `childAppFactory`/`childAppAccessor` replacement, `childAppResolver`, and `setParent`.
+- **PassThrough is kept, not dropped.** joelwetzel doesn't *remap* `hubitat.helper.*`, but the sandbox
+  classloader still needs `PassThroughAppValidator` + `sandbox.run()` to force those names to resolve
+  from the parent classloader (the `src/main/groovy/` stubs) — otherwise `RMUtilsMock`'s
+  static-metaclass injection lands on a different class instance than the one the sandbox loads
+  (RM tools silently see no rules) and `hubitat.helper.NetworkUtils` isn't visible at all (NCDFE in
+  the diagnostics tools). All other support classes (`RMUtilsMock`, `McpRequestDriver`, `TestDevice`,
+  the PassThrough pair, …) are shared read-only.
+- **Two specs are excluded** as not fork-portable (each hardcodes eighty20results-only sandbox API;
+  the Groovy 3.0 lane covers both): `server/ToolManageVirtualDeviceSpec.groovy` reflects the private
+  `childDeviceFactory` field, and `support/RMUtilsSandboxInterceptionSpec.groovy` passes the
+  `childAppResolver:` option that joelwetzel's `sandbox.run()` rejects (its self-test value — that
+  sandbox-loaded `hubitat.helper.RMUtils` calls reach `RMUtilsMock` — is instead proven by the RM
+  tool specs passing).
+- **Allow-failure** — `continue-on-error: true`; the lane is informational until the 2.5 corpus is
+  fully green and is **not** the ruleset's required `test` check, so it never blocks merge.
+
+## Running locally
+
+```bash
+./gradlew -p ci/groovy2x-spock test          # full corpus under Groovy 2.5
+./gradlew -p ci/groovy2x-spock test --tests "server.ToolListDevicesSpec"
+```
+
+JDK 11 must be discoverable by the toolchain resolver (the lane targets Java 11; Groovy 2.5 is
+unhappy on JDK 17/21).
+
+## Maintenance
+
+The joelwetzel pin is tracked alongside the root eighty20results pin by
+`.github/workflows/hubitat-ci-version-check.yml`. If a spec fails only on the 2.5 lane, it is a real
+2.x-vs-3.0 runtime divergence (or a hub-relevant fork-behaviour gap) — investigate before dismissing.
+If a future change makes the corpus fully green here, flip `continue-on-error` off to promote the
+lane to a gate.

--- a/docs/groovy2x-spock-lane.md
+++ b/docs/groovy2x-spock-lane.md
@@ -74,6 +74,10 @@ scaffold, and all existing workflows stay **byte-untouched**.
   (RM tools silently see no rules) and `hubitat.helper.NetworkUtils` isn't visible at all (NCDFE in
   the diagnostics tools). All other support classes (`RMUtilsMock`, `McpRequestDriver`, `TestDevice`,
   the PassThrough pair, …) are shared read-only.
+- **Two lane self-tests** (`scaffold/support/LaneChildAppWiringSpec`, `scaffold/rules/RuleParentWiringSpec`)
+  assert the fork-specific wiring the lane depends on — that `getChildApps`/`addChildApp`/`deleteChildApp`
+  and `parent` actually route through the AppExecutor `@Delegate` under joelwetzel — so a future fork
+  bump that broke that routing fails loudly here instead of letting tool specs pass against a no-op stub.
 - **Two specs are excluded** as not fork-portable (each hardcodes eighty20results-only sandbox API;
   the Groovy 3.0 lane covers both): `server/ToolManageVirtualDeviceSpec.groovy` reflects the private
   `childDeviceFactory` field, and `support/RMUtilsSandboxInterceptionSpec.groovy` passes the
@@ -95,8 +99,13 @@ unhappy on JDK 17/21).
 
 ## Maintenance
 
-The joelwetzel pin is tracked alongside the root eighty20results pin by
-`.github/workflows/hubitat-ci-version-check.yml`. If a spec fails only on the 2.5 lane, it is a real
-2.x-vs-3.0 runtime divergence (or a hub-relevant fork-behaviour gap) — investigate before dismissing.
-If a future change makes the corpus fully green here, flip `continue-on-error` off to promote the
-lane to a gate.
+The joelwetzel SHA is a **manual pin**: the existing `.github/workflows/hubitat-ci-version-check.yml`
+only tracks the root build's eighty20results *tag* (joelwetzel cuts no tags), so bump
+`ci/groovy2x-spock/build.gradle` by hand when adopting fork fixes. If a spec fails only on the 2.5
+lane, it is a real 2.x-vs-3.0 runtime divergence (or a hub-relevant fork-behaviour gap) — investigate
+before dismissing.
+
+The corpus already passes fully under Groovy 2.5 (locally and in the lane's first CI run); the lane is
+kept on `continue-on-error` deliberately, since Actions runners differ from a dev box and the fork's
+stability there is young. Once it has a track record, flip `continue-on-error` off to promote it to a
+gate.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,6 +7,21 @@ Groovy unit tests run under Spock + HubitatCI via the Gradle wrapper. CI runs `.
 - **JVM:** OpenJDK 17 in CI; locally, JDK 11+ via the Gradle toolchain
 - **Build:** Gradle 8.10 via wrapper (`./gradlew test`)
 
+### Additive hub-closer lanes
+
+Two standalone lanes complement the primary Groovy 3.0 lane without touching it — Hubitat's hub
+runtime is Groovy 2.4.x, so a 3.0-green can still hide hub failures:
+
+- **Groovy 2.4 Parse Check** (`ci/groovy24-parse/`) — parses the two production `.groovy` files under
+  stock Groovy 2.4.21 (antlr2), catching 3.0-only syntax that would fail to load on the hub (issue #227).
+- **Groovy 2.5 Spock** (`ci/groovy2x-spock/`) — runs this same spec corpus against a Groovy 2.5
+  runtime via [joelwetzel/hubitat_ci](https://github.com/joelwetzel/hubitat_ci) (the biocomp-API fork
+  the harness used before the eighty20results migration; Apache 2.0), catching 2.x-vs-3.0 **runtime**
+  divergence (issue #230). Allow-failure; references the specs read-only and carries its own
+  joelwetzel-shaped `HarnessSpec`/`RuleHarnessSpec` under `ci/groovy2x-spock/scaffold/`. See
+  [docs/groovy2x-spock-lane.md](groovy2x-spock-lane.md). Run locally with
+  `./gradlew -p ci/groovy2x-spock test`.
+
 ## Running locally
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,7 +5,7 @@ Groovy unit tests run under Spock + HubitatCI via the Gradle wrapper. CI runs `.
 - **Test framework:** Spock 2.3 on Groovy 3.0 (Hubitat's hub runtime is Groovy 2.4, and `eighty20results/hubitat_ci` actively tests its behaviour against that runtime — case-insensitive enum matching, locale-safe `toLowerCase`, etc. — so Groovy 3.0 stays the closest practical match).
 - **Hubitat sandbox:** [eighty20results/hubitat_ci](https://github.com/eighty20results/hubitat_ci) — an actively-maintained Groovy 3.0 fork of the original [biocomp/hubitat_ci](https://github.com/biocomp/hubitat_ci) (Apache 2.0). Consumed as `com.github.eighty20results:hubitat_ci:<tag>` via JitPack; the pinned release tag in `build.gradle` is bumped by tracking issues from `.github/workflows/hubitat-ci-version-check.yml`. Sandbox-loaded production code that references `hubitat.helper.{RMUtils, NetworkUtils}` is routed through `support.PassThroughSandboxClassLoader` (installed via `support.PassThroughAppValidator`) so our literal-named stubs at `src/main/groovy/hubitat/helper/` resolve without hitting the JVM's §5.3.5 name-equality check — the raw-vs-remapped class mismatch that would otherwise NCDFE at runtime. Groovy 3 is module-aware, so the JDK 11+ `--add-opens` workaround from the Groovy-2.5 era is no longer needed.
 - **JVM:** OpenJDK 17 in CI; locally, JDK 11+ via the Gradle toolchain
-- **Build:** Gradle 8.10 via wrapper (`./gradlew test`)
+- **Build:** Gradle 9.5.1 via wrapper (`./gradlew test`)
 
 ### Additive hub-closer lanes
 


### PR DESCRIPTION
## Summary

- Adds an **additive, allow-failure** CI lane that runs the existing Spock spec corpus against a **Groovy 2.5** runtime, so 2.x-vs-3.0 runtime divergence (and antlr2 parse divergence) is caught before it reaches a hub — the lane exists to surface *real* hub bugs the Groovy 3.0 lane can't see.
- Closes #230. Closes #227 (the 2.5 lane loads the production files under the antlr2 grammar — a superset of the shipped Groovy 2.4 parse lane).
- Zero-touch: the root `build.gradle`, the shared `src/test/groovy/support/` scaffold, and every existing workflow are byte-unchanged.

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `ci` — CI/CD pipeline change

## Changes

- **`ci/groovy2x-spock/`** — isolated Gradle build (own `settings.gradle`), like the sibling `ci/groovy24-parse/`. Consumes `joelwetzel/hubitat_ci` @ `a62a351eed` via JitPack (the biocomp-API fork the harness used before the eighty20results migration; the only fork that builds cleanly on JitPack today), `groovy-all:2.5.23`, `spock-core:2.3-groovy-2.5`, JDK 11 toolchain, and the Groovy-2.5 `--add-opens` block.
  - The live `src/test/groovy` corpus is imported **read-only** via a `Sync` task — the originals are never edited, and the lane always runs the same evolving specs.
  - `ci/groovy2x-spock/scaffold/` carries lane-local `HarnessSpec`/`RuleHarnessSpec` wired for joelwetzel's biocomp `@Delegate`→`AppExecutor` child/parent dispatch (vs eighty20results' reflective `childAppFactory`/`childAppAccessor`/`childAppResolver`/`setParent`). The shared `PassThroughAppValidator` is kept — joelwetzel doesn't *remap* `hubitat.helper.*`, but the sandbox still needs it to resolve those names from the parent stubs so `RMUtilsMock`'s metaclass injection has class identity and `NetworkUtils` is visible.
  - Two lane self-tests (`scaffold/support/LaneChildAppWiringSpec`, `scaffold/rules/RuleParentWiringSpec`) assert that `getChildApps`/`addChildApp`/`deleteChildApp` and `parent` actually route through the AppExecutor `@Delegate` under joelwetzel — so a future fork bump that broke that routing fails loudly here instead of letting tool specs pass against a no-op stub.
  - Two specs are excluded as not fork-portable (each hardcodes eighty20results-only sandbox API; the Groovy 3.0 lane covers both): `server/ToolManageVirtualDeviceSpec` reflects the private `childDeviceFactory` field, and `support/RMUtilsSandboxInterceptionSpec` passes the `childAppResolver:` option that joelwetzel's `sandbox.run()` rejects (its self-test value is instead proven by the RM tool specs passing).
- **`.github/workflows/groovy2x-spock.yml`** — new lane, `continue-on-error: true`, path-scoped, **not** the ruleset's required `test` check, so it never blocks merge. Runs with `-PharnessStrictMetaClass=true` so the harness metaClass dual-wipe is exercised under Groovy 2.5.
- **Docs** — `docs/groovy2x-spock-lane.md` (design + fork rationale) and a `docs/testing.md` subsection; re-credits `joelwetzel/hubitat_ci` (Apache 2.0), which this lane consumes again.

No existing CI, the root build, or the shared scaffold is modified — the lane is purely additive concurrent coverage using the same tests.

## Release Notes

- Development-only: new CI lane that exercises the test suite against a hub-closer Groovy 2.5 runtime. No change to the app users install.

## Testing

- `./gradlew -p ci/groovy2x-spock test -PharnessStrictMetaClass=true` runs the full `src/test/groovy` corpus under Groovy 2.5 / joelwetzel (JDK 11 toolchain): **2,943 tests, 0 failures, 0 errors** across 65 spec classes (the 2 intentionally-excluded fork-coupled specs aside; the count includes 2 lane wiring self-tests). Green both locally and in this PR's CI, with the metaClass dual-wipe verified under 2.5 via the strict flag.
- Reaching green surfaced three test-harness wiring gaps specific to joelwetzel's biocomp API — helper class-identity via the PassThrough classloader, and child-app `addChildApp`/`deleteChildApp` + parent wiring through the AppExecutor `@Delegate`. **None were production-behaviour failures**: the failing cases either threw before the app code ran (class-loading) or asserted on a mock the lane hadn't wired yet, and each fix mirrors the Groovy 3.0 harness exactly. A green delete-rule spec, for instance, is positive evidence the app calls `deleteChildApp` correctly under 2.5.
- The lane is deliberately built to catch **real** 2.x-vs-3.0 runtime divergence going forward; a future red here should be triaged as a potential hub bug first, not silenced.
- The existing Groovy 3.0 `Unit Tests` lane and the Groovy 2.4 `Parse Check` lane are unchanged and continue to gate as before.
- PR-review-toolkit and Gemini Code Assist feedback addressed: cleared the `CURRENT_FEATURE` static in `cleanup()` (leak + cross-class stale-fixture window), added the two wiring self-tests, switched the imported-specs dir to a lazy `Provider`, enabled strict-metaClass verification, and corrected stale comments/docs.

## Checklist

- [ ] **Unit tests added for any new MCP tools** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes) — n/a (no tool changes; adds a CI lane over existing specs)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py` — n/a (no production `.groovy` change; the lint workflow doesn't trigger)
- [x] `./gradlew test` passes locally (or CI confirms) — existing 3.0 lane unaffected; new 2.5 lane runs allow-failure
- [x] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`) — n/a (no behaviour change)
- [x] Documentation updated if user-facing behaviour or tool surface changed — added lane docs
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules — n/a (no tools)
