### PR TITLE
feat: PR2b/2c backend robustness, performance, and cleanup (issue #105)

### DIFF
--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -37,7 +37,7 @@ get_lease_value() {
 set_lease_value() {
   # Arg is the JSON-stringified value (already double-quoted + escaped).
   local value_json="$1"
-  mcp_call "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"hub_manage_variables\",\"arguments\":{\"tool\":\"set_variable\",\"args\":{\"name\":\"_TEST_HUB_LEASED_BY\",\"value\":${value_json}}}}}" >/dev/null
+  mcp_call "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"hub_manage_variables\",\"arguments\":{\"tool\":\"hub_set_variable\",\"args\":{\"name\":\"_TEST_HUB_LEASED_BY\",\"value\":${value_json}}}}}" >/dev/null
 }
 
 CURRENT="$(get_lease_value)"

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -29,7 +29,7 @@ mcp_call() {
 }
 
 get_lease_value() {
-  mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"manage_hub_variables","arguments":{"tool":"get_variable","args":{"name":"_TEST_HUB_LEASED_BY"}}}}' \
+  mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_manage_variables","arguments":{"tool":"hub_get_variable","args":{"name":"_TEST_HUB_LEASED_BY"}}}}' \
     | jq -r '.result.content[0].text' \
     | jq -r '.value // ""'
 }
@@ -37,7 +37,7 @@ get_lease_value() {
 set_lease_value() {
   # Arg is the JSON-stringified value (already double-quoted + escaped).
   local value_json="$1"
-  mcp_call "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"manage_hub_variables\",\"arguments\":{\"tool\":\"set_variable\",\"args\":{\"name\":\"_TEST_HUB_LEASED_BY\",\"value\":${value_json}}}}}" >/dev/null
+  mcp_call "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"hub_manage_variables\",\"arguments\":{\"tool\":\"set_variable\",\"args\":{\"name\":\"_TEST_HUB_LEASED_BY\",\"value\":${value_json}}}}}" >/dev/null
 }
 
 CURRENT="$(get_lease_value)"

--- a/.github/scripts/lease_release.sh
+++ b/.github/scripts/lease_release.sh
@@ -13,7 +13,7 @@ set -uo pipefail
 
 if curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
     -H "Content-Type: application/json" \
-    -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"manage_hub_variables","arguments":{"tool":"set_variable","args":{"name":"_TEST_HUB_LEASED_BY","value":""}}}}' \
+    -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"hub_manage_variables","arguments":{"tool":"hub_set_variable","args":{"name":"_TEST_HUB_LEASED_BY","value":""}}}}' \
     >/dev/null; then
   echo "Lease released."
 else

--- a/.github/scripts/mcp_deploy_source.sh
+++ b/.github/scripts/mcp_deploy_source.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Snapshot the hub's current parent-app source, then attempt to push the
-# PR's source via update_app_code. On a verified write, drops a
+# PR's source via hub_update_app. On a verified write, drops a
 # "deploy landed" marker that mcp_restore_source.sh checks before
 # pushing anything back -- so a no-op deploy (e.g. blocked by cloud
 # body cap) doesn't trigger a wasted 1.5MB cleanup write.
@@ -9,16 +9,16 @@
 # Env:   MCP_URL     -- full cloud OAuth URL with access_token
 #        RUNNER_TEMP -- GHA temp dir; falls back to /tmp
 #
-# Preconditions (enforced hub-side by update_app_code):
+# Preconditions (enforced hub-side by hub_update_app):
 #   - Developer Mode ON (self-update guard)
 #   - enableHubAdminWrite ON
-#   - Hub backup <24h (best-effort create_hub_backup attempted here;
+#   - Hub backup <24h (best-effort hub_create_backup attempted here;
 #     gateway timeouts tolerated -- the gate is timestamp-cached and
 #     CI runs keep the window populated)
 #
 # The MCP URL's app ID (e.g. 38) is the installed-instance ID, NOT the
 # source-bearing Apps Code class ID. We look up the class ID via
-# list_hub_apps and match by (namespace, name) from definition().
+# hub_list_apps and match by (namespace, name) from definition().
 
 set -euo pipefail
 
@@ -39,7 +39,7 @@ APP_NAME="MCP Rule Server"
 
 # Cloud's gateway window is ~10s; a 1.5MB Groovy recompile on a real C-7/
 # C-8 hub takes ~10-25s. When cloud returns 5xx, we sleep, then poll
-# get_app_source until totalLength changes from PRE_LEN (proving the
+# hub_get_source until totalLength changes from PRE_LEN (proving the
 # write landed) or we hit the timeout.
 POST_DEPLOY_VERIFY_SLEEP=20
 POST_DEPLOY_VERIFY_TIMEOUT=90
@@ -54,7 +54,7 @@ if [ ! -f "$SOURCE_FILE" ]; then
 fi
 
 # Two-arg call for small/in-process payloads; large payloads (the source
-# blob in update_app_code) pipe stdin via mcp_call_stdin to dodge ARG_MAX.
+# blob in hub_update_app) pipe stdin via mcp_call_stdin to dodge ARG_MAX.
 mcp_call() {
   curl -sS --max-time 120 -X POST "$MCP_URL" \
     -H "Content-Type: application/json" \
@@ -74,19 +74,19 @@ mcp_call_stdin() {
 }
 
 echo "Triggering hub backup (best-effort; tolerated if it 504s -- the <24h gate is timestamp-cached)..."
-BACKUP_RPC='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_hub_backup","arguments":{"confirm":true}}}'
+BACKUP_RPC='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_create_backup","arguments":{"confirm":true}}}'
 # `>/dev/null` (not `2>&1`) so genuine curl errors -- DNS, connection refused,
 # TLS handshake -- stay visible in the log even though the response body is
 # discarded.
 mcp_call "$BACKUP_RPC" >/dev/null || \
-  echo "::warning::create_hub_backup call failed/timed out; relying on cached <24h backup timestamp"
+  echo "::warning::hub_create_backup call failed/timed out; relying on cached <24h backup timestamp"
 
-echo "Looking up Apps Code class ID for $APP_NAMESPACE:$APP_NAME via list_hub_apps..."
-LIST_RPC='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_hub_apps","arguments":{}}}'
+echo "Looking up Apps Code class ID for $APP_NAMESPACE:$APP_NAME via hub_list_apps..."
+LIST_RPC='{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_list_apps","arguments":{}}}'
 LIST_RESP=$(mcp_call "$LIST_RPC")
 LIST_TEXT=$(echo "$LIST_RESP" | jq -r '.result.content[0].text // empty')
 if [ -z "$LIST_TEXT" ]; then
-  echo "::error::list_hub_apps returned empty MCP content (resp head: $(echo "$LIST_RESP" | head -c 500))"
+  echo "::error::hub_list_apps returned empty MCP content (resp head: $(echo "$LIST_RESP" | head -c 500))"
   exit 1
 fi
 
@@ -99,8 +99,8 @@ CLASS_ID=$(echo "$LIST_TEXT" | jq -r \
   '.apps[]? | select(.namespace == $ns and .name == $name) | .id' | head -n1)
 
 if [ -z "$CLASS_ID" ] || [ "$CLASS_ID" = "null" ]; then
-  echo "::error::Apps Code class for $APP_NAMESPACE:$APP_NAME not found via list_hub_apps."
-  echo "DEBUG list_hub_apps envelope keys: $(echo "$LIST_TEXT" | jq -r 'keys | join(",")')"
+  echo "::error::Apps Code class for $APP_NAMESPACE:$APP_NAME not found via hub_list_apps."
+  echo "DEBUG hub_list_apps envelope keys: $(echo "$LIST_TEXT" | jq -r 'keys | join(",")')"
   echo "DEBUG first 5 entries: $(echo "$LIST_TEXT" | jq -c '.apps[0:5] // []')"
   exit 1
 fi
@@ -118,17 +118,17 @@ while :; do
     --arg id "$CLASS_ID" \
     --argjson off "$OFFSET" \
     --argjson len "$CHUNK_LEN" \
-    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"get_app_source",arguments:{appId:$id,offset:$off,length:$len}}}')
+    '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_get_source",arguments:{appId:$id,offset:$off,length:$len}}}')
   RESP=$(mcp_call "$RPC")
   TEXT=$(echo "$RESP" | jq -r '.result.content[0].text // empty')
   if [ -z "$TEXT" ]; then
-    echo "::error::get_app_source returned empty MCP content (resp head: $(echo "$RESP" | head -c 500))"
+    echo "::error::hub_get_source returned empty MCP content (resp head: $(echo "$RESP" | head -c 500))"
     rm -f "$PRE_SOURCE_FILE"
     exit 1
   fi
   OK=$(echo "$TEXT" | jq -r '.success // false')
   if [ "$OK" != "true" ]; then
-    echo "::error::get_app_source failed: $(echo "$TEXT" | jq -r '.error // empty')"
+    echo "::error::hub_get_source failed: $(echo "$TEXT" | jq -r '.error // empty')"
     rm -f "$PRE_SOURCE_FILE"
     exit 1
   fi
@@ -159,26 +159,29 @@ if [ "$PRE_BYTES" -lt 1000 ]; then
 fi
 
 NEW_BYTES=$(wc -c < "$SOURCE_FILE")
-: "${PR_SOURCE_URL:?PR_SOURCE_URL env var required -- the raw URL the hub fetches via update_app_code importUrl mode (the workflow sets it from the PR head SHA)}"
+: "${PR_SOURCE_URL:?PR_SOURCE_URL env var required -- the raw URL the hub fetches via hub_update_app importUrl mode (the workflow sets it from the PR head SHA)}"
 echo "Deploying class $CLASS_ID via importUrl (hub fetches ${NEW_BYTES} bytes from ${PR_SOURCE_URL})..."
 
 # importUrl mode (issue #228): the hub fetches the PR branch's raw source
 # directly, so the ~1.5MB blob never crosses the cloud gateway -- an inline
 # source=... write reliably 504s before the hub receives it, but the
-# importUrl RPC body is tiny (just the URL). importUrl shipped on
-# update_app_code in #213 (2026-05-26), BEFORE the hub_ rename in #224
-# (2026-06-02), so the pre-rename server currently on the test hub already
-# exposes it. Self-update recompiles the MCP app mid-call, so the call may
+# importUrl RPC body is tiny (just the URL). importUrl shipped in #213
+# (2026-05-26) on the then-named update_app_code and carried through the
+# #224 (2026-06-02) hub_ rename to hub_update_app, so it has stayed
+# continuously available. The bootstrap above (hub_list_apps / hub_get_source
+# / hub_update_app) uses this PR's hub_-prefixed names; the test hub already
+# runs a post-#224 server that exposes them (a prior importUrl deploy flipped
+# it forward). Self-update recompiles the MCP app mid-call, so the call may
 # not return cleanly -- the 5xx / curl-failure tolerance and the
-# get_app_source verify below already handle that.
+# hub_get_source verify below already handle that.
 DEPLOY_RPC_FILE="${RUNNER_TEMP:-/tmp}/mcp_deploy_rpc.json"
 jq -nc \
   --arg id "$CLASS_ID" \
   --arg url "$PR_SOURCE_URL" \
-  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,importUrl:$url,confirm:true}}}' \
+  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_update_app",arguments:{appId:$id,importUrl:$url,confirm:true}}}' \
   > "$DEPLOY_RPC_FILE"
 
-# Poll get_app_source until totalLength differs from PRE_LEN, proving the
+# Poll hub_get_source until totalLength differs from PRE_LEN, proving the
 # write landed even when cloud bailed mid-recompile with a 5xx. Edge case:
 # if the PR source happens to have identical char length to the pre-image
 # (rare; whitespace-only or coincidentally length-matching diffs), this
@@ -189,7 +192,7 @@ verify_deploy_landed() {
   local rpc resp text current_len ok
   while [ $elapsed -lt $POST_DEPLOY_VERIFY_TIMEOUT ]; do
     rpc=$(jq -nc --arg id "$CLASS_ID" \
-      '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"get_app_source",arguments:{appId:$id,offset:0,length:1}}}')
+      '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_get_source",arguments:{appId:$id,offset:0,length:1}}}')
     resp=$(mcp_call "$rpc")
     text=$(echo "$resp" | jq -r '.result.content[0].text // empty')
     ok=$(echo "$text" | jq -r '.success // false')
@@ -235,14 +238,14 @@ if [ "$HTTP_CODE" = "200" ]; then
   # jq stderr passes through so parse errors are visible in CI logs.
   DEPLOY_TEXT=$(printf '%s' "$DEPLOY_BODY" | jq -r '.result.content[0].text // empty' || true)
   if [ -z "$DEPLOY_TEXT" ]; then
-    echo "::error::update_app_code returned 200 but body was not parseable MCP JSON"
+    echo "::error::hub_update_app returned 200 but body was not parseable MCP JSON"
     echo "Body head (first 1500 bytes):"
     printf '%s' "$DEPLOY_BODY" | head -c 1500
     exit 1
   fi
   DEPLOY_OK=$(echo "$DEPLOY_TEXT" | jq -r '.success // false')
   if [ "$DEPLOY_OK" != "true" ]; then
-    echo "::error::update_app_code failed: $(echo "$DEPLOY_TEXT" | jq -r '.error // .message // empty')"
+    echo "::error::hub_update_app failed: $(echo "$DEPLOY_TEXT" | jq -r '.error // .message // empty')"
     echo "Tool response: $DEPLOY_TEXT" | head -c 2000
     exit 1
   fi
@@ -250,9 +253,9 @@ if [ "$HTTP_CODE" = "200" ]; then
   printf 'verified-via=200-json bytes=%s\n' "$NEW_BYTES" > "$DEPLOY_LANDED_FILE"
 elif [ "$HTTP_CODE" = "504" ] || [ "$HTTP_CODE" = "502" ] || [ "$HTTP_CODE" = "503" ]; then
   # Cloud bailed before the hub finished recompiling. The hub usually
-  # keeps working; poll get_app_source totalLength until it diverges
+  # keeps working; poll hub_get_source totalLength until it diverges
   # from the pre-deploy snapshot.
-  echo "::notice::Hub returned HTTP $HTTP_CODE (cloud gateway timeout). Sleeping ${POST_DEPLOY_VERIFY_SLEEP}s for the hub-side recompile, then polling get_app_source to verify..."
+  echo "::notice::Hub returned HTTP $HTTP_CODE (cloud gateway timeout). Sleeping ${POST_DEPLOY_VERIFY_SLEEP}s for the hub-side recompile, then polling hub_get_source to verify..."
   sleep $POST_DEPLOY_VERIFY_SLEEP
   if verify_deploy_landed; then
     echo "Deploy verified despite HTTP $HTTP_CODE. PR source is on the hub."
@@ -262,7 +265,7 @@ elif [ "$HTTP_CODE" = "504" ] || [ "$HTTP_CODE" = "502" ] || [ "$HTTP_CODE" = "5
     exit 1
   fi
 else
-  echo "::error::update_app_code got unexpected HTTP $HTTP_CODE"
+  echo "::error::hub_update_app got unexpected HTTP $HTTP_CODE"
   echo "Body head: $(printf '%s' "$DEPLOY_BODY" | head -c 1000)"
   exit 1
 fi

--- a/.github/scripts/mcp_deploy_source.sh
+++ b/.github/scripts/mcp_deploy_source.sh
@@ -3,7 +3,7 @@
 # PR's source via update_app_code. On a verified write, drops a
 # "deploy landed" marker that mcp_restore_source.sh checks before
 # pushing anything back -- so a no-op deploy (e.g. blocked by cloud
-# body cap) doesn't trigger a wasted 1.2MB cleanup write.
+# body cap) doesn't trigger a wasted 1.5MB cleanup write.
 #
 # Usage: mcp_deploy_source.sh [path/to/hubitat-mcp-server.groovy]
 # Env:   MCP_URL     -- full cloud OAuth URL with access_token
@@ -37,7 +37,7 @@ DEPLOY_LANDED_FILE="${RUNNER_TEMP:-/tmp}/mcp_deploy_landed"
 APP_NAMESPACE="mcp"
 APP_NAME="MCP Rule Server"
 
-# Cloud's gateway window is ~10s; a 1.2MB Groovy recompile on a real C-7/
+# Cloud's gateway window is ~10s; a 1.5MB Groovy recompile on a real C-7/
 # C-8 hub takes ~10-25s. When cloud returns 5xx, we sleep, then poll
 # get_app_source until totalLength changes from PRE_LEN (proving the
 # write landed) or we hit the timeout.
@@ -159,16 +159,23 @@ if [ "$PRE_BYTES" -lt 1000 ]; then
 fi
 
 NEW_BYTES=$(wc -c < "$SOURCE_FILE")
-echo "Pushing $SOURCE_FILE ($NEW_BYTES bytes) to class $CLASS_ID..."
+: "${PR_SOURCE_URL:?PR_SOURCE_URL env var required -- the raw URL the hub fetches via update_app_code importUrl mode (the workflow sets it from the PR head SHA)}"
+echo "Deploying class $CLASS_ID via importUrl (hub fetches ${NEW_BYTES} bytes from ${PR_SOURCE_URL})..."
 
-# Build the RPC envelope as a file (jq --rawfile handles JSON-escaping the
-# 1.2MB source), then pipe to curl via stdin so we never put the body on
-# the command line. Same dodge for the restore script.
+# importUrl mode (issue #228): the hub fetches the PR branch's raw source
+# directly, so the ~1.5MB blob never crosses the cloud gateway -- an inline
+# source=... write reliably 504s before the hub receives it, but the
+# importUrl RPC body is tiny (just the URL). importUrl shipped on
+# update_app_code in #213 (2026-05-26), BEFORE the hub_ rename in #224
+# (2026-06-02), so the pre-rename server currently on the test hub already
+# exposes it. Self-update recompiles the MCP app mid-call, so the call may
+# not return cleanly -- the 5xx / curl-failure tolerance and the
+# get_app_source verify below already handle that.
 DEPLOY_RPC_FILE="${RUNNER_TEMP:-/tmp}/mcp_deploy_rpc.json"
 jq -nc \
   --arg id "$CLASS_ID" \
-  --rawfile src "$SOURCE_FILE" \
-  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}' \
+  --arg url "$PR_SOURCE_URL" \
+  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,importUrl:$url,confirm:true}}}' \
   > "$DEPLOY_RPC_FILE"
 
 # Poll get_app_source until totalLength differs from PRE_LEN, proving the

--- a/.github/scripts/mcp_restore_env.sh
+++ b/.github/scripts/mcp_restore_env.sh
@@ -23,7 +23,7 @@ echo "Restoring pre-run state: $PRE_STATE"
 # update_mcp_settings expects a Map<key, value>. The pre-state file is
 # already in the right shape — wrap it in the tool's argument envelope.
 SETTINGS_PAYLOAD="$(jq -nc --argjson s "$PRE_STATE" '{settings: $s, confirm: true}')"
-RPC_BODY="$(jq -nc --argjson p "$SETTINGS_PAYLOAD" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"manage_mcp_self",arguments:{tool:"update_mcp_settings",args:$p}}}')"
+RPC_BODY="$(jq -nc --argjson p "$SETTINGS_PAYLOAD" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_manage_mcp",arguments:{tool:"hub_update_mcp_settings",args:$p}}}')"
 
 curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
   -H "Content-Type: application/json" \

--- a/.github/scripts/mcp_restore_source.sh
+++ b/.github/scripts/mcp_restore_source.sh
@@ -67,7 +67,7 @@ RESTORE_RPC_FILE="${RUNNER_TEMP:-/tmp}/mcp_restore_rpc.json"
 jq -nc \
   --arg id "$CLASS_ID" \
   --rawfile src "$PRE_SOURCE_FILE" \
-  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"update_app_code",arguments:{appId:$id,source:$src,confirm:true}}}' \
+  '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_update_app",arguments:{appId:$id,source:$src,confirm:true}}}' \
   > "$RESTORE_RPC_FILE"
 
 RESTORE_RESP_FILE="${RUNNER_TEMP:-/tmp}/mcp_restore_resp.txt"
@@ -84,7 +84,7 @@ RESTORE_BODY=$(sed '$d' "$RESTORE_RESP_FILE")
 echo "Hub responded HTTP $HTTP_CODE; body length=$(printf '%s' "$RESTORE_BODY" | wc -c)"
 rm -f "$RESTORE_RESP_FILE"
 
-# Polls get_app_source until totalLength matches the pre-deploy charlen
+# Polls hub_get_source until totalLength matches the pre-deploy charlen
 # (meaning the restore landed).
 verify_restored_to_pre_len() {
   if [ -z "$PRE_LEN" ] || [ "$PRE_LEN" = "0" ]; then
@@ -95,7 +95,7 @@ verify_restored_to_pre_len() {
   local rpc resp text current_len ok
   while [ $elapsed -lt $POST_RESTORE_VERIFY_TIMEOUT ]; do
     rpc=$(jq -nc --arg id "$CLASS_ID" \
-      '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"get_app_source",arguments:{appId:$id,offset:0,length:1}}}')
+      '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_get_source",arguments:{appId:$id,offset:0,length:1}}}')
     resp=$(curl -sS --max-time 30 -X POST "$MCP_URL" \
       -H "Content-Type: application/json" \
       --data-binary "$rpc" || true)

--- a/.github/scripts/mcp_setup_env.sh
+++ b/.github/scripts/mcp_setup_env.sh
@@ -9,7 +9,7 @@
 #
 # Toggles enabled (all in update_mcp_settings allowlist):
 #   - enableCustomRuleEngine (custom_create_rule / custom_update_rule / custom_delete_rule paths)
-#   - enableHubAdminRead     (get_hub_info PII fields, list_hub_apps, etc.)
+#   - enableHubAdminRead     (hub_get_info PII fields, hub_list_apps, etc.)
 #   - enableBuiltinApp       (list_installed_apps, list_rm_rules, native CRUD tools)
 #
 # Not touched here:
@@ -32,10 +32,10 @@ mcp_call() {
     -d "$1"
 }
 
-# Pull the toggle state from get_hub_info. The settings-visibility block on
+# Pull the toggle state from hub_get_info. The settings-visibility block on
 # lines 3026+ of hubitat-mcp-server.groovy exposes these fields without
 # requiring Hub Admin Read.
-PRE_INFO_JSON="$(mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_hub_info","arguments":{}}}' \
+PRE_INFO_JSON="$(mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_get_info","arguments":{}}}' \
   | jq -r '.result.content[0].text')"
 
 DEV_MODE="$(echo "$PRE_INFO_JSON" | jq -r '.developerModeEnabled // false')"
@@ -60,7 +60,7 @@ cat "$PRE_STATE_FILE"
 
 # Enable everything E2E needs in a single batch. update_mcp_settings is
 # atomic — a single bad key would block the whole batch.
-mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"manage_mcp_self","arguments":{"tool":"update_mcp_settings","args":{"settings":{"enableCustomRuleEngine":true,"enableHubAdminRead":true,"enableBuiltinApp":true},"confirm":true}}}}' \
+mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hub_manage_mcp","arguments":{"tool":"hub_update_mcp_settings","args":{"settings":{"enableCustomRuleEngine":true,"enableHubAdminRead":true,"enableBuiltinApp":true},"confirm":true}}}}' \
   | jq -e '.result.content[0].text | fromjson | .success == true' >/dev/null
 
 echo "Test environment configured: enableCustomRuleEngine=true, enableHubAdminRead=true, enableBuiltinApp=true"

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -131,17 +131,57 @@ jobs:
         # itself is off (UI-only to enable).
         run: bash .github/scripts/mcp_setup_env.sh
 
+      - name: Compute PR source URL for importUrl deploy
+        if: steps.gate.outputs.available == 'true'
+        # The hub fetches the PR branch's raw source itself (importUrl mode), so the
+        # ~1.5MB blob never crosses the cloud gateway. Resolve head repo + SHA for the
+        # three trigger shapes (PR, dispatch-with-pr_number, plain dispatch).
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_INPUT: ${{ inputs.pr_number }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DEFAULT_REPO: ${{ github.repository }}
+          DEFAULT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            REPO="$PR_HEAD_REPO"; SHA="$PR_HEAD_SHA"
+          elif [ -n "${PR_INPUT:-}" ]; then
+            # Validate the dispatch input before it reaches gh api.
+            if ! printf '%s' "$PR_INPUT" | grep -qE '^[0-9]+$'; then
+              echo "::error::pr_number must be numeric"; exit 1
+            fi
+            REPO=$(gh api "repos/$DEFAULT_REPO/pulls/$PR_INPUT" --jq '.head.repo.full_name')
+            SHA=$(gh api "repos/$DEFAULT_REPO/pulls/$PR_INPUT" --jq '.head.sha')
+          else
+            REPO="$DEFAULT_REPO"; SHA="$DEFAULT_SHA"
+          fi
+          # Defense-in-depth: only a 40-hex SHA and an owner/name repo may form the
+          # URL, so a malformed value can't inject into $GITHUB_ENV or the URL.
+          if ! printf '%s' "$SHA" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::unexpected head SHA shape"; exit 1
+          fi
+          if ! printf '%s' "$REPO" | grep -qE '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$'; then
+            echo "::error::unexpected head repo shape"; exit 1
+          fi
+          URL="https://raw.githubusercontent.com/$REPO/$SHA/hubitat-mcp-server.groovy"
+          echo "PR_SOURCE_URL=$URL" >> "$GITHUB_ENV"
+          echo "::notice::importUrl deploy source: $URL"
+
       - name: Deploy PR source to test hub
         if: steps.gate.outputs.available == 'true'
         # Self-update is permitted because mcp_setup_env.sh already verified
         # Developer Mode is on (the guard update_app_code checks for
         # self-modification on the MCP server's own app row).
         #
-        # continue-on-error: a ~1.18 MB inline update_app_code(source=...)
-        # reliably 504s at the cloud gateway before the hub receives it.
-        # Until a chunked manage_files write tool exists, deploy is
-        # advisory — the snapshot reads (small) still work, so restore
-        # logic stays meaningful once a deploy ever lands.
+        # continue-on-error: the hub recompiles the MCP app mid-call when it
+        # self-updates, so the deploy call can return a cloud 5xx / drop the
+        # connection; the script tolerates that and polls get_app_source to
+        # verify. importUrl mode (issue #228) has the hub fetch the source
+        # itself, so the ~1.5MB blob never crosses the cloud gateway (an inline
+        # source=... write reliably 504s before the hub receives it).
         continue-on-error: true
         run: bash .github/scripts/mcp_deploy_source.sh hubitat-mcp-server.groovy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,7 @@ Defaults for unannotated tools are deliberately cautious (non-read-only, potenti
 ### Testing & eval
 
 - Every new MCP tool ships with BOTH a direct-call (unit) test AND a dispatch-envelope (integration) test under `src/test/groovy/` (existing CONTRIBUTING.md rule; reaffirmed).
+- **e2e coverage is mandatory for changes and bug fixes, not just new tools.** Any change to tool behaviour, dispatch/gateway routing, the transport/protocol layer, or any bug fix that a live-hub MCP client could observe MUST add or update a `tests/e2e_test.py` scenario in the same PR, alongside the Spock unit/integration tests. The Spock suite proves the logic in isolation against the `hubitat_ci` harness; the `e2e` job proves it against a real hub through the cloud MCP endpoint. A green Spock matrix is necessary but not sufficient — if a client could see the difference, e2e must cover it. When adding or renaming a tool, keep `tests/e2e_test.py` and the e2e deploy scripts under `.github/scripts/` in lockstep with the tool surface — stale tool names there are a silent e2e-only break.
 - If the tool's behaviour affects live-hub flows, add a `tests/BAT-v2.md` scenario in the same PR.
 - Track tool errors during eval. High invalid-parameter rates usually indicate the description or examples are the bug, not the model. Anthropic's example: Claude was appending `2025` to web-search queries until the description was fixed.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ Defaults for unannotated tools are deliberately cautious (non-read-only, potenti
 ### Testing & eval
 
 - Every new MCP tool ships with BOTH a direct-call (unit) test AND a dispatch-envelope (integration) test under `src/test/groovy/` (existing CONTRIBUTING.md rule; reaffirmed).
+- **e2e coverage is mandatory for changes and bug fixes, not just new tools.** Any change to tool behaviour, dispatch/gateway routing, the transport/protocol layer, or any bug fix that a live-hub MCP client could observe MUST add or update a `tests/e2e_test.py` scenario in the same PR, alongside the Spock unit/integration tests. The Spock suite proves the logic in isolation against the `hubitat_ci` harness; the `e2e` job proves it against a real hub through the cloud MCP endpoint. A green Spock matrix is necessary but not sufficient — if a client could see the difference, e2e must cover it. When adding or renaming a tool, keep `tests/e2e_test.py` and the e2e deploy scripts under `.github/scripts/` in lockstep with the tool surface — stale tool names there are a silent e2e-only break.
 - If the tool's behaviour affects live-hub flows, add a `tests/BAT-v2.md` scenario in the same PR.
 - Track tool errors during eval. High invalid-parameter rates usually indicate the description or examples are the bug, not the model. Anthropic's example: Claude was appending `2025` to web-search queries until the description was fixed.
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -32,7 +32,7 @@ Default is **ON** (gateways enabled). Existing installations keep the gateway be
 
 ### `tools/call` Response-Size Guard (v1.3.x+, fail-soft)
 
-Every `tools/call` response is measured before send. If the wire-encoded response exceeds the universal 120 KB cap (8 KB headroom under the hub's 128 KB JSON-RPC limit), the inner content is replaced with a structured fail-soft envelope:
+Every `tools/call` response is measured before send. If the wire-encoded response exceeds the universal 120,000-byte cap (~11 KB headroom under the hub's 131072-byte (128 KiB) JSON-RPC limit), the inner content is replaced with a structured fail-soft envelope:
 
 ```json
 {

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -32,6 +32,7 @@ definition(
 preferences {
     page(name: "mainPage")
     page(name: "confirmDeletePage")
+    page(name: "confirmRegenerateTokenPage")
 }
 
 def mainPage() {
@@ -49,6 +50,9 @@ def mainPage() {
                 if (state.updateCheck?.updateAvailable) {
                     paragraph "<b style='color: orange;'>&#9888; Update available: v${state.updateCheck.latestVersion}</b> (you have v${currentVersion()}). Update via <a href='https://github.com/kingpanther13/Hubitat-local-MCP-server' target='_blank'>GitHub</a> or Hubitat Package Manager."
                 }
+                href name: "regenerateToken", page: "confirmRegenerateTokenPage",
+                     title: "Regenerate access token",
+                     description: "Issue a new token if the current one may be compromised. WARNING: the token is part of the endpoint URL above, so regenerating CHANGES both endpoint URLs -- you must re-copy the new URL into every MCP client afterward."
             }
         }
 
@@ -252,6 +256,22 @@ def confirmDeletePage(params) {
     }
 }
 
+def confirmRegenerateTokenPage() {
+    dynamicPage(name: "confirmRegenerateTokenPage", title: "Regenerate access token?") {
+        section {
+            paragraph "<b>Are you sure you want to regenerate the MCP access token?</b>"
+            paragraph "The access token is part of the MCP endpoint URL. Regenerating it <b>immediately changes both the Local and Cloud endpoint URLs</b>."
+            paragraph "<b style='color: red;'>&#9888; Every MCP client using the old URL will stop working until you re-copy the new URL.</b> After regenerating, reopen this app and copy the new endpoint URL into each client."
+            paragraph "Use this only if the current token may be compromised. This action cannot be undone."
+        }
+
+        section {
+            input "regenerateTokenBtn", "button", title: "Yes, Regenerate Token"
+            href name: "cancelRegenerate", page: "mainPage", title: "Cancel"
+        }
+    }
+}
+
 def appButtonHandler(btn) {
     if (btn == "confirmDeleteBtn" && state.ruleToDelete) {
         def childApp = getChildAppById(state.ruleToDelete)
@@ -261,6 +281,15 @@ def appButtonHandler(btn) {
             log.info "Deleted rule: ${ruleName}"
         }
         state.remove("ruleToDelete")
+    } else if (btn == "regenerateTokenBtn") {
+        // User-initiated token rotation. Clearing state.accessToken then calling
+        // createAccessToken() re-issues a fresh token, which changes both endpoint
+        // URLs (the token is in the URL); the user must re-copy the new URL into
+        // every MCP client. initialize()'s !state.accessToken guard is the only
+        // other caller, so the token is otherwise stable (never auto-rotated).
+        state.remove("accessToken")
+        createAccessToken()
+        mcpLog("warn", "server", "MCP access token regenerated via UI; endpoint URLs changed, clients must re-copy the new URL")
     }
 }
 
@@ -277,7 +306,9 @@ def installed() {
 
 def updated() {
     log.info "MCP Rule Server updated"
-    state.remove("toolSearchCorpus")  // Invalidate BM25 search cache on app update
+    atomicState.remove("toolSearchCorpus")        // Invalidate BM25 corpus cache on app update
+    atomicState.remove("toolSearchTokens")        // ...and the paired BM25 token cache in lockstep
+    atomicState.remove("requiredParamsByTool")    // ...and the gateway required-param memo
     initialize()
 
     // ===== One-time custom-engine rename migration =====
@@ -318,6 +349,20 @@ def updated() {
 
 def uninstalled() {
     log.info "MCP Rule Server uninstalled"
+
+    // Clean up this app's hub-variable in-use registrations so deleting the
+    // app doesn't leave Hubitat warning users about vars no rule references
+    // anymore. Diff against our tracked set (NOT removeAllInUseGlobalVar) so we
+    // only clear registrations this app made. Idempotent, mirrors the
+    // _refreshHubVarInUseRegistrations try/catch pattern.
+    ((atomicState.inUseHubVars ?: []) as List).each { name ->
+        try { removeInUseGlobalVar(name) } catch (Exception e) { /* idempotent */ }
+    }
+    atomicState.remove('inUseHubVars')
+
+    // Drop the variable subscriptions and the daily checkForUpdate schedule.
+    try { unsubscribe() } catch (Exception e) { /* best-effort teardown */ }
+    try { unschedule() } catch (Exception e) { /* best-effort teardown */ }
 }
 
 def initialize() {
@@ -328,9 +373,19 @@ def initialize() {
     if (!state.ruleVariables) {
         state.ruleVariables = [:]
     }
-    // Schedule daily version update check at 3am and run immediately
+    // Schedule daily version update check at 3am and run immediately.
+    // unschedule() first so each updated()->initialize() cycle declaratively
+    // rebuilds the schedule set instead of stacking duplicate cron jobs
+    // (mirrors the unsubscribe() symmetry below). Must precede schedule() and
+    // checkForUpdate() so the immediate run still fires.
+    try { unschedule() }
+    catch (Exception e) { mcpLog("warn", "server", "unschedule() before re-schedule failed: ${e.message} -- duplicate schedules may persist") }
     schedule("0 0 3 ? * *", "checkForUpdate")
-    checkForUpdate()
+    // Only egress to GitHub immediately on first install. state.updateCheck is
+    // null until the first check completes; once set, routine settings saves
+    // skip the immediate call and rely on the daily schedule + the in-function
+    // 24h guard for steady-state freshness.
+    if (state.updateCheck == null) checkForUpdate()
 
     // Issue #92: subscribe to every hub variable's location event
     // ("variable:NAME") so the AI can see what changed and when via
@@ -418,11 +473,11 @@ private void _refreshHubVarInUseRegistrations() {
         // they delete a variable a rule depends on. Warn-level would be
         // dropped at the default mcpLogLevel="error" config.
         try { addInUseGlobalVar(name) }
-        catch (Exception e) { mcpLog("error", "hub-vars", "addInUseGlobalVar('${name}') failed: ${e.message} -- in-use safety warning will not surface for this var") }
+        catch (Exception e) { mcpLogError("hub-vars", "addInUseGlobalVar('${name}') failed -- in-use safety warning will not surface for this var", e) }
     }
     toRemove.each { name ->
         try { removeInUseGlobalVar(name) }
-        catch (Exception e) { mcpLog("error", "hub-vars", "removeInUseGlobalVar('${name}') failed: ${e.message} -- stale in-use registration will linger") }
+        catch (Exception e) { mcpLogError("hub-vars", "removeInUseGlobalVar('${name}') failed -- stale in-use registration will linger", e) }
     }
 
     atomicState.inUseHubVars = (currentVars as List).sort()
@@ -518,6 +573,10 @@ def handleHubVariableEvent(evt) {
         timestamp: now(),
         descriptionText: evt.descriptionText?.toString()
     ]
+    // Best-effort, non-transactional read-append-cap-write. atomicState gives
+    // per-write durability, not read-then-write atomicity, and the sandbox has
+    // no CAS primitive: concurrent variable: events may read the same snapshot
+    // and drop an append. Acceptable for a best-effort history buffer.
     def history = atomicState.variableHistory ?: []
     history << entry
     // Cap the buffer. 200 entries is enough to survive an MCP-tool
@@ -562,6 +621,10 @@ def toolGetVariableHistory(args) {
 // ==================== MCP REQUEST HANDLERS ====================
 
 mappings {
+    // Server-to-server only; no CORS/OPTIONS by design (token-in-query local
+    // endpoint). Browser/cross-origin clients are out of scope, and Hubitat
+    // render() cannot emit Access-Control-* headers from a mapped endpoint, so
+    // no OPTIONS handler is registered (a stub would only pretend to do CORS).
     path("/mcp") {
         action: [
             GET: "handleMcpGet",
@@ -573,19 +636,43 @@ mappings {
     }
 }
 
+// Single source of truth for the hub's hard JSON-RPC response cap (131072 = 128 KiB).
+// Method-constant, not `private static final` (script-scope rejects the field in the
+// Hubitat sandbox). The two response-size guards and toolGetHubLogs derive their
+// thresholds from this with explicit headroom so the cap lives in exactly one place.
+def hubResponseCapBytes() { 131072 }
+
 def handleHealth() {
-    def ver = currentVersion()
-    return render(contentType: "application/json", data: """{"status":"ok","server":"hubitat-mcp-rule-server","version":"${ver}"}""")
+    return render(contentType: "application/json", data: groovy.json.JsonOutput.toJson([
+        status: "ok",
+        server: "hubitat-mcp-rule-server",
+        version: currentVersion()
+    ]))
 }
 
+// POST-only: this MCP endpoint is request-response over POST. No SSE/GET
+// streaming is supported (intentional -- SSE is impractical on the Hubitat
+// HEM endpoint). GET returns a JSON-RPC-shaped 405 so a JSON-RPC client sees
+// a coherent error rather than an ad-hoc body.
 def handleMcpGet() {
     return render(status: 405, contentType: "application/json",
-                  data: '{"error":"GET not supported, use POST"}')
+                  data: groovy.json.JsonOutput.toJson(jsonRpcError(null, -32600,
+                      "This MCP endpoint is request-response only (POST). SSE/GET streaming is not supported.")))
 }
 
+// Transport contract: JSON-RPC application errors (parse / invalid-request /
+// method-not-found / internal) are returned with HTTP 200 and an error envelope
+// per JSON-RPC 2.0. Only transport-level conditions set a non-200 status:
+// 405 for GET (handleMcpGet), and 204/202 for an all-notifications POST (no
+// response objects). Do NOT convert application-level JSON-RPC errors to 4xx --
+// spec-compliant clients expect the error inside a 200 body.
 def handleMcpRequest() {
     def requestBody
     try {
+        // Content-Type is intentionally not validated: Hubitat's mapped-endpoint
+        // inbound request object does not reliably expose the header in the
+        // sandbox, and a wrong content-type already degrades to the -32700
+        // parse-error path below (request.JSON throws or returns null).
         requestBody = request.JSON
     } catch (Exception e) {
         // Bug fix: return proper JSON-RPC parse error (-32700)
@@ -598,35 +685,58 @@ def handleMcpRequest() {
         return render(contentType: "application/json", data: groovy.json.JsonOutput.toJson(errResp))
     }
 
-    logDebug("MCP Request: ${requestBody}")
+    logDebug("MCP Request: ${requestBody.toString().take(500)}${requestBody.toString().length() > 500 ? '...[truncated]' : ''}")
 
     def response
     if (requestBody instanceof List) {
         // Bug fix: empty batch array must return error per JSON-RPC 2.0 spec
         if (requestBody.isEmpty()) {
             response = jsonRpcError(null, -32600, "Invalid Request: empty batch array")
+        } else if (requestBody.size() > 50) {
+            // Inbound batch cap: reject oversized batches before per-element
+            // dispatch so a single request can't fan out unbounded hub work.
+            return render(contentType: "application/json", data: groovy.json.JsonOutput.toJson(
+                jsonRpcError(null, -32600, "Invalid Request: batch too large (${requestBody.size()} elements, max 50)")))
         } else {
-            response = requestBody.collect { msg -> processJsonRpcMessage(msg) }.findAll { it != null }
+            // Batch members must serialize normally. handleToolsCall hands back a
+            // {__preserialized: <json string>} sentinel on the single-message fast path;
+            // unwrap any such element back to a parsed object here so a sentinel can never
+            // leak into the batch JSON array (the rare batch tools/call accepts a re-parse).
+            response = requestBody.collect { msg -> processJsonRpcMessage(msg) }.findAll { it != null }.collect { _unwrapPreserialized(it) }
         }
     } else {
         response = processJsonRpcMessage(requestBody)
     }
 
-    // Per JSON-RPC 2.0 spec: if no response objects (all notifications), return nothing
+    // Per JSON-RPC 2.0 spec: if no response objects (all notifications), return
+    // nothing. MCP Streamable HTTP prescribes 202 Accepted for this case.
     if (response == null || (response instanceof List && response.isEmpty())) {
-        return render(status: 204, contentType: "application/json", data: "")
+        return render(status: 202, contentType: "application/json", data: "")
     }
 
-    def jsonResponse = groovy.json.JsonOutput.toJson(response)
+    // Single-message verbatim-passthrough: when handleToolsCall already produced the wire
+    // JSON (the common under-cap tools/call path), it returns a {__preserialized: <string>}
+    // sentinel. Render that string as-is rather than re-encoding the object a second time.
+    // Only the exact sentinel shape takes this branch -- every normal response is
+    // {jsonrpc, id, result|error} and falls through to the standard encode.
+    def jsonResponse
+    if (response instanceof Map && response.containsKey("__preserialized")) {
+        jsonResponse = response.__preserialized
+    } else {
+        jsonResponse = groovy.json.JsonOutput.toJson(response)
+    }
 
     // Safety guard: hub enforces 128KB response limit — use byte length for accurate sizing
-    def maxResponseSize = 124000 // Leave 4KB headroom under 128KB limit
+    def maxResponseSize = hubResponseCapBytes() - 7072 // =124000; ~7 KB headroom under the 131072-byte (128 KiB) hub cap
     // Only compute byte length for large responses (avoid byte array allocation for small ones)
     def responseBytes = jsonResponse.length() > (maxResponseSize - 8000) ? jsonResponse.getBytes("UTF-8").length : jsonResponse.length()
     if (responseBytes > maxResponseSize) {
-        mcpLog("error", "system", "MCP response too large: ${responseBytes} bytes (limit ${maxResponseSize}). Returning error instead.")
+        mcpLog("error", "server", "MCP response too large: ${responseBytes} bytes (limit ${maxResponseSize}). Returning error instead.")
+        // On the preserialized fast path `response` is the sentinel, not a JSON-RPC object,
+        // so there is no id to echo -- fall back to null (matches the prior non-Map behaviour).
+        def echoId = (response instanceof Map && !response.containsKey("__preserialized")) ? response.id : null
         def errResp = jsonRpcError(
-            (response instanceof Map) ? response.id : null,
+            echoId,
             -32603,
             "Response too large (${responseBytes} bytes exceeds hub's 128KB limit). Try requesting less data or use a more specific query."
         )
@@ -678,9 +788,30 @@ def processJsonRpcMessage(msg) {
     }
 }
 
+// Unwrap the {__preserialized: <json string>} sentinel handleToolsCall emits on the
+// single-message fast path back into a parsed object, so batch members serialize normally
+// and no sentinel key leaks into the batch JSON array. Non-sentinel values pass through.
+def _unwrapPreserialized(item) {
+    if (item instanceof Map && item.containsKey("__preserialized")) {
+        return new groovy.json.JsonSlurper().parseText(item.__preserialized)
+    }
+    return item
+}
+
 def handleNotification(msg) {
     logDebug("MCP Notification: ${msg.method}")
 }
+
+def serverInstructions() {
+    "Gateway tools (hub_manage_* / hub_read_*) expose sub-tools -- call a gateway with no arguments to list its sub-tools and their schemas. Tool responses are capped near 120KB; on large lists use cursor pagination (pass the returned nextCursor to fetch the next page)."
+}
+
+// Protocol versions this server can speak, newest first. Echo-allowlist:
+// handleInitialize honors the client's requested version when it is one of
+// these, else falls back to the default. PR1C ships outputSchema (a 2025-06-18
+// feature) on every tool, so a strict 2025-06-18 client is fully supported.
+def supportedProtocolVersions() { ["2025-06-18", "2025-03-26", "2024-11-05"] }
+def defaultProtocolVersion() { "2024-11-05" }
 
 def handleInitialize(msg) {
     def info = [
@@ -690,12 +821,17 @@ def handleInitialize(msg) {
     if (state.updateCheck?.updateAvailable) {
         info.updateAvailable = state.updateCheck.latestVersion
     }
+    // Echo the client's requested protocolVersion when supported; otherwise the
+    // default. A client that omits it (or sends an unknown one) gets the default.
+    def requested = msg.params?.protocolVersion
+    def negotiated = supportedProtocolVersions().contains(requested) ? requested : defaultProtocolVersion()
     return jsonRpcResult(msg.id, [
-        protocolVersion: "2024-11-05",
+        protocolVersion: negotiated,
         capabilities: [
             tools: [:]
         ],
-        serverInfo: info
+        serverInfo: info,
+        instructions: serverInstructions()
     ])
 }
 
@@ -771,8 +907,14 @@ def handleToolsCall(msg) {
         // could slip the inner guard yet still trip the outer -32603 fallback that
         // #174 was filed to eliminate.
         def candidateResponse = jsonRpcResult(msg.id, [content: [[type: "text", text: jsonText]]])
-        int wireBytes = groovy.json.JsonOutput.toJson(candidateResponse).getBytes("UTF-8").length
-        final int responseSizeLimit = 120000  // 8KB headroom under the 128KB hub cap
+        // Serialize the wire form ONCE here. We measure its byte length for the inner cap,
+        // then (on the common under-limit path) hand the already-built string to
+        // handleMcpRequest via a __preserialized sentinel so it renders verbatim instead of
+        // re-encoding the same object a second time. KEEP byte-accurate getBytes("UTF-8")
+        // sizing -- do NOT regress to char length.
+        String candidateJson = groovy.json.JsonOutput.toJson(candidateResponse)
+        int wireBytes = candidateJson.getBytes("UTF-8").length
+        final int responseSizeLimit = hubResponseCapBytes() - 11072  // =120000; ~11 KB headroom under the 131072-byte (128 KiB) hub cap
         if (wireBytes > responseSizeLimit) {
             // Gateway calls (manage_*) carry the real sub-tool name in args.tool; the
             // gateway-config whitelist check rules out a non-gateway caller who happens
@@ -784,7 +926,12 @@ def handleToolsCall(msg) {
             ])
             return jsonRpcResult(msg.id, [content: [[type: "text", text: groovy.json.JsonOutput.toJson(_responseTooLargeEnvelope(hintTool, wireBytes, responseSizeLimit))]]])
         }
-        return candidateResponse
+        // Single-message verbatim-passthrough: handleMcpRequest's single-Map branch detects
+        // this sentinel and renders __preserialized as-is (no re-encode). The batch-collect
+        // path re-parses it back to an object so it never leaks into the batch JSON array.
+        // The sentinel is internal -- never visible on the wire. The oversize branch above
+        // deliberately returns a normal Map (not a sentinel); re-encoding that rare path is fine.
+        return [__preserialized: candidateJson]
     } catch (IllegalArgumentException e) {
         mcpLog("warn", "server", "Validation error in ${toolName}: ${e.message}", null, [
             details: [tool: toolName, error: e.message]
@@ -1366,7 +1513,8 @@ def annotationsForGateway(List visibleSubTools, Set readOnlyNames) {
 }
 
 def handleGateway(gatewayName, toolName, toolArgs) {
-    def config = getGatewayConfig()[gatewayName]
+    def gwConfig = getGatewayConfig()
+    def config = gwConfig[gatewayName]
     if (!config) {
         throw new IllegalArgumentException("Unknown gateway: ${gatewayName}")
     }
@@ -1404,7 +1552,7 @@ def handleGateway(gatewayName, toolName, toolArgs) {
     // fires first if toolName matches a registered gateway. Kept as a guard
     // in case a future gateway config ever lists another gateway's name in
     // its tools array.
-    if (getGatewayConfig().containsKey(toolName)) {
+    if (gwConfig.containsKey(toolName)) {
         throw new IllegalArgumentException("Cannot call a gateway from within a gateway")
     }
 
@@ -1433,13 +1581,14 @@ def handleGateway(gatewayName, toolName, toolArgs) {
         toolArgs = parsed as Map
     }
 
-    // Option D: Pre-validate required parameters and return helpful error with full schema.
-    // Strip [[FLAT_TRIM]] marker tokens before reading param descriptions for the hint --
-    // missing-param error is a client-visible surface where markers would leak.
+    // Option D: Pre-validate required parameters and return a helpful error.
     def safeArgs = toolArgs ?: [:]
-    def defMap = applyDescriptionTransform(getAllToolDefinitions(), false)
-        .collectEntries { [(it.name): it] }
-    def toolDef = defMap[toolName]
+    // Read this tool's required-param list from the small memoized map instead of
+    // rebuilding the whole ~111-tool catalog on every gateway call. A missing key
+    // means the tool has no required params. The full catalog (with the
+    // [[FLAT_TRIM]]-stripped param descriptions for the hint) is rebuilt lazily
+    // only inside the if (missing) branch below, which fires rarely.
+    def required = requiredParamsByTool()[toolName]
     // Gate-bypassing meta-calls return pure static content with NO hub mutation and
     // short-circuit at the very top of their handler (before any gate / appId check),
     // so they must also bypass this required-param pre-validation -- otherwise the
@@ -1451,12 +1600,18 @@ def handleGateway(gatewayName, toolName, toolArgs) {
         (safeArgs.addTrigger instanceof Map && safeArgs.addTrigger.discover == true) ||
         (safeArgs.addAction instanceof Map && safeArgs.addAction.discover == true)
     )
-    if (toolDef?.inputSchema?.required && !isGatedMetaCall) {
-        def missing = toolDef.inputSchema.required.findAll { !safeArgs.containsKey(it) }
+    if (required && !isGatedMetaCall) {
+        def missing = required.findAll { !safeArgs.containsKey(it) }
         if (missing) {
-            def props = toolDef.inputSchema.properties ?: [:]
+            // Missing-param hint only (rare path): rebuild the full catalog here so
+            // param descriptions are available. Strip [[FLAT_TRIM]] marker tokens --
+            // this error is a client-visible surface where markers would leak.
+            def defMap = applyDescriptionTransform(getAllToolDefinitions(), false)
+                .collectEntries { [(it.name): it] }
+            def toolDef = defMap[toolName]
+            def props = toolDef?.inputSchema?.properties ?: [:]
             def paramList = props.collect { pName, pDef ->
-                def req = toolDef.inputSchema.required.contains(pName) ? "REQUIRED" : "optional"
+                def req = required.contains(pName) ? "REQUIRED" : "optional"
                 def hint = "  ${pName} (${pDef.type ?: 'any'}, ${req})"
                 if (pDef.enum) hint += " — one of: ${pDef.enum.join(', ')}"
                 else if (pDef.description) hint += " — ${pDef.description}"
@@ -1673,6 +1828,32 @@ def getToolDefinitions() {
 // Returns ALL tool definitions (used internally by gateway catalog and executeTool dispatch)
 def getAllToolDefinitions() {
     return _getAllToolDefinitions_part1() + _getAllToolDefinitions_part2() + _getAllToolDefinitions_part3() + _getAllToolDefinitions_part4() + _getAllToolDefinitions_part5() + _getAllToolDefinitions_part6() + _getAllToolDefinitions_part7() + _getAllToolDefinitions_part8()
+}
+
+// Lightweight memoized name -> inputSchema.required map for the gateway
+// dispatch-path missing-param pre-check. handleGateway used to rebuild the
+// entire ~111-tool catalog (applyDescriptionTransform(getAllToolDefinitions())
+// + collectEntries) on EVERY gateway call just to read one tool's required
+// array. required arrays carry no [[FLAT_TRIM]] markers and applyDescriptionTransform
+// never touches them (it only rewrites descriptions), and required is identical
+// in flat and gateway mode -- so no transform is needed here. Stored as a plain
+// Map<String,List<String>> (fresh String copies, never the mutable raw def list)
+// in atomicState; invalidated in updated() alongside the BM25 corpus. Tools with
+// no/empty inputSchema.required are omitted, so a miss == "no required params".
+def requiredParamsByTool() {
+    def cached = atomicState.requiredParamsByTool
+    if (cached instanceof Map) {
+        return cached
+    }
+    def built = [:]
+    getAllToolDefinitions().each { tool ->
+        def req = tool?.inputSchema?.required
+        if (req instanceof List && !req.isEmpty()) {
+            built[tool.name as String] = req.collect { it as String }
+        }
+    }
+    atomicState.requiredParamsByTool = built
+    return built
 }
 
 def _getAllToolDefinitions_part1() {
@@ -4974,12 +5155,10 @@ def executeTool(toolName, args) {
         // Version Check
         case "hub_get_update_status": return toolCheckForUpdate(args)
 
-        // Hub Admin Read Tools
-        // get_hub_details merged into hub_get_info
+        // Hub Admin Read Tools (hub_get_details + hub_get_health merged into hub_get_info)
         case "hub_list_apps": return (args?.scope == "types") ? toolListHubApps(args) : toolListInstalledApps(args)
         case "hub_list_drivers": return toolListHubDrivers(args)
         case "hub_get_radio_details": return toolGetRadioDetails(args)
-        // get_hub_health merged into hub_get_info
 
         // Monitoring Tools
         case "hub_get_logs": return toolGetHubLogs(args)
@@ -5852,7 +6031,7 @@ def toolPollUntilAttribute(args) {
             // pauseExecution wraps Thread.sleep() and throws InterruptedException
             // when the hub is restarting or the app is being reloaded.
             elapsedMs = (now() - startMs) as Integer
-            mcpLog("warn", "device-tools", "poll_until_attribute interrupted after ${polledCount} poll(s) (elapsed=${elapsedMs}ms): ${e.message}")
+            mcpLog("warn", "device", "poll_until_attribute interrupted after ${polledCount} poll(s) (elapsed=${elapsedMs}ms): ${e.message}")
             return [
                 success     : false,
                 interrupted : true,
@@ -6702,7 +6881,7 @@ def toolGetHubInfo(args = null) {
             def msg = e.message ?: e.toString()
             info.identifyHubTriggered = false
             info.identifyHubError = msg
-            mcpLog("warn", "system", "identifyHub blinkLED request failed [${e.class.simpleName}]: ${msg}")
+            mcpLog("warn", "server", "identifyHub blinkLED request failed [${e.class.simpleName}]: ${msg}")
         }
     }
 
@@ -6761,7 +6940,7 @@ def toolListVariables(args = null) {
         // Surface to mcpLog (not just logDebug) so a "no hub variables" response can be
         // distinguished from "hub variable API broke" via hub_get_debug_logs.
         hubVarsError = e.message ?: e.toString()
-        mcpLog("warn", "variables", "hub_list_variables: getAllGlobalVars() failed: ${hubVarsError} -- returning empty hubVariables", null, [details: [error: hubVarsError]])
+        mcpLog("warn", "hub-vars", "hub_list_variables: getAllGlobalVars() failed: ${hubVarsError} -- returning empty hubVariables", null, [details: [error: hubVarsError]])
     }
 
     def ruleVariables = state.ruleVariables?.collect { name, value ->
@@ -7620,7 +7799,7 @@ def listCapturedStates() {
             stateId: stateId,
             deviceCount: entry.deviceCount ?: entry.devices?.size() ?: (entry instanceof List ? entry.size() : 0),
             timestamp: entry.timestamp ?: null,
-            capturedAt: entry.timestamp ? new Date(entry.timestamp).format("yyyy-MM-dd HH:mm:ss") : "unknown"
+            capturedAt: formatTimestamp(entry.timestamp)
         ]
     }.sort { a, b -> (b.timestamp ?: 0) <=> (a.timestamp ?: 0) } // Sort newest first
 }
@@ -8300,6 +8479,14 @@ def getSelectedDevices() {
  * Returns null if Hub Security is not enabled or credentials are not configured.
  * Caches the cookie for 30 minutes to avoid excessive login requests.
  */
+// Single source for the hub's internal API base URI (was an 11x-repeated literal).
+def hubBaseUri() { "http://127.0.0.1:8080" }
+
+// Timeout rationale: reads are fast localhost fetches; writes (native-RM wizard steps,
+// large app/driver/library save+compile) can legitimately take minutes.
+def hubReadTimeoutSec() { 30 }
+def hubWriteTimeoutSec() { 420 }
+
 def getHubSecurityCookie() {
     if (!settings.hubSecurityEnabled) return null
     if (!settings.hubSecurityUser || !settings.hubSecurityPassword) {
@@ -8307,16 +8494,17 @@ def getHubSecurityCookie() {
         return null
     }
 
-    // Check if we have a valid cached cookie
-    if (state.hubSecurityCookie && state.hubSecurityCookieExpiry && state.hubSecurityCookieExpiry > now()) {
-        return state.hubSecurityCookie
+    // Cached cookie lives in atomicState (thread-safe): it authorizes every hubInternal* call
+    // and is touched concurrently by overlapping requests and the cookie-refresh retry path.
+    if (atomicState.hubSecurityCookie && atomicState.hubSecurityCookieExpiry && atomicState.hubSecurityCookieExpiry > now()) {
+        return atomicState.hubSecurityCookie
     }
 
     // Authenticate
     def cookie = null
     try {
         httpPost([
-            uri: "http://127.0.0.1:8080",
+            uri: hubBaseUri(),
             path: "/login",
             body: [username: settings.hubSecurityUser, password: settings.hubSecurityPassword],
             textParser: true,
@@ -8325,13 +8513,13 @@ def getHubSecurityCookie() {
             cookie = resp?.headers?.'Set-Cookie'?.split(';')?.getAt(0)
         }
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Hub Security authentication failed: ${e.message}")
+        mcpLogError("hub-admin", "Hub Security authentication failed", e)
         throw new RuntimeException("Hub Security authentication failed. Check your username and password in MCP Rule Server settings.")
     }
 
     if (cookie) {
-        state.hubSecurityCookie = cookie
-        state.hubSecurityCookieExpiry = now() + (30 * 60 * 1000) // 30 minutes
+        atomicState.hubSecurityCookie = cookie
+        atomicState.hubSecurityCookieExpiry = now() + (30 * 60 * 1000) // 30 minutes
         mcpLog("debug", "hub-admin", "Hub Security authentication successful")
     } else {
         mcpLog("warn", "hub-admin", "Hub Security authentication returned no cookie")
@@ -8345,13 +8533,110 @@ def getHubSecurityCookie() {
  * If so, clears the cached cookie and returns true.
  */
 private boolean shouldRetryWithFreshCookie(Exception e, boolean isRetry) {
-    if (!isRetry && settings.hubSecurityEnabled &&
-        (e.message?.contains("401") || e.message?.contains("403") || e.message?.contains("Unauthorized"))) {
-        state.hubSecurityCookie = null
-        state.hubSecurityCookieExpiry = null
+    if (isRetry || !settings.hubSecurityEnabled) return false
+    // Prefer the HTTP status the exception carries (duck-typed e.response.status -- naming
+    // HttpResponseException NCDFEs at parse time on the test classpath). Fall back to a
+    // message substring only when no status is available.
+    def resp = null
+    try { resp = e.response } catch (Exception ignore) { resp = null }
+    Integer status = null
+    try { status = resp?.status as Integer } catch (Exception ignore) { status = null }
+    boolean authFail = (status == 401 || status == 403) ||
+        (status == null && (e.message?.contains("401") || e.message?.contains("403") || e.message?.contains("Unauthorized")))
+    if (authFail) {
+        atomicState.hubSecurityCookie = null
+        atomicState.hubSecurityCookieExpiry = null
         return true
     }
     return false
+}
+
+/**
+ * Read an HTTPBuilder response body as text. With textParser:true the hub hands back a Reader,
+ * but some paths (and test stubs) hand back a plain String. A CharSequence is already its own
+ * text, so we take it as-is -- we never call toString() on a half-consumed Reader/InputStream,
+ * which would yield junk like "java.io.BufferedReader@1a2b3c" that downstream code would treat
+ * as a real body. A genuine Reader/stream read failure (socket reset mid-stream, gzip CRC,
+ * decode error) propagates so the caller can re-throw rather than swallow junk.
+ */
+private String _readRespText(resp) {
+    def d = resp?.data
+    if (d == null) return null
+    if (d instanceof CharSequence) return d.toString()
+    return d.text  // Reader/InputStream -- may throw on a mid-stream read failure
+}
+
+/**
+ * Shared core for the six hubInternal* variants: cookie attach, request, duck-typed body read
+ * (read failures are re-thrown, never swallowed into a Reader.toString() junk string), and the
+ * single cookie-refresh retry. The thin public wrappers below project their distinguishing
+ * options + return shape. This is the clean seam #209 can later lift into a HubHttpClientLib.
+ */
+private _hubRequest(String method, String path, Map opts = [:]) {
+    def cookie = getHubSecurityCookie()
+    def params = [
+        uri: hubBaseUri(),
+        path: path,
+        textParser: true,
+        ignoreSSLIssues: true,
+        timeout: (opts.timeout != null ? opts.timeout : hubReadTimeoutSec())
+    ]
+    if (opts.query) params.query = opts.query
+    if (opts.requestContentType) params.requestContentType = opts.requestContentType
+    if (opts.followRedirects != null) params.followRedirects = opts.followRedirects
+    def headers = [:]
+    if (opts.keepAlive) headers["Connection"] = "keep-alive"
+    if (cookie) headers["Cookie"] = cookie
+    if (headers) params.headers = headers
+    if (opts.body != null) params.body = opts.body
+
+    def result = null
+    def readError = null
+    def reader = { resp ->
+        def bodyText = null
+        try { bodyText = _readRespText(resp) }
+        catch (Exception re) { readError = re }
+        if (opts.returnShape == 'struct') {
+            // Struct callers (form/raw/getRaw) key on .status; the HTTPBuilder closure
+            // only runs for a non-error (2xx) response (4xx/5xx throw into the catch
+            // below), so a body-read failure here is a write that COMMITTED with an
+            // unreadable body -- surface status + null data rather than failing the
+            // operation for a status-only caller (e.g. _rmClickAppButton). The read
+            // error is consumed here; text callers, whose body IS the result, still
+            // re-throw it after the closure.
+            result = [status: resp.status, location: resp.headers?."Location"?.toString(), data: (readError != null ? null : bodyText)]
+            readError = null
+        } else if (readError == null) {
+            result = bodyText
+        }
+    }
+    try {
+        if (method == 'GET') httpGet(params, reader)
+        else httpPost(params, reader)
+    } catch (Exception e) {
+        // hubInternalGetRaw path: a 3xx with followRedirects=false is the success case (read the
+        // Location header), not an error.
+        if (opts.handle3xx) {
+            def resp = null
+            try { resp = e.response } catch (Exception ignore) { resp = null }
+            Integer st = null
+            try { st = resp?.status as Integer } catch (Exception ignore) { st = null }
+            if (resp != null && st != null && st >= 300 && st < 400) {
+                def b = null
+                try { b = _readRespText(resp) } catch (Exception ignore) { b = null }
+                return [status: st, location: resp.headers?."Location"?.toString(), data: b]
+            }
+        }
+        if (shouldRetryWithFreshCookie(e, opts.isRetry)) {
+            mcpLog("debug", "hub-admin", "Retrying with fresh cookie after auth failure on ${method} ${path}")
+            return _hubRequest(method, path, opts + [isRetry: true])
+        }
+        throw e
+    }
+    // Re-throw a mid-stream read failure rather than returning a Reader/stream toString() junk
+    // string that downstream code would treat as a real body (matches the hardened deploy path).
+    if (readError != null) throw readError
+    return result
 }
 
 /**
@@ -8360,40 +8645,7 @@ private boolean shouldRetryWithFreshCookie(Exception e, boolean isRetry) {
  * Returns the response body as text.
  */
 def hubInternalGet(String path, Map query = null, int timeout = 30, boolean isRetry = false) {
-    def cookie = getHubSecurityCookie()
-    def params = [
-        uri: "http://127.0.0.1:8080",
-        path: path,
-        textParser: true,
-        ignoreSSLIssues: true,
-        timeout: timeout
-    ]
-    if (query) {
-        params.query = query
-    }
-    if (cookie) {
-        params.headers = ["Cookie": cookie]
-    }
-
-    def responseText = null
-    try {
-        httpGet(params) { resp ->
-            // textParser: true returns a Reader/InputStream — try .text first to read it fully
-            // Sandbox blocks instanceof and getClass(), so use try-catch duck typing
-            try {
-                responseText = resp.data.text
-            } catch (Exception readErr) {
-                responseText = resp.data?.toString()
-            }
-        }
-    } catch (Exception e) {
-        if (shouldRetryWithFreshCookie(e, isRetry)) {
-            mcpLog("debug", "hub-admin", "Retrying with fresh cookie after auth failure on GET ${path}")
-            return hubInternalGet(path, query, timeout, true)
-        }
-        throw e
-    }
-    return responseText
+    _hubRequest('GET', path, [query: query, timeout: timeout, returnShape: 'text', isRetry: isRetry])
 }
 
 /**
@@ -8408,59 +8660,9 @@ def hubInternalGet(String path, Map query = null, int timeout = 30, boolean isRe
  * Spock test classpath, and naming it would NCDFE at parse time.
  */
 def hubInternalGetRaw(String path, Map query = null, int timeout = 30, boolean isRetry = false) {
-    def cookie = getHubSecurityCookie()
-    def params = [
-        uri: "http://127.0.0.1:8080",
-        path: path,
-        textParser: true,
-        ignoreSSLIssues: true,
-        timeout: timeout,
-        // HTTPBuilder follows redirects by default; disable so we can read
-        // the 302 Location header. Keep the cookie so auth still works.
-        followRedirects: false
-    ]
-    if (query) params.query = query
-    if (cookie) params.headers = ["Cookie": cookie]
-
-    def result = null
-    try {
-        httpGet(params) { resp ->
-            def body
-            try { body = resp.data.text } catch (Exception readErr) { body = resp.data?.toString() }
-            result = [
-                status: resp.status,
-                location: resp.headers?."Location"?.toString(),
-                data: body
-            ]
-        }
-    } catch (Exception e) {
-        // HTTPBuilder throws on non-2xx when followRedirects=false. The
-        // exception carries a `response` property (duck-typed — avoids a
-        // hard dependency on groovyx.net.http.HttpResponseException). If
-        // the failure is a 3xx redirect, that's exactly what we want —
-        // extract status + Location and return. Anything else escalates
-        // through the existing cookie-retry / rethrow paths.
-        def resp = null
-        try { resp = e.response } catch (Exception ignore) { resp = null }
-        def status = null
-        try { status = resp?.status as Integer } catch (Exception ignore) { status = null }
-        if (resp != null && status != null && status >= 300 && status < 400) {
-            def body
-            try { body = resp.data?.text } catch (Exception readErr) { body = resp.data?.toString() }
-            result = [
-                status: status,
-                location: resp.headers?."Location"?.toString(),
-                data: body
-            ]
-            return result
-        }
-        if (shouldRetryWithFreshCookie(e, isRetry)) {
-            mcpLog("debug", "hub-admin", "Retrying with fresh cookie after auth failure on GET-raw ${path}")
-            return hubInternalGetRaw(path, query, timeout, true)
-        }
-        throw e
-    }
-    return result
+    // followRedirects:false + handle3xx so the 302 Location header (new-child id) is readable.
+    _hubRequest('GET', path, [query: query, timeout: timeout, returnShape: 'struct',
+                              followRedirects: false, handle3xx: true, isRetry: isRetry])
 }
 
 /**
@@ -8648,35 +8850,8 @@ private Map _createUserAppInstance(Integer codeAppId) {
  * Automatically includes Hub Security cookie if configured.
  * Returns the response body as text.
  */
-def hubInternalPost(String path, Map body = null, boolean isRetry = false) {
-    def cookie = getHubSecurityCookie()
-    def params = [
-        uri: "http://127.0.0.1:8080",
-        path: path,
-        textParser: true,
-        ignoreSSLIssues: true,
-        timeout: 30
-    ]
-    if (cookie) {
-        params.headers = ["Cookie": cookie]
-    }
-    if (body) {
-        params.body = body
-    }
-
-    def responseText = null
-    try {
-        httpPost(params) { resp ->
-            responseText = resp.data?.text?.toString() ?: resp.data?.toString()
-        }
-    } catch (Exception e) {
-        if (shouldRetryWithFreshCookie(e, isRetry)) {
-            mcpLog("debug", "hub-admin", "Retrying with fresh cookie after auth failure on POST ${path}")
-            return hubInternalPost(path, body, true)
-        }
-        throw e
-    }
-    return responseText
+def hubInternalPost(String path, Map body = null, int timeout = 30, boolean isRetry = false) {
+    _hubRequest('POST', path, [body: body, timeout: timeout, returnShape: 'text', isRetry: isRetry])
 }
 
 /**
@@ -8691,82 +8866,15 @@ def hubInternalPost(String path, Map body = null, boolean isRetry = false) {
  * themselves; this method passes the body string straight through.
  */
 def hubInternalPostFormRaw(String path, String encodedBody, int timeout = 420, boolean isRetry = false) {
-    def cookie = getHubSecurityCookie()
-    def params = [
-        uri: "http://127.0.0.1:8080",
-        path: path,
-        requestContentType: "application/x-www-form-urlencoded",
-        textParser: true,
-        headers: ["Connection": "keep-alive"],
-        body: encodedBody,
-        timeout: timeout,
-        ignoreSSLIssues: true
-    ]
-    if (cookie) params.headers["Cookie"] = cookie
-    def result = null
-    try {
-        httpPost(params) { resp ->
-            def responseData = resp.data
-            try { responseData = responseData.text }
-            catch (Exception readErr) { responseData = responseData?.toString() }
-            result = [
-                status: resp.status,
-                location: resp.headers?."Location"?.toString(),
-                data: responseData
-            ]
-        }
-    } catch (Exception e) {
-        if (shouldRetryWithFreshCookie(e, isRetry)) {
-            mcpLog("debug", "hub-admin", "Retrying with fresh cookie after auth failure on POST-form-raw ${path}")
-            return hubInternalPostFormRaw(path, encodedBody, timeout, true)
-        }
-        throw e
-    }
-    return result
+    _hubRequest('POST', path, [body: encodedBody, timeout: timeout,
+                              requestContentType: "application/x-www-form-urlencoded", keepAlive: true,
+                              returnShape: 'struct', isRetry: isRetry])
 }
 
 def hubInternalPostForm(String path, Map body, int timeout = 420, boolean isRetry = false) {
-    def cookie = getHubSecurityCookie()
-    def params = [
-        uri: "http://127.0.0.1:8080",
-        path: path,
-        requestContentType: "application/x-www-form-urlencoded",
-        textParser: true, // Accept any content type without parse errors
-        headers: [
-            "Connection": "keep-alive"
-        ],
-        body: body,
-        timeout: timeout,
-        ignoreSSLIssues: true
-    ]
-    if (cookie) {
-        params.headers["Cookie"] = cookie
-    }
-
-    def result = null
-    try {
-        httpPost(params) { resp ->
-            def responseData = resp.data
-            // textParser: true returns a Reader/InputStream — try .text to read it fully
-            try {
-                responseData = responseData.text
-            } catch (Exception readErr) {
-                responseData = responseData?.toString()
-            }
-            result = [
-                status: resp.status,
-                location: resp.headers?."Location"?.toString(),
-                data: responseData
-            ]
-        }
-    } catch (Exception e) {
-        if (shouldRetryWithFreshCookie(e, isRetry)) {
-            mcpLog("debug", "hub-admin", "Retrying with fresh cookie after auth failure on POST-form ${path}")
-            return hubInternalPostForm(path, body, timeout, true)
-        }
-        throw e
-    }
-    return result
+    _hubRequest('POST', path, [body: body, timeout: timeout,
+                              requestContentType: "application/x-www-form-urlencoded", keepAlive: true,
+                              returnShape: 'struct', isRetry: isRetry])
 }
 
 /**
@@ -8774,50 +8882,19 @@ def hubInternalPostForm(String path, Map body, int timeout = 420, boolean isRetr
  * which accept Content-Type: application/json (unlike app/driver endpoints that use form-encoded).
  * Returns a parsed Map/List from the JSON response body, or null on empty response.
  */
-def hubInternalPostJson(String path, String jsonBody, boolean isRetry = false) {
-    def cookie = getHubSecurityCookie()
-    def params = [
-        uri: "http://127.0.0.1:8080",
-        path: path,
-        requestContentType: "application/json",
-        textParser: true, // Prevent sandbox from auto-parsing JSON response; read raw text then parse ourselves
-        headers: [
-            "Connection": "keep-alive"
-        ],
-        body: jsonBody,
-        timeout: 420,
-        ignoreSSLIssues: true
-    ]
-    if (cookie) {
-        params.headers["Cookie"] = cookie
-    }
-
-    def result = null
-    try {
-        httpPost(params) { resp ->
-            def responseData = resp.data
-            try {
-                responseData = responseData.text
-            } catch (Exception readErr) {
-                responseData = responseData?.toString()
-            }
-            if (responseData) {
-                try {
-                    result = new groovy.json.JsonSlurper().parseText(responseData)
-                } catch (Exception parseErr) {
-                    mcpLog("warn", "hub-admin", "hubInternalPostJson response not JSON: ${responseData?.take(200)}")
-                    result = null
-                }
-            }
+def hubInternalPostJson(String path, String jsonBody, int timeout = 420, boolean isRetry = false) {
+    def bodyText = _hubRequest('POST', path, [body: jsonBody, timeout: timeout,
+                              requestContentType: "application/json", keepAlive: true,
+                              returnShape: 'text', isRetry: isRetry])
+    if (bodyText) {
+        try {
+            return new groovy.json.JsonSlurper().parseText(bodyText)
+        } catch (Exception parseErr) {
+            mcpLog("error", "hub-admin", "hubInternalPostJson response not JSON: ${bodyText?.take(200)}")
+            return null
         }
-    } catch (Exception e) {
-        if (shouldRetryWithFreshCookie(e, isRetry)) {
-            mcpLog("debug", "hub-admin", "Retrying with fresh cookie after auth failure on POST-json ${path}")
-            return hubInternalPostJson(path, jsonBody, true)
-        }
-        throw e
     }
-    return result
+    return null
 }
 
 /**
@@ -8897,7 +8974,7 @@ def backupItemSource(String type, String id) {
     try {
         uploadHubFile(fileName, parsed.source.getBytes("UTF-8"))
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Failed to save backup file '${fileName}': ${e.message}")
+        mcpLogError("hub-admin", "Failed to save backup file '${fileName}'", e)
         throw new IllegalArgumentException("Cannot back up ${type} ID ${id}: file upload failed -- ${e.message}")
     }
 
@@ -9019,7 +9096,7 @@ def toolGetItemBackup(args) {
         if (bytes == null) throw new Exception("File not found in File Manager")
         source = new String(bytes, "UTF-8")
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Failed to read backup file '${entry.fileName}': ${e.message}")
+        mcpLogError("hub-admin", "Failed to read backup file '${entry.fileName}'", e)
         return [
             error: "Backup file '${entry.fileName}' could not be read: ${e.message}",
             backupKey: args.backupKey,
@@ -9105,7 +9182,7 @@ def toolRestoreItemBackup(args) {
         try {
             return _rmRestoreFromBackup(entry)
         } catch (Exception e) {
-            mcpLog("error", "hub-admin", "RM rule restore failed for key ${args.backupKey}: ${e.message}")
+            mcpLogError("hub-admin", "RM rule restore failed for key ${args.backupKey}", e)
             return [success: false, error: e.message, backupKey: args.backupKey, type: "rm-rule"]
         }
     }
@@ -9117,7 +9194,7 @@ def toolRestoreItemBackup(args) {
         if (bytes == null) throw new Exception("File not found in File Manager")
         source = new String(bytes, "UTF-8")
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Failed to read backup file '${entry.fileName}' for restore: ${e.message}")
+        mcpLogError("hub-admin", "Failed to read backup file '${entry.fileName}' for restore", e)
         return [
             success: false,
             error: "Backup file '${entry.fileName}' could not be read: ${e.message}",
@@ -9225,7 +9302,7 @@ def toolRestoreItemBackup(args) {
             ]
         }
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Restore failed with exception for ${entryCopy.type} ID ${entryCopy.id}: ${e.message}")
+        mcpLogError("hub-admin", "Restore failed with exception for ${entryCopy.type} ID ${entryCopy.id}", e)
         return [
             success: false,
             error: "Restore failed: ${e.message}",
@@ -9385,7 +9462,7 @@ def toolReadFile(args) {
         if (bytes == null) throw new Exception("File not found in File Manager")
         content = new String(bytes, "UTF-8")
     } catch (Exception e) {
-        mcpLog("error", "file-manager", "Failed to read file '${args.fileName}': ${e.message}")
+        mcpLogError("file-manager", "Failed to read file '${args.fileName}'", e)
         return [
             success: false,
             error: "File '${args.fileName}' could not be read: ${e.message}",
@@ -9475,7 +9552,7 @@ def toolWriteFile(args) {
         }
         return result
     } catch (Exception e) {
-        mcpLog("error", "file-manager", "Failed to write file '${args.fileName}': ${e.message}")
+        mcpLogError("file-manager", "Failed to write file '${args.fileName}'", e)
         return [
             success: false,
             error: "Failed to write file '${args.fileName}': ${e.message}"
@@ -9546,7 +9623,7 @@ def toolDeleteFile(args) {
         }
         return result
     } catch (Exception e) {
-        mcpLog("error", "file-manager", "Failed to delete file '${args.fileName}': ${e.message}")
+        mcpLogError("file-manager", "Failed to delete file '${args.fileName}'", e)
         return [
             success: false,
             error: "Failed to delete '${args.fileName}': ${e.message}",
@@ -9570,6 +9647,10 @@ def formatAge(Long timestamp) {
     return "${days} ${days == 1 ? 'day' : 'days'} ago"
 }
 
+// RC-only protocol items (_meta request echo, ttlMs/cacheScope list-cache
+// hints, tools/list nextCursor) are intentionally NOT implemented -- they are
+// next-revision RC features and no shipped client negotiates that
+// protocolVersion yet. Revisit when the spec publishes and a client uses it.
 def jsonRpcResult(id, result) {
     return [jsonrpc: "2.0", id: id, result: result]
 }
@@ -9627,6 +9708,9 @@ def shouldLog(level) {
     def levels = getLogLevels()
     def currentIndex = levels.indexOf(getConfiguredLogLevel())
     def logIndex = levels.indexOf(level)
+    // Fail open on an unrecognized level so a typo'd level is never silently
+    // swallowed -- the mcpLog switch default below emits a self-diagnosing warn.
+    if (logIndex == -1) return true
     return logIndex >= currentIndex
 }
 
@@ -9642,14 +9726,20 @@ def mcpLog(String level, String component, String message, String ruleId = null,
         timestamp: now(),
         level: level,
         component: component,
-        message: message
+        // Cap stored payload so each buffer entry stays bounded -- the
+        // `state.debugLogs = state.debugLogs` writeback below re-serializes the
+        // whole buffer on every log line, so an uncapped caller message/trace
+        // would inflate every subsequent write. Mirrors the 500-char response
+        // cap idiom in handleMcpRequest. details stays a structured Map (every
+        // caller passes a small bounded Map, not unbounded text).
+        message: message?.take(500)
     ]
 
     if (ruleId) entry.ruleId = ruleId
     if (extraData?.duration) entry.duration = extraData.duration
     if (extraData?.ruleName) entry.ruleName = extraData.ruleName
     if (extraData?.details) entry.details = extraData.details
-    if (extraData?.stackTrace) entry.stackTrace = extraData.stackTrace
+    if (extraData?.stackTrace) entry.stackTrace = extraData.stackTrace?.toString()?.take(1000)
 
     state.debugLogs.entries << entry
 
@@ -9662,12 +9752,16 @@ def mcpLog(String level, String component, String message, String ruleId = null,
     // Force top-level state reassignment to ensure nested mutations are persisted
     state.debugLogs = state.debugLogs
 
-    // Also log to Hubitat logs
+    // Also log to Hubitat logs. Append the structured stackTrace (class + message,
+    // set by mcpLogError) to the warn/error native lines so the exception detail
+    // stays visible on the Hubitat Logs page, not only in the MCP debug buffer.
+    def traceSuffix = extraData?.stackTrace ? " -- ${extraData.stackTrace.toString().take(1000)}" : ""
     switch (level) {
         case "debug": log.debug "[${component}] ${message}"; break
         case "info": log.info "[${component}] ${message}"; break
-        case "warn": log.warn "[${component}] ${message}"; break
-        case "error": log.error "[${component}] ${message}"; break
+        case "warn": log.warn "[${component}] ${message}${traceSuffix}"; break
+        case "error": log.error "[${component}] ${message}${traceSuffix}"; break
+        default: log.warn "[${component}] (unknown level '${level}') ${message}${traceSuffix}"; break
     }
 }
 
@@ -10195,70 +10289,6 @@ _Add any other context, screenshots, or transcripts when filing._
 
 // ==================== HUB ADMIN READ TOOL IMPLEMENTATIONS ====================
 
-def toolGetHubDetails(args) {
-    requireHubAdminRead()
-
-    def hub = location.hub
-    def details = [
-        name: hub?.name,
-        localIP: hub?.localIP,
-        timeZone: location.timeZone?.ID,
-        temperatureScale: location.temperatureScale,
-        latitude: location.latitude,
-        longitude: location.longitude,
-        zipCode: location.zipCode
-    ]
-
-    // Safe property access for hub properties
-    try { details.model = hub?.hardwareID } catch (Exception e) { details.model = "unavailable" }
-    try { details.firmwareVersion = hub?.firmwareVersionString } catch (Exception e) { details.firmwareVersion = "unavailable" }
-    try { details.uptime = hub?.uptime } catch (Exception e) { details.uptime = "unavailable" }
-    try { details.zigbeeChannel = hub?.zigbeeChannel } catch (Exception e) { details.zigbeeChannel = "unavailable" }
-    try { details.zwaveVersion = hub?.zwaveVersion } catch (Exception e) { details.zwaveVersion = "unavailable" }
-    try { details.zigbeeId = hub?.zigbeeId } catch (Exception e) { details.zigbeeId = "unavailable" }
-    try { details.type = hub?.type } catch (Exception e) { details.type = "unavailable" }
-    try { details.hubData = hub?.data } catch (Exception e) { details.hubData = null }
-
-    // Extended info via internal API
-    try {
-        def freeMemory = hubInternalGet("/hub/advanced/freeOSMemory")
-        if (freeMemory) details.freeMemoryKB = freeMemory.trim()
-    } catch (Exception e) {
-        details.freeMemoryKB = "unavailable (${e.message})"
-        mcpLog("debug", "hub-admin", "Could not get free memory: ${e.message}")
-    }
-
-    try {
-        def tempC = hubInternalGet("/hub/advanced/internalTempCelsius")
-        if (tempC) details.internalTempCelsius = tempC.trim()
-    } catch (Exception e) {
-        details.internalTempCelsius = "unavailable (${e.message})"
-        mcpLog("debug", "hub-admin", "Could not get internal temperature: ${e.message}")
-    }
-
-    // Hub database size via internal API
-    try {
-        def dbSize = hubInternalGet("/hub/advanced/databaseSize")
-        if (dbSize) details.databaseSizeKB = dbSize.trim()
-    } catch (Exception e) {
-        details.databaseSizeKB = "unavailable"
-        mcpLog("debug", "hub-admin", "Could not get database size: ${e.message}")
-    }
-
-    details.mcpServerVersion = currentVersion()
-    details.selectedDeviceCount = settings.selectedDevices?.size() ?: 0
-    details.ruleCount = getChildApps()?.size() ?: 0
-    details.hubSecurityConfigured = settings.hubSecurityEnabled ?: false
-    details.hubAdminReadEnabled = settings.enableHubAdminRead ?: false
-    details.hubAdminWriteEnabled = settings.enableHubAdminWrite ?: false
-    details.builtinAppEnabled = settings.enableBuiltinApp ?: false
-    details.customRuleEngineEnabled = settings.enableCustomRuleEngine == true
-    details.developerModeEnabled = settings.enableDeveloperMode ?: false
-
-    mcpLog("info", "hub-admin", "Retrieved extended hub details")
-    return details
-}
-
 def toolListHubApps(args) {
     requireHubAdminRead()
 
@@ -10447,93 +10477,6 @@ def toolGetZigbeeDetails(args) {
 
     mcpLog("info", "hub-admin", "Retrieved Zigbee details")
     return result
-}
-
-def toolGetHubHealth(args) {
-    requireHubAdminRead()
-
-    def hub = location.hub
-    def health = [
-        timestamp: formatTimestamp(now())
-    ]
-
-    // Uptime
-    try { health.uptimeSeconds = hub?.uptime } catch (Exception e) { health.uptimeSeconds = "unavailable" }
-    if (health.uptimeSeconds && health.uptimeSeconds instanceof Number) {
-        def days = (health.uptimeSeconds / 86400).toInteger()
-        def hours = ((health.uptimeSeconds % 86400) / 3600).toInteger()
-        def mins = ((health.uptimeSeconds % 3600) / 60).toInteger()
-        health.uptimeFormatted = "${days}d ${hours}h ${mins}m"
-    }
-
-    // Free memory
-    try {
-        def freeMemory = hubInternalGet("/hub/advanced/freeOSMemory")
-        if (freeMemory) {
-            health.freeMemoryKB = freeMemory.trim()
-            try {
-                def memKB = freeMemory.trim() as Integer
-                if (memKB < 50000) {
-                    health.memoryWarning = "LOW MEMORY: ${memKB}KB free. Consider rebooting the hub."
-                } else if (memKB < 100000) {
-                    health.memoryNote = "Memory is moderate: ${memKB}KB free."
-                }
-            } catch (NumberFormatException nfe) {
-                mcpLog("debug", "hub-admin", "Free memory value not numeric: ${freeMemory.trim()}")
-            }
-        }
-    } catch (Exception e) {
-        health.freeMemoryKB = "unavailable"
-        mcpLog("debug", "hub-admin", "Could not get free memory: ${e.message}")
-    }
-
-    // Internal temperature
-    try {
-        def tempC = hubInternalGet("/hub/advanced/internalTempCelsius")
-        if (tempC) {
-            health.internalTempCelsius = tempC.trim()
-            try {
-                def temp = tempC.trim() as Double
-                if (temp > 70) {
-                    health.temperatureWarning = "HIGH TEMPERATURE: ${temp}°C. Hub may need better ventilation."
-                } else if (temp > 60) {
-                    health.temperatureNote = "Temperature is warm: ${temp}°C."
-                }
-            } catch (NumberFormatException nfe) {
-                mcpLog("debug", "hub-admin", "Temperature value not numeric: ${tempC.trim()}")
-            }
-        }
-    } catch (Exception e) {
-        health.internalTempCelsius = "unavailable"
-        mcpLog("debug", "hub-admin", "Could not get internal temperature: ${e.message}")
-    }
-
-    // Database size
-    try {
-        def dbSize = hubInternalGet("/hub/advanced/databaseSize")
-        if (dbSize) {
-            health.databaseSizeKB = dbSize.trim()
-            try {
-                def dbKB = dbSize.trim() as Integer
-                if (dbKB > 500000) {
-                    health.databaseWarning = "LARGE DATABASE: ${(dbKB / 1024).toInteger()}MB. Consider cleaning up old data."
-                }
-            } catch (NumberFormatException nfe) {
-                mcpLog("debug", "hub-admin", "Database size value not numeric: ${dbSize.trim()}")
-            }
-        }
-    } catch (Exception e) {
-        health.databaseSizeKB = "unavailable"
-    }
-
-    // MCP-specific health
-    health.mcpDeviceCount = settings.selectedDevices?.size() ?: 0
-    health.mcpRuleCount = getChildApps()?.size() ?: 0
-    health.mcpLogEntries = state.debugLogs?.entries?.size() ?: 0
-    health.mcpCapturedStates = atomicState.capturedDeviceStates?.size() ?: 0
-
-    mcpLog("info", "hub-admin", "Hub health check completed")
-    return health
 }
 
 // ==================== MONITORING TOOL IMPLEMENTATIONS ====================
@@ -10758,7 +10701,7 @@ def toolGetHubLogs(args) {
     try {
         responseText = hubInternalGet("/logs/past/json", query, 30)
     } catch (Exception e) {
-        mcpLog("error", "monitoring", "Failed to fetch hub logs: ${e.message}")
+        mcpLogError("monitoring", "Failed to fetch hub logs", e)
         throw new IllegalStateException("Failed to fetch hub logs: ${e.message}")
     }
 
@@ -10932,7 +10875,7 @@ def toolGetHubLogs(args) {
     // count, the per-message take(200) bounds the message body so a single oversized
     // entry can't push the page past the cap on its own.
     def estimatedJsonSize = paged.page.sum(0) { (it.message?.length() ?: 0) + (it.name?.length() ?: 0) + 120 }
-    if (estimatedJsonSize > 120000) {
+    if (estimatedJsonSize > hubResponseCapBytes() - 11072) {  // =120000; matches handleToolsCall responseSizeLimit
         paged.page.each { it.message = it.message?.take(200) }
         result.truncated = true
         result.note = "Log messages truncated to fit response size limit"
@@ -11099,7 +11042,7 @@ def toolGetPerformanceStats(args) {
     try {
         data = fetchLogsJson()
     } catch (Exception e) {
-        mcpLog("error", "monitoring", "Failed to fetch performance stats: ${e.message}")
+        mcpLogError("monitoring", "Failed to fetch performance stats", e)
         return [error: "Failed to fetch performance stats: ${e.message}"]
     }
 
@@ -11178,7 +11121,7 @@ def toolGetHubJobs(args) {
     try {
         data = fetchLogsJson()
     } catch (Exception e) {
-        mcpLog("error", "monitoring", "Failed to fetch hub jobs: ${e.message}")
+        mcpLogError("monitoring", "Failed to fetch hub jobs", e)
         return [error: "Failed to fetch hub jobs: ${e.message}"]
     }
 
@@ -11422,7 +11365,7 @@ def toolGetMemoryHistory(args) {
         if (paged.nextCursor != null) result.nextCursor = paged.nextCursor
     }
 
-    mcpLog("info", "diagnostics", "Memory history retrieved: ${paged.page.size()} entries (${allEntries.size()} total)")
+    mcpLog("info", "server", "Memory history retrieved: ${paged.page.size()} entries (${allEntries.size()} total)")
     return result
 }
 
@@ -11465,7 +11408,7 @@ def toolForceGarbageCollection(args) {
         result.summary = "GC triggered but could not read memory values for comparison"
     }
 
-    mcpLog("info", "diagnostics", "Forced GC: before=${beforeKB}KB, after=${afterKB}KB")
+    mcpLog("info", "server", "Forced GC: before=${beforeKB}KB, after=${afterKB}KB")
     return result
 }
 
@@ -11692,7 +11635,7 @@ def toolCreateHubBackup(args) {
             note: "This backup is stored on the hub. You can download it from the Hubitat web UI at Settings → Backup and Restore."
         ]
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Hub backup FAILED: ${e.message}")
+        mcpLogError("hub-admin", "Hub backup FAILED", e)
         return [
             success: false,
             error: "Backup failed: ${e.message}",
@@ -11717,7 +11660,7 @@ def toolRebootHub(args) {
             response: responseText?.take(500)
         ]
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Hub reboot failed: ${e.message}")
+        mcpLogError("hub-admin", "Hub reboot failed", e)
         return [
             success: false,
             error: "Reboot failed: ${e.message}",
@@ -11741,7 +11684,7 @@ def toolShutdownHub(args) {
             response: responseText?.take(500)
         ]
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Hub shutdown failed: ${e.message}")
+        mcpLogError("hub-admin", "Hub shutdown failed", e)
         return [
             success: false,
             error: "Shutdown failed: ${e.message}",
@@ -11767,7 +11710,7 @@ def toolZwaveRepair(args) {
             response: responseText?.take(500)
         ]
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Z-Wave repair failed to start: ${e.message}")
+        mcpLogError("hub-admin", "Z-Wave repair failed to start", e)
         return [
             success: false,
             error: "Z-Wave repair failed: ${e.message}",
@@ -11843,7 +11786,7 @@ def toolGetItemSource(String type, String idParam, args) {
         }
         return result
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Failed to get ${type} source: ${e.message}")
+        mcpLogError("hub-admin", "Failed to get ${type} source", e)
         return [success: false, error: "Failed to get ${type} source: ${e.message}"]
     }
 }
@@ -12559,7 +12502,7 @@ private Map toolInstallItemSingle(String type, args) {
         if (sourceMode == "importUrl") installResult.note = "Source was fetched from importUrl '${args.importUrl}' (hub-side fetch, no agent transcript)."
         return installResult
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "${type.capitalize()} installation failed: ${e.message}")
+        mcpLogError("hub-admin", "${type.capitalize()} installation failed", e)
         return [
             success: false,
             error: "${type.capitalize()} installation failed: ${e.message}",
@@ -12804,7 +12747,7 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
             ]
         }
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "${type} update failed: ${e.message}")
+        mcpLogError("hub-admin", "${type} update failed", e)
         return [
             success: false,
             error: "${type.capitalize()} update failed: ${e.message}",
@@ -12963,7 +12906,7 @@ private Map _deleteItemViaEndpoint(String type, String idParam, String deletePat
             ]
         }
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "${type.capitalize()} deletion failed: ${e.message}")
+        mcpLogError("hub-admin", "${type.capitalize()} deletion failed", e)
         return [success: false, error: "${type.capitalize()} deletion failed: ${e.message}"]
     }
 }
@@ -13009,7 +12952,7 @@ private Map backupLibrarySource(String libraryId) {
     try {
         uploadHubFile(fileName, backupSource.getBytes("UTF-8"))
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Failed to save library backup file '${fileName}': ${e.message}")
+        mcpLogError("hub-admin", "Failed to save library backup file '${fileName}'", e)
         throw new IllegalArgumentException("Cannot back up library ID ${libraryId}: file upload failed -- ${e.message}")
     }
 
@@ -13122,7 +13065,7 @@ def toolGetLibrarySource(args) {
         }
         return result
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Failed to get library source: ${e.message}")
+        mcpLogError("hub-admin", "Failed to get library source", e)
         return [success: false, error: "Failed to get library source: ${e.message}"]
     }
 }
@@ -13262,7 +13205,7 @@ def toolInstallLibrary(args) {
         if (verifyError != null) installResult.verifyError = "${verifyError} -- use hub_get_source(type='library', id=${newLibraryId}) to confirm."
         return installResult
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Library installation failed: ${e.message}")
+        mcpLogError("hub-admin", "Library installation failed", e)
         return [
             success: false,
             error: "Library installation failed: ${e.message}",
@@ -13409,7 +13352,7 @@ def toolUpdateLibraryCode(args) {
         if (sourceMode == "sourceFile") successResult.note = "Source was read from File Manager file '${args.sourceFile}' -- no cloud size limits."
         return successResult
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Library update failed: ${e.message}")
+        mcpLogError("hub-admin", "Library update failed", e)
         return [success: false, error: "Library update failed: ${e.message}"]
     }
 }
@@ -13496,7 +13439,7 @@ def toolDeleteLibrary(args) {
             ]
         }
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Library deletion failed: ${e.message}")
+        mcpLogError("hub-admin", "Library deletion failed", e)
         return [success: false, error: "Library deletion failed: ${e.message}"]
     }
 }
@@ -13654,7 +13597,7 @@ def toolDeleteDevice(args) {
         def responseText = hubInternalGet("/device/forceDelete/${deviceId}/yes", null, 30)
         mcpLog("debug", "hub-admin", "Force delete response for device ${deviceId}: ${responseText?.take(500)}")
     } catch (Exception e) {
-        mcpLog("error", "hub-admin", "Device force delete FAILED for '${deviceName}' (${deviceId}): ${e.message}")
+        mcpLogError("hub-admin", "Device force delete FAILED for '${deviceName}' (${deviceId})", e)
         return [
             success: false,
             error: "Force delete failed: ${e.message}",
@@ -13978,7 +13921,7 @@ def toolDeleteVirtualDevice(args) {
     try {
         deleteChildDevice(dni)
     } catch (Exception e) {
-        mcpLog("error", "device", "Failed to delete virtual device '${deviceLabel}' (DNI: ${dni}): ${e.message}")
+        mcpLogError("device", "Failed to delete virtual device '${deviceLabel}' (DNI: ${dni})", e)
         throw new RuntimeException("Failed to delete virtual device: ${e.message}")
     }
 
@@ -14139,38 +14082,17 @@ def toolUpdateDevice(args) {
                 def deviceIdInt = deviceId as Integer
 
                 // Helper: POST JSON to /room/save and check for errors
+                // Routed through hubInternalPostJson so room writes share the Hub Security
+                // cookie-refresh retry (a stale cookie no longer fails the save outright).
+                // It returns the parsed body (or null on empty/non-JSON); the
+                // verify-after-write step below is the real safety net for this path.
                 def roomSavePost = { Map bodyMap ->
-                    def cookie = getHubSecurityCookie()
                     def jsonStr = groovy.json.JsonOutput.toJson(bodyMap)
-                    def postParams = [
-                        uri: "http://127.0.0.1:8080",
-                        path: "/room/save",
-                        requestContentType: "application/json",
-                        body: jsonStr,
-                        textParser: true,
-                        timeout: 30,
-                        ignoreSSLIssues: true
-                    ]
-                    if (cookie) { postParams.headers = ["Cookie": cookie] }
-                    def respBody = null
-                    httpPost(postParams) { resp ->
-                        try { respBody = resp.data?.text?.toString() } catch (Exception ignored) { respBody = resp.data?.toString() }
+                    def parsed = hubInternalPostJson("/room/save", jsonStr, 30)
+                    if (parsed?.error) {
+                        throw new RuntimeException("Room API error: ${parsed.error}")
                     }
-                    // Parse JSON response to check for error field
-                    if (respBody) {
-                        try {
-                            def parsed = new groovy.json.JsonSlurper().parseText(respBody)
-                            if (parsed?.error) {
-                                throw new RuntimeException("Room API error: ${parsed.error}")
-                            }
-                        } catch (groovy.json.JsonException ignored) {
-                            // Non-JSON response — check raw text
-                            if (respBody.toLowerCase().contains("error")) {
-                                throw new RuntimeException("Room API error (non-JSON): ${respBody.take(500)}")
-                            }
-                        }
-                    }
-                    return respBody
+                    return parsed
                 }
 
                 // Helper: check if device is in a room's device list
@@ -14450,40 +14372,21 @@ def toolCreateRoom(args) {
     // Build device IDs list
     def deviceIds = args.deviceIds?.collect { it as Integer } ?: []
 
-    // POST /room/save with roomId: 0 to create (Grails convention)
-    def cookie = getHubSecurityCookie()
+    // POST /room/save with roomId: 0 to create (Grails convention). Routed through
+    // hubInternalPostJson for the shared Hub Security cookie-refresh retry; the
+    // creation is confirmed against getRooms() below.
     def body = [roomId: 0, name: roomName, deviceIds: deviceIds]
     def jsonStr = groovy.json.JsonOutput.toJson(body)
     mcpLog("debug", "room", "hub_create_room: POST /room/save body: ${jsonStr}")
 
-    def respBody = null
+    def parsed
     try {
-        def postParams = [
-            uri: "http://127.0.0.1:8080",
-            path: "/room/save",
-            requestContentType: "application/json",
-            body: jsonStr,
-            textParser: true,
-            timeout: 30,
-            ignoreSSLIssues: true
-        ]
-        if (cookie) { postParams.headers = ["Cookie": cookie] }
-        httpPost(postParams) { resp ->
-            try { respBody = resp.data?.text?.toString() } catch (Exception ignored) { respBody = resp.data?.toString() }
-            mcpLog("debug", "room", "hub_create_room: response status=${resp.status} body=${respBody?.take(500)}")
-        }
+        parsed = hubInternalPostJson("/room/save", jsonStr, 30)
     } catch (Exception httpErr) {
         throw new RuntimeException("Failed to create room '${roomName}': ${httpErr.message}")
     }
-
-    // Parse JSON response to check for error
-    if (respBody) {
-        try {
-            def parsed = new groovy.json.JsonSlurper().parseText(respBody)
-            if (parsed?.error) {
-                throw new RuntimeException("Failed to create room: ${parsed.error}")
-            }
-        } catch (groovy.json.JsonException ignored) {}
+    if (parsed?.error) {
+        throw new RuntimeException("Failed to create room: ${parsed.error}")
     }
 
     // Verify creation (case-insensitive to handle any normalization)
@@ -14522,7 +14425,6 @@ def toolDeleteRoom(args) {
     def deviceCount = room.deviceIds?.size() ?: 0
     mcpLog("debug", "room", "hub_delete_room: deleting room '${roomName}' (ID: ${roomId}), ${deviceCount} devices will be unassigned")
 
-    def cookie = getHubSecurityCookie()
     def deleteSuccess = false
     def deleteError = null
 
@@ -14535,29 +14437,10 @@ def toolDeleteRoom(args) {
         if (deleteSuccess) break
         try {
             if (att.method == "POST") {
-                def postParams = [
-                    uri: "http://127.0.0.1:8080",
-                    path: "/room/delete/${roomId}",
-                    requestContentType: "application/json",
-                    body: groovy.json.JsonOutput.toJson([roomId: roomId as Integer]),
-                    textParser: true,
-                    timeout: 30,
-                    ignoreSSLIssues: true
-                ]
-                if (cookie) { postParams.headers = ["Cookie": cookie] }
-                def postRespBody = null
-                httpPost(postParams) { resp ->
-                    try { postRespBody = resp.data?.text?.toString() } catch (Exception ignored) { postRespBody = resp.data?.toString() }
-                    mcpLog("debug", "room", "hub_delete_room: ${att.desc} status=${resp.status} body=${postRespBody?.take(500)}")
-                }
-                // Check response for error
-                if (postRespBody) {
-                    try {
-                        def parsed = new groovy.json.JsonSlurper().parseText(postRespBody)
-                        if (parsed?.error) {
-                            throw new RuntimeException("API error: ${parsed.error}")
-                        }
-                    } catch (groovy.json.JsonException ignored) {}
+                // Routed through hubInternalPostJson for the shared cookie-refresh retry.
+                def parsed = hubInternalPostJson("/room/delete/${roomId}", groovy.json.JsonOutput.toJson([roomId: roomId as Integer]), 30)
+                if (parsed?.error) {
+                    throw new RuntimeException("API error: ${parsed.error}")
                 }
                 deleteSuccess = true
             } else {
@@ -14622,40 +14505,21 @@ def toolRenameRoom(args) {
     def roomId = room.id
     def deviceIds = room.deviceIds?.collect { it as Integer } ?: []
 
-    // POST /room/save with existing roomId and new name
-    def cookie = getHubSecurityCookie()
+    // POST /room/save with existing roomId and new name. Routed through
+    // hubInternalPostJson for the shared cookie-refresh retry; the rename is
+    // confirmed against getRooms() below.
     def body = [roomId: roomId as Integer, name: newName, deviceIds: deviceIds]
     def jsonStr = groovy.json.JsonOutput.toJson(body)
     mcpLog("debug", "room", "hub_update_room: POST /room/save body: ${jsonStr}")
 
-    def respBody = null
+    def parsed
     try {
-        def postParams = [
-            uri: "http://127.0.0.1:8080",
-            path: "/room/save",
-            requestContentType: "application/json",
-            body: jsonStr,
-            textParser: true,
-            timeout: 30,
-            ignoreSSLIssues: true
-        ]
-        if (cookie) { postParams.headers = ["Cookie": cookie] }
-        httpPost(postParams) { resp ->
-            try { respBody = resp.data?.text?.toString() } catch (Exception ignored) { respBody = resp.data?.toString() }
-            mcpLog("debug", "room", "hub_update_room: response status=${resp.status} body=${respBody?.take(500)}")
-        }
+        parsed = hubInternalPostJson("/room/save", jsonStr, 30)
     } catch (Exception httpErr) {
         throw new RuntimeException("Failed to rename room '${oldName}': ${httpErr.message}")
     }
-
-    // Parse JSON response to check for error
-    if (respBody) {
-        try {
-            def parsed = new groovy.json.JsonSlurper().parseText(respBody)
-            if (parsed?.error) {
-                throw new RuntimeException("Failed to rename room: ${parsed.error}")
-            }
-        } catch (groovy.json.JsonException ignored) {}
+    if (parsed?.error) {
+        throw new RuntimeException("Failed to rename room: ${parsed.error}")
     }
 
     // Verify rename
@@ -14771,7 +14635,7 @@ def toolListInstalledApps(args) {
         // Programmer error -- e.g. validFilters / switch drift on the filter whitelist.
         // Don't reframe as a transport failure; surface so the drift gets fixed instead
         // of swallowed under a misleading "hub blip" note.
-        mcpLog("error", "installed-apps", "hub_list_apps internal invariant violated: ${e.message}")
+        mcpLogError("installed-apps", "hub_list_apps internal invariant violated", e)
         throw e
     } catch (Exception e) {
         // The Built-in-App-Tools gate has already passed by the time we reach here, so
@@ -14779,7 +14643,7 @@ def toolListInstalledApps(args) {
         // (network blip, firmware change to /hub2/appsList) or the flatten/filter pipeline
         // (unexpected shape in a child entry). The error message itself will usually
         // distinguish the two.
-        mcpLog("error", "installed-apps", "hub_list_apps failed: ${e.message}")
+        mcpLogError("installed-apps", "hub_list_apps failed", e)
         return [success: false, error: "Failed to list installed apps: ${e.message}", note: "Hub transport error or unexpected /hub2/appsList response shape -- retry; if persistent, inspect the raw response for firmware-side drift."]
     }
 }
@@ -14869,7 +14733,7 @@ def toolGetDeviceInUseBy(args) {
         }
         return result
     } catch (Exception e) {
-        mcpLog("error", "installed-apps", "hub_list_device_dependents failed for device ${deviceId}: ${e.message}")
+        mcpLogError("installed-apps", "hub_list_device_dependents failed for device ${deviceId}", e)
         return [success: false, error: "Failed: ${e.message}", note: "Verify the device ID is valid and Built-in App Tools is enabled."]
     }
 }
@@ -22381,7 +22245,7 @@ def toolCreateNativeApp(args) {
         // common cause is that the registry's namespace/appName combo
         // doesn't match an installed app on this hub. Surface a clear
         // hint instead of the generic "unexpected error".
-        mcpLog("error", "rm-native", "createchild failed for appType='${appType}' (ns=${reg.namespace}, appName=${reg.appName}, parent=${parentId}): ${createExc.message}")
+        mcpLogError("rm-native", "createchild failed for appType='${appType}' (ns=${reg.namespace}, appName=${reg.appName}, parent=${parentId})", createExc)
         throw new IllegalArgumentException(
             "hub_create_native_app failed at the createchild step for appType='${appType}'. " +
             "The hub rejected namespace='${reg.namespace}' + appName='${reg.appName}' " +
@@ -22522,7 +22386,7 @@ def toolCreateNativeApp(args) {
         // Orphan cleanup: caller didn't get a usable app, so remove the
         // half-created shell rather than leaving it under the parent.
         // forcedelete/quiet is idempotent on already-gone ids.
-        mcpLog("error", "rm-native", "hub_create_native_app setup failed after createchild for ${newId} (appType=${appType}): ${e.message} -- cleaning up")
+        mcpLogError("rm-native", "hub_create_native_app setup failed after createchild for ${newId} (appType=${appType}) -- cleaning up", e)
         try { _rmForceDeleteApp(newId) } catch (Exception ce) {
             mcpLog("warn", "rm-native", "Orphan cleanup failed for ${newId}: ${ce.message}")
         }
@@ -24190,7 +24054,7 @@ def toolUpdateNativeApp(args) {
             }
             return result
         } catch (Exception e) {
-            mcpLog("error", "rm-native", "walkStep failed for app ${appId}: ${e.message}")
+            mcpLogError("rm-native", "walkStep failed for app ${appId}", e)
             return [
                 success: false,
                 appId: appId,
@@ -24334,6 +24198,9 @@ def toolUpdateNativeApp(args) {
             // re-derives cleanedError for the same reason -- if e.message
             // didn't carry the marker, replace() returns the original string.
             def cleanedError = e.message?.replace(getAsyncCommitMarker(), "")
+            // Intentionally plain mcpLog (NOT mcpLogError): this site deliberately
+            // sanitizes the asyncCommit marker out of the message, and mcpLogError
+            // would re-leak the raw e.message (marker included) into stackTrace.
             mcpLog("error", "rm-native", "action mutation failed for app ${appId}: ${cleanedError}")
             // Defensive eventual-consistency response shape for the rare
             // clearActions verification-window-exhausted residual. The trashActs
@@ -24505,7 +24372,7 @@ def toolUpdateNativeApp(args) {
                 trigMutResult = _rmModifyTrigger(appId, trigIdxOut, modifyTriggerSpec.mods as Map)
             }
         } catch (Exception e) {
-            mcpLog("error", "rm-native", "trigger mutation failed for app ${appId}: ${e.message}")
+            mcpLogError("rm-native", "trigger mutation failed for app ${appId}", e)
             // removeTrigger / modifyTrigger retry-exhaustion stays on the legacy
             // flat error shape (success:false + restoreHint hint). The structured
             // asyncCommitLikely envelope -- with safeRecovery, actionsRequestedForRemoval,
@@ -24618,7 +24485,7 @@ def toolUpdateNativeApp(args) {
         try {
             trigResult = _rmAddTrigger(appId, addTriggerSpec)
         } catch (Exception e) {
-            mcpLog("error", "rm-native", "addTrigger failed for app ${appId}: ${e.message}")
+            mcpLogError("rm-native", "addTrigger failed for app ${appId}", e)
             return _rmBuildUpdateErrorResponse(appId, e.message, backup)
         }
         // Auto-fire updateRule after a successful commit so eventSubscriptions
@@ -24685,7 +24552,7 @@ def toolUpdateNativeApp(args) {
         try {
             actResult = _rmAddAction(appId, addActionSpec)
         } catch (Exception e) {
-            mcpLog("error", "rm-native", "addAction failed for app ${appId}: ${e.message}")
+            mcpLogError("rm-native", "addAction failed for app ${appId}", e)
             return _rmBuildUpdateErrorResponse(appId, e.message, backup)
         }
         return [
@@ -24919,7 +24786,7 @@ def toolUpdateNativeApp(args) {
             }
         } catch (Exception e) {
             patchErr = e.message
-            mcpLog("error", "rm-native", "patches application failed: ${e.message}")
+            mcpLogError("rm-native", "patches application failed", e)
         }
         def opsOk = patchResults.count { it?.success != false }
         def health = _rmCheckRuleHealth(appId)
@@ -24970,7 +24837,7 @@ def toolUpdateNativeApp(args) {
         try {
             varResult = _rmAddLocalVariable(appId, addLocalVariableSpec)
         } catch (Exception e) {
-            mcpLog("error", "rm-native", "addLocalVariable failed for app ${appId}: ${e.message}")
+            mcpLogError("rm-native", "addLocalVariable failed for app ${appId}", e)
             return _rmBuildUpdateErrorResponse(appId, e.message, backup)
         }
         // Trailing-updateRule failure propagation (sibling pattern from F2 on
@@ -25040,7 +24907,7 @@ def toolUpdateNativeApp(args) {
         try {
             reResult = _rmAddRequiredExpression(appId, addRequiredExpressionSpec)
         } catch (Exception e) {
-            mcpLog("error", "rm-native", "addRequiredExpression failed for app ${appId}: ${e.message}")
+            mcpLogError("rm-native", "addRequiredExpression failed for app ${appId}", e)
             // STPage is the wizard page this branch operates on; the helper threads it
             // into the wizardStuck restoreHint and surfaces preflight refusals with the
             // current health block (which a future preflight on this branch would set).
@@ -25141,7 +25008,7 @@ def toolUpdateNativeApp(args) {
                 }
             }
         } catch (Exception e) {
-            mcpLog("error", "rm-native", "addTriggers/addActions bulk failed for app ${appId}: ${e.message}")
+            mcpLogError("rm-native", "addTriggers/addActions bulk failed for app ${appId}", e)
             def bulkResult = _rmBuildUpdateErrorResponse(appId, e.message, backup)
             bulkResult.triggerResults = triggerResults
             bulkResult.actionResults = actionResults
@@ -25369,7 +25236,7 @@ def toolUpdateNativeApp(args) {
         return result
     } catch (Exception e) {
         def msg = e.message ?: e.toString()
-        mcpLog("error", "rm-native", "hub_update_native_app failed for ${appId}: ${msg}")
+        mcpLogError("rm-native", "hub_update_native_app failed for ${appId}: ${msg}", e)
         return _rmBuildUpdateErrorResponse(appId, msg, backup)
     }
 }
@@ -26289,12 +26156,18 @@ def handleUpdateCheckResponse(resp, data) {
     try {
         if (resp.status != 200) {
             mcpLog("warn", "server", "Version check HTTP error: ${resp.status}")
+            // Stamp a checkedAt-bearing failure sentinel so the first-install gate in
+            // initialize() flips and the 24h guard in checkForUpdate engages even when
+            // the check never succeeds (e.g. a hub that can't reach GitHub) -- otherwise
+            // every settings save would re-egress. updateAvailable:false => no banner.
+            state.updateCheck = [checkedAt: now(), updateAvailable: false, lastError: "http ${resp.status}"]
             return
         }
         def json = new groovy.json.JsonSlurper().parseText(resp.data)
         def latestVersion = json.version
         if (!latestVersion) {
             mcpLog("warn", "server", "Version check: no version field in response")
+            state.updateCheck = [checkedAt: now(), updateAvailable: false, lastError: "no version field"]
             return
         }
         def installed = currentVersion()
@@ -26311,6 +26184,7 @@ def handleUpdateCheckResponse(resp, data) {
         }
     } catch (Exception e) {
         mcpLog("warn", "server", "Version check response parsing failed: ${e.message}")
+        state.updateCheck = [checkedAt: now(), updateAvailable: false, lastError: e.message]
     }
 }
 
@@ -26348,13 +26222,24 @@ def toolSearchTools(args) {
     if (!query?.trim()) return [error: "query is required"]
     def maxResults = args.maxResults != null ? Math.max(0, args.maxResults as Integer) : 5
 
-    // Build searchable corpus (cached in state for performance on resource-constrained hub).
-    // The full corpus is always cached; visibility filtering is applied per-request so that
-    // toggle changes take effect immediately without invalidating the cache.
-    def corpus = state.toolSearchCorpus
-    if (!corpus) {
+    // Build searchable corpus (cached in atomicState for performance on a resource-
+    // constrained hub: build-once/read-many, so the atomicState write cost is negligible
+    // and it stays off the hot state-flush path and survives restart). The full corpus is
+    // always cached; visibility filtering is applied per-request so toggle changes take
+    // effect immediately without invalidating the cache. The per-doc tokenization is cached
+    // in lockstep (atomicState.toolSearchTokens, index-aligned to the FULL corpus) so
+    // queries never re-tokenize; both entries invalidate together in updated(). The cache
+    // is a pure function of the tool definitions, so app-update invalidation is sufficient.
+    def corpus = atomicState.toolSearchCorpus
+    def docTokensAll = atomicState.toolSearchTokens
+    if (!corpus || !docTokensAll || docTokensAll.size() != corpus.size()) {
         corpus = buildToolSearchCorpus()
-        state.toolSearchCorpus = corpus
+        // Tokenize every corpus entry once, in corpus order, so docTokensAll[i] is the
+        // tokenization of corpus[i] (a pure function of that entry). Plain List<List<String>>
+        // (sandbox-safe; whole-value single assignment, no nested-subscript mutation).
+        docTokensAll = corpus.collect { bm25Tokenize("${it.name} ${it.description} ${it.params ?: ''} ${it.hints ?: ''}") }
+        atomicState.toolSearchCorpus = corpus
+        atomicState.toolSearchTokens = docTokensAll
     }
 
     // Apply the same visibility filter that getToolDefinitions() uses so that
@@ -26380,18 +26265,24 @@ def toolSearchTools(args) {
         }
         // hub_get_custom_rule (list/get/diagnostics modes) stays visible in readonly mode
     }
-    // Filter corpus to only tools the current toggle state allows.
-    def visibleCorpus = corpus.findAll { entry ->
-        if (searchHideByName.contains(entry.name)) return false
+    // Filter corpus to only tools the current toggle state allows. Co-filter the cached
+    // full-corpus tokens in the SAME pass so docTokens[k] stays aligned with visibleCorpus[k]
+    // (docTokensAll[i] is the tokenization of corpus[i]; selecting both by the same surviving
+    // index i preserves the pairing). A plain findAll would drop the original index, so
+    // iterate with eachWithIndex and push both lists together.
+    def visibleCorpus = []
+    def docTokens = []
+    corpus.eachWithIndex { entry, i ->
+        if (searchHideByName.contains(entry.name)) return
         if (entry.gateway) {
             def hiddenInGw = searchHideGwSubTools[entry.gateway]
-            if (hiddenInGw && hiddenInGw.contains(entry.name)) return false
+            if (hiddenInGw && hiddenInGw.contains(entry.name)) return
         }
-        return true
+        visibleCorpus << entry
+        docTokens << docTokensAll[i]
     }
 
-    // Tokenize all documents and the query
-    def docTokens = visibleCorpus.collect { bm25Tokenize("${it.name} ${it.description} ${it.params ?: ''} ${it.hints ?: ''}") }
+    // Tokenize the query (docs already tokenized from the cache above)
     def queryTokens = bm25Tokenize(query)
 
     if (!queryTokens) return [results: [], message: "No searchable terms in query"]

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -25758,7 +25758,13 @@ def toolExportNativeApp(args) {
         def refreshResp = _appClonerSubmitForm(clonerAppId, "main", "source", referrer, configUrl, null)
         String jsonContent = _appClonerExtractJsonFromResponse(refreshResp?.data)
         if (!jsonContent) {
-            throw new IllegalStateException("appCloner export fired but no JSON content could be extracted from cloner ${clonerAppId} — wire format may have changed (looked for configPage.sections[].input[].filecontent)")
+            // Distinguish an unreadable response body (the struct read path returns
+            // data:null on a 2xx when the body read fails mid-stream) from a genuine
+            // format change, so the operator isn't sent chasing the wrong root cause.
+            def reason = (refreshResp?.data == null)
+                ? "the cloner response body was empty/unreadable (status ${refreshResp?.status})"
+                : "no JSON content could be extracted (looked for configPage.sections[].input[].filecontent) — wire format may have changed"
+            throw new IllegalStateException("appCloner export fired but ${reason} for cloner ${clonerAppId}")
         }
 
         def result = [
@@ -26156,18 +26162,19 @@ def handleUpdateCheckResponse(resp, data) {
     try {
         if (resp.status != 200) {
             mcpLog("warn", "server", "Version check HTTP error: ${resp.status}")
-            // Stamp a checkedAt-bearing failure sentinel so the first-install gate in
-            // initialize() flips and the 24h guard in checkForUpdate engages even when
-            // the check never succeeds (e.g. a hub that can't reach GitHub) -- otherwise
-            // every settings save would re-egress. updateAvailable:false => no banner.
-            state.updateCheck = [checkedAt: now(), updateAvailable: false, lastError: "http ${resp.status}"]
+            // Merge checkedAt + lastError onto the existing record (do NOT replace it)
+            // so the first-install gate in initialize() flips and the 24h guard engages
+            // even when the check never succeeds (e.g. a hub that can't reach GitHub),
+            // WITHOUT clobbering a previously-known latestVersion/updateAvailable -- a
+            // transient failure must not silently drop an already-surfaced update banner.
+            state.updateCheck = (state.updateCheck ?: [:]) + [checkedAt: now(), lastError: "http ${resp.status}"]
             return
         }
         def json = new groovy.json.JsonSlurper().parseText(resp.data)
         def latestVersion = json.version
         if (!latestVersion) {
             mcpLog("warn", "server", "Version check: no version field in response")
-            state.updateCheck = [checkedAt: now(), updateAvailable: false, lastError: "no version field"]
+            state.updateCheck = (state.updateCheck ?: [:]) + [checkedAt: now(), lastError: "no version field"]
             return
         }
         def installed = currentVersion()
@@ -26184,7 +26191,7 @@ def handleUpdateCheckResponse(resp, data) {
         }
     } catch (Exception e) {
         mcpLog("warn", "server", "Version check response parsing failed: ${e.message}")
-        state.updateCheck = [checkedAt: now(), updateAvailable: false, lastError: e.message]
+        state.updateCheck = (state.updateCheck ?: [:]) + [checkedAt: now(), lastError: e.message]
     }
 }
 

--- a/src/test/groovy/server/AppLifecycleMigrationSpec.groovy
+++ b/src/test/groovy/server/AppLifecycleMigrationSpec.groovy
@@ -256,10 +256,15 @@ class AppLifecycleMigrationSpec extends ToolSpecBase {
         UNSUBSCRIBE_CALL_COUNT.get() == 1
     }
 
-    def "uninstalled() is a no-op for in-use vars when none are tracked (null/empty), without NPE"() {
-        given: 'no tracked registrations'
+    @spock.lang.Unroll
+    def "uninstalled() is a no-op for in-use vars when tracking is #desc, without NPE"() {
+        given: 'no tracked registrations (null key, or an explicit empty list)'
         UNSUBSCRIBE_CALL_COUNT.set(0)
-        atomicStateMap.remove('inUseHubVars')
+        if (val == null) {
+            atomicStateMap.remove('inUseHubVars')
+        } else {
+            atomicStateMap.inUseHubVars = val
+        }
         def removed = []
         script.metaClass.removeInUseGlobalVar = { String n -> removed << n; true }
 
@@ -272,6 +277,11 @@ class AppLifecycleMigrationSpec extends ToolSpecBase {
 
         and: 'unsubscribe still fired (best-effort teardown)'
         UNSUBSCRIBE_CALL_COUNT.get() == 1
+
+        where:
+        desc    | val
+        'null'  | null
+        'empty' | []
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/groovy/server/AppLifecycleMigrationSpec.groovy
+++ b/src/test/groovy/server/AppLifecycleMigrationSpec.groovy
@@ -43,12 +43,26 @@ class AppLifecycleMigrationSpec extends ToolSpecBase {
 
     @Shared private TestChildApp sharedAppStub = new TestChildApp(id: 1L, label: 'MCP')
 
+    // Ordered record of lifecycle wire-up calls. schedule()/unschedule() are
+    // class-2 (declared on the eighty20results delegate chain), so a per-instance
+    // metaClass stub on the script is bypassed -- they must be recorded via
+    // permanent >> dispatchers on the appExecutor mock installed in setupSpec.
+    // Tests reset this in given: with .clear().
+    @Shared protected final List<String> lifecycleCalls = []
+
     def setupSpec() {
         // Additive stub layered on top of HarnessSpec.setupSpec's appExecutor.
         // Gives app.updateSetting(...) a non-null target (same pattern as
         // ToolManageLogsSpec). Must be in setupSpec (not given:) because the
         // @Shared Mock's interaction set is read-only after setup() completes.
         appExecutor.getApp() >> sharedAppStub
+        // Record schedule/unschedule call order for the schedule-symmetry test.
+        appExecutor.schedule(*_) >> { args -> lifecycleCalls << 'schedule' }
+        appExecutor.unschedule() >> { lifecycleCalls << 'unschedule' }
+        // createAccessToken is class-2 (declared on AppExecutor) -- a per-instance
+        // script.metaClass stub would be bypassed -- so stub it here. Models the real
+        // OAuth API: it populates state.accessToken. Used by the token-regenerate test.
+        appExecutor.createAccessToken() >> { stateMap.accessToken = 'new'; 'new' }
     }
 
     def setup() {
@@ -214,4 +228,154 @@ class AppLifecycleMigrationSpec extends ToolSpecBase {
         and: 'migration marker stays true'
         stateMap.customEngineMigrated == true
     }
+
+    // -----------------------------------------------------------------------
+    // uninstalled(): tears down in-use registrations + subscriptions + schedule
+    // (issue #105 PR2b lifecycle-uninstalled-teardown). Do NOT stubUpdatedDeps()
+    // -- that no-ops initialize, irrelevant here; we drive uninstalled() direct.
+    // -----------------------------------------------------------------------
+
+    def "uninstalled() removes each tracked in-use var, clears the set, and unsubscribes"() {
+        given: 'two tracked in-use registrations and a clean unsubscribe counter'
+        UNSUBSCRIBE_CALL_COUNT.set(0)
+        atomicStateMap.inUseHubVars = ['v1', 'v2']
+        def removed = []
+        // class-1 (absent from hubitat_ci jar -> purely dynamic): metaClass wins.
+        script.metaClass.removeInUseGlobalVar = { String n -> removed << n; true }
+
+        when:
+        script.uninstalled()
+
+        then: 'each tracked var was de-registered'
+        removed.toSet() == ['v1', 'v2'] as Set
+
+        and: 'the tracking set was cleared'
+        atomicStateMap.inUseHubVars == null
+
+        and: 'subscriptions were torn down'
+        UNSUBSCRIBE_CALL_COUNT.get() == 1
+    }
+
+    def "uninstalled() is a no-op for in-use vars when none are tracked (null/empty), without NPE"() {
+        given: 'no tracked registrations'
+        UNSUBSCRIBE_CALL_COUNT.set(0)
+        atomicStateMap.remove('inUseHubVars')
+        def removed = []
+        script.metaClass.removeInUseGlobalVar = { String n -> removed << n; true }
+
+        when:
+        script.uninstalled()
+
+        then: 'no de-registration calls and no exception'
+        removed == []
+        noExceptionThrown()
+
+        and: 'unsubscribe still fired (best-effort teardown)'
+        UNSUBSCRIBE_CALL_COUNT.get() == 1
+    }
+
+    // -----------------------------------------------------------------------
+    // initialize(): unschedule() must precede schedule() so each lifecycle
+    // cycle rebuilds the cron set (lifecycle-schedule-symmetry). Direct call;
+    // checkForUpdate/_subscribe*/_refresh* are class-1 script methods.
+    // -----------------------------------------------------------------------
+
+    def "initialize() unschedules BEFORE scheduling the daily checkForUpdate"() {
+        given:
+        lifecycleCalls.clear()
+        stateMap.accessToken = 'tok'                  // skip createAccessToken
+        stateMap.updateCheck = [checkedAt: 1L]        // suppress the immediate check (gate)
+        script.metaClass.checkForUpdate = { -> }
+        script.metaClass._subscribeToAllHubVariables = { -> }
+        script.metaClass._refreshHubVarInUseRegistrations = { -> }
+
+        when:
+        script.initialize()
+
+        then: 'both wire-up calls fired, unschedule strictly before schedule'
+        lifecycleCalls.indexOf('unschedule') >= 0
+        lifecycleCalls.indexOf('schedule') >= 0
+        lifecycleCalls.indexOf('unschedule') < lifecycleCalls.indexOf('schedule')
+    }
+
+    // -----------------------------------------------------------------------
+    // initialize(): immediate checkForUpdate() only on first install
+    // (lifecycle-version-check-on-every-save). state.updateCheck is the key
+    // handleUpdateCheckResponse writes; null == never checked == first install.
+    // -----------------------------------------------------------------------
+
+    def "initialize() runs the immediate version check on first install (state.updateCheck null)"() {
+        given:
+        lifecycleCalls.clear()
+        stateMap.accessToken = 'tok'
+        stateMap.remove('updateCheck')                // first install: never checked
+        def checkCalls = 0
+        script.metaClass.checkForUpdate = { -> checkCalls++ }
+        script.metaClass._subscribeToAllHubVariables = { -> }
+        script.metaClass._refreshHubVarInUseRegistrations = { -> }
+
+        when:
+        script.initialize()
+
+        then: 'the immediate check fired for first-install freshness'
+        checkCalls == 1
+    }
+
+    def "initialize() skips the immediate version check on a routine save (state.updateCheck set)"() {
+        given:
+        lifecycleCalls.clear()
+        stateMap.accessToken = 'tok'
+        stateMap.updateCheck = [checkedAt: 1234567890000L]   // already checked before
+        def checkCalls = 0
+        script.metaClass.checkForUpdate = { -> checkCalls++ }
+        script.metaClass._subscribeToAllHubVariables = { -> }
+        script.metaClass._refreshHubVarInUseRegistrations = { -> }
+
+        when:
+        script.initialize()
+
+        then: 'no GitHub egress on a routine settings save'
+        checkCalls == 0
+    }
+
+    // -----------------------------------------------------------------------
+    // appButtonHandler(regenerateTokenBtn): user-initiated, on-demand token
+    // rotation (issue #105 PR2b lifecycle-token-rotation / Q9, UI-only). The
+    // token is otherwise stable -- only this button (and the first-install
+    // guard) ever calls createAccessToken (class-2, stubbed on appExecutor).
+    // -----------------------------------------------------------------------
+
+    def "appButtonHandler regenerates the access token when the regenerate button is pressed"() {
+        given: 'an existing token and a captured mcpLog'
+        stateMap.accessToken = 'old'
+        def logCalls = []
+        script.metaClass.mcpLog = { String level, String component, String msg ->
+            logCalls << [level: level, component: component, msg: msg]
+        }
+
+        when:
+        script.appButtonHandler('regenerateTokenBtn')
+
+        then: 'createAccessToken (appExecutor stub) re-issued a fresh token'
+        stateMap.accessToken == 'new'
+
+        and: 'a warn-level audit line was emitted for the rotation'
+        logCalls.any { it.level == 'warn' && it.component == 'server' && it.msg.toLowerCase().contains('token') }
+    }
+
+    def "appButtonHandler does nothing to the token for an unknown button name"() {
+        given:
+        stateMap.accessToken = 'old'
+        script.metaClass.mcpLog = { String level, String component, String msg -> }
+
+        when:
+        script.appButtonHandler('someUnknownBtn')
+
+        then: 'the token is untouched (no regenerate, no createAccessToken)'
+        stateMap.accessToken == 'old'
+        noExceptionThrown()
+    }
+    // (confirmRegenerateTokenPage is static UI: dynamicPage cannot be rendered outside a
+    // preferences() reader context in this harness, so its body is compile-validated by the
+    // sandbox load; the regenerate behaviour is covered by the appButtonHandler test above.)
 }

--- a/src/test/groovy/server/AppLifecycleMigrationSpec.groovy
+++ b/src/test/groovy/server/AppLifecycleMigrationSpec.groovy
@@ -378,4 +378,66 @@ class AppLifecycleMigrationSpec extends ToolSpecBase {
     // (confirmRegenerateTokenPage is static UI: dynamicPage cannot be rendered outside a
     // preferences() reader context in this harness, so its body is compile-validated by the
     // sandbox load; the regenerate behaviour is covered by the appButtonHandler test above.)
+
+    // -----------------------------------------------------------------------
+    // handleUpdateCheckResponse failure paths stamp a checkedAt so the
+    // first-install gate flips + the 24h guard engages on offline hubs, but
+    // MUST NOT clobber a previously-known update result (lifecycle-version-
+    // check-on-every-save fix + its review follow-up).
+    // -----------------------------------------------------------------------
+
+    def "handleUpdateCheckResponse on a non-200 stamps checkedAt + lastError without flagging an update"() {
+        given:
+        stateMap.remove('updateCheck')
+
+        when:
+        script.handleUpdateCheckResponse([status: 500, data: ''], null)
+
+        then: 'the gate is flipped (record exists) and the 24h guard is armed, no banner'
+        stateMap.updateCheck != null
+        stateMap.updateCheck.checkedAt == 1234567890000L
+        stateMap.updateCheck.lastError == 'http 500'
+        !stateMap.updateCheck.updateAvailable
+    }
+
+    def "handleUpdateCheckResponse on a 200 with no version field stamps a failure record"() {
+        given:
+        stateMap.remove('updateCheck')
+
+        when:
+        script.handleUpdateCheckResponse([status: 200, data: '{}'], null)
+
+        then:
+        stateMap.updateCheck.checkedAt == 1234567890000L
+        stateMap.updateCheck.lastError == 'no version field'
+        !stateMap.updateCheck.updateAvailable
+    }
+
+    def "handleUpdateCheckResponse on unparseable body stamps a failure record (caught)"() {
+        given:
+        stateMap.remove('updateCheck')
+
+        when:
+        script.handleUpdateCheckResponse([status: 200, data: 'not json at all'], null)
+
+        then:
+        noExceptionThrown()
+        stateMap.updateCheck.checkedAt == 1234567890000L
+        stateMap.updateCheck.lastError != null
+        !stateMap.updateCheck.updateAvailable
+    }
+
+    def "a transient version-check failure does NOT clobber a previously-surfaced 'update available' result"() {
+        given: 'a prior successful check that found an update'
+        stateMap.updateCheck = [latestVersion: '9.9.9', updateAvailable: true, checkedAt: 1L]
+
+        when: 'a later check fails (GitHub briefly unreachable)'
+        script.handleUpdateCheckResponse([status: 503, data: ''], null)
+
+        then: 'the known update is preserved (banner stays); only checkedAt + lastError refresh'
+        stateMap.updateCheck.updateAvailable == true
+        stateMap.updateCheck.latestVersion == '9.9.9'
+        stateMap.updateCheck.checkedAt == 1234567890000L
+        stateMap.updateCheck.lastError == 'http 503'
+    }
 }

--- a/src/test/groovy/server/HandleGatewaySpec.groovy
+++ b/src/test/groovy/server/HandleGatewaySpec.groovy
@@ -207,4 +207,64 @@ class HandleGatewaySpec extends ToolSpecBase {
         result.rooms instanceof List
         result.count == 1
     }
+
+    // ---- pr2c-cat-1: cached required-param memo on the gateway dispatch path ----
+    // handleGateway no longer rebuilds the full ~111-tool catalog for the required-param
+    // pre-check; it reads from the memoized requiredParamsByTool() map cached in atomicState.
+
+    def "memo is populated in atomicState after the first gateway call; a repeat call returns the identical missing-param error"() {
+        given: 'a clean atomicState so the memo builds fresh on the first call'
+        atomicStateMap.remove('requiredParamsByTool')
+
+        when: 'first call with a missing required param (hub_get_room requires room)'
+        def first = script.handleGateway('hub_manage_rooms', 'hub_get_room', [:])
+
+        then: 'soft missing-param error AND the memo is now cached in atomicState'
+        first.isError == true
+        first.tool == 'hub_get_room'
+        first.error.contains('Missing required parameter:')
+        first.error.contains('room')
+        atomicStateMap.requiredParamsByTool instanceof Map
+        atomicStateMap.requiredParamsByTool['hub_get_room'] == ['room']
+        // omission contract: a no-required-param tool is absent from the map
+        !atomicStateMap.requiredParamsByTool.containsKey('hub_list_rooms')
+
+        when: 'a second identical call now served from the cached memo'
+        def second = script.handleGateway('hub_manage_rooms', 'hub_get_room', [:])
+
+        then: 'byte-identical error response -- the memo read is behavior-preserving'
+        second == first
+    }
+
+    def "the missing-param hint stays intact (no FLAT_TRIM leak) even after a flat-mode tools/list strip"() {
+        given: 'flat mode drives the in-place [[FLAT_TRIM]] strip path; clean memo'
+        settingsMap.useGateways = false
+        atomicStateMap.remove('requiredParamsByTool')
+
+        when: 'run the flat strip path first (mutates fresh def copies in place), then a gateway missing-param call'
+        script.getToolDefinitions()
+        def result = script.handleGateway('hub_manage_rooms', 'hub_get_room', [:])
+
+        then: 'the missing-param hint is fully intact -- no marker leakage'
+        result.isError == true
+        result.error.contains('room')
+        result.parameters.contains('room')
+        !result.parameters.contains('FLAT_TRIM')
+    }
+
+    def "two-missing-required path still rebuilds the full catalog for the hint and caches the two-element required list"() {
+        given:
+        atomicStateMap.remove('requiredParamsByTool')
+
+        when: 'hub_create_room requires both name and confirm; omit both'
+        def result = script.handleGateway('hub_manage_rooms', 'hub_create_room', [:])
+
+        then: 'plural form + both names; memo cached the two-element required list (order-independent)'
+        result.isError == true
+        result.tool == 'hub_create_room'
+        result.error.contains('Missing required parameters:')
+        result.error.contains('name')
+        result.error.contains('confirm')
+        (atomicStateMap.requiredParamsByTool['hub_create_room'] as Set) == (['name', 'confirm'] as Set)
+    }
 }

--- a/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
+++ b/src/test/groovy/server/HandleMcpRequestDispatchSpec.groovy
@@ -57,6 +57,26 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         // satisfy a naked truthy check, so pin the actual shape currentVersion()
         // produces.
         response.result.serverInfo.version ==~ /\d+\.\d+\.\d+.*/
+
+        and: 'instructions field is present, non-empty, and survives serialization through the dispatch envelope'
+        // Reading it off parseResponseJson() proves it round-trips
+        // jsonRpcResult -> JsonOutput.toJson -> render -> parse (PR2 owns the
+        // field; PR3 refines the prose, so pin stable keywords, not the text).
+        response.result.instructions instanceof String
+        !response.result.instructions.isEmpty()
+        response.result.instructions.toLowerCase().contains('gateway')
+        response.result.instructions.toLowerCase().contains('pagination')
+    }
+
+    def "hubResponseCapBytes() is the single 131072-byte source and the two derived guards stay ordered inner < outer"() {
+        // Pins the size-cap single-source invariant: the helper is the 128 KiB hub cap,
+        // the outer handleMcpRequest guard (=124000) and inner handleToolsCall guard
+        // (=120000) derive from it, and inner must stay strictly below outer.
+        expect:
+        script.hubResponseCapBytes() == 131072
+        (script.hubResponseCapBytes() - 7072) == 124000   // outer
+        (script.hubResponseCapBytes() - 11072) == 120000  // inner
+        (script.hubResponseCapBytes() - 11072) < (script.hubResponseCapBytes() - 7072)
     }
 
     def "tools/list returns the tool catalog with known tools present"() {
@@ -438,6 +458,55 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         inner.rooms*.name == ['Den']
     }
 
+    def "single tools/call renders correctly via the preserialized fast path with no sentinel leak"() {
+        given:
+        script.metaClass.getRooms = { -> [[id: 1L, name: 'Living Room'], [id: 2L, name: 'Kitchen']] }
+        mcpDriver.pushBody([jsonrpc: '2.0', id: 7, method: 'tools/call', params: [name: 'hub_list_rooms', arguments: [:]]])
+
+        when:
+        script.handleMcpRequest()
+
+        then: 'a well-formed JSON-RPC success envelope wrapping the real rooms payload (toolListRooms sorts by name)'
+        mcpDriver.lastRenderArgs.contentType == 'application/json'
+        def response = mcpDriver.parseResponseJson()
+        response.jsonrpc == '2.0'
+        response.id == 7
+        response.error == null
+        mcpDriver.parseInner(response).rooms*.name == ['Kitchen', 'Living Room']
+
+        and: 'the rendered body is well-formed JSON-RPC and the internal sentinel never leaks onto the wire'
+        def raw = mcpDriver.lastRenderArgs.data as String
+        !raw.contains('__preserialized')
+        new groovy.json.JsonSlurper().parseText(raw).result.content[0].type == 'text'
+    }
+
+    def "batch of two tools/call renders a valid array with no preserialized sentinel leaking"() {
+        given:
+        script.metaClass.getRooms = { -> [[id: 1L, name: 'Den']] }
+        mcpDriver.pushBody([
+            [jsonrpc: '2.0', id: 81, method: 'tools/call', params: [name: 'hub_list_rooms', arguments: [:]]],
+            [jsonrpc: '2.0', id: 82, method: 'tools/call', params: [name: 'hub_list_rooms', arguments: [:]]]
+        ])
+
+        when:
+        script.handleMcpRequest()
+
+        then: 'no sentinel key in the raw rendered body'
+        def raw = mcpDriver.lastRenderArgs.data as String
+        !raw.contains('__preserialized')
+
+        and: 'a 2-element array of well-formed JSON-RPC success envelopes, each carrying the rooms payload'
+        def response = mcpDriver.parseResponseJson()
+        response instanceof List
+        response.size() == 2
+        response.every { it.jsonrpc == '2.0' && it.error == null }
+        response.each { el ->
+            assert el.id in [81, 82]
+            assert !el.containsKey('__preserialized')
+            assert new groovy.json.JsonSlurper().parseText(el.result.content[0].text).rooms*.name == ['Den']
+        }
+    }
+
     def "tools/call surfaces a structured isError envelope when the tool implementation returns null"() {
         // Defends against a future tool whose last expression evaluates to null -- without
         // the explicit null guard, the wire payload becomes text: "null" which looks like
@@ -547,16 +616,33 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         response.result.content[0].text.contains('simulated hub failure')
     }
 
-    def "notification (no id) returns 204 no-content"() {
+    def "notification (no id) returns 202 Accepted no-content"() {
         given: 'a notification-shaped request — id field is absent per JSON-RPC 2.0'
         mcpDriver.pushBody([jsonrpc: '2.0', method: 'initialized', params: [:]])
 
         when:
         script.handleMcpRequest()
 
-        then: 'render was called with 204 and empty body — no JSON envelope'
-        mcpDriver.lastRenderArgs.status == 204
+        then: 'render was called with 202 Accepted and empty body — no JSON envelope (MCP Streamable HTTP)'
+        mcpDriver.lastRenderArgs.status == 202
         mcpDriver.lastRenderArgs.data == ''
+    }
+
+    @spock.lang.Unroll
+    def "initialize echoes supported requested protocolVersion=#requested as #expected (echo-allowlist)"() {
+        when:
+        def result = script.handleInitialize([id: 1, params: [protocolVersion: requested]])
+
+        then:
+        result.result.protocolVersion == expected
+
+        where:
+        requested      || expected
+        '2025-06-18'   || '2025-06-18'
+        '2025-03-26'   || '2025-03-26'
+        '2024-11-05'   || '2024-11-05'
+        'garbage-9999' || '2024-11-05'
+        null           || '2024-11-05'
     }
 
     def "batch request returns an array of responses with matching shapes, skipping notifications"() {
@@ -634,6 +720,44 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         response.error.message == 'Invalid Request: empty batch array'
     }
 
+    def "batch over the 50-element cap returns a single -32600 'batch too large' envelope (no per-element dispatch)"() {
+        given: 'a 51-element batch — one over the inbound cap'
+        // Spy so we can prove the per-element dispatcher was never entered.
+        int perElementCalls = 0
+        script.metaClass.processJsonRpcMessage = { m -> perElementCalls++; null }
+        mcpDriver.pushBody((1..51).collect { i -> [jsonrpc: '2.0', id: i, method: 'ping', params: [:]] })
+
+        when:
+        script.handleMcpRequest()
+
+        then: 'a single error Map (not an array) is rendered'
+        def response = mcpDriver.parseResponseJson()
+        !(response instanceof List)
+        response.jsonrpc == '2.0'
+        response.id == null
+        response.error.code == -32600
+        response.error.message == 'Invalid Request: batch too large (51 elements, max 50)'
+
+        and: 'the cap short-circuited before any per-element dispatch'
+        perElementCalls == 0
+        // No cleanup needed: HarnessSpec.setup() dual-wipes the per-instance
+        // metaClass before each feature, so this override does not leak.
+    }
+
+    def "batch at exactly the 50-element cap dispatches normally and returns an array"() {
+        given: 'exactly 50 ping requests — the boundary is inclusive'
+        mcpDriver.pushBody((1..50).collect { i -> [jsonrpc: '2.0', id: i, method: 'ping', params: [:]] })
+
+        when:
+        script.handleMcpRequest()
+
+        then: 'a 50-element response array, each an empty-map ping success'
+        def response = mcpDriver.parseResponseJson()
+        response instanceof List
+        response.size() == 50
+        response.every { it.jsonrpc == '2.0' && it.error == null && it.result == [:] }
+    }
+
     def "null body returns parse error -32700 (requestBody == null branch)"() {
         given: 'request.JSON is null — production treats this as an unparseable body'
         mcpDriver.pushBody(null)
@@ -695,7 +819,7 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         response.id == 5
     }
 
-    def "handleMcpGet returns 405 with the use-POST hint"() {
+    def "handleMcpGet returns 405 with a JSON-RPC -32600 POST-only envelope"() {
         when:
         script.handleMcpGet()
 
@@ -703,7 +827,11 @@ class HandleMcpRequestDispatchSpec extends ToolSpecBase {
         mcpDriver.lastRenderArgs.status == 405
         mcpDriver.lastRenderArgs.contentType == 'application/json'
         def body = mcpDriver.parseResponseJson()
-        body.error == 'GET not supported, use POST'
+        body.jsonrpc == '2.0'
+        body.id == null
+        body.error.code == -32600
+        body.error.message.contains('POST')
+        body.error.message.contains('SSE')
     }
 
     def "handleHealth returns status/server/version from currentVersion()"() {

--- a/src/test/groovy/server/HandleToolsCallSpec.groovy
+++ b/src/test/groovy/server/HandleToolsCallSpec.groovy
@@ -86,4 +86,30 @@ class HandleToolsCallSpec extends ToolSpecBase {
         inner.logs == []
         inner.count == 0
     }
+
+    def "handleToolsCall returns a __preserialized sentinel on the under-cap success path (serialize-once)"() {
+        // The sentinel is the mechanism that lets handleMcpRequest render verbatim without a
+        // second JsonOutput.toJson. Pinning the sentinel shape here guards the serialize-once
+        // contract -- a regression that went back to returning the plain jsonRpcResult object
+        // would re-introduce the double encode. (Dispatch tests above prove the wire form is
+        // still correct because handleMcpRequest renders __preserialized verbatim.)
+        given:
+        script.metaClass.getRooms = { -> [[id: 1L, name: 'Den']] }
+        def msg = [jsonrpc: '2.0', id: 5, method: 'tools/call', params: [name: 'hub_list_rooms', arguments: [:]]]
+
+        when:
+        def result = script.handleToolsCall(msg)
+
+        then: 'the success path returns the preserialized sentinel, not a bare jsonRpcResult Map'
+        result instanceof Map
+        result.containsKey('__preserialized')
+        result.__preserialized instanceof String
+
+        and: 'the sentinel string is itself the complete, well-formed JSON-RPC wire result'
+        def decoded = new groovy.json.JsonSlurper().parseText(result.__preserialized)
+        decoded.jsonrpc == '2.0'
+        decoded.id == 5
+        decoded.result.content[0].type == 'text'
+        new groovy.json.JsonSlurper().parseText(decoded.result.content[0].text).rooms*.name == ['Den']
+    }
 }

--- a/src/test/groovy/server/HubInfoFieldContractSpec.groovy
+++ b/src/test/groovy/server/HubInfoFieldContractSpec.groovy
@@ -7,8 +7,8 @@ import support.ToolSpecBase
 
 /**
  * Contract spec asserting that {@code customRuleEngineEnabled} and
- * {@code developerModeEnabled} are present in both {@code getHubInfo()} and
- * {@code getHubDetails()} responses.
+ * {@code developerModeEnabled} are present in the {@code getHubInfo()} response
+ * (the merged successor to the removed {@code getHubDetails()}).
  *
  * Both fields are read by {@code .github/scripts/mcp_setup_env.sh} to capture
  * pre-run state before enabling toggles. If either field is dropped or renamed,
@@ -17,7 +17,6 @@ import support.ToolSpecBase
  *
  * Mocking strategy:
  *   - location.hub -> appExecutor.getLocation() returns sharedLocation
- *   - toolGetHubDetails requires enableHubAdminRead; set in given: per-test
  */
 class HubInfoFieldContractSpec extends ToolSpecBase {
 
@@ -146,45 +145,42 @@ class HubInfoFieldContractSpec extends ToolSpecBase {
         result.identifyHubError.toLowerCase().contains('ioexception')
     }
 
-    // -------- toolGetHubDetails --------
+    // -------- toolGetHubInfo toggle-field contract (was toolGetHubDetails, merged in) --------
 
-    def "getHubDetails includes customRuleEngineEnabled=true when enableCustomRuleEngine is true"() {
+    def "getHubInfo (merged from getHubDetails) includes customRuleEngineEnabled=true when enableCustomRuleEngine is true"() {
         given:
-        settingsMap.enableHubAdminRead = true
         settingsMap.enableCustomRuleEngine = true
         sharedLocation.hub = new TestHub()
 
         when:
-        def result = script.toolGetHubDetails([:])
+        def result = script.toolGetHubInfo()
 
         then:
         result.containsKey('customRuleEngineEnabled')
         result.customRuleEngineEnabled == true
     }
 
-    def "getHubDetails includes developerModeEnabled=true when enableDeveloperMode is true"() {
+    def "getHubInfo (merged from getHubDetails) includes developerModeEnabled=true when enableDeveloperMode is true"() {
         given:
-        settingsMap.enableHubAdminRead = true
         settingsMap.enableDeveloperMode = true
         sharedLocation.hub = new TestHub()
 
         when:
-        def result = script.toolGetHubDetails([:])
+        def result = script.toolGetHubInfo()
 
         then:
         result.containsKey('developerModeEnabled')
         result.developerModeEnabled == true
     }
 
-    def "getHubDetails includes both fields as false when toggles are off"() {
+    def "getHubInfo (merged from getHubDetails) includes both fields as false when toggles are off"() {
         given:
-        settingsMap.enableHubAdminRead = true
         settingsMap.enableCustomRuleEngine = false
         settingsMap.enableDeveloperMode = false
         sharedLocation.hub = new TestHub()
 
         when:
-        def result = script.toolGetHubDetails([:])
+        def result = script.toolGetHubInfo()
 
         then:
         result.containsKey('customRuleEngineEnabled')
@@ -193,15 +189,20 @@ class HubInfoFieldContractSpec extends ToolSpecBase {
         result.developerModeEnabled == false
     }
 
-    def "getHubDetails throws when Hub Admin Read is disabled"() {
+    def "getHubInfo does NOT throw when Hub Admin Read is disabled and surfaces hubAdminReadRequired"() {
         given:
-        // enableHubAdminRead not set
+        sharedLocation.hub = new TestHub()
+        // enableHubAdminRead not set -- toolGetHubInfo gates only PII (unlike the
+        // removed toolGetHubDetails which threw via requireHubAdminRead()); it
+        // surfaces a hubAdminReadRequired notice and still returns the toggle fields.
 
         when:
-        script.toolGetHubDetails([:])
+        def result = script.toolGetHubInfo()
 
         then:
-        def ex = thrown(IllegalArgumentException)
-        ex.message.contains('Hub Admin Read')
+        noExceptionThrown()
+        result.containsKey('hubAdminReadRequired')
+        result.hubAdminReadRequired.contains('Hub Admin Read')
+        result.containsKey('customRuleEngineEnabled')
     }
 }

--- a/src/test/groovy/server/HubInternalRetrySpec.groovy
+++ b/src/test/groovy/server/HubInternalRetrySpec.groovy
@@ -1,0 +1,381 @@
+package server
+
+import spock.lang.Shared
+
+import support.ToolSpecBase
+
+/**
+ * Spec for the consolidated hub HTTP client core (_hubRequest) that backs the
+ * six hubInternal* variants. PR2b folded six near-duplicate request bodies into
+ * one shared core; these features pin the behaviours that were either newly
+ * added or easy to regress in that consolidation:
+ *
+ *  - the Hub Security cookie is cached in atomicState (thread-safe) and a live
+ *    cache entry skips the /login round-trip while still attaching the cookie;
+ *  - an auth failure (HTTP 401/403, read duck-typed off the exception) clears
+ *    the cached cookie and retries the request exactly once with a fresh cookie;
+ *  - a non-auth failure (e.g. 500) is NOT retried;
+ *  - a persistent auth failure retries once and then propagates (no loop);
+ *  - a body-read failure mid-stream is re-thrown, never swallowed into a
+ *    Reader.toString() junk string that downstream code would treat as a body.
+ *
+ * Interception point: hubInternalPost is pure dynamic Groovy with no metaClass
+ * shadow in the harness (unlike hubInternalGet), so calling it runs the real
+ * _hubRequest down to appExecutor.httpPost — intercepted here via the same
+ * setupSpec-dispatcher pattern ToolRoomsSpec documents. The dispatcher routes
+ * /login (cookie auth) and the app path (the request under test) by params.path.
+ */
+class HubInternalRetrySpec extends ToolSpecBase {
+
+    @Shared Closure httpPostHandler = null
+    @Shared Closure httpGetHandler = null
+
+    def setupSpec() {
+        appExecutor.httpPost(_, _) >> { args ->
+            if (httpPostHandler) {
+                httpPostHandler.call(args[0], args[1])
+            }
+        }
+        appExecutor.httpGet(_, _) >> { args ->
+            if (httpGetHandler) {
+                httpGetHandler.call(args[0], args[1])
+            }
+        }
+    }
+
+    def cleanup() {
+        httpPostHandler = null
+        httpGetHandler = null
+    }
+
+    /** Enable Hub Security with credentials so the cookie path is live. */
+    private void enableHubSecurity() {
+        settingsMap.hubSecurityEnabled = true
+        settingsMap.hubSecurityUser = 'admin'
+        settingsMap.hubSecurityPassword = 'secret'
+    }
+
+    /** Seed a live (unexpired) cached cookie so getHubSecurityCookie skips /login. */
+    private void seedCachedCookie(String value = 'JSESSIONID=cached') {
+        atomicStateMap.hubSecurityCookie = value
+        atomicStateMap.hubSecurityCookieExpiry = 1234567890000L + 60_000  // now() is fixed at 1234567890000L
+    }
+
+    /** An exception that carries an HTTP status the way HttpResponseException does (duck-typed). */
+    private static class FakeHttpException extends RuntimeException {
+        final def response
+        FakeHttpException(int status) {
+            super("HTTP ${status}")
+            this.response = [status: status]
+        }
+        // For the 3xx redirect path: also expose a Location header, which
+        // _hubRequest's handle3xx branch reads via resp.headers?."Location".
+        FakeHttpException(int status, String location) {
+            super("HTTP ${status}")
+            this.response = [status: status, headers: ['Location': location]]
+        }
+    }
+
+    /** An exception with NO parseable .response.status -- only a message carrying the auth signal. */
+    private static class FakeBareException extends RuntimeException {
+        FakeBareException(String msg) { super(msg) }
+    }
+
+    /** A Reader whose read() always fails, emulating a socket reset mid-body. */
+    private Reader failingReader(String msg) {
+        return new Reader() {
+            int read(char[] cbuf, int off, int len) throws IOException { throw new IOException(msg) }
+            void close() throws IOException {}
+        }
+    }
+
+    def "a live cached cookie is reused without a /login round-trip and is attached to the request"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and: 'record every POST by path so we can prove /login was never called'
+        def loginCalls = 0
+        def appCallHeaders = null
+        httpPostHandler = { Map params, Closure cb ->
+            if (params.path == '/login') {
+                loginCalls++
+                cb.call([headers: ['Set-Cookie': 'JSESSIONID=should-not-be-used; Path=/']])
+            } else {
+                appCallHeaders = params.headers
+                cb.call([status: 200, data: 'OK'])
+            }
+        }
+
+        when:
+        def result = script.hubInternalPost('/foo', [a: 1])
+
+        then: 'cached cookie short-circuits auth and is sent on the request'
+        result == 'OK'
+        loginCalls == 0
+        appCallHeaders?.Cookie == 'JSESSIONID=cached'
+    }
+
+    def "a 401 clears the cached cookie, re-authenticates, and retries once successfully"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=stale')
+
+        and: 'first app POST 401s; /login mints a fresh cookie; the retry succeeds'
+        def appCalls = 0
+        def loginCalls = 0
+        def retryHeaders = null
+        httpPostHandler = { Map params, Closure cb ->
+            if (params.path == '/login') {
+                loginCalls++
+                cb.call([headers: ['Set-Cookie': 'JSESSIONID=fresh; Path=/']])
+            } else {
+                appCalls++
+                if (appCalls == 1) {
+                    throw new FakeHttpException(401)
+                }
+                retryHeaders = params.headers
+                cb.call([status: 200, data: 'RETRIED-OK'])
+            }
+        }
+
+        when:
+        def result = script.hubInternalPost('/foo', [a: 1])
+
+        then: 'the request was retried once with a freshly-minted cookie'
+        result == 'RETRIED-OK'
+        appCalls == 2
+        loginCalls == 1
+        retryHeaders?.Cookie == 'JSESSIONID=fresh'
+
+        and: 'the refreshed cookie is what is now cached'
+        atomicStateMap.hubSecurityCookie == 'JSESSIONID=fresh'
+    }
+
+    def "a non-auth failure (500) is not retried"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and:
+        def appCalls = 0
+        httpPostHandler = { Map params, Closure cb ->
+            if (params.path == '/login') {
+                cb.call([headers: ['Set-Cookie': 'JSESSIONID=fresh; Path=/']])
+            } else {
+                appCalls++
+                throw new FakeHttpException(500)
+            }
+        }
+
+        when:
+        script.hubInternalPost('/foo', [a: 1])
+
+        then: 'the 500 propagates after a single attempt; the cached cookie is left intact'
+        def ex = thrown(Exception)
+        ex.message.contains('500')
+        appCalls == 1
+        atomicStateMap.hubSecurityCookie == 'JSESSIONID=cached'
+    }
+
+    def "a persistent 401 retries exactly once and then propagates (no infinite loop)"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=stale')
+
+        and: 'every app POST 401s, even after re-auth'
+        def appCalls = 0
+        def loginCalls = 0
+        httpPostHandler = { Map params, Closure cb ->
+            if (params.path == '/login') {
+                loginCalls++
+                cb.call([headers: ['Set-Cookie': 'JSESSIONID=fresh; Path=/']])
+            } else {
+                appCalls++
+                throw new FakeHttpException(401)
+            }
+        }
+
+        when:
+        script.hubInternalPost('/foo', [a: 1])
+
+        then: 'original attempt + exactly one retry, then the 401 surfaces'
+        thrown(Exception)
+        appCalls == 2
+        loginCalls == 1
+    }
+
+    def "a mid-stream body read failure is re-thrown, not swallowed into a junk string"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and: 'the POST itself succeeds but reading the response body fails'
+        httpPostHandler = { Map params, Closure cb ->
+            cb.call([status: 200, data: failingReader('simulated socket reset')])
+        }
+
+        when:
+        script.hubInternalPost('/foo', [a: 1])
+
+        then: 'the read error propagates rather than returning a Reader.toString() junk body'
+        def ex = thrown(IOException)
+        ex.message == 'simulated socket reset'
+    }
+
+    // ---- struct returnShape (form/raw/getRaw) + handle3xx + GET path: real _hubRequest ----
+
+    def "hubInternalPostForm returns a {status,location,data} struct on a 2xx success"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and: 'the hub returns a normal 2xx with a body'
+        def sentHeaders = null
+        httpPostHandler = { Map params, Closure cb ->
+            sentHeaders = params.headers
+            cb.call([status: 200, headers: ['Location': null], data: 'BODY'])
+        }
+
+        when:
+        def resp = script.hubInternalPostForm('/foo', [a: 1])
+
+        then: 'the struct shape carries status + body, with the cached cookie attached'
+        resp instanceof Map
+        resp.status == 200
+        resp.data == 'BODY'
+        resp.containsKey('location')
+        sentHeaders?.Cookie == 'JSESSIONID=cached'
+    }
+
+    def "hubInternalGetRaw on a 302 extracts the Location header into the struct (handle3xx)"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and: 'followRedirects:false makes HTTPBuilder throw on the 302; the exception carries the Location'
+        def sawFollowRedirects = null
+        httpGetHandler = { Map params, Closure cb ->
+            sawFollowRedirects = params.followRedirects
+            throw new FakeHttpException(302, '/installedapp/configure/9999/mainPage')
+        }
+
+        when:
+        def resp = script.hubInternalGetRaw('/installedapp/create/310')
+
+        then: 'the 302 is treated as success and the new-child Location is surfaced'
+        sawFollowRedirects == false
+        resp.status == 302
+        resp.location == '/installedapp/configure/9999/mainPage'
+    }
+
+    def "hubInternalGetRaw on a 404 (outside the 3xx window) propagates rather than returning a struct"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and:
+        httpGetHandler = { Map params, Closure cb -> throw new FakeHttpException(404) }
+
+        when:
+        script.hubInternalGetRaw('/installedapp/create/310')
+
+        then: 'a 404 is not mistaken for a redirect success -- it propagates'
+        thrown(Exception)
+    }
+
+    def "the GET branch of _hubRequest attaches the cached cookie and returns the body text"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and: 'capture the request headers on a GET (hubInternalGet is metaClass-shadowed by HarnessSpec, so drive _hubRequest directly)'
+        def sentHeaders = null
+        httpGetHandler = { Map params, Closure cb ->
+            sentHeaders = params.headers
+            cb.call([status: 200, data: 'GETBODY'])
+        }
+
+        when:
+        def body = script._hubRequest('GET', '/bar', [returnShape: 'text'])
+
+        then:
+        body == 'GETBODY'
+        sentHeaders?.Cookie == 'JSESSIONID=cached'
+    }
+
+    def "a struct (form) caller treats a committed 2xx with an unreadable body as success (status + null data), not a failure"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and: 'the POST commits (2xx) but the response body cannot be read'
+        httpPostHandler = { Map params, Closure cb ->
+            cb.call([status: 200, data: failingReader('body unreadable')])
+        }
+
+        when:
+        def resp = script.hubInternalPostForm('/foo', [a: 1])
+
+        then: 'no throw: status-only callers (e.g. _rmClickAppButton) see the committed 2xx with null data'
+        noExceptionThrown()
+        resp.status == 200
+        resp.data == null
+    }
+
+    // ---- status-less message-substring auth detection (shouldRetryWithFreshCookie fallback) ----
+
+    def "a status-less 401 detected only via the exception message clears the cookie and retries once"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=stale')
+
+        and: 'first app POST throws an exception with NO .response.status; message contains "Unauthorized"'
+        def appCalls = 0
+        def loginCalls = 0
+        def retryHeaders = null
+        httpPostHandler = { Map params, Closure cb ->
+            if (params.path == '/login') {
+                loginCalls++
+                cb.call([headers: ['Set-Cookie': 'JSESSIONID=fresh; Path=/']])
+            } else {
+                appCalls++
+                if (appCalls == 1) throw new FakeBareException('server returned: Unauthorized')
+                retryHeaders = params.headers
+                cb.call([status: 200, data: 'RETRIED-OK'])
+            }
+        }
+
+        when:
+        def result = script.hubInternalPost('/foo', [a: 1])
+
+        then: 'the message-substring fallback drove a single cookie-refresh retry'
+        result == 'RETRIED-OK'
+        appCalls == 2
+        loginCalls == 1
+        retryHeaders?.Cookie == 'JSESSIONID=fresh'
+    }
+
+    def "a status-less non-auth error (message lacks 401/403/Unauthorized) does NOT retry"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and:
+        def appCalls = 0
+        def loginCalls = 0
+        httpPostHandler = { Map params, Closure cb ->
+            if (params.path == '/login') { loginCalls++; cb.call([headers: ['Set-Cookie': 'JSESSIONID=fresh; Path=/']]) }
+            else { appCalls++; throw new FakeBareException('Connection reset by peer') }
+        }
+
+        when:
+        script.hubInternalPost('/foo', [a: 1])
+
+        then: 'a non-auth status-less error propagates after one attempt, cookie untouched'
+        thrown(Exception)
+        appCalls == 1
+        loginCalls == 0
+        atomicStateMap.hubSecurityCookie == 'JSESSIONID=cached'
+    }
+}

--- a/src/test/groovy/server/McpToolAnnotationsSpec.groovy
+++ b/src/test/groovy/server/McpToolAnnotationsSpec.groovy
@@ -428,4 +428,45 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         flatInfo != null
         flatInfo.containsKey('outputSchema') == false
     }
+
+    def "getAllToolDefinitions() returns a FRESH list each call -- mutating one return must not leak to the next"() {
+        // Pins the clean-copy invariant: applyDescriptionTransform mutates descriptions
+        // in place, so getAllToolDefinitions() MUST hand back fresh Map literals every
+        // call. A future naive memo that cached and returned the literal list would let
+        // one consumer's in-place edit poison the next caller -- this trips loudly then.
+        when: 'first call, then mutate the returned hub_list_devices description'
+        def first = script.getAllToolDefinitions()
+        def firstDev = first.find { it.name == 'hub_list_devices' }
+        firstDev.description = 'MUTATED-BY-TEST'
+
+        and: 'second call'
+        def second = script.getAllToolDefinitions()
+        def secondDev = second.find { it.name == 'hub_list_devices' }
+
+        then: 'the mutation did not leak into the fresh copy'
+        secondDev.description != 'MUTATED-BY-TEST'
+        secondDev.description.contains('List all devices')
+    }
+
+    def "flat-mode in-place FLAT_TRIM strip does not leak into a subsequent getAllToolDefinitions() call"() {
+        // getToolDefinitions(useGateways=false) strips the [[FLAT_TRIM]] block IN PLACE on
+        // its fresh maps. Because each getAllToolDefinitions() rebuilds, the next caller
+        // must still see the un-stripped FLAT_TRIM content. hub_list_devices carries one.
+        given:
+        settingsMap.useGateways = false
+
+        when: 'run the flat-mode strip path (mutates its own fresh copy in place)'
+        def flat = script.getToolDefinitions()
+        def flatDev = flat.find { it.name == 'hub_list_devices' }
+
+        and: 'a fresh full-definition call afterwards'
+        def freshDev = script.getAllToolDefinitions().find { it.name == 'hub_list_devices' }
+
+        then: 'flat copy had the FLAT_TRIM markers removed'
+        !flatDev.description.contains('[[FLAT_TRIM]]')
+
+        and: 'the fresh copy still carries the original FLAT_TRIM markers + wrapped content'
+        freshDev.description.contains('[[FLAT_TRIM]]')
+        freshDev.description.contains('Summary mode returns currentStates')
+    }
 }

--- a/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/ToolManageDiagnosticsSpec.groovy
@@ -1483,6 +1483,21 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         result.warning.contains('7/10')
     }
 
+    def "hub_list_captured_states formats a missing/zero timestamp as 'Never' via formatTimestamp"() {
+        given: 'one entry with no timestamp and one with a zero timestamp'
+        atomicStateMap.capturedDeviceStates = [
+            no_ts:   [devices: [], deviceCount: 0],
+            zero_ts: [devices: [], timestamp: 0L, deviceCount: 0]
+        ]
+
+        when:
+        def result = script.toolListCapturedStates()
+
+        then: 'both render capturedAt via the shared formatTimestamp null-label, not "unknown" and not a throw'
+        result.capturedStates.every { it.capturedAt == 'Never' }
+        noExceptionThrown()
+    }
+
     // -------- toolDeleteCapturedState --------
 
     def "hub_delete_captured_state with no stateId clears ALL captured states (no-ID = delete all)"() {
@@ -1606,5 +1621,58 @@ class ToolManageDiagnosticsSpec extends ToolSpecBase {
         then:
         result.success == true
         result.cleared == 0
+    }
+
+    // -------- mcpLog unknown-level fail-open (log-unknown-level-silent-drop) --------
+
+    def "mcpLog fails open on an unknown level and retains the entry instead of silently dropping it"() {
+        given: 'threshold error (default) and an empty buffer'
+        settingsMap.mcpLogLevel = 'error'
+        stateMap.debugLogs = [entries: [], config: [logLevel: 'error', maxEntries: 100]]
+
+        when: 'a typo level is logged (would normally be below the error threshold)'
+        script.mcpLog('warning', 'server', 'typo')
+
+        then: 'unknown level is not silently dropped -- it fails open and is retained'
+        stateMap.debugLogs.entries.size() == 1
+        stateMap.debugLogs.entries[-1].level == 'warning'
+        stateMap.debugLogs.entries[-1].message == 'typo'
+    }
+
+    // -------- mcpLogError structured stackTrace capture (log-mcplogerror-low-adoption) --------
+
+    def "converted perf-stats error site captures a structured stackTrace via mcpLogError"() {
+        given: 'logLevel=debug so the error entry is retained, and the hub fetch throws'
+        settingsMap.mcpLogLevel = 'debug'
+        stateMap.debugLogs = [entries: [], config: [logLevel: 'debug', maxEntries: 100]]
+        script.metaClass.fetchLogsJson = { -> throw new IllegalStateException('boom-perf') }
+
+        when:
+        def result = script.toolGetPerformanceStats([:])
+
+        then: 'the tool returns its structured error map'
+        result.error?.contains('boom-perf')
+
+        and: 'the newest debug-log entry carries a class-qualified stackTrace from mcpLogError'
+        def entry = stateMap.debugLogs.entries[-1]
+        entry.level == 'error'
+        entry.component == 'monitoring'
+        entry.stackTrace == 'java.lang.IllegalStateException: boom-perf'
+    }
+
+    def "converted hub-jobs error site captures a structured stackTrace via mcpLogError"() {
+        given:
+        settingsMap.mcpLogLevel = 'debug'
+        stateMap.debugLogs = [entries: [], config: [logLevel: 'debug', maxEntries: 100]]
+        script.metaClass.fetchLogsJson = { -> throw new RuntimeException('boom-jobs') }
+
+        when:
+        def result = script.toolGetHubJobs([:])
+
+        then:
+        result.error?.contains('boom-jobs')
+        def entry = stateMap.debugLogs.entries[-1]
+        entry.component == 'monitoring'
+        entry.stackTrace == 'java.lang.RuntimeException: boom-jobs'
     }
 }

--- a/src/test/groovy/server/ToolManageLogsSpec.groovy
+++ b/src/test/groovy/server/ToolManageLogsSpec.groovy
@@ -825,6 +825,36 @@ class ToolManageLogsSpec extends ToolSpecBase {
         result.totalStored == 10
     }
 
+    // -------- mcpLog per-entry payload cap (Q6-reserialize) --------
+
+    def "mcpLog caps stored message at 500 chars and stackTrace at 1000"() {
+        given: 'logLevel=debug so an error entry is retained, and an oversized payload'
+        settingsMap.mcpLogLevel = 'debug'
+        stateMap.debugLogs = [entries: [], config: [logLevel: 'debug', maxEntries: 100]]
+
+        when:
+        script.mcpLog('error', 'server', 'x' * 2000, null, [stackTrace: 'z' * 5000])
+
+        then: 'the stored entry is bounded at store time'
+        def stored = stateMap.debugLogs.entries[-1]
+        stored.message.length() == 500
+        stored.stackTrace.length() == 1000
+    }
+
+    def "mcpLog leaves a short message and absent stackTrace untouched"() {
+        given:
+        settingsMap.mcpLogLevel = 'debug'
+        stateMap.debugLogs = [entries: [], config: [logLevel: 'debug', maxEntries: 100]]
+
+        when:
+        script.mcpLog('error', 'server', 'short message')
+
+        then:
+        def stored = stateMap.debugLogs.entries[-1]
+        stored.message == 'short message'
+        !stored.containsKey('stackTrace')
+    }
+
     // -------- toolClearDebugLogs --------
 
     def "hub_delete_debug_logs empties state.debugLogs.entries and reports count"() {

--- a/src/test/groovy/server/ToolPollUntilAttributeSpec.groovy
+++ b/src/test/groovy/server/ToolPollUntilAttributeSpec.groovy
@@ -1218,7 +1218,7 @@ class ToolPollUntilAttributeSpec extends ToolSpecBase {
 
         // mcpLog is a script-defined method (bucket 1 -- purely dynamic; not on
         // AppExecutor/BaseExecutor). Per-instance metaClass overrides intercept
-        // cleanly. The production code calls mcpLog("warn", "device-tools", ...)
+        // cleanly. The production code calls mcpLog("warn", "device", ...)
         // in the interrupt catch block.
         def mcpLogCalls = []
         script.metaClass.mcpLog = { String level, String component, String msg ->
@@ -1242,7 +1242,7 @@ class ToolPollUntilAttributeSpec extends ToolSpecBase {
         result.success     == false
         result.interrupted == true
         // A warn was emitted via mcpLog naming the poll count and component
-        mcpLogCalls.any { it.level == 'warn' && it.component == 'device-tools' &&
+        mcpLogCalls.any { it.level == 'warn' && it.component == 'device' &&
                           it.msg ==~ /poll_until_attribute interrupted after \d+ poll\(s\).*/ }
     }
 

--- a/src/test/groovy/server/ToolSearchToolsSpec.groovy
+++ b/src/test/groovy/server/ToolSearchToolsSpec.groovy
@@ -61,25 +61,45 @@ class ToolSearchToolsSpec extends ToolSpecBase {
         second.results == first.results
     }
 
-    def "a toggle flip re-filters visibility per-request without rebuilding the shared full-corpus token cache"() {
-        given: 'cache built over the full corpus with both engines on'
+    def "a toggle flip hides the right tools per-request without rebuilding the shared full-corpus token cache"() {
+        given: 'a clean cache with the custom rule engine ON'
         searchEnabled()
         atomicStateMap.remove('toolSearchCorpus')
         atomicStateMap.remove('toolSearchTokens')
-        script.toolSearchTools([query: 'rule create delete', maxResults: 20])
+
+        when: 'search with the engine ON'
+        def onResult = script.toolSearchTools([query: 'custom rule create delete clone', maxResults: 25])
         def fullSize = atomicStateMap.toolSearchTokens.size()
 
-        when: 'flip a visibility toggle WITHOUT clearing the cache, then search again'
-        settingsMap.enableCustomRuleEngine = false
-        def offResult = script.toolSearchTools([query: 'rule create delete', maxResults: 20])
+        then: 'a custom_* tool is visible'
+        onResult.results*.tool.contains('hub_create_custom_rule')
 
-        then: 'the full-corpus token cache is untouched by the toggle (filtering is per-request, not a rebuild)'
+        when: 'flip the engine OFF WITHOUT clearing the cache, then search again'
+        settingsMap.enableCustomRuleEngine = false
+        def offResult = script.toolSearchTools([query: 'custom rule create delete clone', maxResults: 25])
+
+        then: 'the custom_* tool is now hidden (per-request visibility filter, NOT a cache rebuild)'
+        !offResult.results*.tool.contains('hub_create_custom_rule')
+
+        and: 'the full-corpus token cache is untouched by the toggle'
         atomicStateMap.toolSearchTokens.size() == fullSize
         atomicStateMap.toolSearchTokens.size() == atomicStateMap.toolSearchCorpus.size()
 
-        and: 'the search still returns a well-formed result set under the new toggle state'
-        offResult.results instanceof List
+        and: 'results remain well-formed (deduped)'
         offResult.results*.tool == offResult.results*.tool.unique()
+    }
+
+    def "a query semantically anchors to the right corpus entry (proves token<->corpus alignment)"() {
+        given:
+        searchEnabled()
+
+        when: 'a query whose strongest matches are the room tools'
+        def result = script.toolSearchTools([query: 'room rooms list', maxResults: 8])
+
+        then: 'a room tool surfaces with positive relevance -- the score is tied to the right corpus entry'
+        def roomHit = result.results.find { it.tool.contains('room') }
+        roomHit != null
+        roomHit.relevance > 0
     }
 
     def "updated() invalidates both BM25 atomicState entries and the gateway requiredParams memo in lockstep"() {

--- a/src/test/groovy/server/ToolSearchToolsSpec.groovy
+++ b/src/test/groovy/server/ToolSearchToolsSpec.groovy
@@ -1,0 +1,103 @@
+package server
+
+import support.ToolSpecBase
+
+/**
+ * Direct-call coverage for the BM25 hub_search_tools path after the PR2c perf change
+ * (bm25-corpus-state-not-atomicstate + bm25-df-table-rebuild-Q15): the corpus and the
+ * per-doc tokenization are cached in atomicState (index-aligned to the FULL corpus) and
+ * served from cache; df/avgDl are recomputed over the visible subset so ranking stays
+ * byte-identical. These pin: a stable ranked shape, cache-hit (no rebuild), per-request
+ * visibility filtering over the shared full-corpus token cache, and updated() invalidation
+ * of both BM25 entries (and the gateway requiredParams memo) in lockstep.
+ */
+class ToolSearchToolsSpec extends ToolSpecBase {
+
+    private void searchEnabled() {
+        settingsMap.useGateways = true
+        settingsMap.enableBuiltinApp = true
+        settingsMap.enableCustomRuleEngine = true
+    }
+
+    def "search_tools returns a well-formed ranked result list (sorted descending, deduped)"() {
+        given:
+        searchEnabled()
+
+        when:
+        def result = script.toolSearchTools([query: 'switch motion contact', maxResults: 5])
+
+        then: 'non-empty, bounded, deduped by tool name, sorted by descending relevance'
+        result.results.size() > 0
+        result.results.size() <= 5
+        def names = result.results*.tool
+        names == names.unique()
+        def rel = result.results*.relevance
+        rel == rel.sort { -it }
+    }
+
+    def "the corpus + tokens are built once into atomicState and a second identical query is served from cache"() {
+        given:
+        searchEnabled()
+        atomicStateMap.remove('toolSearchCorpus')
+        atomicStateMap.remove('toolSearchTokens')
+
+        when: 'first query builds and caches the corpus + tokens'
+        def first = script.toolSearchTools([query: 'switch motion contact', maxResults: 5])
+        def cachedCorpus = atomicStateMap.toolSearchCorpus
+        def cachedTokens = atomicStateMap.toolSearchTokens
+
+        then: 'both are populated in atomicState (not state), index-aligned to the full corpus'
+        cachedCorpus != null
+        cachedTokens != null
+        cachedTokens.size() == cachedCorpus.size()
+        !stateMap.containsKey('toolSearchCorpus')
+
+        when: 'a second identical query'
+        def second = script.toolSearchTools([query: 'switch motion contact', maxResults: 5])
+
+        then: 'the cache was NOT rebuilt (same object) and results are identical'
+        atomicStateMap.toolSearchCorpus.is(cachedCorpus)
+        atomicStateMap.toolSearchTokens.is(cachedTokens)
+        second.results == first.results
+    }
+
+    def "a toggle flip re-filters visibility per-request without rebuilding the shared full-corpus token cache"() {
+        given: 'cache built over the full corpus with both engines on'
+        searchEnabled()
+        atomicStateMap.remove('toolSearchCorpus')
+        atomicStateMap.remove('toolSearchTokens')
+        script.toolSearchTools([query: 'rule create delete', maxResults: 20])
+        def fullSize = atomicStateMap.toolSearchTokens.size()
+
+        when: 'flip a visibility toggle WITHOUT clearing the cache, then search again'
+        settingsMap.enableCustomRuleEngine = false
+        def offResult = script.toolSearchTools([query: 'rule create delete', maxResults: 20])
+
+        then: 'the full-corpus token cache is untouched by the toggle (filtering is per-request, not a rebuild)'
+        atomicStateMap.toolSearchTokens.size() == fullSize
+        atomicStateMap.toolSearchTokens.size() == atomicStateMap.toolSearchCorpus.size()
+
+        and: 'the search still returns a well-formed result set under the new toggle state'
+        offResult.results instanceof List
+        offResult.results*.tool == offResult.results*.tool.unique()
+    }
+
+    def "updated() invalidates both BM25 atomicState entries and the gateway requiredParams memo in lockstep"() {
+        given: 'populated caches and a no-op initialize so updated() does not hit platform APIs'
+        atomicStateMap.toolSearchCorpus = [[name: 'x', description: 'd']]
+        atomicStateMap.toolSearchTokens = [['x']]
+        atomicStateMap.requiredParamsByTool = [hub_get_room: ['room']]
+        script.metaClass.initialize = { -> }
+
+        when:
+        script.updated()
+
+        then: 'all three derived caches are cleared (rebuilt lazily on next use)'
+        atomicStateMap.toolSearchCorpus == null
+        atomicStateMap.toolSearchTokens == null
+        atomicStateMap.requiredParamsByTool == null
+
+        and: 'the legacy state entry is never reintroduced'
+        !stateMap.containsKey('toolSearchCorpus')
+    }
+}

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -170,12 +170,41 @@ class HubitatMcpClient:
 
     # -- MCP protocol methods ------------------------------------------------
 
-    def initialize(self) -> dict:
+    def initialize(self, protocol_version: str = "2024-11-05") -> dict:
         return self._send("initialize", {
-            "protocolVersion": "2024-11-05",
+            "protocolVersion": protocol_version,
             "capabilities": {},
             "clientInfo": {"name": "e2e-test", "version": "1.0.0"},
         })
+
+    def raw_request(self, payload: Any) -> "requests.Response":
+        """POST a raw JSON-RPC body (single object, batch array, or notification)
+        and return the raw requests.Response — no result-unwrapping, no
+        error-raising. Retries transient 5xx/network flake like _send. Used by
+        transport/protocol tests that must inspect the raw HTTP status and
+        envelope (batch caps, 202-for-notifications, JSON-RPC framing) — paths
+        the result-unwrapping call_tool/_send helpers deliberately hide.
+        """
+        time.sleep(0.2)
+        last_exc: Optional[Exception] = None
+        for attempt in range(3):
+            try:
+                resp = requests.post(
+                    self.endpoint,
+                    params={"access_token": self.access_token},
+                    json=payload,
+                    timeout=60,
+                )
+                if 500 <= resp.status_code < 600:
+                    last_exc = requests.HTTPError(f"{resp.status_code} {resp.reason} on raw_request")
+                    time.sleep((2 ** attempt) + random.uniform(0, 1))
+                    continue
+                return resp
+            except (requests.ConnectionError, requests.Timeout,
+                    requests.exceptions.ChunkedEncodingError) as exc:
+                last_exc = exc
+                time.sleep((2 ** attempt) + random.uniform(0, 1))
+        raise last_exc if last_exc else McpError("transport failure on raw_request")
 
     def list_tools(self) -> dict:
         """Fetch the full tool catalog, iterating cursor-based pagination per MCP 2024-11-05.
@@ -283,7 +312,7 @@ class TestRunner:
 
         # Check if one already exists from a previous test group
         try:
-            vdevs = self.client.call_tool("list_virtual_devices")
+            vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
             dev_list = vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])
             for d in dev_list:
                 lbl = d.get("label") or d.get("name") or ""
@@ -308,7 +337,7 @@ class TestRunner:
         # Response may not include ID directly — look it up
         if not dev_id:
             time.sleep(0.3)
-            vdevs = self.client.call_tool("list_virtual_devices")
+            vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
             dev_list = vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])
             for d in dev_list:
                 lbl = d.get("label") or d.get("name") or ""
@@ -380,7 +409,7 @@ class TestRunner:
                          value: str = "test") -> None:
         """Create a hub variable via the gateway."""
         self.client.call_tool("hub_manage_variables", {
-            "tool": "set_variable", "args": {"name": name, "type": var_type, "value": value},
+            "tool": "hub_set_variable", "args": {"name": name, "type": var_type, "value": value},
         })
         self.created_variable_names.append(name)
 
@@ -498,13 +527,13 @@ class TestRunner:
             "confirm": True,
         })
         # Response may be {success: true, message: "..."} without device IDs at top level
-        # Track DNI if available, otherwise look it up from list_virtual_devices
+        # Track DNI if available, otherwise look it up via hub_list_devices (labelFilter)
         dni = result.get("deviceNetworkId", result.get("dni", ""))
         if dni:
             self.created_device_dnis.append(str(dni))
         elif result.get("success"):
             # Look up the created device to get its DNI for cleanup
-            vdevs = self.client.call_tool("list_virtual_devices")
+            vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
             dev_list = vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])
             for d in dev_list:
                 lbl = d.get("label") or d.get("name") or ""
@@ -518,8 +547,8 @@ class TestRunner:
 
     @test("virtual_device_lifecycle")
     def test_command_virtual_switch(self) -> None:
-        # Find the device we just created via list_virtual_devices (core tool)
-        vdevs = self.client.call_tool("list_virtual_devices")
+        # Find the device we just created via hub_list_devices (core tool)
+        vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
         dev_list = vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])
         target = None
         for d in dev_list:
@@ -550,7 +579,7 @@ class TestRunner:
 
     @test("virtual_device_lifecycle")
     def test_list_virtual_devices(self) -> None:
-        result = self.client.call_tool("list_virtual_devices")
+        result = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
         dev_list = result if isinstance(result, list) else result.get("devices", [])
         found = any(
             f"{PREFIX}Switch_Test" in (d.get("label") or d.get("name") or "")
@@ -561,7 +590,7 @@ class TestRunner:
     @test("virtual_device_lifecycle")
     def test_delete_virtual_switch(self) -> None:
         # Find DNI of our test device
-        vdevs = self.client.call_tool("list_virtual_devices")
+        vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
         dev_list = vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])
         target_dni = None
         for d in dev_list:
@@ -581,7 +610,7 @@ class TestRunner:
             self.created_device_dnis.remove(target_dni)
 
         # Verify it is gone
-        vdevs2 = self.client.call_tool("list_virtual_devices")
+        vdevs2 = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
         dev_list2 = vdevs2 if isinstance(vdevs2, list) else vdevs2.get("devices", [])
         still_there = any(
             f"{PREFIX}Switch_Test" in (d.get("label") or d.get("name") or "")
@@ -1173,7 +1202,7 @@ class TestRunner:
         var_name = f"{PREFIX}DELETE_T224"
         # Setup
         self.client.call_tool("hub_manage_variables", {
-            "tool": "set_variable",
+            "tool": "hub_set_variable",
             "args": {"name": var_name, "value": "scratch-t224"},
         })
         # Track for cleanup in case assertion fails partway
@@ -1226,7 +1255,7 @@ class TestRunner:
         """
         var_name = f"{PREFIX}NO_CONFIRM_T226"
         self.client.call_tool("hub_manage_variables", {
-            "tool": "set_variable",
+            "tool": "hub_set_variable",
             "args": {"name": var_name, "value": "safe"},
         })
         self.created_variable_names.append(var_name)
@@ -1299,7 +1328,7 @@ class TestRunner:
             assert "boolean" in msg.lower(), f"error didn't say boolean: {msg}"
 
     # -----------------------------------------------------------------------
-    # GROUP 11: poll_until_attribute (2 tests -- wall-clock coverage, I7)
+    # GROUP 11: hub_get_device_attribute poll mode (2 tests -- wall-clock coverage, I7)
     # These exercise the real pauseExecution + now() path that Spock unit tests
     # cannot reach because the test harness fixes now() to a constant.
     # -----------------------------------------------------------------------
@@ -1313,7 +1342,7 @@ class TestRunner:
         self.client.call_tool("hub_call_device_command", {"deviceId": dev_id, "command": "off"})
         time.sleep(0.3)
 
-        result = self.client.call_tool("poll_until_attribute", {
+        result = self.client.call_tool("hub_get_device_attribute", {
             "deviceId": dev_id,
             "attribute": "switch",
             "expectedValue": "off",
@@ -1333,7 +1362,7 @@ class TestRunner:
 
         import time as _time
         t0 = _time.monotonic()
-        result = self.client.call_tool("poll_until_attribute", {
+        result = self.client.call_tool("hub_get_device_attribute", {
             "deviceId": dev_id,
             "attribute": "switch",
             "expectedValue": "on",
@@ -1378,6 +1407,69 @@ class TestRunner:
                     # Soft check: warn but don't fail
         except Exception as exc:
             print(f"    [WARN] Could not check hub logs: {exc}")
+
+    # -----------------------------------------------------------------------
+    # GROUP 13: protocol (6 tests — initialize echo-allowlist, instructions,
+    # inbound batch cap, and 202-for-notifications. These exercise the
+    # transport/protocol layer end-to-end through the cloud relay, which the
+    # Spock harness (in-process dispatch) cannot reach.)
+    # -----------------------------------------------------------------------
+
+    @test("protocol")
+    def test_initialize_echoes_supported_protocol(self) -> None:
+        """Echo-allowlist: a supported protocolVersion is echoed back verbatim."""
+        result = self.client.initialize("2025-06-18")
+        assert result.get("protocolVersion") == "2025-06-18", \
+            f"Expected echoed 2025-06-18, got: {result.get('protocolVersion')}"
+
+    @test("protocol")
+    def test_initialize_echoes_alt_supported_protocol(self) -> None:
+        """A second supported version (2025-03-26) is also echoed — proves the
+        allowlist isn't hardcoded to a single value."""
+        result = self.client.initialize("2025-03-26")
+        assert result.get("protocolVersion") == "2025-03-26", \
+            f"Expected echoed 2025-03-26, got: {result.get('protocolVersion')}"
+
+    @test("protocol")
+    def test_initialize_falls_back_on_unsupported_protocol(self) -> None:
+        """An unsupported protocolVersion falls back to the server default
+        (2024-11-05) rather than erroring."""
+        result = self.client.initialize("1999-01-01")
+        assert result.get("protocolVersion") == "2024-11-05", \
+            f"Expected fallback 2024-11-05, got: {result.get('protocolVersion')}"
+
+    @test("protocol")
+    def test_initialize_returns_instructions(self) -> None:
+        """initialize advertises a non-empty instructions string (gateway +
+        pagination usage hint) so MCP clients can surface server guidance."""
+        result = self.client.initialize()
+        instructions = result.get("instructions")
+        assert isinstance(instructions, str) and instructions.strip(), \
+            f"Expected non-empty instructions string, got: {instructions!r}"
+
+    @test("protocol")
+    def test_batch_too_large_rejected(self) -> None:
+        """A JSON-RPC batch over the 50-element cap is rejected wholesale with a
+        single -32600 error before any element runs (inbound batch cap)."""
+        batch = [{"jsonrpc": "2.0", "id": i, "method": "tools/list"} for i in range(51)]
+        resp = self.client.raw_request(batch)
+        data = resp.json()
+        # A single error object, NOT an array — the cap trips before per-element dispatch.
+        assert isinstance(data, dict), f"Expected one error object, got {type(data).__name__}: {data}"
+        err = data.get("error", {})
+        assert err.get("code") == -32600, f"Expected -32600, got: {data}"
+        assert "batch too large" in err.get("message", ""), \
+            f"Expected 'batch too large' message, got: {err.get('message')!r}"
+
+    @test("protocol")
+    def test_notification_returns_202(self) -> None:
+        """An all-notifications POST (no id) returns HTTP 202 Accepted with an
+        empty body per MCP Streamable HTTP — replaces the prior 204, which some
+        clients/relays mishandle."""
+        resp = self.client.raw_request({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        assert resp.status_code == 202, \
+            f"Expected HTTP 202 for a notification, got {resp.status_code}: {resp.text[:200]!r}"
+        assert resp.text.strip() == "", f"Expected empty body for 202, got: {resp.text[:200]!r}"
 
     # -----------------------------------------------------------------------
     # Cleanup
@@ -1425,7 +1517,7 @@ class TestRunner:
 
         # Layer 2: sweep virtual devices with BAT_E2E_ prefix
         try:
-            vdevs = self.client.call_tool("list_virtual_devices")
+            vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
             dev_list = vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])
             for d in dev_list:
                 lbl = d.get("label") or d.get("name") or ""
@@ -1446,7 +1538,7 @@ class TestRunner:
 
         # Layer 3: sweep rules with BAT_E2E_ prefix
         try:
-            rules_result = self.client.call_tool("custom_list_rules")
+            rules_result = self.client.call_tool("hub_get_custom_rule")
             rules = rules_result if isinstance(rules_result, list) else rules_result.get("rules", [])
             for r in rules:
                 rname = r.get("name", "")


### PR DESCRIPTION
## Summary

- Lands **PR2b** (robustness / infrastructure hygiene) and **PR2c** (performance + in-file cleanup) from the issue #105 backend best-practices audit, in one PR.
- Hardens the internal HTTP client, logging, lifecycle, and JSON-RPC transport; removes dead code; adds per-request caches and a serialize-once fast path; adds on-demand access-token rotation.
- Wires the live-hub e2e suite onto the renamed `hub_` tool surface and adds protocol-layer e2e coverage; the `hub-e2e` CI job is green.
- The HTTP-client consolidation and dead-handler removal more than offset the additions, so the server shrinks overall (net −102 lines).

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

**HTTP client** — consolidate the six `hubInternal*` variants into one `_hubRequest` core (single base-URI, atomicState-cached Hub Security cookie, duck-typed 401/403 cookie-refresh retry, body read that re-throws a genuine mid-stream read failure instead of returning a junk string). Struct callers treat a committed 2xx with an unreadable body as success. Route the four room-write sites through `hubInternalPostJson` so they inherit the retry.

**Logging** — cap stored buffer payloads; fail open on an unknown level (+ default switch arm); `mcpLog` now appends the captured exception class+message to the native Hubitat log line, and ~43 error sites were converted to `mcpLogError` so they surface it; bound the inbound request-body debug log; fold synonym component tags.

**State / lifecycle** — `uninstalled()` removes tracked in-use vars + unsubscribes + unschedules; `initialize()` unschedules before re-scheduling; the immediate version check is gated to first install (failure paths stamp a sentinel so offline hubs stop re-checking every save).

**Protocol / transport** — GET returns a JSON-RPC `-32600` envelope; `/health` via `JsonOutput`; inbound batch cap (50); all-notifications POST returns `202`; `initialize` echo-allowlists the requested `protocolVersion` and carries an `instructions` field.

**Performance (2c)** — `hubResponseCapBytes()` single-sources the three size literals; `getGatewayConfig()` single-fetch; the gateway required-param map and BM25 corpus + token index cached in atomicState (ranking-neutral); serialize-once verbatim-passthrough on the single-message `tools/call` path.

**Cleanup (2c)** — remove the dead `toolGetHubDetails` / `toolGetHubHealth` handler bodies (their behaviour was folded into `hub_get_info` in an earlier PR; the handlers were never dispatched). `toolGetHubDetails`'s contract tests are redirected to `hub_get_info`; `toolGetHubHealth` had none.

**e2e / CI** — wire the live-hub e2e suite onto the `hub_`-prefixed tool surface: `tests/e2e_test.py` and the six `.github/scripts` deploy/lease/setup helpers now call `hub_list_devices` (label-scoped), `hub_get_device_attribute`, `hub_get_custom_rule`, `hub_set_variable`, etc. Add a `protocol` test group (6 tests) + a `raw_request` client helper covering the transport changes (protocol-version negotiation, `instructions`, the batch cap, 202-for-notifications) end-to-end through the cloud relay. Deploy via `hub_update_app` `importUrl` (issue #228) so the ~1.5MB source never crosses the cloud gateway, with a workflow step that computes + validates `PR_SOURCE_URL`; also fixed a lease-acquire rename miss that aborted runs as "lease stolen". `AGENTS.md`/`CLAUDE.md` now mandate e2e coverage for changes and bug fixes, not just new tools.

**Feature** — on-demand-only access-token rotation: a confirm-gated "Regenerate access token" button re-issues the token (changing the endpoint URL; the page warns to re-copy it). The token never rotates otherwise.

Part of #105. The monolith file-split remains deferred to #209.

## Release Notes

- More resilient hub communication: internal requests retry once on an expired Hub Security session, and a successful write whose response was unreadable is no longer mis-reported as a failure.
- Clearer diagnostics: error logs carry the exception type on the Hubitat Logs page, and unusual log levels are surfaced instead of silently dropped.
- Cleaner app lifecycle: removing the app cleans up its hub-variable registrations, subscriptions, and scheduled jobs; routine settings saves no longer re-check GitHub for updates.
- Standards-aligned MCP transport: protocol-version negotiation, a 202 response for notification-only requests, a JSON-RPC error for GET, and a guard against oversized request batches.
- Faster tool search and gateway dispatch on busy hubs (internal caching; results unchanged).
- New: a confirm-gated "Regenerate access token" button for rotating a possibly-compromised token on demand. Regenerating changes your MCP endpoint URL -- re-copy the new URL into your MCP client(s).

## Testing

- Full Spock suite green (`./gradlew test`, 3080 tests), incl. two new specs (`HubInternalRetrySpec`, `ToolSearchToolsSpec`) and coverage for every behaviour above.
- Live-hub **e2e job green** (CI `hub-e2e`): deploys PR source via `importUrl` and runs the full `tests/e2e_test.py` suite against a real hub, including the new `protocol` group (version negotiation/instructions, batch cap, 202-for-notifications).
- `python tests/sandbox_lint.py` passes.
- An adversarial multi-agent review of the diff surfaced 9 issues (test gaps + behaviour edges); all fixed and re-validated.
- Live-hub BAT testing to be run before merge.

## Checklist

- [x] Unit + e2e tests added (no new MCP tools; behaviour coverage added; two new specs; `protocol` e2e group)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms)
- [x] Live-hub e2e suite green (CI `hub-e2e`)
- [ ] Live-hub BAT tests -- to be run before merge (token-rotation + transport changes warrant a live-hub pass)
- [x] Documentation updated (`TOOL_GUIDE.md` byte-precision note; `AGENTS.md`/`CLAUDE.md` e2e mandate)
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (n/a -- no new tools)
