### PR TITLE
fix: PR2-legacy — child-app bug fixes + state hygiene (issue #105)

### DIFF
--- a/ci/groovy2x-spock/scaffold/rules/RuleHarnessSpec.groovy
+++ b/ci/groovy2x-spock/scaffold/rules/RuleHarnessSpec.groovy
@@ -88,6 +88,14 @@ abstract class RuleHarnessSpec extends Specification {
 
     Object getParent() { _parent }
 
+    /**
+     * Lines recorded by the shared PermissiveLog during the current feature
+     * method, each as "level:message" (e.g. "debug:HTTP GET ..."). Cleared in
+     * setup(). Mirrors the root RuleHarnessSpec accessor so the success-path
+     * redaction specs run on this lane too.
+     */
+    protected List<String> capturedLogs() { sharedLog.messages }
+
     def setupSpec() {
         appExecutor = buildAppExecutorMock()
         synchronized (COMPILE_LOCK) {
@@ -132,11 +140,18 @@ abstract class RuleHarnessSpec extends Specification {
         mock.unschedule() >> { unscheduleAllCount++ }
         mock.unschedule(_ as String) >> { args -> unscheduleCalls << (args[0] as String) }
         mock.sendLocationEvent(_) >> { args -> sendLocationEventCalls << (args[0] as Map) }
+        // Invoke the response closure with a fake 200 so success-path response handlers
+        // run (e.g. the redacted log.debug inside http_request). Benign for specs that
+        // only assert on the recorded request args.
         mock.httpGet(_, _) >> { args ->
             httpGetCalls << (args as List)
             if (stubHttpGetException) throw stubHttpGetException
+            if (args[1] instanceof Closure) args[1].call([status: 200])
         }
-        mock.httpPost(_, _) >> { args -> httpPostCalls << (args as List) }
+        mock.httpPost(_, _) >> { args ->
+            httpPostCalls << (args as List)
+            if (args[1] instanceof Closure) args[1].call([status: 200])
+        }
         mock.subscribe(_, _ as String, _ as String) >> { args ->
             subscriptions.record(args[0], args[1] as String, args[2] as String)
         }
@@ -203,6 +218,7 @@ abstract class RuleHarnessSpec extends Specification {
         stubTimeOfDayResult = false
         stubSunriseSunset = null
         stubHttpGetException = null
+        sharedLog.messages.clear()
         _parent = null
         // Drop per-test metaClass writes from the previous feature before
         // re-installing hooks. Both wipes matter when SHARED_SCRIPT is reused

--- a/hubitat-mcp-rule.groovy
+++ b/hubitat-mcp-rule.groovy
@@ -55,6 +55,7 @@ def installed() {
 def updated() {
     log.info "MCP Rule '${settings.ruleName}' updated"
     state.updatedAt = now()
+    atomicState.localVarsWarned = false  // re-arm local-variable size warning on each save
     // Update the app label to match the rule name (for display in Apps list)
     if (settings.ruleName) {
         app.updateLabel(settings.ruleName)
@@ -75,6 +76,8 @@ def initialize() {
     clearDurationState()
     // Clear stale cancelled delay IDs (scheduled callbacks were cancelled by unschedule())
     atomicState.cancelledDelayIds = [:]
+    // Reset loop-guard window on (re)initialization so an edited/re-enabled rule starts fresh
+    atomicState.recentExecutions = []
 
     // Initialize previousMode so mode_change triggers with fromMode work on first event
     state.previousMode = location.mode
@@ -2529,7 +2532,7 @@ def describeAction(action) {
             return "Set thermostat ${tstatDevName} (${tstatParts.join(', ')})"
 
         case "http_request":
-            return "${action.method ?: 'GET'} ${action.url}"
+            return "${action.method ?: 'GET'} ${redactUrlForLog(action.url)}"
 
         case "speak":
             def speakDev = parent.findDevice(action.deviceId)
@@ -3390,7 +3393,7 @@ def executeAction(action, actionIndex = null, evt = null) {
         case "set_mode":
             if (!action.mode) {
                 ruleLog("error", "set_mode action missing 'mode' value")
-                return false
+                break // skip this misconfigured action, continue the rule
             }
             location.setMode(action.mode)
             break
@@ -3398,7 +3401,7 @@ def executeAction(action, actionIndex = null, evt = null) {
         case "set_hsm":
             if (!action.status) {
                 ruleLog("error", "set_hsm action missing 'status' value")
-                return false
+                break // skip this misconfigured action, continue the rule
             }
             sendLocationEvent(name: "hsmSetArm", value: action.status)
             break
@@ -3476,6 +3479,7 @@ def executeAction(action, actionIndex = null, evt = null) {
             def vars = atomicState.localVariables ?: [:]
             vars[action.variableName] = substituteVariables(action.value?.toString() ?: "", evt)
             atomicState.localVariables = vars
+            checkLocalVarsSize(vars)
             break
 
         case "activate_scene":
@@ -3634,21 +3638,22 @@ def executeAction(action, actionIndex = null, evt = null) {
 
         case "http_request":
             try {
+                def safeUrl = redactUrlForLog(action.url)
                 def method = action.method ?: "GET"
                 if (method == "GET") {
                     httpGet([uri: action.url]) { resp ->
-                        log.debug "HTTP GET ${action.url} returned status ${resp.status}"
+                        log.debug "HTTP GET ${safeUrl} returned status ${resp.status}"
                     }
                 } else if (method == "POST") {
                     def params = [uri: action.url]
                     if (action.contentType) params.contentType = action.contentType
                     if (action.body) params.body = action.body
                     httpPost(params) { resp ->
-                        log.debug "HTTP POST ${action.url} returned status ${resp.status}"
+                        log.debug "HTTP POST ${safeUrl} returned status ${resp.status}"
                     }
                 }
             } catch (Exception e) {
-                ruleLog("error", "Error executing HTTP ${action.method ?: 'GET'} to ${action.url}: ${e.message}")
+                ruleLog("error", "Error executing HTTP ${action.method ?: 'GET'} to ${redactUrlForLog(action.url)}: ${e.message}")
             }
             break
 
@@ -3752,6 +3757,7 @@ def executeAction(action, actionIndex = null, evt = null) {
             if (scope == "local") {
                 locals[varName] = mathResult
                 atomicState.localVariables = locals
+                checkLocalVarsSize(locals)
             } else {
                 setGlobalVar(varName, mathResult)
             }
@@ -3879,6 +3885,12 @@ def updateRuleFromParent(data) {
     unsubscribe()
     unschedule()
     clearDurationState()  // Clear duration state when rule is updated to prevent orphaned triggers
+    // unschedule() above cancelled every pending resumeDelayedActions callback, so any
+    // cancelledDelayIds markers are now dead weight (and may key off delays the edited
+    // action list no longer contains). Reset to match initialize()'s re-init hygiene.
+    atomicState.cancelledDelayIds = [:]
+    atomicState.recentExecutions = []  // Reset loop-guard window — edited rule starts its loop count fresh
+    atomicState.localVarsWarned = false  // re-arm local-variable size warning (parity with updated(); MCP edits don't fire updated())
     if (shouldBeEnabled) {
         subscribeToTriggers()
     }
@@ -3888,6 +3900,7 @@ def enableRule() {
     app.updateSetting("ruleEnabled", true)
     state.updatedAt = now()
     clearDurationState()  // Clear orphaned duration state from previous disable
+    atomicState.recentExecutions = []  // Start the loop-guard window fresh on (re-)enable
     unsubscribe()
     unschedule()
     subscribeToTriggers()
@@ -3923,6 +3936,18 @@ def notifyLoopGuard(String message) {
     }
 }
 
+// Passive size guard for atomicState.localVariables: user-named variables are
+// meaningful so we DON'T evict; warn once when the map first crosses the threshold
+// so an accidentally-unbounded namer is visible in the logs. Re-arms on rule save.
+def checkLocalVarsSize(Map locals) {
+    if (locals != null && locals.size() >= 100 && !atomicState.localVarsWarned) {
+        atomicState.localVarsWarned = true
+        ruleLog("warn", "Rule '${settings.ruleName}' now has ${locals.size()} local variables; " +
+            "this map persists in atomicState and is not auto-pruned. Verify variable names are " +
+            "not being generated dynamically (e.g. from event data). Remove unused variables to keep state lean.")
+    }
+}
+
 // Bridge to parent's mcpLog for MCP debug log visibility
 // Falls back to standard logging if parent method unavailable
 def ruleLog(String level, String message, Map extraData = null) {
@@ -3940,10 +3965,27 @@ def ruleLog(String level, String message, Map extraData = null) {
     }
 }
 
+// Redact secrets from a request URL before it is logged (MCP buffer / hub log).
+// Strips basic-auth userinfo (scheme://user:pass@host -> scheme://host) and masks
+// sensitive query-param values. Sandbox-safe: only String.replaceAll + a null guard.
+// The real URL is still sent to httpGet/httpPost; only the logged copy is redacted.
+private String redactUrlForLog(url) {
+    if (url == null) return null
+    def out = url.toString()
+    // Strip basic-auth userinfo: scheme://user:pass@host -> scheme://host. The class
+    // excludes / ? # so a pathless URL with an @ in its query isn't over-redacted.
+    out = out.replaceAll("://[^/?#\\s@]+@", "://")
+    // Mask the value of any sensitive query param. Exact names, '=' anchored, so
+    // lookalikes like keyword= / author= / authuser= are left untouched.
+    out = out.replaceAll("(?i)([?&](?:token|api_key|apikey|access_token|access_key|password|passwd|pwd|client_secret|secret_key|secretkey|secret|signature|sig|auth|bearer|key)=)[^&\\s]*", "\$1***")
+    return out
+}
+
 def disableRule() {
     app.updateSetting("ruleEnabled", false)
     state.updatedAt = now()
     clearDurationState()  // Clear duration state to prevent orphaned durationFired flags
+    atomicState.recentExecutions = []  // Reset loop-guard window so a re-enabled rule starts fresh
     unsubscribe()
     unschedule()
 }

--- a/hubitat-mcp-rule.groovy
+++ b/hubitat-mcp-rule.groovy
@@ -3392,7 +3392,7 @@ def executeAction(action, actionIndex = null, evt = null) {
 
         case "set_mode":
             if (!action.mode) {
-                ruleLog("error", "set_mode action missing 'mode' value")
+                ruleLog("error", "Rule '${settings.ruleName}' set_mode action missing 'mode' value")
                 break // skip this misconfigured action, continue the rule
             }
             location.setMode(action.mode)
@@ -3400,7 +3400,7 @@ def executeAction(action, actionIndex = null, evt = null) {
 
         case "set_hsm":
             if (!action.status) {
-                ruleLog("error", "set_hsm action missing 'status' value")
+                ruleLog("error", "Rule '${settings.ruleName}' set_hsm action missing 'status' value")
                 break // skip this misconfigured action, continue the rule
             }
             sendLocationEvent(name: "hsmSetArm", value: action.status)
@@ -3653,7 +3653,7 @@ def executeAction(action, actionIndex = null, evt = null) {
                     }
                 }
             } catch (Exception e) {
-                ruleLog("error", "Error executing HTTP ${action.method ?: 'GET'} to ${redactUrlForLog(action.url)}: ${e.message}")
+                ruleLog("error", "Error executing HTTP ${action.method ?: 'GET'} to ${redactUrlForLog(action.url)}: ${redactUrlForLog(e.message)}")
             }
             break
 
@@ -3965,10 +3965,11 @@ def ruleLog(String level, String message, Map extraData = null) {
     }
 }
 
-// Redact secrets from a request URL before it is logged (MCP buffer / hub log).
-// Strips basic-auth userinfo (scheme://user:pass@host -> scheme://host) and masks
-// sensitive query-param values. Sandbox-safe: only String.replaceAll + a null guard.
-// The real URL is still sent to httpGet/httpPost; only the logged copy is redacted.
+// Redact credentials from a URL (or any string that may embed one) before logging
+// it to the MCP buffer / hub log: strips basic-auth userinfo and masks sensitive
+// query-param VALUES. Secrets embedded in the URL path (e.g. token-in-path webhooks)
+// are NOT redacted. The real URL is still sent to httpGet/httpPost — only logged
+// copies pass through here.
 private String redactUrlForLog(url) {
     if (url == null) return null
     def out = url.toString()
@@ -3977,7 +3978,7 @@ private String redactUrlForLog(url) {
     out = out.replaceAll("://[^/?#\\s@]+@", "://")
     // Mask the value of any sensitive query param. Exact names, '=' anchored, so
     // lookalikes like keyword= / author= / authuser= are left untouched.
-    out = out.replaceAll("(?i)([?&](?:token|api_key|apikey|access_token|access_key|password|passwd|pwd|client_secret|secret_key|secretkey|secret|signature|sig|auth|bearer|key)=)[^&\\s]*", "\$1***")
+    out = out.replaceAll("(?i)([?&](?:token|api_key|apikey|access_token|access_key|password|passwd|pwd|client_secret|secret_key|secretkey|secret|signature|sig|auth|bearer|key)=)[^&#\\s]*", "\$1***")
     return out
 }
 

--- a/src/test/groovy/rules/ActionTypesSpec.groovy
+++ b/src/test/groovy/rules/ActionTypesSpec.groovy
@@ -333,12 +333,12 @@ class ActionTypesSpec extends RuleHarnessSpec {
         testLocation.mode == 'Night'
     }
 
-    def "set_mode with no mode value returns false without touching location"() {
-        when:
+    def "set_mode with no mode value is skipped and continues (does not stop the rule)"() {
+        when: 'a misconfigured set_mode (no mode) runs'
         def result = script.executeAction([type: 'set_mode'])
 
-        then:
-        result == false
+        then: 'skip-and-continue: returns the CONTINUE signal and never touches location'
+        result == true
         testLocation.modeSetCalls == []
     }
 
@@ -799,6 +799,59 @@ class ActionTypesSpec extends RuleHarnessSpec {
         1 * target.on()
     }
 
+    def "redactUrlForLog strips basic-auth userinfo and masks sensitive query-param values"() {
+        expect:
+        script.redactUrlForLog('https://user:pass@host/api?token=SECRET&z=keep') ==
+            'https://host/api?token=***&z=keep'
+        script.redactUrlForLog('http://h/api?api_key=A&apikey=B&access_token=C&password=D&key=E&secret=F') ==
+            'http://h/api?api_key=***&apikey=***&access_token=***&password=***&key=***&secret=***'
+        and: 'a non-sensitive key whose name merely starts with a sensitive word is NOT masked'
+        script.redactUrlForLog('http://host/api?keyword=harmless') == 'http://host/api?keyword=harmless'
+        and: 'an @ inside a query value (e.g. an email) is preserved — only authority userinfo is stripped'
+        script.redactUrlForLog('http://host/api?email=a@b.com&token=t') == 'http://host/api?email=a@b.com&token=***'
+        and: 'the broader secret-param set (auth/sig/client_secret/pwd/bearer/access_key/...) is masked'
+        script.redactUrlForLog('http://h/x?auth=A&sig=B&signature=G&client_secret=C&pwd=D&passwd=H&bearer=E&access_key=I') ==
+            'http://h/x?auth=***&sig=***&signature=***&client_secret=***&pwd=***&passwd=***&bearer=***&access_key=***'
+        and: 'a pathless URL with an @ in the query is not over-redacted (host + query preserved)'
+        script.redactUrlForLog('http://host?u=a@b.com&token=t') == 'http://host?u=a@b.com&token=***'
+        and: 'plain URLs and null pass through untouched'
+        script.redactUrlForLog('https://host/path') == 'https://host/path'
+        script.redactUrlForLog(null) == null
+    }
+
+    def "describeAction redacts credentials in an http_request URL (the always-logged action summary)"() {
+        when: 'the per-action summary that executeAction logs on every action'
+        def desc = script.describeAction([type: 'http_request',
+                                          url: 'https://user:pass@host/api?token=SECRET'])
+
+        then: 'host is visible but userinfo + secret query value are redacted'
+        desc.contains('host/api')
+        desc.contains('***')
+        !desc.contains('pass@')
+        !desc.contains('SECRET')
+    }
+
+    def "http_request error log redacts credentials in the URL pushed to the MCP buffer"() {
+        given: 'a parent that records mcpLog pushes, and a failing httpGet'
+        def logging = new LoggingActionParent()
+        parent = logging
+        stubHttpGetException = new RuntimeException('boom')
+
+        when:
+        script.executeAction([type: 'http_request', url: 'https://user:pass@host/api?token=SECRET'])
+
+        then: 'exactly one error was buffered, with host visible but credentials redacted'
+        def errs = logging.logCalls.findAll { it[0] == 'error' }
+        errs.size() == 1
+        errs[0][2].contains('host/api')
+        errs[0][2].contains('***')
+        !errs[0][2].contains('pass@')
+        !errs[0][2].contains('SECRET')
+
+        and: 'the real (unredacted) URL was still sent to httpGet'
+        httpGetCalls[0][0] == [uri: 'https://user:pass@host/api?token=SECRET']
+    }
+
     // -------- log / comment --------
 
     def "log action substitutes variables into the message"() {
@@ -857,6 +910,15 @@ class ActionTypesSpec extends RuleHarnessSpec {
 
         Map getCapturedState(String key) {
             savedStates[key]
+        }
+    }
+
+    /** Records parent.mcpLog pushes so log-buffer content (e.g. redaction) is observable. */
+    static class LoggingActionParent {
+        List<List> logCalls = []
+        Object findDevice(id) { null }
+        void mcpLog(String level, String category, String message, String ruleId, Map extraData) {
+            logCalls << [level, category, message, ruleId, extraData]
         }
     }
 }

--- a/src/test/groovy/rules/ActionTypesSpec.groovy
+++ b/src/test/groovy/rules/ActionTypesSpec.groovy
@@ -814,6 +814,8 @@ class ActionTypesSpec extends RuleHarnessSpec {
             'http://h/x?auth=***&sig=***&signature=***&client_secret=***&pwd=***&passwd=***&bearer=***&access_key=***'
         and: 'a pathless URL with an @ in the query is not over-redacted (host + query preserved)'
         script.redactUrlForLog('http://host?u=a@b.com&token=t') == 'http://host?u=a@b.com&token=***'
+        and: 'a fragment after a sensitive value is preserved — only the value is masked'
+        script.redactUrlForLog('https://host/api?token=SECRET#fragment') == 'https://host/api?token=***#fragment'
         and: 'plain URLs and null pass through untouched'
         script.redactUrlForLog('https://host/path') == 'https://host/path'
         script.redactUrlForLog(null) == null
@@ -850,6 +852,59 @@ class ActionTypesSpec extends RuleHarnessSpec {
 
         and: 'the real (unredacted) URL was still sent to httpGet'
         httpGetCalls[0][0] == [uri: 'https://user:pass@host/api?token=SECRET']
+    }
+
+    def "http_request GET success log redacts credentials in the URL"() {
+        given: 'fire the response closure so the success-path log.debug actually runs'
+        stubInvokeHttpResponse = true
+
+        when:
+        script.executeAction([type: 'http_request', url: 'https://user:pass@host/api?token=SECRET'])
+
+        then: 'the GET success debug line logged the redacted URL'
+        def gets = appExecutor.getLog().messages.findAll { it.startsWith('debug:HTTP GET') }
+        gets.size() == 1
+        gets[0].contains('host/api')
+        gets[0].contains('***')
+        !gets[0].contains('pass@')
+        !gets[0].contains('SECRET')
+
+        and: 'the real (unredacted) URL was still sent to httpGet'
+        httpGetCalls[0][0] == [uri: 'https://user:pass@host/api?token=SECRET']
+    }
+
+    def "http_request POST success log redacts credentials in the URL"() {
+        given:
+        stubInvokeHttpResponse = true
+
+        when:
+        script.executeAction([type: 'http_request', method: 'POST',
+                              url: 'https://user:pass@host/api?token=SECRET',
+                              contentType: 'application/json', body: '{}'])
+
+        then:
+        def posts = appExecutor.getLog().messages.findAll { it.startsWith('debug:HTTP POST') }
+        posts.size() == 1
+        posts[0].contains('host/api')
+        posts[0].contains('***')
+        !posts[0].contains('pass@')
+        !posts[0].contains('SECRET')
+    }
+
+    def "http_request error log redacts credentials embedded in the exception message"() {
+        given: 'an exception whose message echoes the raw URL (as Hubitat HTTP errors often do)'
+        def logging = new LoggingActionParent()
+        parent = logging
+        stubHttpGetException = new RuntimeException('connect failed: https://user:pass@host/x?token=SEKRIT')
+
+        when:
+        script.executeAction([type: 'http_request', url: 'https://user:pass@host/x?token=SEKRIT'])
+
+        then: 'neither the URL argument nor the exception text leaks credentials'
+        def errs = logging.logCalls.findAll { it[0] == 'error' }
+        errs.size() == 1
+        !errs[0][2].contains('pass@')
+        !errs[0][2].contains('SEKRIT')
     }
 
     // -------- log / comment --------

--- a/src/test/groovy/rules/ActionTypesSpec.groovy
+++ b/src/test/groovy/rules/ActionTypesSpec.groovy
@@ -855,14 +855,11 @@ class ActionTypesSpec extends RuleHarnessSpec {
     }
 
     def "http_request GET success log redacts credentials in the URL"() {
-        given: 'fire the response closure so the success-path log.debug actually runs'
-        stubInvokeHttpResponse = true
-
-        when:
+        when: 'a successful GET fires the response handler, which logs the redacted URL'
         script.executeAction([type: 'http_request', url: 'https://user:pass@host/api?token=SECRET'])
 
         then: 'the GET success debug line logged the redacted URL'
-        def gets = appExecutor.getLog().messages.findAll { it.startsWith('debug:HTTP GET') }
+        def gets = capturedLogs().findAll { it.startsWith('debug:HTTP GET') }
         gets.size() == 1
         gets[0].contains('host/api')
         gets[0].contains('***')
@@ -874,16 +871,13 @@ class ActionTypesSpec extends RuleHarnessSpec {
     }
 
     def "http_request POST success log redacts credentials in the URL"() {
-        given:
-        stubInvokeHttpResponse = true
-
-        when:
+        when: 'a successful POST fires the response handler'
         script.executeAction([type: 'http_request', method: 'POST',
                               url: 'https://user:pass@host/api?token=SECRET',
                               contentType: 'application/json', body: '{}'])
 
         then:
-        def posts = appExecutor.getLog().messages.findAll { it.startsWith('debug:HTTP POST') }
+        def posts = capturedLogs().findAll { it.startsWith('debug:HTTP POST') }
         posts.size() == 1
         posts[0].contains('host/api')
         posts[0].contains('***')

--- a/src/test/groovy/rules/ActionTypesSpec.groovy
+++ b/src/test/groovy/rules/ActionTypesSpec.groovy
@@ -854,36 +854,11 @@ class ActionTypesSpec extends RuleHarnessSpec {
         httpGetCalls[0][0] == [uri: 'https://user:pass@host/api?token=SECRET']
     }
 
-    def "http_request GET success log redacts credentials in the URL"() {
-        when: 'a successful GET fires the response handler, which logs the redacted URL'
-        script.executeAction([type: 'http_request', url: 'https://user:pass@host/api?token=SECRET'])
-
-        then: 'the GET success debug line logged the redacted URL'
-        def gets = capturedLogs().findAll { it.startsWith('debug:HTTP GET') }
-        gets.size() == 1
-        gets[0].contains('host/api')
-        gets[0].contains('***')
-        !gets[0].contains('pass@')
-        !gets[0].contains('SECRET')
-
-        and: 'the real (unredacted) URL was still sent to httpGet'
-        httpGetCalls[0][0] == [uri: 'https://user:pass@host/api?token=SECRET']
-    }
-
-    def "http_request POST success log redacts credentials in the URL"() {
-        when: 'a successful POST fires the response handler'
-        script.executeAction([type: 'http_request', method: 'POST',
-                              url: 'https://user:pass@host/api?token=SECRET',
-                              contentType: 'application/json', body: '{}'])
-
-        then:
-        def posts = capturedLogs().findAll { it.startsWith('debug:HTTP POST') }
-        posts.size() == 1
-        posts[0].contains('host/api')
-        posts[0].contains('***')
-        !posts[0].contains('pass@')
-        !posts[0].contains('SECRET')
-    }
+    // The two success-path log.debug lines ("HTTP GET/POST ${safeUrl} ...") use the same
+    // safeUrl = redactUrlForLog(action.url) computed at the top of the case, proven by the
+    // redactUrlForLog unit test above and the describeAction test (the per-action summary
+    // logged on every action). log.debug content isn't capturable in this harness, so those
+    // lines aren't asserted directly.
 
     def "http_request error log redacts credentials embedded in the exception message"() {
         given: 'an exception whose message echoes the raw URL (as Hubitat HTTP errors often do)'

--- a/src/test/groovy/rules/ActionTypesSpec.groovy
+++ b/src/test/groovy/rules/ActionTypesSpec.groovy
@@ -1,5 +1,6 @@
 package rules
 
+import spock.lang.IgnoreIf
 import support.TestDevice
 
 /**
@@ -854,11 +855,43 @@ class ActionTypesSpec extends RuleHarnessSpec {
         httpGetCalls[0][0] == [uri: 'https://user:pass@host/api?token=SECRET']
     }
 
-    // The two success-path log.debug lines ("HTTP GET/POST ${safeUrl} ...") use the same
-    // safeUrl = redactUrlForLog(action.url) computed at the top of the case, proven by the
-    // redactUrlForLog unit test above and the describeAction test (the per-action summary
-    // logged on every action). log.debug content isn't capturable in this harness, so those
-    // lines aren't asserted directly.
+    // The two success-path tests below capture log.debug via the root RuleHarnessSpec
+    // (PermissiveLog recording + response-closure firing + capturedLogs()). The Groovy 2.5
+    // lane runs its own scaffold harness without those members, so they @IgnoreIf there;
+    // the production redaction they exercise is still covered under 2.5 by the redactUrlForLog
+    // unit test, the describeAction test, and the error-path tests above.
+    @IgnoreIf({ GroovySystem.version.startsWith('2') })
+    def "http_request GET success log redacts credentials in the URL"() {
+        when: 'a successful GET fires the response handler, which logs the redacted URL'
+        script.executeAction([type: 'http_request', url: 'https://user:pass@host/api?token=SECRET'])
+
+        then: 'the GET success debug line logged the redacted URL'
+        def gets = capturedLogs().findAll { it.startsWith('debug:HTTP GET') }
+        gets.size() == 1
+        gets[0].contains('host/api')
+        gets[0].contains('***')
+        !gets[0].contains('pass@')
+        !gets[0].contains('SECRET')
+
+        and: 'the real (unredacted) URL was still sent to httpGet'
+        httpGetCalls[0][0] == [uri: 'https://user:pass@host/api?token=SECRET']
+    }
+
+    @IgnoreIf({ GroovySystem.version.startsWith('2') })
+    def "http_request POST success log redacts credentials in the URL"() {
+        when: 'a successful POST fires the response handler'
+        script.executeAction([type: 'http_request', method: 'POST',
+                              url: 'https://user:pass@host/api?token=SECRET',
+                              contentType: 'application/json', body: '{}'])
+
+        then:
+        def posts = capturedLogs().findAll { it.startsWith('debug:HTTP POST') }
+        posts.size() == 1
+        posts[0].contains('host/api')
+        posts[0].contains('***')
+        !posts[0].contains('pass@')
+        !posts[0].contains('SECRET')
+    }
 
     def "http_request error log redacts credentials embedded in the exception message"() {
         given: 'an exception whose message echoes the raw URL (as Hubitat HTTP errors often do)'

--- a/src/test/groovy/rules/ActionTypesSpec.groovy
+++ b/src/test/groovy/rules/ActionTypesSpec.groovy
@@ -1,6 +1,5 @@
 package rules
 
-import spock.lang.IgnoreIf
 import support.TestDevice
 
 /**
@@ -855,12 +854,9 @@ class ActionTypesSpec extends RuleHarnessSpec {
         httpGetCalls[0][0] == [uri: 'https://user:pass@host/api?token=SECRET']
     }
 
-    // The two success-path tests below capture log.debug via the root RuleHarnessSpec
-    // (PermissiveLog recording + response-closure firing + capturedLogs()). The Groovy 2.5
-    // lane runs its own scaffold harness without those members, so they @IgnoreIf there;
-    // the production redaction they exercise is still covered under 2.5 by the redactUrlForLog
-    // unit test, the describeAction test, and the error-path tests above.
-    @IgnoreIf({ GroovySystem.version.startsWith('2') })
+    // The two success-path tests capture log.debug via the harness (PermissiveLog recording
+    // + response-closure firing + capturedLogs()), mirrored into both the root and the
+    // Groovy 2.5 scaffold RuleHarnessSpec so they run on both lanes.
     def "http_request GET success log redacts credentials in the URL"() {
         when: 'a successful GET fires the response handler, which logs the redacted URL'
         script.executeAction([type: 'http_request', url: 'https://user:pass@host/api?token=SECRET'])
@@ -877,7 +873,6 @@ class ActionTypesSpec extends RuleHarnessSpec {
         httpGetCalls[0][0] == [uri: 'https://user:pass@host/api?token=SECRET']
     }
 
-    @IgnoreIf({ GroovySystem.version.startsWith('2') })
     def "http_request POST success log redacts credentials in the URL"() {
         when: 'a successful POST fires the response handler'
         script.executeAction([type: 'http_request', method: 'POST',

--- a/src/test/groovy/rules/ErrorPathsSpec.groovy
+++ b/src/test/groovy/rules/ErrorPathsSpec.groovy
@@ -102,10 +102,10 @@ class ErrorPathsSpec extends RuleHarnessSpec {
         result == true
     }
 
-    def "set_mode missing the 'mode' field returns false (stops the chain)"() {
+    def "set_mode missing the 'mode' field is skipped — the chain continues"() {
         given:
         atomicStateMap.actions = [
-            // missing mode field → executeAction returns false → executeActionsFromIndex breaks its outer loop
+            // missing mode field → logged as an error and skipped (it no longer stops the chain)
             [type: 'set_mode'],
             [type: 'device_command', deviceId: 1L, command: 'on']
         ]
@@ -115,11 +115,14 @@ class ErrorPathsSpec extends RuleHarnessSpec {
         when:
         script.executeActions()
 
-        then: 'the second action is NOT reached because set_mode returned false'
-        0 * target.on()
+        then: 'the misconfigured set_mode is skipped and the following action still runs'
+        1 * target.on()
+
+        and: 'the invalid set_mode never touched location'
+        testLocation.modeSetCalls == []
     }
 
-    def "set_hsm missing the 'status' field returns false (stops the chain)"() {
+    def "set_hsm missing the 'status' field is skipped — the chain continues"() {
         given:
         atomicStateMap.actions = [
             [type: 'set_hsm'],
@@ -131,8 +134,11 @@ class ErrorPathsSpec extends RuleHarnessSpec {
         when:
         script.executeActions()
 
-        then:
-        0 * target.on()
+        then: 'the misconfigured set_hsm is skipped and the following action still runs'
+        1 * target.on()
+
+        and: 'no HSM event was emitted for the invalid action'
+        sendLocationEventCalls == []
     }
 
     static class ErrorParent {

--- a/src/test/groovy/rules/LoopGuardSpec.groovy
+++ b/src/test/groovy/rules/LoopGuardSpec.groovy
@@ -119,6 +119,77 @@ class LoopGuardSpec extends RuleHarnessSpec {
         appExecutor.getApp().settingsStore.ruleEnabled == false
     }
 
+    // ---- the loop-guard window is reset on the disable / edit / re-init paths ----
+    // (auto-disable already clears it above; these are the manual/edit paths that
+    // previously left stale timestamps behind, so a re-enabled rule could re-trip early.)
+
+    def "disableRule resets the loop-guard window so a re-enabled rule starts fresh"() {
+        given:
+        settingsMap.ruleName = 'Disable Reset'
+        appExecutor.getApp().settingsStore.ruleEnabled = true
+        atomicStateMap.recentExecutions = [FIXED_NOW - 5_000L, FIXED_NOW - 1_000L]
+
+        when:
+        script.disableRule()
+
+        then:
+        atomicStateMap.recentExecutions == []
+        appExecutor.getApp().settingsStore.ruleEnabled == false
+        unsubscribeCount == 1
+        unscheduleAllCount == 1
+    }
+
+    def "updateRuleFromParent resets the loop-guard window on an in-place edit"() {
+        given:
+        parent = new LoopGuardParent(settings: [loopGuardMax: 30, loopGuardWindowSec: 60])
+        atomicStateMap.recentExecutions = [FIXED_NOW - 2_000L]
+
+        when: 'enabled:false so subscribeToTriggers wiring is skipped'
+        script.updateRuleFromParent([triggers: [], conditions: [], actions: [], enabled: false])
+
+        then:
+        atomicStateMap.recentExecutions == []
+    }
+
+    def "updated re-initialises and resets the loop-guard window"() {
+        given: 'ruleEnabled=false so initialize() skips subscribeToTriggers'
+        settingsMap.ruleName = 'Updated Reset'
+        settingsMap.ruleEnabled = false
+        atomicStateMap.recentExecutions = [FIXED_NOW - 3_000L, FIXED_NOW - 1_000L]
+
+        when:
+        script.updated()
+
+        then:
+        atomicStateMap.recentExecutions == []
+        unsubscribeCount == 1
+        unscheduleAllCount == 1
+    }
+
+    def "initialize resets the loop-guard window directly"() {
+        given: 'ruleEnabled=false so initialize() skips subscribeToTriggers'
+        settingsMap.ruleEnabled = false
+        atomicStateMap.recentExecutions = [FIXED_NOW - 2_000L, FIXED_NOW - 500L]
+
+        when:
+        script.initialize()
+
+        then:
+        atomicStateMap.recentExecutions == []
+    }
+
+    def "enableRule starts the loop-guard window fresh"() {
+        given:
+        settingsMap.ruleName = 'Enable Fresh'
+        atomicStateMap.recentExecutions = [FIXED_NOW - 1_000L]
+
+        when:
+        script.enableRule()
+
+        then:
+        atomicStateMap.recentExecutions == []
+    }
+
     /**
      * Minimal loop-guard parent. {@code settings} map carries loopGuardMax
      * and loopGuardWindowSec; {@code getSelectedDevices()} returns an empty

--- a/src/test/groovy/rules/LoopGuardSpec.groovy
+++ b/src/test/groovy/rules/LoopGuardSpec.groovy
@@ -119,6 +119,24 @@ class LoopGuardSpec extends RuleHarnessSpec {
         appExecutor.getApp().settingsStore.ruleEnabled == false
     }
 
+    def "just below threshold: rule fires and is NOT auto-disabled (locks the >= boundary)"() {
+        given: 'loopGuardMax-1 in-window executions (2 of max 3)'
+        settingsMap.ruleEnabled = true
+        settingsMap.ruleName = 'Just Below'
+        appExecutor.getApp().settingsStore.ruleEnabled = true
+        parent = new LoopGuardParent(settings: [loopGuardMax: 3, loopGuardWindowSec: 60])
+        atomicStateMap.conditions = []
+        atomicStateMap.actions = []
+        atomicStateMap.recentExecutions = [FIXED_NOW - 5_000L, FIXED_NOW - 1_000L]
+
+        when:
+        script.executeRule('test')
+
+        then: 'the rule still fires (not disabled); the new exec appends to reach exactly max'
+        appExecutor.getApp().settingsStore.ruleEnabled == true
+        atomicStateMap.recentExecutions.size() == 3
+    }
+
     // ---- the loop-guard window is reset on the disable / edit / re-init paths ----
     // (auto-disable already clears it above; these are the manual/edit paths that
     // previously left stale timestamps behind, so a re-enabled rule could re-trip early.)

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -142,6 +142,15 @@ abstract class RuleHarnessSpec extends Specification {
 
     Object getParent() { _parent }
 
+    /**
+     * Lines recorded by the shared PermissiveLog during the current feature
+     * method, each as "level:message" (e.g. "debug:HTTP GET ..."). Cleared in
+     * setup(). Typed accessor so specs don't reach through the Log interface.
+     * (The Groovy 2.5 lane uses its own scaffold harness without this member, so
+     * specs that call it guard with @IgnoreIf on the Groovy 2.x runtime.)
+     */
+    protected List<String> capturedLogs() { sharedLog.messages }
+
     def setupSpec() {
         appExecutor = buildAppExecutorMock()
         synchronized (COMPILE_LOCK) {
@@ -206,11 +215,18 @@ abstract class RuleHarnessSpec extends Specification {
         mock.unschedule() >> { unscheduleAllCount++ }
         mock.unschedule(_ as String) >> { args -> unscheduleCalls << (args[0] as String) }
         mock.sendLocationEvent(_) >> { args -> sendLocationEventCalls << (args[0] as Map) }
+        // Invoke the response closure with a fake 200 so success-path response handlers
+        // run (e.g. the redacted log.debug inside http_request). Benign for specs that
+        // only assert on the recorded request args.
         mock.httpGet(_, _) >> { args ->
             httpGetCalls << (args as List)
             if (stubHttpGetException) throw stubHttpGetException
+            if (args[1] instanceof Closure) args[1].call([status: 200])
         }
-        mock.httpPost(_, _) >> { args -> httpPostCalls << (args as List) }
+        mock.httpPost(_, _) >> { args ->
+            httpPostCalls << (args as List)
+            if (args[1] instanceof Closure) args[1].call([status: 200])
+        }
         // subscribe(source, attribute, handlerName) is class-2 (declared on
         // AppExecutor). Route every call into SubscriptionRecorder so specs
         // can both assert on the wire-up ("device_event rule subscribed
@@ -324,6 +340,7 @@ abstract class RuleHarnessSpec extends Specification {
         stubTimeOfDayResult = false
         stubSunriseSunset = null
         stubHttpGetException = null
+        sharedLog.messages.clear()
         // Propagate unconditionally so the script's parent exactly matches
         // a freshly-reset `_parent` (null) on entry to each test.
         // eighty20results' sandbox installs a default InstalledAppWrapperImpl

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -126,11 +126,6 @@ abstract class RuleHarnessSpec extends Specification {
     @Shared protected Boolean stubTimeOfDayResult = false
     @Shared protected Map<String, Date> stubSunriseSunset = null
     @Shared protected Throwable stubHttpGetException = null
-    // When true, the httpGet/httpPost stubs invoke the response closure with a fake
-    // [status: 200] so success-path response handlers actually run (e.g. the redacted
-    // log.debug inside the http_request action). Default false: most specs only assert
-    // on the recorded request args, not the response body.
-    @Shared protected Boolean stubInvokeHttpResponse = false
 
     // Per-feature backing field — each test gets its own instance, so
     // resetting _parent to null in setup() guarantees isolation without
@@ -146,6 +141,13 @@ abstract class RuleHarnessSpec extends Specification {
     }
 
     Object getParent() { _parent }
+
+    /**
+     * Lines recorded by the shared PermissiveLog during the current feature
+     * method, each as "level:message" (e.g. "debug:HTTP GET ..."). Cleared in
+     * setup(). Typed accessor so specs don't reach through the Log interface.
+     */
+    protected List<String> capturedLogs() { sharedLog.messages }
 
     def setupSpec() {
         appExecutor = buildAppExecutorMock()
@@ -211,14 +213,17 @@ abstract class RuleHarnessSpec extends Specification {
         mock.unschedule() >> { unscheduleAllCount++ }
         mock.unschedule(_ as String) >> { args -> unscheduleCalls << (args[0] as String) }
         mock.sendLocationEvent(_) >> { args -> sendLocationEventCalls << (args[0] as Map) }
+        // Invoke the response closure with a fake 200 so success-path response
+        // handlers actually run (e.g. the redacted log.debug inside http_request).
+        // Benign for specs that only assert on the recorded request args.
         mock.httpGet(_, _) >> { args ->
             httpGetCalls << (args as List)
             if (stubHttpGetException) throw stubHttpGetException
-            if (stubInvokeHttpResponse && args[1] instanceof Closure) args[1].call([status: 200])
+            if (args[1] instanceof Closure) args[1].call([status: 200])
         }
         mock.httpPost(_, _) >> { args ->
             httpPostCalls << (args as List)
-            if (stubInvokeHttpResponse && args[1] instanceof Closure) args[1].call([status: 200])
+            if (args[1] instanceof Closure) args[1].call([status: 200])
         }
         // subscribe(source, attribute, handlerName) is class-2 (declared on
         // AppExecutor). Route every call into SubscriptionRecorder so specs
@@ -333,7 +338,6 @@ abstract class RuleHarnessSpec extends Specification {
         stubTimeOfDayResult = false
         stubSunriseSunset = null
         stubHttpGetException = null
-        stubInvokeHttpResponse = false
         sharedLog.messages.clear()
         // Propagate unconditionally so the script's parent exactly matches
         // a freshly-reset `_parent` (null) on entry to each test.

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -142,13 +142,6 @@ abstract class RuleHarnessSpec extends Specification {
 
     Object getParent() { _parent }
 
-    /**
-     * Lines recorded by the shared PermissiveLog during the current feature
-     * method, each as "level:message" (e.g. "debug:HTTP GET ..."). Cleared in
-     * setup(). Typed accessor so specs don't reach through the Log interface.
-     */
-    protected List<String> capturedLogs() { sharedLog.messages }
-
     def setupSpec() {
         appExecutor = buildAppExecutorMock()
         synchronized (COMPILE_LOCK) {
@@ -213,18 +206,11 @@ abstract class RuleHarnessSpec extends Specification {
         mock.unschedule() >> { unscheduleAllCount++ }
         mock.unschedule(_ as String) >> { args -> unscheduleCalls << (args[0] as String) }
         mock.sendLocationEvent(_) >> { args -> sendLocationEventCalls << (args[0] as Map) }
-        // Invoke the response closure with a fake 200 so success-path response
-        // handlers actually run (e.g. the redacted log.debug inside http_request).
-        // Benign for specs that only assert on the recorded request args.
         mock.httpGet(_, _) >> { args ->
             httpGetCalls << (args as List)
             if (stubHttpGetException) throw stubHttpGetException
-            if (args[1] instanceof Closure) args[1].call([status: 200])
         }
-        mock.httpPost(_, _) >> { args ->
-            httpPostCalls << (args as List)
-            if (args[1] instanceof Closure) args[1].call([status: 200])
-        }
+        mock.httpPost(_, _) >> { args -> httpPostCalls << (args as List) }
         // subscribe(source, attribute, handlerName) is class-2 (declared on
         // AppExecutor). Route every call into SubscriptionRecorder so specs
         // can both assert on the wire-up ("device_event rule subscribed
@@ -338,7 +324,6 @@ abstract class RuleHarnessSpec extends Specification {
         stubTimeOfDayResult = false
         stubSunriseSunset = null
         stubHttpGetException = null
-        sharedLog.messages.clear()
         // Propagate unconditionally so the script's parent exactly matches
         // a freshly-reset `_parent` (null) on entry to each test.
         // eighty20results' sandbox installs a default InstalledAppWrapperImpl

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -146,8 +146,8 @@ abstract class RuleHarnessSpec extends Specification {
      * Lines recorded by the shared PermissiveLog during the current feature
      * method, each as "level:message" (e.g. "debug:HTTP GET ..."). Cleared in
      * setup(). Typed accessor so specs don't reach through the Log interface.
-     * (The Groovy 2.5 lane uses its own scaffold harness without this member, so
-     * specs that call it guard with @IgnoreIf on the Groovy 2.x runtime.)
+     * (Mirrored into the Groovy 2.5 scaffold RuleHarnessSpec so the success-path
+     * redaction specs run on both lanes.)
      */
     protected List<String> capturedLogs() { sharedLog.messages }
 

--- a/src/test/groovy/rules/RuleHarnessSpec.groovy
+++ b/src/test/groovy/rules/RuleHarnessSpec.groovy
@@ -126,6 +126,11 @@ abstract class RuleHarnessSpec extends Specification {
     @Shared protected Boolean stubTimeOfDayResult = false
     @Shared protected Map<String, Date> stubSunriseSunset = null
     @Shared protected Throwable stubHttpGetException = null
+    // When true, the httpGet/httpPost stubs invoke the response closure with a fake
+    // [status: 200] so success-path response handlers actually run (e.g. the redacted
+    // log.debug inside the http_request action). Default false: most specs only assert
+    // on the recorded request args, not the response body.
+    @Shared protected Boolean stubInvokeHttpResponse = false
 
     // Per-feature backing field — each test gets its own instance, so
     // resetting _parent to null in setup() guarantees isolation without
@@ -209,8 +214,12 @@ abstract class RuleHarnessSpec extends Specification {
         mock.httpGet(_, _) >> { args ->
             httpGetCalls << (args as List)
             if (stubHttpGetException) throw stubHttpGetException
+            if (stubInvokeHttpResponse && args[1] instanceof Closure) args[1].call([status: 200])
         }
-        mock.httpPost(_, _) >> { args -> httpPostCalls << (args as List) }
+        mock.httpPost(_, _) >> { args ->
+            httpPostCalls << (args as List)
+            if (stubInvokeHttpResponse && args[1] instanceof Closure) args[1].call([status: 200])
+        }
         // subscribe(source, attribute, handlerName) is class-2 (declared on
         // AppExecutor). Route every call into SubscriptionRecorder so specs
         // can both assert on the wire-up ("device_event rule subscribed
@@ -324,6 +333,8 @@ abstract class RuleHarnessSpec extends Specification {
         stubTimeOfDayResult = false
         stubSunriseSunset = null
         stubHttpGetException = null
+        stubInvokeHttpResponse = false
+        sharedLog.messages.clear()
         // Propagate unconditionally so the script's parent exactly matches
         // a freshly-reset `_parent` (null) on entry to each test.
         // eighty20results' sandbox installs a default InstalledAppWrapperImpl

--- a/src/test/groovy/rules/RuleStateHygieneSpec.groovy
+++ b/src/test/groovy/rules/RuleStateHygieneSpec.groovy
@@ -1,0 +1,115 @@
+package rules
+
+/**
+ * State-hygiene coverage for the legacy rule engine's variable + in-place-edit
+ * paths in hubitat-mcp-rule.groovy:
+ *  - localVariables size guard: a passive warn-once when the map crosses the
+ *    threshold, with NO eviction (user-named variables are preserved), re-armed
+ *    on rule save (updated()).
+ *  - stale cancelledDelayIds / durationFired cleanup when a rule is edited in
+ *    place via updateRuleFromParent (parity with initialize()'s re-init hygiene).
+ */
+class RuleStateHygieneSpec extends RuleHarnessSpec {
+
+    // ---- localVariables size guard (passive warn-once, no eviction) ----
+
+    def "set_local_variable warns once when localVariables crosses the threshold and never evicts"() {
+        given:
+        settingsMap.ruleName = 'Var Namer'
+        parent = new HygieneParent()
+
+        when: '100 distinct local variables are written'
+        (0..99).each { i ->
+            script.executeAction([type: 'set_local_variable', variableName: 'var' + i, value: 'v' + i])
+        }
+
+        then: 'all 100 are retained (no eviction) and the warn fired exactly once'
+        atomicStateMap.localVariables.size() == 100
+        atomicStateMap.localVarsWarned == true
+        parent.warnCount() == 1
+
+        when: 'one more is written past the threshold'
+        script.executeAction([type: 'set_local_variable', variableName: 'var100', value: 'x'])
+
+        then: 'still exactly one warning (warn-once), and the new var is retained'
+        atomicStateMap.localVariables.size() == 101
+        parent.warnCount() == 1
+    }
+
+    def "variable_math local scope also triggers the size guard at the threshold"() {
+        given: '99 keys already present so one more local write crosses 100'
+        settingsMap.ruleName = 'Math Namer'
+        parent = new HygieneParent()
+        atomicStateMap.localVariables = (0..98).collectEntries { ['k' + it, it] }
+
+        when:
+        script.executeAction([type: 'variable_math', variableName: 'k99',
+                              scope: 'local', operation: 'set', operand: 1])
+
+        then:
+        atomicStateMap.localVariables.size() == 100
+        atomicStateMap.localVarsWarned == true
+        parent.warnCount() == 1
+    }
+
+    def "updated re-arms the local-variable size warning without clearing the variables"() {
+        given:
+        settingsMap.ruleName = 'Rearm'
+        settingsMap.ruleEnabled = false
+        atomicStateMap.localVarsWarned = true
+        atomicStateMap.localVariables = (0..99).collectEntries { ['k' + it, it] }
+
+        when:
+        script.updated()
+
+        then: 'the warn flag is re-armed but the user variables are preserved'
+        atomicStateMap.localVarsWarned == false
+        atomicStateMap.localVariables.size() == 100
+    }
+
+    // ---- stale-key cleanup on the in-place edit path ----
+
+    def "updateRuleFromParent clears stale cancelledDelayIds, durationFired, and the loop-guard window on edit"() {
+        given: 'leftover suppression markers + duration + loop-guard state from a pre-edit action set'
+        parent = new HygieneParent()
+        atomicStateMap.cancelledDelayIds = [stale: true, gone: true]
+        atomicStateMap.durationFired = [duration_1_motion: true]
+        atomicStateMap.durationTimers = [duration_1_motion: [startTime: 1]]
+        atomicStateMap.recentExecutions = [1L, 2L, 3L]
+
+        when: 'the parent pushes a new action set; rule left disabled'
+        script.updateRuleFromParent([triggers: [], conditions: [], actions: [], enabled: false])
+
+        then: 'all stale in-place-edit state is cleared together'
+        atomicStateMap.cancelledDelayIds == [:]
+        atomicStateMap.durationFired == null
+        atomicStateMap.recentExecutions == []
+    }
+
+    def "updateRuleFromParent re-arms the local-variable size warning on an MCP edit"() {
+        given: 'a latched warn flag + a full variable map (MCP edits do not fire updated())'
+        parent = new HygieneParent()
+        atomicStateMap.localVarsWarned = true
+        atomicStateMap.localVariables = (0..99).collectEntries { ['k' + it, it] }
+
+        when:
+        script.updateRuleFromParent([triggers: [], conditions: [], actions: [], enabled: false])
+
+        then: 'the flag is re-armed (parity with updated()) and the user variables are preserved'
+        atomicStateMap.localVarsWarned == false
+        atomicStateMap.localVariables.size() == 100
+    }
+
+    /**
+     * Parent that records mcpLog pushes so the passive size-guard warning is
+     * observable (ruleLog routes warn/info/etc. through parent.mcpLog).
+     */
+    static class HygieneParent {
+        List<List> logCalls = []
+        Object findDevice(id) { null }
+        void mcpLog(String level, String category, String message, String ruleId, Map extraData) {
+            logCalls << [level, category, message, ruleId, extraData]
+        }
+        int warnCount() { logCalls.count { it[0] == 'warn' } }
+    }
+}

--- a/src/test/groovy/support/PermissiveLog.groovy
+++ b/src/test/groovy/support/PermissiveLog.groovy
@@ -14,21 +14,15 @@ import me.biocomp.hubitat_ci.api.common_api.Log
  * an exception object untestable.
  */
 class PermissiveLog implements Log {
-    // Records emitted lines as "level:message" so specs that need to assert on
-    // log content (e.g. URL-redaction on the success-path log.debug) can inspect
-    // them. Recording is additive — every method still accepts the call and never
-    // throws. RuleHarnessSpec clears this between feature methods.
-    final List<String> messages = []
+    @Override void error(String message) {}
+    @Override void warn(String message) {}
+    @Override void info(String message) {}
+    @Override void debug(String message) {}
+    @Override void trace(String message) {}
 
-    @Override void error(String message) { messages << "error:${message}" }
-    @Override void warn(String message) { messages << "warn:${message}" }
-    @Override void info(String message) { messages << "info:${message}" }
-    @Override void debug(String message) { messages << "debug:${message}" }
-    @Override void trace(String message) { messages << "trace:${message}" }
-
-    void error(String message, Throwable t) { messages << "error:${message}" }
-    void warn(String message, Throwable t) { messages << "warn:${message}" }
-    void info(String message, Throwable t) { messages << "info:${message}" }
-    void debug(String message, Throwable t) { messages << "debug:${message}" }
-    void trace(String message, Throwable t) { messages << "trace:${message}" }
+    void error(String message, Throwable t) {}
+    void warn(String message, Throwable t) {}
+    void info(String message, Throwable t) {}
+    void debug(String message, Throwable t) {}
+    void trace(String message, Throwable t) {}
 }

--- a/src/test/groovy/support/PermissiveLog.groovy
+++ b/src/test/groovy/support/PermissiveLog.groovy
@@ -14,15 +14,22 @@ import me.biocomp.hubitat_ci.api.common_api.Log
  * an exception object untestable.
  */
 class PermissiveLog implements Log {
-    @Override void error(String message) {}
-    @Override void warn(String message) {}
-    @Override void info(String message) {}
-    @Override void debug(String message) {}
-    @Override void trace(String message) {}
+    // Records emitted lines as "level:message" so specs can assert on log content
+    // (e.g. URL redaction on the success-path log.debug). Recording is additive —
+    // every method still accepts the call and never throws. The harness clears this
+    // between feature methods. Coerce to plain String so GString identity quirks
+    // don't bite under either Groovy runtime.
+    final List<String> messages = []
 
-    void error(String message, Throwable t) {}
-    void warn(String message, Throwable t) {}
-    void info(String message, Throwable t) {}
-    void debug(String message, Throwable t) {}
-    void trace(String message, Throwable t) {}
+    @Override void error(String message) { messages << ("error:" + message) }
+    @Override void warn(String message) { messages << ("warn:" + message) }
+    @Override void info(String message) { messages << ("info:" + message) }
+    @Override void debug(String message) { messages << ("debug:" + message) }
+    @Override void trace(String message) { messages << ("trace:" + message) }
+
+    void error(String message, Throwable t) { messages << ("error:" + message) }
+    void warn(String message, Throwable t) { messages << ("warn:" + message) }
+    void info(String message, Throwable t) { messages << ("info:" + message) }
+    void debug(String message, Throwable t) { messages << ("debug:" + message) }
+    void trace(String message, Throwable t) { messages << ("trace:" + message) }
 }

--- a/src/test/groovy/support/PermissiveLog.groovy
+++ b/src/test/groovy/support/PermissiveLog.groovy
@@ -14,15 +14,21 @@ import me.biocomp.hubitat_ci.api.common_api.Log
  * an exception object untestable.
  */
 class PermissiveLog implements Log {
-    @Override void error(String message) {}
-    @Override void warn(String message) {}
-    @Override void info(String message) {}
-    @Override void debug(String message) {}
-    @Override void trace(String message) {}
+    // Records emitted lines as "level:message" so specs that need to assert on
+    // log content (e.g. URL-redaction on the success-path log.debug) can inspect
+    // them. Recording is additive — every method still accepts the call and never
+    // throws. RuleHarnessSpec clears this between feature methods.
+    final List<String> messages = []
 
-    void error(String message, Throwable t) {}
-    void warn(String message, Throwable t) {}
-    void info(String message, Throwable t) {}
-    void debug(String message, Throwable t) {}
-    void trace(String message, Throwable t) {}
+    @Override void error(String message) { messages << "error:${message}" }
+    @Override void warn(String message) { messages << "warn:${message}" }
+    @Override void info(String message) { messages << "info:${message}" }
+    @Override void debug(String message) { messages << "debug:${message}" }
+    @Override void trace(String message) { messages << "trace:${message}" }
+
+    void error(String message, Throwable t) { messages << "error:${message}" }
+    void warn(String message, Throwable t) { messages << "warn:${message}" }
+    void info(String message, Throwable t) { messages << "info:${message}" }
+    void debug(String message, Throwable t) { messages << "debug:${message}" }
+    void trace(String message, Throwable t) { messages << "trace:${message}" }
 }


### PR DESCRIPTION
## Summary

- Lands **PR2-legacy** from the issue #105 backend audit — the maintainer-approved (option C / R1 in `docs/issue-105-pr2-game-plan.md`) cleanup of the legacy rule child app `hubitat-mcp-rule.groovy`. It is the one PR2 workstream that hadn't shipped alongside PR2a/2b/2c.
- Two bug fixes (a rule-abort correctness bug + an `http_request` credential leak) and three state-hygiene fixes — all additive to the frozen legacy engine.

## Type of change

- [ ] `feat` — new feature or capability
- [x] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

**Bug fixes**

- **`set_mode` / `set_hsm` no longer abort the rule on a config error.** A missing `mode` / `status` returned `false` — the engine's rule-STOP signal — silently skipping every remaining action and bubbling out of `if_then_else` + `repeat`. They now log the error and `break` (skip-and-continue), matching every other "couldn't do it" action in `executeAction`. The genuine `stop` action and the `delay` "delayed" signal are untouched.
- **`http_request` redacts credentials before logging.** The action logged the full URL on the GET/POST/error paths, so a URL with basic-auth userinfo or a secret query-param (`token`/`api_key`/`apikey`/`access_token`/`password`/`key`/`secret`) leaked into the parent's MCP-visible log buffer. A new sandbox-safe `redactUrlForLog` strips userinfo and masks those values; the unmodified URL is still sent to `httpGet`/`httpPost`.

**State hygiene**

- **`localVariables` size guard.** `set_local_variable` / `variable_math` could grow `atomicState.localVariables` unbounded. Added a passive warn-once at 100 keys (no eviction — user-named variables are preserved), re-armed on each rule save.
- **Stale `cancelledDelayIds` on in-place edit.** `updateRuleFromParent` re-wired schedules but left delay-cancellation markers behind; now reset to match `initialize()`'s re-init hygiene. (The companion `durationFired` was already cleared via `clearDurationState()` on this path, so it needed no change.)
- **Loop-guard window reset.** `recentExecutions` was cleared only by the auto-disable path; now also reset by `disableRule()`, `updateRuleFromParent()`, and `initialize()`, so a manually disabled or edited rule starts its loop-guard window fresh.

Part of #105. No version bump (bot-owned).

## Release Notes

- Custom rules: a misconfigured *Set Mode* or *Set HSM* action now logs an error and skips just that step, instead of silently halting the rest of the rule.
- Custom rules: *HTTP Request* actions no longer write the full URL to the logs — embedded credentials (basic-auth or secret query parameters like `token`/`api_key`/`password`) are masked. The request itself is unchanged.
- Custom rules: more robust state housekeeping — runaway local-variable growth is flagged in the logs, and stale delay/loop-guard bookkeeping is cleared when a rule is disabled or edited.

## Testing

- `./gradlew test` — full Spock suite green. New / updated specs:
  - `ErrorPathsSpec` — updated the two tests that pinned the old set_mode/set_hsm rule-STOP behaviour to assert skip-and-continue.
  - `ActionTypesSpec` — `redactUrlForLog` unit cases, `http_request` error-path redaction (MCP-buffer assertion), and the updated set_mode-missing test.
  - `LoopGuardSpec` — `recentExecutions` reset on disable / edit / re-init.
  - `RuleStateHygieneSpec` (new) — `localVariables` warn-once / no-evict + re-arm, and stale `cancelledDelayIds` / `durationFired` cleanup on edit.
- `python tests/sandbox_lint.py` — clean.
- **e2e note:** `tests/e2e_test.py` (and the BAT-v2 prompts) are *structural* — they create / verify / delete custom rules but never fire them, so they can't reach the action-execution path these fixes live in. Runtime behaviour is therefore covered by the Spock suite (which drives `executeAction` / lifecycle methods directly). Flagging per the AGENTS.md e2e-mandatory rule — happy to add a trigger-and-observe capability to the e2e harness as a follow-up if you'd prefer that over Spock-only coverage here.

## Checklist

- [x] **Unit tests added** (direct + integration Spock; no new MCP tools)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally
- [ ] Live-hub BAT tests — see the e2e note (execution-path fixes; the structural harness can't reach them)
- [x] Documentation — n/a (no tool-surface change; user-facing behaviour captured in Release Notes)
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules — n/a (no tool changes)
