### PR TITLE
ci: auto-run e2e on trusted fork PRs, gate other contributors; lease waits for a busy hub

### DIFF
--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -28,11 +28,12 @@ LEASE_WAIT_TIMEOUT_S="${LEASE_WAIT_TIMEOUT_S:-600}"
 LEASE_POLL_INTERVAL_S="${LEASE_POLL_INTERVAL_S:-15}"
 VERIFY_SLEEP_S=2
 
-# Portable epoch helpers (date +%s%N is GNU-only — fails on BSD/macOS).
+# Portable epoch helpers (date +%s%N is GNU-only — fails on BSD/macOS). Seconds are
+# derived from ms by the callers (NOW_MS / 1000) to avoid a second subprocess per poll.
 now_ms() { python3 -c 'import time; print(int(time.time() * 1000))'; }
-now_s()  { python3 -c 'import time; print(int(time.time()))'; }
-# epoch-ms -> ISO8601 UTC, for human-readable log lines.
-fmt_ts() { python3 -c "import datetime,sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1])//1000, datetime.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'))" "$1"; }
+# epoch-ms -> ISO8601 UTC, for human-readable log lines. timezone.utc (not datetime.UTC)
+# so this stays valid on Python 3.2+, not just 3.11+.
+fmt_ts() { python3 -c "import datetime,sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1])//1000, datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))" "$1"; }
 
 # Retry on transient cloud-gateway failures (the ~10s relay ceiling returns a 504,
 # which --fail turns into curl exit 22). Without this a single 504 on lease acquire
@@ -69,9 +70,10 @@ set_lease_value() {
 # Wait (polling) until the lease is free, expired, or already ours — or until the
 # wait budget runs out. The job's own timeout-minutes bounds the total, and because
 # we claim only AFTER this wait, the lease TTL below starts at acquisition.
-WAIT_DEADLINE_S=$(( $(now_s) + LEASE_WAIT_TIMEOUT_S ))
+WAIT_DEADLINE_S=$(( $(now_ms) / 1000 + LEASE_WAIT_TIMEOUT_S ))
 while :; do
   NOW_MS="$(now_ms)"
+  NOW_S=$(( NOW_MS / 1000 ))
   CURRENT="$(get_lease_value)"
 
   if [ -z "$CURRENT" ]; then
@@ -88,11 +90,11 @@ while :; do
 
   # Held by someone else and still valid — wait for it.
   UNTIL_TS="$(fmt_ts "$CURRENT_UNTIL")"
-  if [ "$(now_s)" -ge "$WAIT_DEADLINE_S" ]; then
+  if [ "$NOW_S" -ge "$WAIT_DEADLINE_S" ]; then
     echo "::error::Test hub still leased by '$CURRENT_BY' until ${UNTIL_TS} after waiting ${LEASE_WAIT_TIMEOUT_S}s. Aborting."
     exit 1
   fi
-  REMAIN_S=$(( WAIT_DEADLINE_S - $(now_s) ))
+  REMAIN_S=$(( WAIT_DEADLINE_S - NOW_S ))
   echo "::notice::Test hub leased by '$CURRENT_BY' until ${UNTIL_TS}; waiting for release (poll every ${LEASE_POLL_INTERVAL_S}s, up to ${REMAIN_S}s more)..."
   sleep "$LEASE_POLL_INTERVAL_S"
 done

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -3,9 +3,16 @@
 #
 # Usage:  lease_acquire.sh <by-identifier>
 # Env:    MCP_URL — full cloud OAuth URL with access_token
+#         LEASE_WAIT_TIMEOUT_S  — max seconds to WAIT for a busy lease to free
+#                                 before aborting (default 600). Set 0 to fail fast.
+#         LEASE_POLL_INTERVAL_S — seconds between polls while waiting (default 15).
 #
-# Exits 0 on successful claim. Exits 1 if the lease is held by someone else
-# (active and not us), or if the post-write race-check fails.
+# Exits 0 on successful claim. While the lease is held by someone else and not
+# expired, this WAITS (polling) and claims it automatically the moment it frees or
+# the holder's TTL lapses — so a run queued behind another holder, or behind a manual
+# hub session that GitHub's `concurrency` group can't see, starts on its own instead
+# of needing a manual re-run. Exits 1 only if the lease is STILL held after
+# LEASE_WAIT_TIMEOUT_S, or if the post-write race-check shows another claim landed last.
 #
 # Lease shape (JSON, written into Hubitat Hub Variable `_TEST_HUB_LEASED_BY`):
 #   {"by":"<who>","since":<epoch_ms>,"until":<epoch_ms>}
@@ -16,11 +23,16 @@ set -euo pipefail
 BY="${1:?Usage: $0 <by-identifier>}"
 : "${MCP_URL:?MCP_URL env var required (full cloud OAuth URL with access_token)}"
 
-# Portable epoch milliseconds (date +%s%N is GNU-only — fails on BSD/macOS).
-NOW_MS=$(python3 -c 'import time; print(int(time.time() * 1000))')
 LEASE_DURATION_MIN=30
-EXPIRES_MS=$((NOW_MS + LEASE_DURATION_MIN * 60 * 1000))
+LEASE_WAIT_TIMEOUT_S="${LEASE_WAIT_TIMEOUT_S:-600}"
+LEASE_POLL_INTERVAL_S="${LEASE_POLL_INTERVAL_S:-15}"
 VERIFY_SLEEP_S=2
+
+# Portable epoch helpers (date +%s%N is GNU-only — fails on BSD/macOS).
+now_ms() { python3 -c 'import time; print(int(time.time() * 1000))'; }
+now_s()  { python3 -c 'import time; print(int(time.time()))'; }
+# epoch-ms -> ISO8601 UTC, for human-readable log lines.
+fmt_ts() { python3 -c "import datetime,sys; print(datetime.datetime.fromtimestamp(int(sys.argv[1])//1000, datetime.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'))" "$1"; }
 
 # Retry on transient cloud-gateway failures (the ~10s relay ceiling returns a 504,
 # which --fail turns into curl exit 22). Without this a single 504 on lease acquire
@@ -54,18 +66,40 @@ set_lease_value() {
   mcp_call "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"hub_manage_variables\",\"arguments\":{\"tool\":\"hub_set_variable\",\"args\":{\"name\":\"_TEST_HUB_LEASED_BY\",\"value\":${value_json}}}}}" >/dev/null
 }
 
-CURRENT="$(get_lease_value)"
+# Wait (polling) until the lease is free, expired, or already ours — or until the
+# wait budget runs out. The job's own timeout-minutes bounds the total, and because
+# we claim only AFTER this wait, the lease TTL below starts at acquisition.
+WAIT_DEADLINE_S=$(( $(now_s) + LEASE_WAIT_TIMEOUT_S ))
+while :; do
+  NOW_MS="$(now_ms)"
+  CURRENT="$(get_lease_value)"
 
-if [ -n "$CURRENT" ]; then
+  if [ -z "$CURRENT" ]; then
+    break  # released
+  fi
   CURRENT_BY="$(echo "$CURRENT" | jq -r '.by // ""' 2>/dev/null || echo "")"
   CURRENT_UNTIL="$(echo "$CURRENT" | jq -r '.until // 0' 2>/dev/null || echo 0)"
-  if [ "$CURRENT_UNTIL" -gt "$NOW_MS" ] && [ "$CURRENT_BY" != "$BY" ]; then
-    UNTIL_EPOCH=$((CURRENT_UNTIL / 1000))
-    UNTIL_TS=$(python3 -c "import datetime; print(datetime.datetime.fromtimestamp(${UNTIL_EPOCH}, datetime.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'))")
-    echo "::error::Test hub leased by '$CURRENT_BY' until ${UNTIL_TS}. Aborting."
+  if [ "$CURRENT_BY" = "$BY" ]; then
+    break  # re-entrant: already held by this run
+  fi
+  if [ "$CURRENT_UNTIL" -le "$NOW_MS" ]; then
+    break  # holder's TTL lapsed -> reclaimable
+  fi
+
+  # Held by someone else and still valid — wait for it.
+  UNTIL_TS="$(fmt_ts "$CURRENT_UNTIL")"
+  if [ "$(now_s)" -ge "$WAIT_DEADLINE_S" ]; then
+    echo "::error::Test hub still leased by '$CURRENT_BY' until ${UNTIL_TS} after waiting ${LEASE_WAIT_TIMEOUT_S}s. Aborting."
     exit 1
   fi
-fi
+  REMAIN_S=$(( WAIT_DEADLINE_S - $(now_s) ))
+  echo "::notice::Test hub leased by '$CURRENT_BY' until ${UNTIL_TS}; waiting for release (poll every ${LEASE_POLL_INTERVAL_S}s, up to ${REMAIN_S}s more)..."
+  sleep "$LEASE_POLL_INTERVAL_S"
+done
+
+# Claim. Compute the TTL now, at acquisition time, so a preceding wait doesn't eat into it.
+NOW_MS="$(now_ms)"
+EXPIRES_MS=$((NOW_MS + LEASE_DURATION_MIN * 60 * 1000))
 
 # Build the lease JSON, then JSON-stringify it for the set_variable arg.
 CLAIM_JSON="$(jq -nc \
@@ -88,6 +122,5 @@ if [ "$AFTER_BY" != "$BY" ]; then
   exit 1
 fi
 
-EXPIRES_EPOCH=$((EXPIRES_MS / 1000))
-EXPIRES_TS=$(python3 -c "import datetime; print(datetime.datetime.fromtimestamp(${EXPIRES_EPOCH}, datetime.UTC).strftime('%Y-%m-%dT%H:%M:%SZ'))")
+EXPIRES_TS="$(fmt_ts "$EXPIRES_MS")"
 echo "Lease acquired: by=$BY, until=${EXPIRES_TS} (${LEASE_DURATION_MIN} min TTL)"

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -11,7 +11,9 @@
 # expired, this WAITS (polling) and claims it automatically the moment it frees or
 # the holder's TTL lapses — so a run queued behind another holder, or behind a manual
 # hub session that GitHub's `concurrency` group can't see, starts on its own instead
-# of needing a manual re-run. Exits 1 only if the lease is STILL held after
+# of needing a manual re-run. A transient read failure or a malformed/corrupt lease
+# value mid-wait is treated as "still busy" and polled through, never as free. Exits 1
+# only if the lease is STILL held (or stays unreadable/malformed) after
 # LEASE_WAIT_TIMEOUT_S, or if the post-write race-check shows another claim landed last.
 #
 # Lease shape (JSON, written into Hubitat Hub Variable `_TEST_HUB_LEASED_BY`):
@@ -72,15 +74,43 @@ set_lease_value() {
 # we claim only AFTER this wait, the lease TTL below starts at acquisition.
 WAIT_DEADLINE_S=$(( $(now_ms) / 1000 + LEASE_WAIT_TIMEOUT_S ))
 while :; do
-  NOW_MS="$(now_ms)"
-  NOW_S=$(( NOW_MS / 1000 ))
-  CURRENT="$(get_lease_value)"
+  # A read failure (cloud gateway down past mcp_call's own 5 retries) is NOT fatal
+  # mid-wait: a failed read claims nothing, so keep polling within the budget rather
+  # than aborting the run this wait exists to keep alive.
+  if ! CURRENT="$(get_lease_value)"; then
+    if [ "$(( $(now_ms) / 1000 ))" -ge "$WAIT_DEADLINE_S" ]; then
+      echo "::error::Lease unreadable (cloud gateway) through the ${LEASE_WAIT_TIMEOUT_S}s wait budget. Aborting."
+      exit 1
+    fi
+    echo "::warning::Lease read failed (cloud gateway); retrying next poll..."
+    sleep "$LEASE_POLL_INTERVAL_S"
+    continue
+  fi
 
   if [ -z "$CURRENT" ]; then
     break  # released
   fi
-  CURRENT_BY="$(echo "$CURRENT" | jq -r '.by // ""' 2>/dev/null || echo "")"
-  CURRENT_UNTIL="$(echo "$CURRENT" | jq -r '.until // 0' 2>/dev/null || echo 0)"
+
+  NOW_MS="$(now_ms)"
+  NOW_S=$(( NOW_MS / 1000 ))
+
+  # Parse defensively. A non-empty value that isn't well-formed JSON, or whose `until`
+  # is missing/non-numeric, means the variable holds SOMETHING (corrupt/truncated read,
+  # partial write) — treat it as BUSY, never as free. Claiming over an unparseable value
+  # would double-book the hub, which is exactly what the lease exists to prevent. (A bare
+  # `// 0` fallback here would read as "expired -> reclaimable" and silently double-claim.)
+  if ! CURRENT_BY="$(printf '%s' "$CURRENT" | jq -re '.by // ""' 2>/dev/null)" \
+     || ! CURRENT_UNTIL="$(printf '%s' "$CURRENT" | jq -re '.until' 2>/dev/null)" \
+     || ! printf '%s' "$CURRENT_UNTIL" | grep -qE '^[0-9]+$'; then
+    if [ "$NOW_S" -ge "$WAIT_DEADLINE_S" ]; then
+      echo "::error::Lease variable malformed/non-JSON through the ${LEASE_WAIT_TIMEOUT_S}s wait budget: $(printf '%.120s' "$CURRENT"). Aborting."
+      exit 1
+    fi
+    echo "::warning::Lease variable holds a malformed/non-JSON value (corrupt or truncated read?); treating as busy: $(printf '%.120s' "$CURRENT")"
+    sleep "$LEASE_POLL_INTERVAL_S"
+    continue
+  fi
+
   if [ "$CURRENT_BY" = "$BY" ]; then
     break  # re-entrant: already held by this run
   fi

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -54,20 +54,10 @@ permissions:
   contents: read
 
 jobs:
-  # Hub-less guard. No secret, no hub, no approval -- runs on EVERY PR (including
-  # before the maintainer approves an outside contributor's e2e) so the jq
-  # `// empty`-on-false regression in the self-deploy recovery extraction (issue #237)
-  # can't slip in unseen. Safe to run untrusted-PR code here: there is no secret in
-  # this job and the token is contents:read.
-  unit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || github.event.pull_request.head.sha || github.ref }}
-
-      - name: Unit-test self-deploy recovery extraction (hub-less)
-        run: bash .github/scripts/test_self_deploy_recovery.sh
+  # The hub-less self-deploy recovery guard (issue #237) is NOT here: running untrusted
+  # PR code in this privileged pull_request_target workflow is a cache-poisoning vector,
+  # so it lives in the unprivileged self-deploy-recovery.yml (pull_request) instead --
+  # it needs no secret and no hub, and runs on every PR there in a safe context.
 
   # Approval gate. The environment NAME is chosen from the PR author's relationship to
   # the repo:
@@ -94,7 +84,7 @@ jobs:
         run: echo "e2e approved to run against the shared test hub"
 
   e2e:
-    needs: [unit, approve]
+    needs: [approve]
     runs-on: ubuntu-latest
     # Bounds the whole job (lease wait + hold). Kept equal to the lease TTL in
     # lease_acquire.sh: the lease is claimed only AFTER any wait, so the

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -98,10 +98,12 @@ jobs:
 
     # Serialize against the shared test hub at the JOB level (not workflow level) so the
     # `approve` gate -- which may sit waiting on a human reviewer -- never holds this
-    # group. lease_acquire.sh ABORTS red if the hub is already leased (it does not
-    # wait), so this serialization is what keeps two e2e jobs from colliding on the
-    # lease. Don't cancel in-progress: a running job holds the lease and needs to
-    # release it cleanly via its `if: always()` cleanup step.
+    # group. This group is the PRIMARY serializer: it stops two CI e2e jobs from running
+    # against the single-tenant hub at once, so they never even both enter lease_acquire's
+    # wait loop. lease_acquire.sh's in-script wait (it polls a busy lease, it does NOT
+    # abort on sight) is the SECONDARY net -- it covers a manual hub session GitHub's
+    # `concurrency` can't see. Don't cancel in-progress: a running job holds the lease and
+    # needs to release it cleanly via its `if: always()` cleanup step.
     concurrency:
       group: hub-e2e
       cancel-in-progress: false

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -5,12 +5,22 @@ name: Hub E2E (test hub)
 #
 # Failure mode: BLOCKING. Per the maintainer this check is required for merge --
 # a red e2e means the change could not be proven against a real hub, so it gates.
-# When the job genuinely can't run (fork PR with no secret, or no test hub
-# configured) it skips cleanly rather than failing (see the secret gate below);
-# a confirmed infra/flake failure is triaged by the maintainer, not auto-ignored.
+#
+# Trigger is pull_request_target (NOT pull_request) so the run executes in the base
+# repo's trusted context and therefore has the hub secret even for fork PRs -- the
+# only way to auto-run e2e on a contributor's fork. The workflow file itself always
+# comes from the base branch under pull_request_target, so a PR cannot alter the CI
+# logic; it can only change the app source / tests that get deployed and run, which
+# is gated for untrusted authors by the `approve` job below.
+#
+# Who runs automatically vs. who waits for approval is decided by the `approve` job's
+# environment selection. When the hub secret genuinely isn't configured (someone
+# forked the whole project without a donated test hub) the e2e job skips cleanly
+# rather than failing -- see the secret gate inside it. A confirmed infra/flake
+# failure is triaged by the maintainer, not auto-ignored.
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     # Skip when only docs / non-test files change. Cuts CI cost on
     # README-only / SKILL-only PRs that can't break the hub-side surface.
@@ -40,24 +50,71 @@ on:
         description: 'PR number to test (blank = current ref)'
         required: false
 
-# Serialize concurrent runs against the shared test hub. Don't cancel
-# in-progress — they hold the lease and need to release it cleanly via
-# the `if: always()` cleanup step. A cancelled run that leaves a
-# stranded lease will eventually expire via the 30-min TTL, but it's
-# better to let things finish and release explicitly.
-concurrency:
-  group: hub-e2e
-  cancel-in-progress: false
-
 permissions:
   contents: read
 
 jobs:
-  e2e:
+  # Hub-less guard. No secret, no hub, no approval -- runs on EVERY PR (including
+  # before the maintainer approves an outside contributor's e2e) so the jq
+  # `// empty`-on-false regression in the self-deploy recovery extraction (issue #237)
+  # can't slip in unseen. Safe to run untrusted-PR code here: there is no secret in
+  # this job and the token is contents:read.
+  unit:
     runs-on: ubuntu-latest
-    # Must match the lease duration in lease_acquire.sh so the job can't
-    # outlive the lease and let another run trample state mid-test.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || github.event.pull_request.head.sha || github.ref }}
+
+      - name: Unit-test self-deploy recovery extraction (hub-less)
+        run: bash .github/scripts/test_self_deploy_recovery.sh
+
+  # Approval gate. The environment NAME is chosen from the PR author's relationship to
+  # the repo:
+  #   - trusted (repo owner / org member / write-access collaborator, plus @level99 and
+  #     @kingpanther13 named explicitly, and any maintainer workflow_dispatch) -> the
+  #     `e2e-auto` environment, which has no protection rules, so this job passes
+  #     immediately and e2e runs automatically.
+  #   - everyone else -> the `e2e-approval` environment, whose required-reviewer rule
+  #     pauses the run behind GitHub's "Review pending deployments" button until the
+  #     maintainer approves. Permanent (every run, not just first-time), e2e-only.
+  # author_association is computed server-side and can't be spoofed, and the workflow
+  # file is taken from the base branch under pull_request_target, so a PR can't edit
+  # this gate to promote itself.
+  #
+  # SEPARATE job from `e2e` on purpose: it holds no hub lease and no concurrency group,
+  # so an outside PR sitting unapproved can't stall the shared test hub for trusted
+  # runs. e2e starts only once this job succeeds (`needs`).
+  approve:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ (github.event_name == 'workflow_dispatch' || github.event.pull_request.author_association == 'OWNER' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.user.login == 'level99' || github.event.pull_request.user.login == 'kingpanther13') && 'e2e-auto' || 'e2e-approval' }}
+    steps:
+      - name: Gate
+        run: echo "e2e approved to run against the shared test hub"
+
+  e2e:
+    needs: [unit, approve]
+    runs-on: ubuntu-latest
+    # Bounds the whole job (lease wait + hold). Kept equal to the lease TTL in
+    # lease_acquire.sh: the lease is claimed only AFTER any wait, so the
+    # post-acquisition window always stays within the 30-min TTL and the job can't
+    # outlive its own lease and let another run trample state mid-test. lease_acquire.sh
+    # now WAITS for a busy lease (LEASE_WAIT_TIMEOUT_S, default 600s) and claims it when
+    # it frees instead of failing fast; that wait spends part of this same window, so a
+    # run that waits out most of it for a stuck lease times out red rather than running a
+    # truncated test.
     timeout-minutes: 30
+
+    # Serialize against the shared test hub at the JOB level (not workflow level) so the
+    # `approve` gate -- which may sit waiting on a human reviewer -- never holds this
+    # group. lease_acquire.sh ABORTS red if the hub is already leased (it does not
+    # wait), so this serialization is what keeps two e2e jobs from colliding on the
+    # lease. Don't cancel in-progress: a running job holds the lease and needs to
+    # release it cleanly via its `if: always()` cleanup step.
+    concurrency:
+      group: hub-e2e
+      cancel-in-progress: false
 
     env:
       MCP_URL: ${{ secrets.LEVEL99_TEST_HUB_MCP_URL }}
@@ -65,31 +122,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || github.ref }}
-
-      # Hub-less unit test of the self-deploy error-recovery extraction (issue #237). Runs ALWAYS
-      # (no hub / no secret needed) so the jq `// empty`-on-false bug -- which silently broke the
-      # verbatim-error recovery and that Spock can't catch -- cannot regress unnoticed.
-      - name: Unit-test self-deploy recovery extraction (hub-less)
-        run: bash .github/scripts/test_self_deploy_recovery.sh
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || github.event.pull_request.head.sha || github.ref }}
 
       - name: Check secret availability + skip if absent
-        # Two cases where MCP_URL is empty (and we want to skip silently
-        # rather than fail red):
-        #   - PRs from forks: GitHub's security policy strips secrets from
-        #     fork-PR workflow runs, even when the secret is set on the
-        #     upstream repo. The job runs but the env var is empty.
-        #   - Secret intentionally not configured (no donated test hub,
-        #     maintainer-private fork without test infra).
-        # The fork-dispatch path (workflow_dispatch from level99's fork)
-        # DOES have access to the secret, so this gate doesn't block the
-        # intended "run via fork dispatch" use case.
-        # GitHub doesn't allow `secrets` in job-level `if:` conditions, so
-        # the check happens here as a step output and gates everything below.
+        # MCP_URL is empty only when the secret isn't configured at all -- e.g. someone
+        # forked the whole project to a repo without the donated test hub. (Under
+        # pull_request_target on the upstream repo the run is in trusted context, so the
+        # secret IS present for both trusted and approved fork PRs; fork-PR secret
+        # stripping does NOT apply here the way it does to a plain pull_request trigger.)
+        # In the no-secret case we skip cleanly rather than fail red. GitHub doesn't allow
+        # `secrets` in job-level `if:` conditions, so the check happens here as a step
+        # output and gates everything below.
         id: gate
         run: |
           if [ -z "$MCP_URL" ]; then
-            echo "::notice::LEVEL99_TEST_HUB_MCP_URL secret not available — skipping E2E (expected on fork PRs and on repos without the test hub configured)"
+            echo "::notice::LEVEL99_TEST_HUB_MCP_URL secret not available — skipping E2E (expected on repos without the test hub configured)"
             echo "available=false" >> "$GITHUB_OUTPUT"
           else
             echo "available=true" >> "$GITHUB_OUTPUT"
@@ -177,7 +224,10 @@ jobs:
           DEFAULT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          # pull_request_target carries the same pull_request payload (head repo + sha),
+          # so treat it identically to pull_request -- otherwise we'd fall through to the
+          # base repo/sha and deploy BASE source instead of the PR's.
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ]; then
             REPO="$PR_HEAD_REPO"; SHA="$PR_HEAD_SHA"
           elif [ -n "${PR_INPUT:-}" ]; then
             # Validate the dispatch input before it reaches gh api.

--- a/.github/workflows/self-deploy-recovery.yml
+++ b/.github/workflows/self-deploy-recovery.yml
@@ -1,0 +1,27 @@
+name: Self-deploy recovery (hub-less)
+
+# Hub-less unit test of the self-deploy error-recovery extraction (issue #237). Runs on
+# PRs in the UNPRIVILEGED pull_request context (no secret, no hub, contents:read), so the
+# jq `// empty`-on-false bug -- which silently broke the verbatim-error recovery and that
+# Spock can't catch -- cannot regress unnoticed. It deliberately does NOT live in
+# hub-e2e.yml: that workflow is pull_request_target (privileged), where checking out and
+# running PR code is a cache-poisoning / untrusted-execution vector (CodeQL critical/high).
+
+on:
+  pull_request:
+    branches: [main]
+    # The extraction logic under test lives in the deploy scripts, so guard that surface.
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/self-deploy-recovery.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  self-deploy-recovery:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Unit-test self-deploy recovery extraction (hub-less)
+        run: bash .github/scripts/test_self_deploy_recovery.sh


### PR DESCRIPTION
## Summary

- Switch `hub-e2e` to `pull_request_target` so fork PRs run in the base repo's trusted
  context and can reach the test-hub secret — letting e2e run automatically against the
  real hub for trusted contributors' forks (owner, @level99, any write-access collaborator).
- Every other contributor's e2e is held behind a permanent, e2e-only "approve to run"
  button (a GitHub Environment required-reviewer gate) — same UX as the first-time-contributor
  gate, but permanent and only for people without write access.
- `lease_acquire.sh` now waits for a busy hub and claims it when it frees, instead of
  failing red and forcing a manual re-run.

## Type of change

- [x] `ci` — CI/CD pipeline change

## Changes

- **Trigger `pull_request` → `pull_request_target`.** Fork PRs now run in trusted context
  (secret present). The workflow file is always taken from `main` under
  `pull_request_target`, so a PR can't alter the CI logic — only the app source/tests it
  deploys, which is what the approval gate guards.
- **Split the single `e2e` job into three:**
  - `unit` — hub-less self-deploy recovery test (issue #237 guard). No secret, no approval;
    runs on every PR, including before an outside PR is approved.
  - `approve` — picks its Environment from the PR author's `author_association`: trusted
    authors (owner / member / write-access collaborator, plus @level99 and @kingpanther13
    explicitly, and maintainer `workflow_dispatch`) -> `e2e-auto` (no rules, runs immediately);
    everyone else -> `e2e-approval` (required-reviewer gate). Holds no lease/concurrency, so
    an unapproved PR can't stall the shared hub for trusted runs.
  - `e2e` — `needs: [unit, approve]`; carries the `hub-e2e` concurrency group + lease + secret.
- **Lease waits instead of failing fast.** `lease_acquire.sh` polls a busy lease
  (`LEASE_WAIT_TIMEOUT_S`, default 600s) and claims it when it frees or the holder's TTL
  lapses. The claim happens after the wait, so the 30-min TTL still starts at acquisition and
  `timeout-minutes` stays 30 — kept below the dead-man watchdog's 35-min arm window so the
  watchdog can still only fire after a dead job is killed, never mid-live-run.
- **importUrl fix:** the source-URL step now treats `pull_request_target` like
  `pull_request` (same head repo/sha) so it deploys the PR's source, not base.
- Requires two repo Environments: `e2e-auto` (no rules) and `e2e-approval` (required
  reviewer). Both already created.

## Release Notes

- Internal CI change — no user-facing impact.

## Testing

- YAML parse: 3 jobs (`unit`, `approve`, `e2e`), `e2e.needs: [unit, approve]`, job-level
  `hub-e2e` concurrency, `pull_request_target` trigger.
- `bash -n` on `lease_acquire.sh`.
- Ran the hub-less `test_self_deploy_recovery.sh` — all extraction cases pass.
- Auto-run vs approval-gate and the lease wait take effect for PRs opened after this merges
  (`pull_request_target` uses the base-branch workflow), and on this PR's own same-repo checks.

## Checklist

- [ ] Unit tests added for any new MCP tools — n/a (CI only)
- [ ] Sandbox lint / `./gradlew test` — n/a (no Groovy change)
- [ ] Live-hub BAT tests updated — n/a
- [ ] Documentation updated — n/a
- [ ] New/renamed MCP tools follow Tool Design Rules — n/a
