### PR TITLE
ci: speed up the watchdog e2e ~23% (bundle-only deploy, batched fixtures, deferred deletes)

### DIFF
--- a/.github/scripts/mcp_arm_watchdog.sh
+++ b/.github/scripts/mcp_arm_watchdog.sh
@@ -456,6 +456,16 @@ if ! mcp_tool_call_text "hub_write_file (arm flag)" "$WRITE_RPC" >/dev/null; the
   exit 1
 fi
 
+# Run-scope the deferred-native-rule list (PR #251): reset it to [] at arm so a PRIOR run's stale instance
+# ids can never be reaped by THIS run's disarm sweep. The test step overwrites it with THIS run's ids only
+# when E2E_DEFER_NATIVE_DELETES is set; absent that, an empty list is the correct no-op. Best-effort -- a
+# failure must not block the arm (the disarm sweep deletes only exact ids + the --cleanup-only prefix sweep
+# backstops, so a stale list is harmless beyond a no-op re-delete).
+DEFERRED_RULES_FILE="e2e-deferred-native-rules.json"
+mcp_tool_call_text "hub_write_file (reset deferred-rule list)" \
+  "$(jq -nc --arg fn "$DEFERRED_RULES_FILE" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_write_file",arguments:{fileName:$fn,content:"[]",confirm:true}}}')" >/dev/null 2>&1 \
+  || echo "::warning::Could not reset ${DEFERRED_RULES_FILE} at arm (non-fatal -- exact-id sweep + prefix backstop guard against stale ids)."
+
 # Read-back-and-assert: a cloud 504 can no-op a write while returning ambiguously. We assert
 # armed==true AND the manifest's app.classId round-tripped (the restore target landed intact).
 echo "Reading the flag back to confirm it armed..."

--- a/.github/scripts/mcp_arm_watchdog.sh
+++ b/.github/scripts/mcp_arm_watchdog.sh
@@ -240,11 +240,15 @@ if [ -n "${MAIN_CHARS:-}" ] && [ -n "${MAIN_SOURCE_URL:-}" ] && [ -n "${MAIN_SHA
     PRE_LSD_AT=$(printf '%s' "$PRE_INFO" | jq -r '(.lastSelfDeploy.at // 0) | floor' 2>/dev/null || echo 0)
     DM_RPC=$(jq -nc --arg id "$CLASS_ID" --arg url "$MAIN_SOURCE_URL" \
       '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_update_app",arguments:{appId:$id,importUrl:$url,confirm:true}}}')
-    mcp_tool_call_text "hub_update_app (refresh canonical main)" "$DM_RPC" >/dev/null || true
+    # Fire the deploy ONCE (single-shot mcp_call, NOT the 5x-retry mcp_tool_call_text): the ~1.6MB
+    # compile relay-drops the response, and retrying just RE-SENDS the deploy (re-triggering the compile)
+    # for ~80s of wasted timeouts + noisy ::warning:: lines. The fresh-lastSelfDeploy poll below is the
+    # real confirmation -- it tolerates the dropped response by design.
+    mcp_call "$DM_RPC" >/dev/null 2>&1 || true
     DM_LANDED=""
     DM_DEADLINE=$(( $(date +%s) + 420 ))
     while [ "$(date +%s)" -lt "$DM_DEADLINE" ]; do
-      sleep 15
+      sleep 5
       DM_INFO=$(mcp_tool_call_text "hub_get_info (main-refresh poll)" '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_get_info","arguments":{}}}' || true)
       DM_APP=$(printf '%s' "$DM_INFO" | jq -r '.lastSelfDeploy.appId // empty' 2>/dev/null || true)
       DM_AT=$(printf '%s' "$DM_INFO" | jq -r '(.lastSelfDeploy.at // 0) | floor' 2>/dev/null || echo 0)

--- a/.github/scripts/mcp_disarm_watchdog.sh
+++ b/.github/scripts/mcp_disarm_watchdog.sh
@@ -235,22 +235,38 @@ if DEF_TEXT=$(mcp_tool_call_text "hub_read_file (deferred native rules)" \
   DEF_IDS=$(printf '%s' "$DEF_TEXT" | jq -r '(.content // "[]") | fromjson | .[]?' 2>/dev/null || true)
   if [ -n "$DEF_IDS" ]; then
     def_n=0
+    def_fail=0
     while IFS= read -r rid; do
       [ -z "$rid" ] && continue
       def_n=$((def_n + 1))
       echo "Deferred-rule sweep: force-deleting native rule instance ${rid} (overlapping the restore)..."
-      mcp_call "$(jq -nc --arg id "$rid" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_force_delete_app",arguments:{id:$id,confirm:true}}}')" >/dev/null 2>&1 \
-        || echo "::warning::Deferred-rule sweep: force-delete of ${rid} hiccupped (best-effort; the --cleanup-only backstop will reap it)."
+      # mcp_tool_call_text PARSES the JSON-RPC result so we can check tool-level success -- force-delete is
+      # idempotent (deleting a gone rule is a no-op), so its retry is safe. Raw mcp_call would discard a
+      # tool-level error (tool missing, auth fail, 4xx/5xx) and look fine, masking a real failure.
+      if FD_TEXT=$(mcp_tool_call_text "hub_force_delete_app ${rid}" \
+          "$(jq -nc --arg id "$rid" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_force_delete_app",arguments:{id:$id,confirm:true}}}')" 2>/dev/null); then
+        if [ "$(printf '%s' "$FD_TEXT" | jq -r '.content | fromjson | .success' 2>/dev/null)" = "true" ]; then
+          continue
+        fi
+        echo "::warning::Deferred-rule sweep: hub_force_delete_app(${rid}) did not report success: $(printf '%s' "$FD_TEXT" | jq -c '.content|fromjson|{success,error}' 2>/dev/null | head -c 200)"
+      else
+        echo "::warning::Deferred-rule sweep: hub_force_delete_app(${rid}) returned no parseable result (tool missing on the watchdog / endpoint down?)."
+      fi
+      def_fail=$((def_fail + 1))
     done <<< "$DEF_IDS"
-    echo "Deferred-rule sweep: requested force-delete of ${def_n} native rule instance(s)."
-    # Empty the list so a re-run / the backstop never re-processes stale ids.
-    mcp_tool_call_text "hub_write_file (clear deferred list)" \
-      "$(jq -nc --arg fn "$DEFERRED_FILE" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_write_file",arguments:{fileName:$fn,content:"[]",confirm:true}}}')" >/dev/null 2>&1 || true
+    if [ "$def_fail" -eq 0 ]; then
+      echo "Deferred-rule sweep: force-deleted ${def_n} native rule instance(s); clearing the deferred-id list."
+      mcp_tool_call_text "hub_write_file (clear deferred list)" \
+        "$(jq -nc --arg fn "$DEFERRED_FILE" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_write_file",arguments:{fileName:$fn,content:"[]",confirm:true}}}')" >/dev/null 2>&1 \
+        || echo "::warning::Deferred-rule sweep: could not clear ${DEFERRED_FILE} (the arm step truncates it next run; re-deleting already-gone ids is a harmless no-op)."
+    else
+      echo "::warning::Deferred-rule sweep: ${def_fail}/${def_n} force-delete(s) did NOT confirm -- KEEPING ${DEFERRED_FILE} so the post-restore --cleanup-only prefix sweep (and the next run) can still reap them. Not failing the restore (best-effort)."
+    fi
   else
-    echo "Deferred-rule sweep: list empty -- nothing to reap (deferral off or no fixtures left behind)."
+    echo "Deferred-rule sweep: list empty -- nothing to reap (deferral off, or no native fixtures left behind)."
   fi
 else
-  echo "Deferred-rule sweep: no deferred-rule list file -- skipping (deferral was off)."
+  echo "::warning::Deferred-rule sweep: could not READ ${DEFERRED_FILE} after retries (transient transport, NOT necessarily deferral-off) -- relying on the post-restore --cleanup-only prefix sweep to reap any BAT_E2E_ rules."
 fi
 
 # --- 3) Poll for the watchdog's clean-finish restore (restoreResult==restored && restoreFor==runId) -

--- a/.github/scripts/mcp_disarm_watchdog.sh
+++ b/.github/scripts/mcp_disarm_watchdog.sh
@@ -245,10 +245,14 @@ if DEF_TEXT=$(mcp_tool_call_text "hub_read_file (deferred native rules)" \
       # tool-level error (tool missing, auth fail, 4xx/5xx) and look fine, masking a real failure.
       if FD_TEXT=$(mcp_tool_call_text "hub_force_delete_app ${rid}" \
           "$(jq -nc --arg id "$rid" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_force_delete_app",arguments:{id:$id,confirm:true}}}')" 2>/dev/null); then
-        if [ "$(printf '%s' "$FD_TEXT" | jq -r '.content | fromjson | .success' 2>/dev/null)" = "true" ]; then
+        # mcp_tool_call_text already unwraps .result.content[0].text, which the watchdog builds by
+        # JSON-serializing the tool's return map directly -- so success is TOP-LEVEL here ('.success'),
+        # NOT under a '.content' key. (The '.content | fromjson' shape applies only to hub_read_file,
+        # whose payload IS a file body under .content -- see the DEF_IDS read above.)
+        if [ "$(printf '%s' "$FD_TEXT" | jq -r '.success' 2>/dev/null)" = "true" ]; then
           continue
         fi
-        echo "::warning::Deferred-rule sweep: hub_force_delete_app(${rid}) did not report success: $(printf '%s' "$FD_TEXT" | jq -c '.content|fromjson|{success,error}' 2>/dev/null | head -c 200)"
+        echo "::warning::Deferred-rule sweep: hub_force_delete_app(${rid}) did not report success: $(printf '%s' "$FD_TEXT" | jq -c '{success,error}' 2>/dev/null | head -c 200)"
       else
         echo "::warning::Deferred-rule sweep: hub_force_delete_app(${rid}) returned no parseable result (tool missing on the watchdog / endpoint down?)."
       fi

--- a/.github/scripts/mcp_disarm_watchdog.sh
+++ b/.github/scripts/mcp_disarm_watchdog.sh
@@ -232,8 +232,18 @@ fi
 DEFERRED_FILE="e2e-deferred-native-rules.json"
 if DEF_TEXT=$(mcp_tool_call_text "hub_read_file (deferred native rules)" \
     "$(jq -nc --arg fn "$DEFERRED_FILE" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_read_file",arguments:{fileName:$fn}}}')" 2>/dev/null); then
-  DEF_IDS=$(printf '%s' "$DEF_TEXT" | jq -r '(.content // "[]") | fromjson | .[]?' 2>/dev/null || true)
-  if [ -n "$DEF_IDS" ]; then
+  # Split a parse failure from a valid (possibly empty) array. hub_read_file returns the file body
+  # under .content; jq '.[]' errors (exit != 0) on truncated/corrupt JSON but yields empty output on a
+  # valid []. A SWALLOWED parse error must NOT collapse to "nothing to reap" -- that would silently
+  # skip the exact-id sweep and leave the rules to only the non-gating prefix backstop.
+  DEF_CONTENT=$(printf '%s' "$DEF_TEXT" | jq -r '.content // ""' 2>/dev/null || true)
+  if [ -z "$DEF_CONTENT" ]; then
+    echo "Deferred-rule sweep: deferred-id file had no content (deferral off, or no native fixtures left behind)."
+  elif ! DEF_IDS=$(printf '%s' "$DEF_CONTENT" | jq -r '.[]' 2>/dev/null); then
+    echo "::error::Deferred-rule sweep: ${DEFERRED_FILE} is not a valid JSON array (truncated/corrupt write?) -- exact-id sweep SKIPPED; the post-restore --cleanup-only prefix sweep is now the ONLY backstop for these ids. Raw head: $(printf '%s' "$DEF_CONTENT" | head -c 200 | tr '\n' ' ')"
+  elif [ -z "$DEF_IDS" ]; then
+    echo "Deferred-rule sweep: deferred-id list is an empty array -- nothing to reap (no native fixtures left behind)."
+  else
     def_n=0
     def_fail=0
     while IFS= read -r rid; do
@@ -266,8 +276,6 @@ if DEF_TEXT=$(mcp_tool_call_text "hub_read_file (deferred native rules)" \
     else
       echo "::warning::Deferred-rule sweep: ${def_fail}/${def_n} force-delete(s) did NOT confirm -- KEEPING ${DEFERRED_FILE} so the post-restore --cleanup-only prefix sweep (and the next run) can still reap them. Not failing the restore (best-effort)."
     fi
-  else
-    echo "Deferred-rule sweep: list empty -- nothing to reap (deferral off, or no native fixtures left behind)."
   fi
 else
   echo "::warning::Deferred-rule sweep: could not READ ${DEFERRED_FILE} after retries (transient transport, NOT necessarily deferral-off) -- relying on the post-restore --cleanup-only prefix sweep to reap any BAT_E2E_ rules."

--- a/.github/scripts/mcp_disarm_watchdog.sh
+++ b/.github/scripts/mcp_disarm_watchdog.sh
@@ -27,10 +27,13 @@ set -euo pipefail
 
 FLAG_FILE="e2e-deadman-v2.json"
 
-# Bound the wait for the watchdog's once-a-minute checkDeadman to land the restore. ~6 min covers
-# several schedule ticks plus restore time; well under the e2e job's own timeout.
-RESTORE_POLL_ATTEMPTS=18
-RESTORE_POLL_SLEEP=20
+# Bound the wait for the watchdog to land the restore. The disarm flag-write KICKS a one-shot
+# checkDeadman in ~2s (watchdog adminWriteFile -> deadmanKick), so the restore normally starts almost
+# immediately; the runEvery1Minute tick is the fallback if that kick is ever missed. Poll finely (8s)
+# so completion is observed promptly; ~6 min total still covers a retry storm on the periodic schedule
+# and stays well under the e2e job's own timeout.
+RESTORE_POLL_ATTEMPTS=45
+RESTORE_POLL_SLEEP=8
 
 # --- cloud-gateway wrappers (target $WATCHDOG_URL, the watchdog's own MCP endpoint, not $MCP_URL) ----
 

--- a/.github/scripts/mcp_disarm_watchdog.sh
+++ b/.github/scripts/mcp_disarm_watchdog.sh
@@ -222,6 +222,37 @@ if [ "$RB_ARMED" != "false" ] || [ "$RB_INTENT" != "disarm" ]; then
   exit 1
 fi
 
+# --- 2.5) Reap DEFERRED native rules (E2E_DEFER_NATIVE_DELETES) over WATCHDOG_URL -------------------
+# If the test step deferred its per-test native-rule fixture deletes, it wrote the EXACT tracked instance
+# ids to 'e2e-deferred-native-rules.json'. Force-delete each (the INSTANCE, via the watchdog's
+# hub_force_delete_app) NOW -- the round-trips overlap the wall-clock the restore poll below spends
+# sleeping. Precise ids only (no /hub2/appsList shape-guessing -> no wrong-app risk). Best-effort +
+# SEQUENTIAL (RM concurrency rule): a hiccup NEVER fails the step (the post-restore --cleanup-only step
+# is the idempotent prefix backstop). Absent file / deferral-off -> clean no-op.
+DEFERRED_FILE="e2e-deferred-native-rules.json"
+if DEF_TEXT=$(mcp_tool_call_text "hub_read_file (deferred native rules)" \
+    "$(jq -nc --arg fn "$DEFERRED_FILE" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_read_file",arguments:{fileName:$fn}}}')" 2>/dev/null); then
+  DEF_IDS=$(printf '%s' "$DEF_TEXT" | jq -r '(.content // "[]") | fromjson | .[]?' 2>/dev/null || true)
+  if [ -n "$DEF_IDS" ]; then
+    def_n=0
+    while IFS= read -r rid; do
+      [ -z "$rid" ] && continue
+      def_n=$((def_n + 1))
+      echo "Deferred-rule sweep: force-deleting native rule instance ${rid} (overlapping the restore)..."
+      mcp_call "$(jq -nc --arg id "$rid" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_force_delete_app",arguments:{id:$id,confirm:true}}}')" >/dev/null 2>&1 \
+        || echo "::warning::Deferred-rule sweep: force-delete of ${rid} hiccupped (best-effort; the --cleanup-only backstop will reap it)."
+    done <<< "$DEF_IDS"
+    echo "Deferred-rule sweep: requested force-delete of ${def_n} native rule instance(s)."
+    # Empty the list so a re-run / the backstop never re-processes stale ids.
+    mcp_tool_call_text "hub_write_file (clear deferred list)" \
+      "$(jq -nc --arg fn "$DEFERRED_FILE" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_write_file",arguments:{fileName:$fn,content:"[]",confirm:true}}}')" >/dev/null 2>&1 || true
+  else
+    echo "Deferred-rule sweep: list empty -- nothing to reap (deferral off or no fixtures left behind)."
+  fi
+else
+  echo "Deferred-rule sweep: no deferred-rule list file -- skipping (deferral was off)."
+fi
+
 # --- 3) Poll for the watchdog's clean-finish restore (restoreResult==restored && restoreFor==runId) -
 # checkDeadman runs every minute and processes intent=disarm exactly once per runId, stamping
 # restoreFor=runId + restoreResult. We poll the flag until that stamp matches THIS run, then assert it

--- a/.github/scripts/mcp_watchdog_deploy.sh
+++ b/.github/scripts/mcp_watchdog_deploy.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Install THIS PR's package onto the live test hub via the WATCHDOG MCP endpoint,
-# in Hubitat Package Manager's exact order: LIBRARIES first, then the BUNDLE (if
-# the package ships one), then the APP last.
+# in Hubitat Package Manager's order: the BUNDLE (which delivers every #included
+# library) first, then the APP last. Libraries are NOT installed individually --
+# the bundle ships them; doing both was redundant and forced an extra recompile.
 #
 # This single script REPLACES the four cloud-relay deploy scripts it consolidates:
 #   - mcp_install_libraries.sh   (install/update every #included library)
@@ -14,8 +15,8 @@
 # code-install plumbing. Its advantage over self-deploying through the primary
 # endpoint is that the watchdog is a DIFFERENT running app, so installing the MCP
 # package does NOT reload the app answering the request -- it never bricks itself
-# and stays queryable throughout. Small/fast calls (the libraries, the package's
-# libraries bundle, get_source, get_info) return the hub's VERBATIM compile/save
+# and stays queryable throughout. Small/fast calls (the package's libraries bundle,
+# get_source, get_info) return the hub's VERBATIM compile/save
 # result synchronously within the ~10s cloud relay window (a bundle install is the hub
 # fetching + unpacking a small zip, well within the window), so VERIFY for those is
 # simply: parse the tool
@@ -27,9 +28,10 @@
 # as a secondary source for the hub's verbatim compile error if it never does.
 #
 # Install order (HPM's order; #include deps must exist before the app compiles):
-#   1. LIBRARIES  hub_update_library / hub_create_library  importUrl=<lib raw url>  confirm:true
-#   2. BUNDLE     hub_install_bundle                        importUrl=<bundle zip url> confirm:true  (only if present)
-#   3. APP        hub_update_app  appId=<MCP class id>      importUrl=<app raw url>  confirm:true
+#   1. BUNDLE  hub_install_bundle  importUrl=<bundle zip url>  confirm:true  (delivers EVERY #included library)
+#   2. APP     hub_update_app  appId=<MCP class id>  importUrl=<app raw url>  confirm:true
+# Libraries are delivered ONLY by the bundle -- there is no per-#include hub_update_library/hub_create_library
+# step (section 1 only DISCOVERS the #includes + sanity-checks the manifest declares a bundle to deliver them).
 #
 # Usage: mcp_watchdog_deploy.sh [path/to/hubitat-mcp-server.groovy]
 # Env:   WATCHDOG_URL          -- full watchdog MCP endpoint URL with access_token (secret WATCHDOG_MCP_URL)
@@ -39,7 +41,7 @@
 #
 # The app's importUrl points the hub at the PR branch's raw source so the ~1.5MB
 # blob never has to cross the MCP transport as an inline argument (importUrl
-# deploy, issue #228); each library/bundle importUrl is built from PR_RAW_BASE +
+# deploy, issue #228); the bundle importUrl is built from PR_RAW_BASE +
 # the resolved head SHA + the repo-relative path.
 set -euo pipefail
 

--- a/.github/scripts/mcp_watchdog_deploy.sh
+++ b/.github/scripts/mcp_watchdog_deploy.sh
@@ -52,7 +52,6 @@ if [ ! -f "$APP_FILE" ]; then
   echo "::error::App file not found: $APP_FILE (wrong working directory or bad path arg). Refusing to silently report 'nothing to install'."
   exit 1
 fi
-LIB_DIR="$(dirname "$APP_FILE")/libraries"
 
 # Pulled from the parent app's definition() block -- keep in sync if the parent
 # ever changes its namespace/name (HPM tracks it, so it shouldn't).
@@ -88,93 +87,23 @@ mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_cr
   || echo "::warning::hub_create_backup call failed/timed out; continuing (the backup is a defensive snapshot, not required for writes)"
 
 # ===========================================================================
-# 1) LIBRARIES FIRST -- install/update every library the app #includes so the
-#    `#include` directives resolve when the app compiles (issue #209). Matches
-#    each #include to its library file by the (namespace, name) declared in the
-#    library() block (NOT by filename, mirroring how the hub resolves #includes).
+# 1) LIBRARIES are delivered ONLY by the BUNDLE below (section 2) -- the bundle is the real HPM/user
+#    "one Update click" delivery path, and it ships every library the app #includes. Re-installing each
+#    #included library INDIVIDUALLY here (the old per-#include hub_update_library/create loop) was
+#    redundant -- the bundle delivers the same libraries -- and it triggered an extra hub recompile of
+#    the running app per library touched. So this step now only DISCOVERS the #include set and
+#    sanity-checks the package can deliver it (a manifest with #includes but no bundle would leave the
+#    directives unresolved and the app would fail to compile). The exact library bytes land in section 2.
 # ===========================================================================
 mapfile -t INCLUDES < <(
   grep -hoE '^[[:space:]]*#include[[:space:]]+[A-Za-z0-9_]+\.[A-Za-z0-9_]+' "$APP_FILE" \
     | sed -E 's/^[[:space:]]*#include[[:space:]]+//' | sort -u || true
 )
-
-if [ "${#INCLUDES[@]}" -eq 0 ]; then
-  echo "No #include directives in $APP_FILE -- no libraries to install."
-else
-  echo "App #includes ${#INCLUDES[@]} library(ies): ${INCLUDES[*]}"
-
-  # Snapshot existing hub libraries once, to choose update-vs-create per library. Use the RETRYING
-  # read: this is an idempotent list, and a single cloud-relay drop here (the hub is briefly busy right
-  # after the best-effort backup above + the arm's canonical-main bundle refresh) must not hard-fail the
-  # whole deploy. (Retry is safe for reads; the create/update/delete WRITES below stay single-shot.)
-  LIB_LIST_TEXT=$(call_tool_retry '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_list_libraries","arguments":{}}}')
-  if [ -z "$LIB_LIST_TEXT" ]; then
-    echo "::error::hub_list_libraries returned no MCP content from the watchdog endpoint after retries -- cannot plan create-vs-update. Re-run; if it persists, check the watchdog app logs."
-    exit 1
-  fi
-
-  for tok in "${INCLUDES[@]}"; do
-    ns="${tok%%.*}"
-    name="${tok##*.}"
-
-    # Find the local library file whose library() declares this (namespace, name).
-    libfile=""
-    for f in "$LIB_DIR"/*.groovy; do
-      [ -f "$f" ] || continue
-      if grep -qE 'library[[:space:]]*\(' "$f" \
-        && grep -qE "name:[[:space:]]*[\"']${name}[\"']" "$f" \
-        && grep -qE "namespace:[[:space:]]*[\"']${ns}[\"']" "$f"; then
-        libfile="$f"
-        break
-      fi
-    done
-    if [ -z "$libfile" ]; then
-      echo "::error::#include ${tok} has no matching library file in ${LIB_DIR}"
-      exit 1
-    fi
-    rel="${libfile#./}"
-    url="${PR_RAW_BASE}/${PR_HEAD_SHA_RESOLVED}/${rel}"
-
-    existing_id=$(printf '%s' "$LIB_LIST_TEXT" | jq -r --arg ns "$ns" --arg name "$name" \
-      '(.libraries // []) | map(select(.namespace==$ns and .name==$name)) | (.[0].id // empty)' 2>/dev/null || true)
-
-    if [ -n "$existing_id" ] && [ "$existing_id" != "null" ]; then
-      echo "Updating existing library ${tok} (id ${existing_id}) from ${url} ..."
-      UPD_RPC=$(jq -nc --arg id "$existing_id" --arg url "$url" \
-        '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_update_library",arguments:{libraryId:$id,importUrl:$url,confirm:true}}}')
-      UPD_TEXT=$(call_tool "$UPD_RPC")
-      if [ "$(ok_of "$UPD_TEXT")" = "true" ]; then
-        echo "Library ${tok} updated."
-        continue
-      fi
-      # Update failed. The existing copy may be BUNDLE-MANAGED (a prior bundle run
-      # delivered it) and non-editable in place. Self-heal so a previous bundle run
-      # can't strand this step on a later PR: delete the existing copy, recreate fresh.
-      echo "::warning::hub_update_library failed for ${tok}; deleting + recreating (existing copy may be bundle-managed): $(printf '%s' "$UPD_TEXT" | jq -c '{success,error}' 2>/dev/null || printf '%s' "$UPD_TEXT" | head -c 200)"
-      DEL_RPC=$(jq -nc --arg id "$existing_id" \
-        '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_delete_item",arguments:{type:"library",id:$id,confirm:true}}}')
-      DEL_TEXT=$(call_tool "$DEL_RPC")
-      if [ "$(ok_of "$DEL_TEXT")" != "true" ]; then
-        echo "::error::Could not update OR delete existing library ${tok} (id ${existing_id}) -- it appears locked (e.g. bundle-managed) and this script cannot reconcile it. Remove it manually on the hub (FOR DEVELOPERS > Libraries code, or the bundle in Bundle Manager): $(printf '%s' "$DEL_TEXT" | jq -c '{success,error}' 2>/dev/null || printf '%s' "$DEL_TEXT" | head -c 300)"
-        exit 1
-      fi
-      echo "Deleted stale ${tok}; will recreate from source."
-    else
-      echo "Creating library ${tok} from ${url} ..."
-    fi
-
-    CRT_RPC=$(jq -nc --arg url "$url" \
-      '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_create_library",arguments:{importUrl:$url,confirm:true}}}')
-    CRT_TEXT=$(call_tool "$CRT_RPC")
-    if [ "$(ok_of "$CRT_TEXT")" != "true" ]; then
-      echo "::error::Library ${tok} create failed (transient relay error or a hub-side rejection). Hub verbatim: $(err_of "$CRT_TEXT") -- full: $(printf '%s' "$CRT_TEXT" | jq -c '{success,error,note,verified}' 2>/dev/null || printf '%s' "$CRT_TEXT" | head -c 400)"
-      exit 1
-    fi
-    echo "Library ${tok} OK."
-  done
-
-  echo "All ${#INCLUDES[@]} PR library(ies) installed/updated -- the app's #include directives will resolve on deploy."
+if [ "${#INCLUDES[@]}" -gt 0 ] && [ -z "$BUNDLE_RELS" ]; then
+  echo "::error::App #includes ${#INCLUDES[@]} library(ies) (${INCLUDES[*]}) but packageManifest.json declares NO bundle to deliver them. A bundle-only install would leave the #include directives unresolved and the app would not compile. Add the libraries' bundle to the manifest."
+  exit 1
 fi
+echo "App #includes ${#INCLUDES[@]} library(ies): ${INCLUDES[*]:-<none>} -- delivered via the package bundle (section 2), the HPM way (no redundant per-library install)."
 
 # ===========================================================================
 # 2) BUNDLE(S) -- install every bundle the manifest declares, the HPM way (HPM

--- a/.github/scripts/mcp_watchdog_lib.sh
+++ b/.github/scripts/mcp_watchdog_lib.sh
@@ -105,7 +105,7 @@ deploy_app_via_watchdog() {
   local deadline info cur_app cur_at cur_ok cur_err
   deadline=$(( $(date +%s) + 420 ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    sleep 15
+    sleep 5
     info=$(call_tool '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_get_info","arguments":{}}}')
     cur_app=$(printf '%s' "$info" | jq -r '.lastSelfDeploy.appId // empty' 2>/dev/null || true)
     cur_at=$(printf '%s' "$info" | jq -r '(.lastSelfDeploy.at // 0) | floor' 2>/dev/null || echo 0)

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -335,12 +335,12 @@ jobs:
           MAIN_CHARS: ${{ env.MAIN_CHARS }}
         run: bash .github/scripts/mcp_arm_watchdog.sh
 
-      # Install THIS PR's source + libraries + bundle onto the test hub through the watchdog's
-      # install plumbing ($WATCHDOG_URL). Replaces the old separate install-libraries / deploy-source /
-      # verify-deploy / install-bundle-HPM steps: the watchdog endpoint is a single driver of the
-      # same loopback restore/install plumbing, so it installs the #include libraries, then the bundle
-      # the HPM way, then lands + verifies the app source last (HPM's libraries -> bundle -> app order)
-      # in one step. Blocking:
+      # Install THIS PR's source onto the test hub through the watchdog's install plumbing
+      # ($WATCHDOG_URL). Replaces the old separate install-libraries / deploy-source / verify-deploy /
+      # install-bundle-HPM steps: the watchdog endpoint is a single driver of the same loopback
+      # restore/install plumbing, so it installs the package bundle the HPM way (the bundle delivers
+      # every #include library -- no separate per-library install), then lands + verifies the app
+      # source last (HPM's bundle -> app order) in one step. Blocking:
       # a failed PR install means the tests would run against stale/broken hub code.
       - name: Watchdog - install PR
         if: steps.gate.outputs.available == 'true'

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -353,7 +353,7 @@ jobs:
         if: steps.gate.outputs.available == 'true'
         env:
           # Defer per-test native-rule fixture deletes to the disarm step's force sweep (over
-          # WATCHDOG_URL, overlapping the ~100s restore poll) instead of the test critical path.
+          # WATCHDOG_URL, overlapping the restore-poll wait) instead of the test critical path.
           # NOT set on the post-restore --cleanup-only step below, which stays the idempotent backstop.
           E2E_DEFER_NATIVE_DELETES: '1'
         run: python tests/e2e_test.py

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -351,6 +351,11 @@ jobs:
 
       - name: Run E2E tests
         if: steps.gate.outputs.available == 'true'
+        env:
+          # Defer per-test native-rule fixture deletes to the disarm step's force sweep (over
+          # WATCHDOG_URL, overlapping the ~100s restore poll) instead of the test critical path.
+          # NOT set on the post-restore --cleanup-only step below, which stays the idempotent backstop.
+          E2E_DEFER_NATIVE_DELETES: '1'
         run: python tests/e2e_test.py
 
       # The install above landed THIS PR's app on the hub, so hub_update_package now

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ Per-run flow (all over `WATCHDOG_URL` unless noted), driven by `.github/scripts/
 2. **Lease** — serialize runs on the single shared hub (a hub variable with a TTL).
 3. **Self-update** — deploy THIS PR's `e2e-deadman-watchdog-v2.groovy` onto the watchdog itself (`mcp_watchdog_self_update.sh`), so e2e exercises the watchdog the PR ships. After the one-time manual install, the watchdog never needs to be re-imported.
 4. **Arm** (`mcp_arm_watchdog.sh`) — refresh the hub to canonical `main` if it drifted or `main`'s SHA changed (skip when current), cache main (app + each `#include`d library) to File Manager, and write an armed flag with a ~35-min deadline.
-5. **Install PR** (`mcp_watchdog_deploy.sh`) — libraries → bundle → app, each confirmed via a FRESH `lastSelfDeploy` success (survives the relay-dropped ~1.6 MB response AND a same-length change, so a stale source can't false-green).
+5. **Install PR** (`mcp_watchdog_deploy.sh`) — bundle → app (the bundle delivers every `#include`d library, so there is no separate per-library install step; installing a library individually AND via the bundle was redundant and forced an extra recompile). The app deploy is confirmed via a FRESH `lastSelfDeploy` success (survives the relay-dropped ~1.6 MB response AND a same-length change, so a stale source can't false-green).
 6. **Tests** — `tests/e2e_test.py` against `MCP_URL`.
 7. **Disarm / restore** (`mcp_disarm_watchdog.sh`) — the watchdog's on-hub `checkDeadman` timer restores main from the cache (libraries-first, app-last). CI fires an early disarm on a clean finish; if CI can't (the run crashed), the watchdog auto-restores at the deadline — the dead-man.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ Per-run flow (all over `WATCHDOG_URL` unless noted), driven by `.github/scripts/
 2. **Lease** — serialize runs on the single shared hub (a hub variable with a TTL).
 3. **Self-update** — deploy THIS PR's `e2e-deadman-watchdog-v2.groovy` onto the watchdog itself (`mcp_watchdog_self_update.sh`), so e2e exercises the watchdog the PR ships. After the one-time manual install, the watchdog never needs to be re-imported.
 4. **Arm** (`mcp_arm_watchdog.sh`) — refresh the hub to canonical `main` if it drifted or `main`'s SHA changed (skip when current), cache main (app + each `#include`d library) to File Manager, and write an armed flag with a ~35-min deadline.
-5. **Install PR** (`mcp_watchdog_deploy.sh`) — libraries → bundle → app, each confirmed via a FRESH `lastSelfDeploy` success (survives the relay-dropped ~1.6 MB response AND a same-length change, so a stale source can't false-green).
+5. **Install PR** (`mcp_watchdog_deploy.sh`) — bundle → app (the bundle delivers every `#include`d library, so there is no separate per-library install step; installing a library individually AND via the bundle was redundant and forced an extra recompile). The app deploy is confirmed via a FRESH `lastSelfDeploy` success (survives the relay-dropped ~1.6 MB response AND a same-length change, so a stale source can't false-green).
 6. **Tests** — `tests/e2e_test.py` against `MCP_URL`.
 7. **Disarm / restore** (`mcp_disarm_watchdog.sh`) — the watchdog's on-hub `checkDeadman` timer restores main from the cache (libraries-first, app-last). CI fires an early disarm on a clean finish; if CI can't (the run crashed), the watchdog auto-restores at the deadline — the dead-man.
 

--- a/e2e-deadman-watchdog-v2.groovy
+++ b/e2e-deadman-watchdog-v2.groovy
@@ -663,6 +663,7 @@ def executeAdminTool(String toolName, Map args) {
         case "hub_create_library":  return adminCreateLibrary(args)
         case "hub_update_library":  return adminUpdateLibrary(args)
         case "hub_delete_item":     return adminDeleteItem(args)
+        case "hub_force_delete_app": return adminForceDeleteInstalledApp(args)
         case "hub_install_bundle":  return adminInstallBundle(args)
         case "hub_list_bundles":    return adminListBundles(args)
         case "hub_delete_bundle":   return adminDeleteBundle(args)
@@ -1083,6 +1084,25 @@ def adminDeleteItem(args) {
         log.error "adminDeleteItem(${type}): ${e.message}"
         return [success: false, error: "${type.capitalize()} deletion failed: ${e.message}"]
     }
+}
+
+// hub_force_delete_app: force-delete an INSTALLED-APP INSTANCE (e.g. an RM rule) via
+// /installedapp/forcedelete/<id>/quiet -- the same path RM's "Delete Rule" button uses, bypassing
+// child/device checks (mirrors the server's _rmForceDeleteApp). DISTINCT from hub_delete_item(type:'app'),
+// which hits /app/edit/deleteJsonSafe (an Apps Code CLASS, not a running instance). Used by the disarm-
+// time deferred-native-rule sweep; best-effort -- the GET reaching the hub triggers the delete regardless
+// of how the 302 redirect body parses, so a dropped/empty response is NOT treated as failure (the sweep
+// re-lists to confirm the rule is actually gone).
+def adminForceDeleteInstalledApp(args) {
+    requireConfirm(args)
+    def id = (args.id != null) ? args.id : args.appId
+    if (!id) throw new IllegalArgumentException("id (the installed-app instance id) is required")
+    if (!id.toString().isInteger() || id.toString().toInteger() <= 0) {
+        throw new IllegalArgumentException("id must be a positive integer (got: '${id}')")
+    }
+    mcpAdminLog "Force-deleting installed app instance ${id} (/installedapp/forcedelete/${id}/quiet)"
+    hubGet("/installedapp/forcedelete/${id}/quiet", [:])
+    return [success: true, message: "Force-delete requested for installed app ${id}.", id: id]
 }
 
 // hub_install_bundle: copied from toolInstallBundle + _firmwareAtLeast + _bundleResponseSucceeded
@@ -1566,6 +1586,8 @@ def getAdminToolDefinitions() {
             required: ["libraryId", "confirm"]]],
         [name: "hub_delete_item", description: "Delete an app/driver/library by id. confirm:true required.",
          inputSchema: [type: "object", properties: [type: [type: "string", enum: ["app", "driver", "library"]], id: [type: "string"], confirm: [type: "boolean"]], required: ["type", "id", "confirm"]]],
+        [name: "hub_force_delete_app", description: "Force-delete an INSTALLED-APP instance (e.g. an RM rule) via /installedapp/forcedelete/<id>/quiet. confirm:true required.",
+         inputSchema: [type: "object", properties: [id: [type: "string"], confirm: [type: "boolean"]], required: ["id", "confirm"]]],
         [name: "hub_install_bundle", description: "Install a code bundle .zip from a URL the hub fetches itself (HPM-style). confirm:true required.",
          inputSchema: [type: "object", properties: [importUrl: [type: "string"], primary: [type: "boolean"], confirm: [type: "boolean"]], required: ["importUrl", "confirm"]]],
         [name: "hub_list_bundles", description: "List installed code bundle containers (id/name/namespace). Read-only.",

--- a/e2e-deadman-watchdog-v2.groovy
+++ b/e2e-deadman-watchdog-v2.groovy
@@ -143,6 +143,12 @@ def checkDeadman() {
     actAndRecord(flag, "fire")
 }
 
+// One-shot accelerator scheduled by adminWriteFile right after CI writes the armed flag. A handler
+// name DISTINCT from "checkDeadman" is deliberate: it guarantees runIn() never overwrites the
+// runEvery1Minute("checkDeadman") periodic dead-man job. Delegates to the same idempotent check, so it
+// just makes the disarm restore happen ~2s after the flag write instead of on the next minute tick.
+def deadmanKick() { checkDeadman() }
+
 // Run the package restore, then record result + idempotency stamp into the flag (the signal CI
 // polls). BOTH triggers retry up to a 5-tick cap before latching "failed" (a transient miss must not
 // latch the restore failed); a success stamps restoreFor=runId so it runs at most once per run.
@@ -1405,6 +1411,13 @@ def adminWriteFile(args) {
     }
     try {
         uploadHubFile(args.fileName, args.content.getBytes("UTF-8"))
+        // Accelerate the dead-man: kick a one-shot checkDeadman ~2s after CI writes the armed flag,
+        // instead of waiting up to ~60s for the next runEvery1Minute tick (the single biggest avoidable
+        // cost in the disarm/restore step). A DEDICATED handler (deadmanKick, NOT "checkDeadman") means
+        // scheduling it can never overwrite the periodic dead-man job, so the brick/GitHub-down floor
+        // stays intact; checkDeadman is idempotent (restoreFor stamp), so an arm-write kick is a harmless
+        // no-op and only a disarm write actually restores -- ~58s sooner.
+        if (args.fileName == (flagFileName ?: "e2e-deadman-v2.json")) runIn(2, "deadmanKick")
         return [success: true, message: "File '${args.fileName}' written.", fileName: args.fileName, contentLength: args.content.length()]
     } catch (Exception e) {
         log.error "adminWriteFile: ${e.message}"

--- a/e2e-deadman-watchdog-v2.groovy
+++ b/e2e-deadman-watchdog-v2.groovy
@@ -1088,13 +1088,13 @@ def adminDeleteItem(args) {
 
 // hub_force_delete_app: force-delete an INSTALLED-APP INSTANCE (e.g. an RM rule) via
 // /installedapp/forcedelete/<id>/quiet -- the same path RM's "Delete Rule" button uses, bypassing
-// child/device checks. Loosely based on the server's _rmForceDeleteApp (same endpoint), adapted to the
-// watchdog's fire-and-forget hubGet -- no status check, no backup. DISTINCT from hub_delete_item(type:'app'),
-// which hits /app/edit/deleteJsonSafe (an Apps Code CLASS, not a running instance). Used by the disarm-time
-// deferred-native-rule sweep. On success the 302 redirect is followed to the apps-list page, so hubGet
-// returns non-null; hubGet returns NULL on a 4xx/5xx, an auth/cookie failure, or a request that never
-// reached the hub -- report THAT as success:false so the disarm sweep can warn + keep its recovery list
-// (any rule that survives is reaped by the separate post-restore --cleanup-only prefix sweep, not a re-list).
+// child/device checks. Loosely based on the server's _rmForceDeleteApp (same endpoint). Status-aware
+// via hubGetStatus: the forcedelete endpoint answers SUCCESS with a 302 redirect, so a 2xx/3xx status
+// is success while >=400 -- or no status at all, meaning the request never reached the hub (auth/
+// transport) -- is reported as success:false so the disarm sweep can warn + keep its recovery list
+// (any rule that survives is reaped by the separate post-restore --cleanup-only prefix sweep, not a
+// re-list). DISTINCT from hub_delete_item(type:'app'), which hits /app/edit/deleteJsonSafe (an Apps
+// Code CLASS, not a running instance). Used by the disarm-time deferred-native-rule sweep.
 def adminForceDeleteInstalledApp(args) {
     requireConfirm(args)
     def id = (args.id != null) ? args.id : args.appId

--- a/e2e-deadman-watchdog-v2.groovy
+++ b/e2e-deadman-watchdog-v2.groovy
@@ -1088,11 +1088,13 @@ def adminDeleteItem(args) {
 
 // hub_force_delete_app: force-delete an INSTALLED-APP INSTANCE (e.g. an RM rule) via
 // /installedapp/forcedelete/<id>/quiet -- the same path RM's "Delete Rule" button uses, bypassing
-// child/device checks (mirrors the server's _rmForceDeleteApp). DISTINCT from hub_delete_item(type:'app'),
-// which hits /app/edit/deleteJsonSafe (an Apps Code CLASS, not a running instance). Used by the disarm-
-// time deferred-native-rule sweep; best-effort -- the GET reaching the hub triggers the delete regardless
-// of how the 302 redirect body parses, so a dropped/empty response is NOT treated as failure (the sweep
-// re-lists to confirm the rule is actually gone).
+// child/device checks. Loosely based on the server's _rmForceDeleteApp (same endpoint), adapted to the
+// watchdog's fire-and-forget hubGet -- no status check, no backup. DISTINCT from hub_delete_item(type:'app'),
+// which hits /app/edit/deleteJsonSafe (an Apps Code CLASS, not a running instance). Used by the disarm-time
+// deferred-native-rule sweep. On success the 302 redirect is followed to the apps-list page, so hubGet
+// returns non-null; hubGet returns NULL on a 4xx/5xx, an auth/cookie failure, or a request that never
+// reached the hub -- report THAT as success:false so the disarm sweep can warn + keep its recovery list
+// (any rule that survives is reaped by the separate post-restore --cleanup-only prefix sweep, not a re-list).
 def adminForceDeleteInstalledApp(args) {
     requireConfirm(args)
     def id = (args.id != null) ? args.id : args.appId
@@ -1101,7 +1103,10 @@ def adminForceDeleteInstalledApp(args) {
         throw new IllegalArgumentException("id must be a positive integer (got: '${id}')")
     }
     mcpAdminLog "Force-deleting installed app instance ${id} (/installedapp/forcedelete/${id}/quiet)"
-    hubGet("/installedapp/forcedelete/${id}/quiet", [:])
+    def resp = hubGet("/installedapp/forcedelete/${id}/quiet", [:])
+    if (resp == null) {
+        return [success: false, error: "Force-delete of installed app ${id} got no response -- endpoint error, auth failure, or 4xx/5xx (the request may not have reached the hub).", id: id]
+    }
     return [success: true, message: "Force-delete requested for installed app ${id}.", id: id]
 }
 

--- a/e2e-deadman-watchdog-v2.groovy
+++ b/e2e-deadman-watchdog-v2.groovy
@@ -1103,11 +1103,15 @@ def adminForceDeleteInstalledApp(args) {
         throw new IllegalArgumentException("id must be a positive integer (got: '${id}')")
     }
     mcpAdminLog "Force-deleting installed app instance ${id} (/installedapp/forcedelete/${id}/quiet)"
-    def resp = hubGet("/installedapp/forcedelete/${id}/quiet", [:])
-    if (resp == null) {
-        return [success: false, error: "Force-delete of installed app ${id} got no response -- endpoint error, auth failure, or 4xx/5xx (the request may not have reached the hub).", id: id]
+    def resp = hubGetStatus("/installedapp/forcedelete/${id}/quiet", [:])
+    Integer st = (resp?.status != null) ? (resp.status as Integer) : null
+    // The forcedelete endpoint answers SUCCESS with a 302 redirect to the apps list (a plain 2xx is
+    // also fine). >=400 -- or no status at all, meaning the request never reached the hub
+    // (auth/transport) -- is a real failure: report it so the disarm sweep warns + keeps its id list.
+    if (st != null && st < 400) {
+        return [success: true, message: "Force-deleted installed app ${id} (HTTP ${st}).", id: id]
     }
-    return [success: true, message: "Force-delete requested for installed app ${id}.", id: id]
+    return [success: false, error: "Force-delete of installed app ${id} did not confirm (status=${st ?: 'none'}) -- endpoint error, auth failure, or the request never reached the hub.", id: id]
 }
 
 // hub_install_bundle: copied from toolInstallBundle + _firmwareAtLeast + _bundleResponseSucceeded
@@ -1669,6 +1673,35 @@ String hubGet(String path, Map query, int timeoutSec = 30) {
     String out = null
     try { httpGet(params) { resp -> out = respText(resp) } }
     catch (Exception e) { log.error "hubGet ${path}: ${e.message}" }
+    return out
+}
+
+// Status-aware loopback GET. Unlike hubGet (text body, swallows every exception -> null), this
+// returns [status, location, data] and treats a 3xx the way the hub editor does: endpoints like
+// /installedapp/forcedelete answer SUCCESS with a 302 redirect, which Hubitat's httpGet THROWS on
+// when followRedirects:false. Mirrors hubitat-mcp-server.groovy _hubRequest(handle3xx) -- the
+// proven sandbox-safe e.response.status capture. status stays null only on a real transport failure.
+Map hubGetStatus(String path, Map query, int timeoutSec = 30) {
+    def params = [uri: "http://127.0.0.1:8080", path: path, query: query,
+                  textParser: true, ignoreSSLIssues: true, followRedirects: false, timeout: timeoutSec]
+    def cookie = secCookie()
+    if (cookie) params.headers = [Cookie: cookie]
+    Map out = [status: null, location: null, data: null]
+    try {
+        httpGet(params) { resp -> out = [status: resp.status, location: resp.headers?."Location"?.toString(), data: respText(resp)] }
+    } catch (Exception e) {
+        def resp = null
+        try { resp = e.response } catch (Exception ignore) { resp = null }
+        Integer st = null
+        try { st = resp?.status as Integer } catch (Exception ignore) { st = null }
+        if (st != null) {
+            def loc = null
+            try { loc = resp.headers?."Location"?.toString() } catch (Exception ignore) { loc = null }
+            out = [status: st, location: loc, data: null]
+        } else {
+            log.error "hubGetStatus ${path}: ${e.message}"
+        }
+    }
     return out
 }
 

--- a/src/test/groovy/server/WatchdogV2Spec.groovy
+++ b/src/test/groovy/server/WatchdogV2Spec.groovy
@@ -22,6 +22,7 @@ import support.PermissiveLog
  */
 class WatchdogV2Spec extends Specification {
     HubitatAppScript script
+    List<List<Object>> runInCalls = []     // captures (delaySeconds, handler[, opts]) of every runIn
 
     def setup() {
         File appFile = new File('e2e-deadman-watchdog-v2.groovy')
@@ -30,6 +31,7 @@ class WatchdogV2Spec extends Specification {
             api: Mock(AppExecutor) {
                 _ * getLog() >> new PermissiveLog()
                 _ * getSettings() >> [hubSecurityEnabled: false, debugLogging: false]
+                _ * runIn(*_) >> { args -> runInCalls << (args as List) }
             },
             userSettingValues: [hubSecurityEnabled: false, debugLogging: false],
             validator: new PassThroughAppValidator([
@@ -160,6 +162,43 @@ class WatchdogV2Spec extends Specification {
         noExceptionThrown()
         appRestored                              // unparseable deadline -> treated as expired -> FIRE
         written?.restoreResult == 'restored'
+    }
+
+    // ---- disarm acceleration: adminWriteFile kicks a one-shot checkDeadman past the ~60s tick ----
+
+    def "deadmanKick delegates to checkDeadman (so the periodic check stays the single decision point)"() {
+        given:
+        boolean checked = false
+        script.metaClass.checkDeadman = { -> checked = true }
+
+        when:
+        script.deadmanKick()
+
+        then:
+        checked
+    }
+
+    @Unroll
+    def "adminWriteFile schedules a one-shot deadmanKick ONLY when the armed-flag file is written (#scenario)"() {
+        given:
+        // A flag write must accelerate the restore (runIn 2s -> deadmanKick); a write to any OTHER file
+        // must NOT schedule anything. The handler MUST be the dedicated 'deadmanKick', never
+        // 'checkDeadman' (scheduling that name would overwrite the runEvery1Minute periodic dead-man).
+        script.metaClass.uploadHubFile = { String fn, byte[] bytes -> }
+
+        when:
+        def r = script.adminWriteFile([fileName: fileName, content: '{"armed":false,"intent":"disarm"}', confirm: true])
+
+        then:
+        r.success == true
+        runInCalls.findAll { it[1] == 'deadmanKick' }.size() == expectedKicks
+        runInCalls.findAll { it[1] == 'deadmanKick' && it[0] == 2 }.size() == expectedKicks   // 2s delay
+        runInCalls.findAll { it[1] == 'checkDeadman' }.isEmpty()                              // never the periodic name
+
+        where:
+        scenario                  | fileName                || expectedKicks
+        'flag file -> kick'       | 'e2e-deadman-v2.json'   || 1
+        'other file -> no kick'   | 'mcp-source-app.groovy' || 0
     }
 
     // ---- PR #247: bundle tools mirrored into the watchdog + the no-stale restore cleanup ----

--- a/src/test/groovy/server/WatchdogV2Spec.groovy
+++ b/src/test/groovy/server/WatchdogV2Spec.groovy
@@ -217,6 +217,20 @@ class WatchdogV2Spec extends Specification {
         calledPath == "/installedapp/forcedelete/123/quiet"     // NOT /app/edit/deleteJsonSafe (code class)
     }
 
+    def "adminForceDeleteInstalledApp reports success:false when hubGet returns null (4xx/5xx/auth/transport)"() {
+        given:
+        // hubGet returns null on a thrown non-2xx, an auth/cookie failure, or a request that never reached
+        // the hub -- the tool must NOT report success then, so the disarm sweep can warn + keep its list.
+        script.metaClass.hubGet = { String path, Map q -> null }
+
+        when:
+        def r = script.adminForceDeleteInstalledApp([id: "123", confirm: true])
+
+        then:
+        r.success == false
+        r.error?.contains("no response")
+    }
+
     @Unroll
     def "adminForceDeleteInstalledApp rejects a bad instance id (#scenario)"() {
         when:

--- a/src/test/groovy/server/WatchdogV2Spec.groovy
+++ b/src/test/groovy/server/WatchdogV2Spec.groovy
@@ -205,8 +205,10 @@ class WatchdogV2Spec extends Specification {
 
     def "adminForceDeleteInstalledApp GETs /installedapp/forcedelete/<id>/quiet (instance, not code class)"() {
         given:
+        // The forcedelete endpoint answers SUCCESS with a 302 redirect to the apps list; hubGetStatus
+        // captures that status off the thrown response (followRedirects:false), so the tool sees a 3xx.
         String calledPath = null
-        script.metaClass.hubGet = { String path, Map q -> calledPath = path; "" }
+        script.metaClass.hubGetStatus = { String path, Map q -> calledPath = path; [status: 302, location: "/installedapp/list", data: null] }
 
         when:
         def r = script.adminForceDeleteInstalledApp([id: "123", confirm: true])
@@ -217,18 +219,34 @@ class WatchdogV2Spec extends Specification {
         calledPath == "/installedapp/forcedelete/123/quiet"     // NOT /app/edit/deleteJsonSafe (code class)
     }
 
-    def "adminForceDeleteInstalledApp reports success:false when hubGet returns null (4xx/5xx/auth/transport)"() {
+    @Unroll
+    def "adminForceDeleteInstalledApp treats #status as #expected (302 redirect + 2xx = success)"() {
         given:
-        // hubGet returns null on a thrown non-2xx, an auth/cookie failure, or a request that never reached
-        // the hub -- the tool must NOT report success then, so the disarm sweep can warn + keep its list.
-        script.metaClass.hubGet = { String path, Map q -> null }
+        script.metaClass.hubGetStatus = { String path, Map q -> [status: status, location: null, data: null] }
+
+        expect:
+        script.adminForceDeleteInstalledApp([id: "123", confirm: true]).success == expected
+
+        where:
+        status || expected
+        302    || true       // forcedelete success redirect
+        200    || true       // plain OK (some firmwares)
+        404    || false      // instance already gone / bad id -> real failure, sweep keeps its list
+        500    || false      // hub error
+    }
+
+    def "adminForceDeleteInstalledApp reports success:false when the request never reaches the hub (status null)"() {
+        given:
+        // hubGetStatus leaves status null on an auth/cookie failure or a request that never reached the
+        // hub -- the tool must NOT report success then, so the disarm sweep can warn + keep its id list.
+        script.metaClass.hubGetStatus = { String path, Map q -> [status: null, location: null, data: null] }
 
         when:
         def r = script.adminForceDeleteInstalledApp([id: "123", confirm: true])
 
         then:
         r.success == false
-        r.error?.contains("no response")
+        r.error?.contains("did not confirm")
     }
 
     @Unroll

--- a/src/test/groovy/server/WatchdogV2Spec.groovy
+++ b/src/test/groovy/server/WatchdogV2Spec.groovy
@@ -201,6 +201,37 @@ class WatchdogV2Spec extends Specification {
         'other file -> no kick'   | 'mcp-source-app.groovy' || 0
     }
 
+    // ---- defer-native-deletes: force-delete an installed-app instance (RM rule) for the disarm sweep ----
+
+    def "adminForceDeleteInstalledApp GETs /installedapp/forcedelete/<id>/quiet (instance, not code class)"() {
+        given:
+        String calledPath = null
+        script.metaClass.hubGet = { String path, Map q -> calledPath = path; "" }
+
+        when:
+        def r = script.adminForceDeleteInstalledApp([id: "123", confirm: true])
+
+        then:
+        r.success == true
+        r.id == "123"
+        calledPath == "/installedapp/forcedelete/123/quiet"     // NOT /app/edit/deleteJsonSafe (code class)
+    }
+
+    @Unroll
+    def "adminForceDeleteInstalledApp rejects a bad instance id (#scenario)"() {
+        when:
+        script.adminForceDeleteInstalledApp([id: badId, confirm: true])
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        scenario      | badId
+        'non-integer' | 'abc'
+        'zero'        | '0'
+        'missing'     | null
+    }
+
     // ---- PR #247: bundle tools mirrored into the watchdog + the no-stale restore cleanup ----
 
     @Unroll

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -298,6 +298,13 @@ class TestRunner:
         self.created_device_dnis: list[str] = []
         self.created_rule_ids: list[str] = []
         self.created_native_app_ids: list[str] = []
+        # When set (the CI 'Run E2E tests' step only), per-test native-rule fixture deletes are SKIPPED
+        # (see _delete_native + cleanup Layer 4) and the rules are reaped by the disarm step's force
+        # sweep over WATCHDOG_URL, overlapping the ~100s restore poll instead of adding to the test
+        # critical path. Defaults OFF, so local runs + the post-restore --cleanup-only backstop are
+        # unchanged. The lifecycle/delete-assertion tests delete inline (not via _delete_native), so
+        # they are unaffected.
+        self.defer_native_deletes = os.environ.get("E2E_DEFER_NATIVE_DELETES") == "1"
         self.created_variable_names: list[str] = []
 
         # Cached helpers
@@ -850,6 +857,12 @@ class TestRunner:
         assert h.get("ok") is not False, f"hub_get_rule_health reports the rule broken: {h}"
 
     def _delete_native(self, app_id: Any, gateway: str = "hub_manage_rule_machine") -> None:
+        # Fixture-teardown delete. When deferral is on, skip it (rule stays tracked) so it's reaped by
+        # the disarm sweep during the restore window, not inline on the test critical path. Tests whose
+        # delete IS the assertion call hub_delete_native_app directly (not this helper), so they keep
+        # deleting inline regardless.
+        if self.defer_native_deletes:
+            return
         self.client.call_tool(gateway, {"tool": "hub_delete_native_app", "args": {"appId": app_id, "force": True, "confirm": True}})
         self._untrack_native_app(app_id)
 
@@ -2284,32 +2297,50 @@ class TestRunner:
 
         # Layer 4: native RM rules / classic apps (issue #137). Tracked ids first,
         # then a list-based sweep for anything a failed native_apps test left behind.
-        for app_id in list(self.created_native_app_ids):
+        # When deferral is on, the disarm step's force sweep (over WATCHDOG_URL, overlapping the
+        # restore poll) owns these deletes, so skip them here to keep them off the test critical path.
+        # The post-restore --cleanup-only step runs WITHOUT the flag, so it's the idempotent backstop.
+        if self.defer_native_deletes:
+            deferred_ids = [str(a) for a in self.created_native_app_ids]
+            print(f"  Layer 4: deferring {len(deferred_ids)} native-rule delete(s) to the disarm sweep")
+            # Hand the EXACT tracked instance ids to the disarm sweep via File Manager so it force-deletes
+            # ONLY these (no guessing the /hub2/appsList shape -> no risk of deleting the wrong app). The
+            # post-restore --cleanup-only prefix sweep (no flag) is the backstop if this list is missed.
             try:
-                print(f"  Deleting tracked native app {app_id}")
-                self.client.call_tool("hub_manage_rule_machine", {
-                    "tool": "hub_delete_native_app", "args": {"appId": app_id, "confirm": True},
+                self.client.call_tool("hub_manage_files", {
+                    "tool": "hub_write_file",
+                    "args": {"fileName": "e2e-deferred-native-rules.json",
+                             "content": json.dumps(deferred_ids), "confirm": True},
                 })
             except Exception as exc:
-                print(f"  [WARN] Failed to delete native app {app_id}: {exc}")
-        self.created_native_app_ids.clear()
-        try:
-            nrules = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_list_rules", "args": {}})
-            nlist = nrules if isinstance(nrules, list) else nrules.get("rules", [])
-            for r in nlist:
-                rname = r.get("name") or r.get("label") or ""
-                if PREFIX in rname:
-                    rid = str(r.get("id", r.get("appId", "")))
-                    if rid:
-                        try:
-                            print(f"  Sweep: deleting native rule '{rname}' (id={rid})")
-                            self.client.call_tool("hub_manage_rule_machine", {
-                                "tool": "hub_delete_native_app", "args": {"appId": rid, "confirm": True},
-                            })
-                        except Exception as exc:
-                            print(f"  [WARN] Native rule sweep delete failed for '{rname}': {exc}")
-        except Exception as exc:
-            print(f"  [WARN] Native rule sweep failed: {exc}")
+                print(f"  [WARN] could not write the deferred-rule id list; the prefix backstop will reap them: {exc}")
+        else:
+            for app_id in list(self.created_native_app_ids):
+                try:
+                    print(f"  Deleting tracked native app {app_id}")
+                    self.client.call_tool("hub_manage_rule_machine", {
+                        "tool": "hub_delete_native_app", "args": {"appId": app_id, "confirm": True},
+                    })
+                except Exception as exc:
+                    print(f"  [WARN] Failed to delete native app {app_id}: {exc}")
+            self.created_native_app_ids.clear()
+            try:
+                nrules = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_list_rules", "args": {}})
+                nlist = nrules if isinstance(nrules, list) else nrules.get("rules", [])
+                for r in nlist:
+                    rname = r.get("name") or r.get("label") or ""
+                    if PREFIX in rname:
+                        rid = str(r.get("id", r.get("appId", "")))
+                        if rid:
+                            try:
+                                print(f"  Sweep: deleting native rule '{rname}' (id={rid})")
+                                self.client.call_tool("hub_manage_rule_machine", {
+                                    "tool": "hub_delete_native_app", "args": {"appId": rid, "confirm": True},
+                                })
+                            except Exception as exc:
+                                print(f"  [WARN] Native rule sweep delete failed for '{rname}': {exc}")
+            except Exception as exc:
+                print(f"  [WARN] Native rule sweep failed: {exc}")
 
         # Layer 5: stranded deadman install-fix throwaway. The @test("deadman") test installs
         # 'Deadman Test Target' (namespace mcptest) + its code class; neither carries the BAT_E2E_

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -2458,6 +2458,24 @@ class TestRunner:
 
         print("--- Cleanup complete ---\n")
 
+    def verify_native_rules_clean(self) -> list[str] | None:
+        """Re-list native RM rules and return the BAT_E2E_ ones still present (empty list = clean).
+        Returns None if the hub could not be listed after retries -- the caller treats that as
+        'cannot prove cleanup' and fails closed. Retries ride out a transient transport blip."""
+        for attempt in range(1, 4):
+            try:
+                nrules = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_list_rules", "args": {}})
+                rlist = nrules if isinstance(nrules, list) else nrules.get("rules", [])
+                return [
+                    f"{r.get('name') or r.get('label')} (id={r.get('id', r.get('appId'))})"
+                    for r in rlist
+                    if PREFIX in (r.get("name") or r.get("label") or "")
+                ]
+            except Exception as exc:
+                print(f"  [WARN] verify_native_rules_clean: list attempt {attempt}/3 failed: {exc}")
+                time.sleep(2)
+        return None
+
     # -----------------------------------------------------------------------
     # Run
     # -----------------------------------------------------------------------
@@ -2676,7 +2694,20 @@ def main() -> None:
 
     if args.cleanup_only:
         runner.cleanup()
-        print("Cleanup-only mode complete.")
+        # Gating verification: cleanup() and the disarm-time deferred sweep are otherwise all
+        # best-effort (warn-only), so a silently-failed native-rule cleanup could leave BAT_E2E_ RM
+        # apps on the SHARED hub behind a green run. This backstop FAILS CLOSED -- re-list and exit
+        # nonzero if any BAT_E2E_ native rule survived, or if the hub can't be listed to prove it.
+        leftovers = runner.verify_native_rules_clean()
+        if leftovers is None:
+            print("ERROR: cleanup-only could not list native rules to verify cleanup -- failing "
+                  "closed (cannot prove the shared hub is free of BAT_E2E_ rules).")
+            sys.exit(1)
+        if leftovers:
+            print(f"ERROR: cleanup-only left {len(leftovers)} BAT_E2E_ native rule(s) on the hub: "
+                  f"{leftovers}")
+            sys.exit(1)
+        print("Cleanup-only mode complete; verified no BAT_E2E_ native rules remain.")
         sys.exit(0)
 
     # Verify connectivity before running tests

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -518,28 +518,14 @@ class TestRunner:
                 switch_dev = d
                 break
         if switch_dev is None:
-            # No switch on the hub -- provision a throwaway virtual one so this test ALWAYS runs
-            # (never skips; skips are failures). Labeled with the BAT_E2E_ prefix so the standard
-            # cleanup sweep removes it.
-            self.client.call_tool("hub_manage_virtual_device", {
-                "action": "create",
-                "deviceType": "Virtual Switch",
-                "deviceLabel": f"{PREFIX}AttrProbe",
-                "confirm": True,
-            })
-            vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
-            dev_list = vdevs if isinstance(vdevs, list) else (vdevs.get("devices", []) if isinstance(vdevs, dict) else [])
-            for d in dev_list:
-                if f"{PREFIX}AttrProbe" in (d.get("label") or d.get("name") or ""):
-                    switch_dev = d
-                    dni = str(d.get("deviceNetworkId", d.get("dni", "")))
-                    if dni:
-                        self.created_device_dnis.append(dni)
-                    break
-            assert switch_dev is not None, \
-                "no switch on the hub and could not provision a virtual one for the attribute read"
+            # No real switch on the hub -- fall back to the persistent scaffolding switch
+            # (get_test_switch_id find-or-reuse) instead of provisioning + deleting a throwaway probe.
+            # This test ALWAYS runs (skips are failures).
+            switch_id = self.get_test_switch_id()
+        else:
+            switch_id = str(switch_dev["id"])
         result = self.client.call_tool("hub_get_device_attribute", {
-            "deviceId": str(switch_dev["id"]),
+            "deviceId": switch_id,
             "attribute": "switch",
         })
         # Result should contain the value (on/off or similar)
@@ -2259,6 +2245,11 @@ class TestRunner:
             dev_list = vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])
             for d in dev_list:
                 lbl = d.get("label") or d.get("name") or ""
+                # Keep the persistent scaffolding switch (get_test_switch_id find-and-reuse): sweeping it
+                # would defeat the reuse and pay a create every run. Narrow suffix match, NOT a blanket
+                # prefix skip, so genuine under-test device leftovers are still reclaimed.
+                if lbl.endswith("Action_Switch"):
+                    continue
                 if PREFIX in lbl:
                     dni = str(d.get("deviceNetworkId", d.get("dni", "")))
                     if dni:

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -58,6 +58,17 @@ class McpToolError(McpError):
 # ---------------------------------------------------------------------------
 
 
+def _op_key(name: str, arguments: dict | None) -> str:
+    """Resolve the per-op timing key for the run summary: the gateway sub-tool (args['tool']) when present,
+    else the flat tool name; hub_set_rule is split into :create (no inner appId) vs :edit so fixture cost is
+    separable from mutation cost. Pure dict logic (unit-tested in test_e2e_test_helpers.py)."""
+    args = arguments or {}
+    key = args.get("tool", name)
+    if key == "hub_set_rule":
+        key += ":create" if not (args.get("args") or {}).get("appId") else ":edit"
+    return key
+
+
 class HubitatMcpClient:
     """Thin client for the Hubitat MCP Server JSON-RPC 2.0 endpoint."""
 
@@ -230,12 +241,7 @@ class HubitatMcpClient:
     def call_tool(self, name: str, arguments: dict | None = None) -> Any:
         """Call an MCP tool. Returns parsed content text (dict/list/str)."""
         args = arguments or {}
-        # Resolve the meaningful op key for the timing summary: for a gateway call the sub-tool
-        # (args["tool"]) is what matters, and for hub_set_rule split create (no appId) from edit so the
-        # real fixture-vs-mutation cost is separable.
-        op_key = args.get("tool", name)
-        if op_key == "hub_set_rule":
-            op_key += ":create" if not (args.get("args") or {}).get("appId") else ":edit"
+        op_key = _op_key(name, args)   # gateway sub-tool / flat name; hub_set_rule split create-vs-edit
         _t0 = time.monotonic()
         result = self._send("tools/call", {"name": name, "arguments": args})
         self.op_timings.append((op_key, time.monotonic() - _t0))
@@ -300,7 +306,7 @@ class TestRunner:
         self.created_native_app_ids: list[str] = []
         # When set (the CI 'Run E2E tests' step only), per-test native-rule fixture deletes are SKIPPED
         # (see _delete_native + cleanup Layer 4) and the rules are reaped by the disarm step's force
-        # sweep over WATCHDOG_URL, overlapping the ~100s restore poll instead of adding to the test
+        # sweep over WATCHDOG_URL, overlapping the restore-poll wait instead of adding to the test
         # critical path. Defaults OFF, so local runs + the post-restore --cleanup-only backstop are
         # unchanged. The lifecycle/delete-assertion tests delete inline (not via _delete_native), so
         # they are unaffected.
@@ -416,15 +422,22 @@ class TestRunner:
             f"Rule name mismatch: expected '{name}', got '{fetched.get('name')}'"
         return rule_id
 
-    def _assert_rule_array_len(self, rule_id: str, key: str, expected: int) -> None:
-        """Fetch a custom rule and assert its triggers/conditions/actions array has the expected count.
-        Catches the legacy engine silently rejecting/dropping a type inside a batched type-coverage rule
-        (a plain create-success check would miss a dropped entry)."""
+    def _assert_rule_types(self, rule_id: str, key: str, expected_types: list[str],
+                           normalize_away: tuple[str, ...] = ()) -> None:
+        """Fetch a custom rule and assert its triggers/conditions/actions array carries the expected COUNT
+        AND each expected TYPE -- catches the legacy engine silently dropping a type OR drop-and-duplicating
+        one (which a length-only check would miss). `normalize_away` lists input types the engine rewrites
+        server-side (triggers: 'sunrise'/'sunset' -> 'time'), so they aren't required to appear under their
+        original name; the count still must match."""
         fetched = self.client.call_tool("hub_get_custom_rule", {"ruleId": rule_id})
         arr = fetched.get(key)
-        got = len(arr) if isinstance(arr, list) else arr
-        assert isinstance(arr, list) and len(arr) == expected, \
-            f"custom rule '{key}': expected {expected} entries, got {got} -- a type was rejected/dropped: {fetched.get(key)!r}"
+        assert isinstance(arr, list), f"custom rule '{key}' is not a list: {fetched.get(key)!r}"
+        got = [e.get("type") for e in arr if isinstance(e, dict)]
+        assert len(arr) == len(expected_types), \
+            f"custom rule '{key}': expected {len(expected_types)} entries, got {len(arr)} -- a type was rejected/dropped: {got!r}"
+        missing = [t for t in expected_types if t not in normalize_away and t not in got]
+        assert not missing, \
+            f"custom rule '{key}': types missing after round-trip: {missing} (got {got!r}) -- a type was dropped or replaced by a duplicate"
 
     def _delete_rule_safe(self, rule_id: str) -> None:
         """Delete a rule, swallowing errors."""
@@ -1114,7 +1127,8 @@ class TestRunner:
             "triggers": triggers,
             "actions": [{"type": "log", "message": "trigger types batch"}],
         })
-        self._assert_rule_array_len(rule_id, "triggers", len(triggers))
+        self._assert_rule_types(rule_id, "triggers", [t["type"] for t in triggers],
+                                normalize_away=("sunrise", "sunset"))
         self._delete_rule_safe(rule_id)
 
     # -----------------------------------------------------------------------
@@ -1144,7 +1158,7 @@ class TestRunner:
                 "conditions": conditions,
                 "actions": [{"type": "log", "message": "condition types batch"}],
             })
-            self._assert_rule_array_len(rule_id, "conditions", len(conditions))
+            self._assert_rule_types(rule_id, "conditions", [c["type"] for c in conditions])
             self._delete_rule_safe(rule_id)
         finally:
             self._delete_variable_safe(var_name)
@@ -1187,7 +1201,7 @@ class TestRunner:
                 "triggers": [{"type": "time", "time": "03:00"}],
                 "actions": actions,
             })
-            self._assert_rule_array_len(rule_id, "actions", len(actions))
+            self._assert_rule_types(rule_id, "actions", [a["type"] for a in actions])
             self._delete_rule_safe(rule_id)
         finally:
             self._delete_variable_safe(var_name)
@@ -2301,10 +2315,24 @@ class TestRunner:
         # restore poll) owns these deletes, so skip them here to keep them off the test critical path.
         # The post-restore --cleanup-only step runs WITHOUT the flag, so it's the idempotent backstop.
         if self.defer_native_deletes:
-            deferred_ids = [str(a) for a in self.created_native_app_ids]
+            deferred_ids = {str(a) for a in self.created_native_app_ids}
+            # Also fold in any PREFIX-matched native rule a FAILED test created but never tracked (the rule
+            # is hub-created before its id is appended), so the disarm exact-id sweep reaps those too --
+            # otherwise an untracked leftover would survive until the post-restore --cleanup-only prefix
+            # sweep. This is the deferral-branch equivalent of the non-deferral prefix sweep below.
+            try:
+                nrules = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_list_rules", "args": {}})
+                for r in (nrules if isinstance(nrules, list) else nrules.get("rules", [])):
+                    if PREFIX in (r.get("name") or r.get("label") or ""):
+                        rid = str(r.get("id", r.get("appId", "")))
+                        if rid:
+                            deferred_ids.add(rid)
+            except Exception as exc:
+                print(f"  [WARN] could not list native rules for the deferred union (tracked ids still deferred): {exc}")
+            deferred_ids = sorted(deferred_ids)
             print(f"  Layer 4: deferring {len(deferred_ids)} native-rule delete(s) to the disarm sweep")
-            # Hand the EXACT tracked instance ids to the disarm sweep via File Manager so it force-deletes
-            # ONLY these (no guessing the /hub2/appsList shape -> no risk of deleting the wrong app). The
+            # Hand the EXACT instance ids to the disarm sweep via File Manager so it force-deletes ONLY
+            # these (no guessing the /hub2/appsList shape -> no risk of deleting the wrong app). The
             # post-restore --cleanup-only prefix sweep (no flag) is the backstop if this list is missed.
             try:
                 self.client.call_tool("hub_manage_files", {

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -409,6 +409,16 @@ class TestRunner:
             f"Rule name mismatch: expected '{name}', got '{fetched.get('name')}'"
         return rule_id
 
+    def _assert_rule_array_len(self, rule_id: str, key: str, expected: int) -> None:
+        """Fetch a custom rule and assert its triggers/conditions/actions array has the expected count.
+        Catches the legacy engine silently rejecting/dropping a type inside a batched type-coverage rule
+        (a plain create-success check would miss a dropped entry)."""
+        fetched = self.client.call_tool("hub_get_custom_rule", {"ruleId": rule_id})
+        arr = fetched.get(key)
+        got = len(arr) if isinstance(arr, list) else arr
+        assert isinstance(arr, list) and len(arr) == expected, \
+            f"custom rule '{key}': expected {expected} entries, got {got} -- a type was rejected/dropped: {fetched.get(key)!r}"
+
     def _delete_rule_safe(self, rule_id: str) -> None:
         """Delete a rule, swallowing errors."""
         try:
@@ -1083,232 +1093,105 @@ class TestRunner:
                     print(f"  [WARN] deadman cleanup: delete code class {code_app_id} failed: {exc}")
 
     # -----------------------------------------------------------------------
-    # GROUP 5: trigger_types (6 tests)
+    # GROUP 5: trigger_types (1 batched test -- all trigger types in one rule)
     # -----------------------------------------------------------------------
 
-    def _test_trigger(self, suffix: str, trigger: dict) -> None:
-        """Helper: create rule with given trigger, verify, delete."""
-        name = f"{PREFIX}Trigger_{suffix}"
+    @test("trigger_types")
+    def test_trigger_types(self) -> None:
+        """Legacy custom engine: every trigger TYPE parses + lands. Batched into ONE rule (1 create +
+        1 delete instead of 6 per-type rules) -- keeps per-type create coverage and the count assert
+        catches a silently-dropped type, while cutting the fixture churn the legacy engine doesn't
+        warrant exhaustively. New trigger types: add to this list, not a new rule."""
         dev_id = self.get_first_device_id()
-        # Replace placeholder device ID
-        trigger = _inject_device_id(trigger, dev_id)
-        rule_id = self._create_rule_and_verify(name, {
-            "triggers": [trigger],
-            "actions": [{"type": "log", "message": f"trigger test: {suffix}"}],
+        triggers = [
+            _inject_device_id({"type": "device_event", "deviceId": "PLACEHOLDER", "attribute": "switch"}, dev_id),
+            {"type": "time", "time": "08:00"},
+            {"type": "periodic", "interval": 30, "unit": "minutes"},
+            {"type": "mode_change", "mode": "Away"},
+            {"type": "sunrise", "offset": 0},
+            {"type": "sunset", "offset": -30},
+        ]
+        rule_id = self._create_rule_and_verify(f"{PREFIX}Trigger_Types", {
+            "triggers": triggers,
+            "actions": [{"type": "log", "message": "trigger types batch"}],
         })
+        self._assert_rule_array_len(rule_id, "triggers", len(triggers))
         self._delete_rule_safe(rule_id)
 
-    @test("trigger_types")
-    def test_trigger_device_event(self) -> None:
-        self._test_trigger("device_event", {
-            "type": "device_event", "deviceId": "PLACEHOLDER", "attribute": "switch",
-        })
-
-    @test("trigger_types")
-    def test_trigger_time(self) -> None:
-        self._test_trigger("time", {"type": "time", "time": "08:00"})
-
-    @test("trigger_types")
-    def test_trigger_periodic(self) -> None:
-        self._test_trigger("periodic", {
-            "type": "periodic", "interval": 30, "unit": "minutes",
-        })
-
-    @test("trigger_types")
-    def test_trigger_mode_change(self) -> None:
-        self._test_trigger("mode_change", {"type": "mode_change", "mode": "Away"})
-
-    @test("trigger_types")
-    def test_trigger_sunrise(self) -> None:
-        self._test_trigger("sunrise", {"type": "sunrise", "offset": 0})
-
-    @test("trigger_types")
-    def test_trigger_sunset(self) -> None:
-        self._test_trigger("sunset", {"type": "sunset", "offset": -30})
-
     # -----------------------------------------------------------------------
-    # GROUP 6: condition_types (7 tests)
+    # GROUP 6: condition_types (1 batched test -- all condition types in one rule)
     # -----------------------------------------------------------------------
 
-    def _test_condition(self, suffix: str, condition: dict,
-                        setup=None, teardown=None) -> None:
-        """Create rule with given condition, verify, delete. Optional setup/teardown callables."""
-        if setup:
-            setup()
+    @test("condition_types")
+    def test_condition_types(self) -> None:
+        """Legacy custom engine: every condition TYPE parses + lands. Batched into ONE rule (1 create +
+        1 delete instead of 7). The variable condition needs a backing hub variable. New condition
+        types: add to this list."""
+        dev_id = self.get_first_device_id()
+        var_name = f"{PREFIX}CondVar"
+        self._create_variable(var_name, "String", "test")
         try:
-            name = f"{PREFIX}Cond_{suffix}"
-            dev_id = self.get_first_device_id()
-            condition = _inject_device_id(condition, dev_id)
-            rule_id = self._create_rule_and_verify(name, {
+            conditions = [
+                _inject_device_id({"type": "device_state", "deviceId": "PLACEHOLDER", "attribute": "switch", "operator": "==", "value": "on"}, dev_id),
+                _inject_device_id({"type": "device_was", "deviceId": "PLACEHOLDER", "attribute": "switch", "operator": "==", "value": "on", "forSeconds": 300}, dev_id),
+                {"type": "time_range", "start": "08:00", "end": "22:00"},
+                {"type": "mode", "mode": "Day"},
+                {"type": "variable", "variableName": var_name, "operator": "==", "value": "1"},
+                {"type": "days_of_week", "days": ["Monday", "Wednesday", "Friday"]},
+                {"type": "sun_position", "position": "up"},
+            ]
+            rule_id = self._create_rule_and_verify(f"{PREFIX}Condition_Types", {
                 "triggers": [{"type": "time", "time": "03:00"}],
-                "conditions": [condition],
-                "actions": [{"type": "log", "message": f"condition test: {suffix}"}],
+                "conditions": conditions,
+                "actions": [{"type": "log", "message": "condition types batch"}],
             })
+            self._assert_rule_array_len(rule_id, "conditions", len(conditions))
             self._delete_rule_safe(rule_id)
         finally:
-            if teardown:
-                teardown()
-
-    @test("condition_types")
-    def test_condition_device_state(self) -> None:
-        self._test_condition("device_state", {
-            "type": "device_state", "deviceId": "PLACEHOLDER",
-            "attribute": "switch", "operator": "==", "value": "on",
-        })
-
-    @test("condition_types")
-    def test_condition_device_was(self) -> None:
-        self._test_condition("device_was", {
-            "type": "device_was", "deviceId": "PLACEHOLDER",
-            "attribute": "switch", "operator": "==", "value": "on", "forSeconds": 300,
-        })
-
-    @test("condition_types")
-    def test_condition_time_range(self) -> None:
-        self._test_condition("time_range", {
-            "type": "time_range", "start": "08:00", "end": "22:00",
-        })
-
-    @test("condition_types")
-    def test_condition_mode(self) -> None:
-        self._test_condition("mode", {
-            "type": "mode", "mode": "Day",
-        })
-
-    @test("condition_types")
-    def test_condition_variable(self) -> None:
-        var_name = f"{PREFIX}TestVar"
-        self._test_condition(
-            "variable",
-            {"type": "variable", "variableName": var_name, "operator": "==", "value": "1"},
-            setup=lambda: self._create_variable(var_name, "String", "test"),
-            teardown=lambda: self._delete_variable_safe(var_name),
-        )
-
-    @test("condition_types")
-    def test_condition_days_of_week(self) -> None:
-        self._test_condition("days_of_week", {
-            "type": "days_of_week", "days": ["Monday", "Wednesday", "Friday"],
-        })
-
-    @test("condition_types")
-    def test_condition_sun_position(self) -> None:
-        self._test_condition("sun_position", {
-            "type": "sun_position", "position": "up",
-        })
+            self._delete_variable_safe(var_name)
 
     # -----------------------------------------------------------------------
-    # GROUP 7: action_types (13 tests)
+    # GROUP 7: action_types (1 batched test -- all action types in one rule)
     # -----------------------------------------------------------------------
 
-    def _test_action(self, suffix: str, actions: list[dict],
-                     setup=None, teardown=None) -> None:
-        """Create rule with given actions, verify, delete."""
-        if setup:
-            setup()
+    @test("action_types")
+    def test_action_types(self) -> None:
+        """Legacy custom engine: every action TYPE parses + lands. Batched into ONE rule (1 create +
+        1 delete instead of 13). Covers device commands, variable/mode/delay, control flow
+        (if_then_else, repeat, cancel_delayed, stop) and log/http/comment. 'stop' is placed LAST so it
+        can't truncate the stored action list. set_variable needs a backing hub variable. New action
+        types: add to this list."""
+        dev_id = self.get_first_device_id()
+        switch_id = self.get_test_switch_id()
+        var_name = f"{PREFIX}ActVar"
+        self._create_variable(var_name, "String", "initial")
         try:
-            name = f"{PREFIX}Action_{suffix}"
-            dev_id = self.get_first_device_id()
-            actions = [_inject_device_id(a, dev_id) for a in actions]
-            rule_id = self._create_rule_and_verify(name, {
+            actions = [
+                {"type": "device_command", "deviceId": switch_id, "command": "on"},
+                {"type": "toggle_device", "deviceId": switch_id},
+                {"type": "set_variable", "variableName": var_name, "value": "hello"},
+                {"type": "set_local_variable", "variableName": "localTestVar", "value": "42"},
+                {"type": "set_mode", "mode": "Day"},
+                {"type": "delay", "seconds": 5},
+                {"type": "cancel_delayed"},
+                {"type": "if_then_else",
+                 "condition": {"type": "device_state", "deviceId": dev_id, "attribute": "switch", "operator": "==", "value": "on"},
+                 "thenActions": [{"type": "log", "message": "then branch"}],
+                 "elseActions": [{"type": "log", "message": "else branch"}]},
+                {"type": "repeat", "count": 3, "actions": [{"type": "log", "message": "repeat iteration"}]},
+                {"type": "log", "message": "E2E test log action"},
+                {"type": "http_request", "method": "GET", "url": "http://example.com"},
+                {"type": "comment", "text": "This is a test comment"},
+                {"type": "stop"},
+            ]
+            rule_id = self._create_rule_and_verify(f"{PREFIX}Action_Types", {
                 "triggers": [{"type": "time", "time": "03:00"}],
                 "actions": actions,
             })
+            self._assert_rule_array_len(rule_id, "actions", len(actions))
             self._delete_rule_safe(rule_id)
         finally:
-            if teardown:
-                teardown()
-
-    @test("action_types")
-    def test_action_device_command(self) -> None:
-        switch_id = self.get_test_switch_id()
-        self._test_action("device_command", [
-            {"type": "device_command", "deviceId": switch_id, "command": "on"},
-        ])
-
-    @test("action_types")
-    def test_action_toggle(self) -> None:
-        switch_id = self.get_test_switch_id()
-        self._test_action("toggle", [
-            {"type": "toggle_device", "deviceId": switch_id},
-        ])
-
-    @test("action_types")
-    def test_action_set_variable(self) -> None:
-        var_name = f"{PREFIX}ActionVar"
-        self._test_action(
-            "set_variable",
-            [{"type": "set_variable", "variableName": var_name, "value": "hello"}],
-            setup=lambda: self._create_variable(var_name, "String", "initial"),
-            teardown=lambda: self._delete_variable_safe(var_name),
-        )
-
-    @test("action_types")
-    def test_action_set_local_variable(self) -> None:
-        self._test_action("set_local_variable", [
-            {"type": "set_local_variable", "variableName": "localTestVar", "value": "42"},
-        ])
-
-    @test("action_types")
-    def test_action_set_mode(self) -> None:
-        self._test_action("set_mode", [
-            {"type": "set_mode", "mode": "Day"},
-        ])
-
-    @test("action_types")
-    def test_action_delay(self) -> None:
-        self._test_action("delay", [
-            {"type": "delay", "seconds": 5},
-        ])
-
-    @test("action_types")
-    def test_action_if_then_else(self) -> None:
-        dev_id = self.get_first_device_id()
-        self._test_action("if_then_else", [{
-            "type": "if_then_else",
-            "condition": {
-                "type": "device_state", "deviceId": dev_id,
-                "attribute": "switch", "operator": "==", "value": "on",
-            },
-            "thenActions": [{"type": "log", "message": "then branch"}],
-            "elseActions": [{"type": "log", "message": "else branch"}],
-        }])
-
-    @test("action_types")
-    def test_action_cancel_delayed(self) -> None:
-        self._test_action("cancel_delayed", [
-            {"type": "cancel_delayed"},
-        ])
-
-    @test("action_types")
-    def test_action_repeat(self) -> None:
-        self._test_action("repeat", [{
-            "type": "repeat",
-            "count": 3,
-            "actions": [{"type": "log", "message": "repeat iteration"}],
-        }])
-
-    @test("action_types")
-    def test_action_stop(self) -> None:
-        self._test_action("stop", [{"type": "stop"}])
-
-    @test("action_types")
-    def test_action_log(self) -> None:
-        self._test_action("log", [
-            {"type": "log", "message": "E2E test log action"},
-        ])
-
-    @test("action_types")
-    def test_action_http_request(self) -> None:
-        self._test_action("http_request", [
-            {"type": "http_request", "method": "GET", "url": "http://example.com"},
-        ])
-
-    @test("action_types")
-    def test_action_comment(self) -> None:
-        self._test_action("comment", [
-            {"type": "comment", "text": "This is a test comment"},
-        ])
+            self._delete_variable_safe(var_name)
 
     # -----------------------------------------------------------------------
     # GROUP 8: complex_patterns (2 tests)

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -78,6 +78,10 @@ class HubitatMcpClient:
         self.access_token = access_token
         self.verbose = verbose
         self._request_id = 0
+        # Per-op wall-clock timings (op_key, seconds) for the end-of-run "Per-op wall-clock" summary --
+        # the only place real per-operation cost (RM create vs edit vs delete, etc.) is visible, since
+        # the >> call traces are verbose-gated and never reach the CI log.
+        self.op_timings: list[tuple[str, float]] = []
         # Mask token for safe logging: show first 4 chars only
         self._masked_token = access_token[:4] + "..." if len(access_token) > 4 else "****"
 
@@ -225,7 +229,16 @@ class HubitatMcpClient:
 
     def call_tool(self, name: str, arguments: dict | None = None) -> Any:
         """Call an MCP tool. Returns parsed content text (dict/list/str)."""
-        result = self._send("tools/call", {"name": name, "arguments": arguments or {}})
+        args = arguments or {}
+        # Resolve the meaningful op key for the timing summary: for a gateway call the sub-tool
+        # (args["tool"]) is what matters, and for hub_set_rule split create (no appId) from edit so the
+        # real fixture-vs-mutation cost is separable.
+        op_key = args.get("tool", name)
+        if op_key == "hub_set_rule":
+            op_key += ":create" if not (args.get("args") or {}).get("appId") else ":edit"
+        _t0 = time.monotonic()
+        result = self._send("tools/call", {"name": name, "arguments": args})
+        self.op_timings.append((op_key, time.monotonic() - _t0))
 
         # Check for tool-level error
         if result.get("isError"):
@@ -330,9 +343,11 @@ class TestRunner:
             "deviceLabel": f"{PREFIX}Action_Switch",
             "confirm": True,
         })
-        dni = result.get("deviceNetworkId", result.get("dni", ""))
-        if dni:
-            self.created_device_dnis.append(str(dni))
+        # The test switch is PERSISTENT scaffolding, not a fixture-under-test: rule/trigger tests merely
+        # reference it. Deliberately NOT tracked in created_device_dnis, so teardown leaves it on the hub
+        # for the next run to find-and-reuse (the existing-device lookup at the top of this method) --
+        # skipping a create+delete of the switch every run. Devices that ARE under test (test_create_*)
+        # still track + delete themselves. One inert virtual switch persists on the test hub; harmless.
         dev_id = result.get("id", result.get("deviceId", ""))
 
         # Response may not include ID directly — look it up
@@ -344,9 +359,6 @@ class TestRunner:
                 lbl = d.get("label") or d.get("name") or ""
                 if f"{PREFIX}Action_Switch" in lbl:
                     dev_id = str(d["id"])
-                    found_dni = str(d.get("deviceNetworkId", d.get("dni", "")))
-                    if found_dni and found_dni not in self.created_device_dnis:
-                        self.created_device_dnis.append(found_dni)
                     break
 
         self._test_switch_id = str(dev_id) if dev_id else ""
@@ -2591,6 +2603,19 @@ class TestRunner:
             print("\n  Slowest tests:")
             for r in slow:
                 print(f"    {r.get('duration', 0.0):6.1f}s  {r.get('group', '?')}/{r['name']}")
+
+        # Per-op wall-clock (diagnostic -- real per-operation cost, the basis for fixture/cleanup
+        # optimization: how much is RM create vs edit vs delete vs reads). Aggregated by op key.
+        ops = getattr(self.client, "op_timings", [])
+        if ops:
+            agg: dict[str, list[float]] = {}
+            for op_key, dur in ops:
+                slot = agg.setdefault(op_key, [0, 0.0])
+                slot[0] += 1
+                slot[1] += dur
+            print("\n  Per-op wall-clock (total / count / avg, slowest total first):")
+            for op_key, (cnt, tot) in sorted(agg.items(), key=lambda kv: kv[1][1], reverse=True)[:20]:
+                print(f"    {tot:6.1f}s  {int(cnt):3d}x  {tot / cnt:4.1f}s avg  {op_key}")
 
         # List failures
         failures = [r for r in self.results if r["status"] == "fail"]

--- a/tests/test_deploy_bundle_only.py
+++ b/tests/test_deploy_bundle_only.py
@@ -1,0 +1,40 @@
+"""pytest: the watchdog e2e deploy delivers libraries ONLY via the bundle (no per-#include install).
+
+Regression guard for the bundle-only conversion of ``.github/scripts/mcp_watchdog_deploy.sh``. The
+deploy used to install each ``#include``d library INDIVIDUALLY (a ``hub_update_library`` /
+``hub_create_library`` per ``#include``) AND install the bundle that ships those same libraries --
+redundant work plus an extra recompile of the running app. The bundle is now the sole library delivery
+path (the HPM "one Update click" flow). If a future edit re-introduces a per-library install, e2e
+silently regains the redundant recompile -- this test fails first. It checks the actual tool-CALL RPCs
+(``name:"hub_..."``), not bare mentions, so the explanatory comment naming the old loop is fine.
+"""
+
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / ".github" / "scripts" / "mcp_watchdog_deploy.sh"
+
+
+def test_deploy_does_not_install_libraries_individually():
+    text = SCRIPT.read_text()
+    for rpc in ('name:"hub_update_library"', 'name:"hub_create_library"'):
+        assert rpc not in text, (
+            f"{SCRIPT.name} issues a {rpc} call -- the deploy must deliver #included libraries ONLY via "
+            "the bundle (hub_install_bundle). A per-#include library install is the redundant "
+            "pre-bundle-only flow and forces an extra recompile of the running app."
+        )
+
+
+def test_deploy_installs_the_bundle():
+    text = SCRIPT.read_text()
+    assert 'name:"hub_install_bundle"' in text, (
+        f"{SCRIPT.name} no longer calls hub_install_bundle -- bundle-only delivery requires it (the "
+        "bundle is the sole #include library source)."
+    )
+
+
+def test_deploy_guards_includes_without_a_bundle():
+    text = SCRIPT.read_text()
+    assert "declares NO bundle to deliver them" in text, (
+        f"{SCRIPT.name} dropped the bundle-coverage guard: an app that #includes libraries while the "
+        "manifest declares no bundle must fail loudly, not deploy an app whose #includes can't resolve."
+    )

--- a/tests/test_e2e_test_helpers.py
+++ b/tests/test_e2e_test_helpers.py
@@ -175,3 +175,28 @@ def test_inject_device_id_recurses_into_else_actions():
     }
     result = et._inject_device_id(obj, "22")
     assert result["elseActions"][0]["deviceId"] == "22"
+
+
+# ---------------------------------------------------------------------------
+# _op_key (per-op timing key resolution)
+# ---------------------------------------------------------------------------
+
+def test_op_key_gateway_set_rule_create():
+    """Gateway-wrapped hub_set_rule with no inner appId resolves to a :create op."""
+    assert et._op_key("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": {}}) == "hub_set_rule:create"
+
+
+def test_op_key_gateway_set_rule_edit():
+    """An inner appId marks an :edit (mutation), so fixture-create cost stays separable in the summary."""
+    assert et._op_key("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": {"appId": "5"}}) == "hub_set_rule:edit"
+
+
+def test_op_key_gateway_other_subtool_uses_sub_tool():
+    """A gateway call resolves to its sub-tool, not the gateway name."""
+    assert et._op_key("hub_manage_rule_machine", {"tool": "hub_list_rules", "args": {}}) == "hub_list_rules"
+
+
+def test_op_key_flat_tool_uses_name():
+    """A flat (non-gateway) call resolves to the tool name; None args are tolerated."""
+    assert et._op_key("hub_get_info", {}) == "hub_get_info"
+    assert et._op_key("hub_get_info", None) == "hub_get_info"


### PR DESCRIPTION
## Summary

- Cuts the watchdog-driven `hub-e2e` wall-clock from ~793s to ~607s (suite 342s → 273s), all green, with the dead-man restore guarantee intact.
- Follow-up to #247 (the #209 modularization). No server/runtime behaviour change — only e2e tooling and test structure.

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `ci` — CI/CD pipeline change

## Changes

- **Bundle-only install** (`mcp_watchdog_deploy.sh`): drop the redundant per-`#include` library installs — the package bundle already ships them — plus a coverage guard. Also removes the `hub_list_libraries` install failure mode.
- **Faster restore** (`e2e-deadman-watchdog-v2.groovy`, `mcp_disarm_watchdog.sh`): a one-shot `runIn(2,"deadmanKick")` starts the restore ~2s after the disarm flag instead of waiting for the next periodic tick. It uses a **dedicated** handler, so scheduling it can never disturb the `runEvery1Minute` dead-man. Plus tighter completion polls.
- **Arm refresh, single-shot** (`mcp_arm_watchdog.sh`): fire the canonical-main refresh **once** instead of through the 5×-retry wrapper (which re-sent the ~1.6 MB deploy up to 5×) — removes ~80s of wasted timeouts and the 5 warning lines when it fires. The cache mechanism is unchanged.
- **Custom-rule batching** (`tests/e2e_test.py`): the 26 legacy custom-engine trigger/condition/action *type* tests collapse into 3 batched rules (every type still created + count-asserted) — ~61s, since the legacy engine doesn't warrant exhaustive per-type fixtures.
- **Persistent fixtures** (`tests/e2e_test.py`): the `BAT_E2E_` scaffolding test switch is created once and reused (excluded from the teardown sweeps); the conditional AttrProbe switch folds into it. The device create/delete *tests* are unchanged.
- **Deferred native-rule deletes**: `E2E_DEFER_NATIVE_DELETES` (off by default) defers per-test RM-rule fixture deletes; the disarm step then force-deletes the **exact tracked ids** over the watchdog, overlapping the ~100s restore poll (~29s off the suite). Adds the watchdog `hub_force_delete_app` tool (force-deletes an installed-app *instance* via `/installedapp/forcedelete/<id>/quiet`, mirroring the server's `_rmForceDeleteApp`) + a `WatchdogV2Spec` case. The post-restore `--cleanup-only` prefix sweep stays the backstop.
- **Diagnostics**: a real per-operation wall-clock summary in the test runner.

## Release Notes

- None — internal e2e / CI tooling and test-suite changes only. The dead-man watchdog is test-hub-only and never shipped; no user-facing or server behaviour change.

## Testing

- 4 green `workflow_dispatch` runs on the test hub: wall-clock 793s → 728s → 669s → **607s**, suite 342s → **273s**, 75/75 passing each.
- The deferred-rule sweep verified live: it force-deleted exactly the 10 deferred rule instances over the watchdog, followed by a byte-identical clean restore and zero stale bundles/libraries.
- `WatchdogV2Spec` green (incl. the new `hub_force_delete_app` cases); `python tests/sandbox_lint.py`, `bash -n` on the scripts, and `py_compile` / ruff on `tests/e2e_test.py` all clean. CrameHub confirmed the live package has no drift.
- Note: the `E2E_DEFER_NATIVE_DELETES` flag lives on the `Run E2E tests` workflow step, so the `pull_request_target` auto-check (which runs *main's* workflow) won't set it — there the deletes simply stay inline (no regression); this branch's behaviour is proven via the dispatch runs above.

## Checklist

- [x] **Unit tests added for any new MCP tools** (`hub_force_delete_app` → `WatchdogV2Spec`)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (N/A — `hub_force_delete_app` is test-hub watchdog-only, not a shipped server tool)
- [x] Documentation updated if user-facing behaviour or tool surface changed (`AGENTS.md` / `CLAUDE.md` e2e install-flow line)
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (watchdog-only tool; mirrors the existing watchdog/server delete tools)
