### PR TITLE
feat: surface pending hub firmware update + health alerts from /hub2/hubData

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1270,7 +1270,7 @@ def getGatewayConfig() {
             description: "Health monitoring, diagnostics, and radio details: hub metrics, memory history, garbage collection, device health, radio info, Z-Wave repair, and state snapshots. (Custom-rule diagnostics: use hub_get_custom_rule with detailed=true.)",
             tools: ["hub_get_metrics", "hub_get_memory_history", "hub_call_gc", "hub_get_device_health", "hub_get_radio_details", "hub_call_zwave_repair", "hub_list_captured_states", "hub_delete_captured_state"],
             summaries: [
-                hub_get_metrics: "Get hub metrics (memory, temp, DB) with CSV trend history. Read-only by default; recordSnapshot=true also persists a snapshot. Args: recordSnapshot, trendPoints",
+                hub_get_metrics: "Get hub metrics (memory, temp, DB) with CSV trend history + the hub's own health alerts (radio offline, backup failures, low memory, DB bloat, safeMode). Read-only by default; recordSnapshot=true also persists a snapshot. Args: recordSnapshot, trendPoints",
                 hub_get_memory_history: "Get free OS memory and CPU load history. Returns most recent entries with summary stats. Args: limit (default 100, 0 for all). Requires Read master",
                 hub_call_gc: "Force JVM garbage collection to reclaim memory. Returns before/after free memory. Requires the Write master",
                 hub_get_device_health: "Check device staleness, ICMP-ping arbitrary IPs (router, NAS, server), and/or blink the hub identify-LED. Args: staleHours, includeHealthy, pingHosts (max 5 IPv4), pingCount (1-5), identifyHub",
@@ -1280,7 +1280,7 @@ def getGatewayConfig() {
                 hub_delete_captured_state: "Delete a captured state by stateId, or ALL captured states when stateId is omitted. Args: stateId (optional)"
             ],
             searchHints: [
-                hub_get_metrics: "temperature database size trending monitoring over time",
+                hub_get_metrics: "temperature database size trending monitoring over time health alerts safe mode radio offline backup failed low memory",
                 hub_get_memory_history: "ram free used leak trending over time java heap nio",
                 hub_call_gc: "gc garbage collection free reclaim ram cleanup java heap memory",
                 hub_get_device_health: "stale offline dead unresponsive battery not reporting ping icmp reachable network ip lan host router gateway identify led blink locate physical hub",
@@ -1314,7 +1314,7 @@ def getGatewayConfig() {
                 hub_get_performance_stats: "Get device/app performance stats (count, % busy, total ms, state size, events). Args: type, sortBy, limit",
                 hub_get_jobs: "Get scheduled jobs, running jobs, and hub actions",
                 hub_get_debug_logs: "Get MCP internal debug logs (mode='logs') or logging status (mode='status'). Args: mode, level, component (e.g. server/rule), ruleId, limit",
-                hub_get_metrics: "Get hub metrics (memory, temp, DB) with CSV trend history. Read-only by default; pass recordSnapshot=true to also append a snapshot to the File Manager. Args: recordSnapshot?, trendPoints?",
+                hub_get_metrics: "Get hub metrics (memory, temp, DB) with CSV trend history + the hub's own health alerts (radio offline, backup failures, low memory, DB bloat, safeMode). Read-only by default; pass recordSnapshot=true to also append a snapshot to the File Manager. Args: recordSnapshot?, trendPoints?",
                 hub_get_memory_history: "Get free OS memory and CPU load history with summary stats. Args: limit",
                 hub_get_device_health: "Check device staleness, ICMP-ping arbitrary IPs, and/or blink the hub identify-LED. Args: staleHours, includeHealthy, pingHosts, pingCount, identifyHub",
                 hub_get_radio_details: "Z-Wave and/or Zigbee radio info (firmware, channel, PAN/home ID, device count). Args: radio (zwave|zigbee, omit for both)",
@@ -1325,7 +1325,7 @@ def getGatewayConfig() {
                 hub_get_performance_stats: "slow cpu busy resource usage hog bottleneck",
                 hub_get_jobs: "scheduled cron timer recurring what is running next automation",
                 hub_get_debug_logs: "mcp internal troubleshoot trace logging status buffer capacity level",
-                hub_get_metrics: "temperature database size trending monitoring memory over time snapshot history",
+                hub_get_metrics: "temperature database size trending monitoring memory over time snapshot history health alerts safe mode radio offline backup failed weak mesh",
                 hub_get_memory_history: "ram free used leak trending over time java heap nio",
                 hub_get_device_health: "stale offline dead unresponsive battery not reporting ping icmp reachable network ip lan host router identify led blink locate",
                 hub_get_radio_details: "zwave zigbee mesh network frequency firmware channel pan coordinator radio",
@@ -2353,11 +2353,12 @@ Verify rule after creation.""",
         // System Tools
         [
             name: "hub_get_info",
-            description: "Get comprehensive hub diagnostics in one call: model, firmware, uptime, free memory, internal temperature, database size, MCP server stats, and current security/toggle settings. Use this for health checks, version lookups, or when triaging hub performance. Location/PII fields (name, local IP, timezone, coordinates, zip code) are returned only when Read master is enabled; otherwise they are omitted.",
+            description: "Get comprehensive hub diagnostics in one call: model, firmware, uptime, free memory, internal temperature, database size, MCP server stats, and current security/toggle settings. Also surfaces the pending hub firmware/platform update (platformUpdate) + Safe Mode (safeMode).[[FLAT_TRIM]] Pass includeHealthAlerts=true for the hub's full health-alerts block from /hub2/hubData (radio offline, backup failures, low memory, DB bloat, weak mesh). Use this for health checks, version lookups, or when triaging hub performance. Location/PII fields (name, local IP, timezone, coordinates, zip code) are returned only when Read master is enabled; otherwise they are omitted.[[/FLAT_TRIM]]",
             inputSchema: [
                 type: "object",
                 properties: [
-                    identifyHub: [type: "boolean", description: "Blink hub LED to identify hub. Default: false.", default: false]
+                    identifyHub: [type: "boolean", description: "Blink hub LED to identify hub. Default: false.", default: false],
+                    includeHealthAlerts: [type: "boolean", description: "Include the full health-alerts block (default false).[[FLAT_TRIM]] Every /hub2/hubData alert flag + messages under healthAlerts; platformUpdate and safeMode are returned regardless.[[/FLAT_TRIM]]", default: false]
                 ]
             ],
             outputSchema: [
@@ -2401,7 +2402,10 @@ Verify rule after creation.""",
                     hubData: [type: "object", description: "Hub data map (Read master only)"],
                     readDisabledNote: [type: "string", description: "Present when the Read master is disabled; PII excluded"],
                     identifyHubTriggered: [type: "boolean", description: "Present when identifyHub requested; LED blink result"],
-                    identifyHubError: [type: "string", description: "Present when identifyHub blink failed"]
+                    identifyHubError: [type: "string", description: "Present when identifyHub blink failed"],
+                    platformUpdate: [type: "object", description: "Pending HUB FIRMWARE/platform update from /hub2/hubData: {available (bool or null), currentVersion, availableVersion (when available)}. Distinct from hub_get_update_status's MCP-server-app check; available=null means /hub2/hubData was unreadable."],
+                    safeMode: [type: "boolean", description: "Whether the hub is running in Safe Mode (from /hub2/hubData). Absent if /hub2/hubData was unreadable."],
+                    healthAlerts: [type: "object", description: "Present only when includeHealthAlerts=true: the hub's health alerts from /hub2/hubData -- {safeMode, active (list of currently-firing alert flags), details (full alert map + message strings)}."]
                 ]
             ]
         ],
@@ -3028,7 +3032,7 @@ def _getAllToolDefinitions_part4() {
     return [
         [
             name: "hub_get_update_status",
-            description: "Check if a newer version of MCP Rule Server is available on GitHub. The check is asynchronous: the first call usually returns latestVersion='unknown (check in progress)' — call again in a few seconds for the result.",
+            description: "Check for available updates: the MCP Rule Server APP version on GitHub (installedVersion/latestVersion/updateAvailable) AND, separately, platformUpdate -- the pending Hubitat FIRMWARE update on the hub.[[FLAT_TRIM]] The app check is asynchronous: the first call usually returns latestVersion='unknown (check in progress)', so call again in a few seconds. platformUpdate comes from /hub2/hubData. The two are unrelated; do not conflate the app update with the firmware update.[[/FLAT_TRIM]]",
             inputSchema: [
                 type: "object",
                 properties: [:]
@@ -3037,11 +3041,12 @@ def _getAllToolDefinitions_part4() {
                 type: "object",
                 properties: [
                     success: [type: "boolean", description: "Whether the check ran"],
-                    installedVersion: [type: "string", description: "Currently installed version"],
-                    latestVersion: [type: "string", description: "Latest version on GitHub; 'unknown' while async check pending"],
-                    updateAvailable: [type: "boolean", description: "Whether a newer version is available"],
-                    lastChecked: [type: "string", description: "When the check last completed"],
-                    note: [type: "string", description: "Async-check guidance"]
+                    installedVersion: [type: "string", description: "Currently installed MCP Rule Server APP version"],
+                    latestVersion: [type: "string", description: "Latest MCP server app version on GitHub; 'unknown' while async check pending"],
+                    updateAvailable: [type: "boolean", description: "Whether a newer MCP server app version is available"],
+                    lastChecked: [type: "string", description: "When the app-version check last completed"],
+                    platformUpdate: [type: "object", description: "Pending HUB FIRMWARE/platform update from /hub2/hubData: {available (bool or null), currentVersion, availableVersion (when available)}. Separate from the MCP server app check above; available=null when /hub2/hubData was unreadable."],
+                    note: [type: "string", description: "Guidance distinguishing the two update types + async-check hint"]
                 ],
                 required: ["success", "installedVersion"]
             ]
@@ -3289,7 +3294,7 @@ Pass cursor (opaque string from a prior call's nextCursor) to page through the l
         ],
         [
             name: "hub_get_metrics",
-            description: "Retrieve hub metrics (memory, temp, DB size) with CSV trend history. The trend reflects ONLY previously-recorded snapshots — the hub does not auto-sample, so it can be sparse or stale (and resets if the CSV is cleared) unless recordSnapshot=true is called periodically. Read-only by default; pass recordSnapshot=true to ALSO append the current snapshot to the performance-history CSV in the hub File Manager (the only write side-effect). Requires Read master.",
+            description: "Retrieve hub metrics (memory, temp, DB size) with CSV trend history. The trend reflects ONLY previously-recorded snapshots — the hub does not auto-sample, so it can be sparse or stale (and resets if the CSV is cleared) unless recordSnapshot=true is called periodically. Read-only by default; pass recordSnapshot=true to ALSO append the current snapshot to the performance-history CSV in the hub File Manager (the only write side-effect).[[FLAT_TRIM]] Also folds in the hub's own health alerts under healthAlerts (radio offline, backup failures, low memory, DB bloat, weak mesh, safeMode) from /hub2/hubData.[[/FLAT_TRIM]] Requires Read master.",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -3316,6 +3321,7 @@ Pass cursor (opaque string from a prior call's nextCursor) to page through the l
                         databaseSizeKB: [description: "Database size (KB)"],
                         uptimeSeconds: [description: "Uptime in seconds"]
                     ]]],
+                    healthAlerts: [type: "object", description: "The hub's own health alerts from /hub2/hubData -- {safeMode, active (list of currently-firing alert flags like hubLowMemory/hubLargeDatabase/zwaveOffline/localBackupFailed/weakZigbee), details (full alert flag map + the hub's message strings)}. Complements the locally-derived warnings on `current`. null if /hub2/hubData was unreadable."],
                     trendPointsAvailable: [type: "integer", description: "Total history rows available"],
                     historyFile: [type: "string", description: "CSV history filename in File Manager"]
                 ],
@@ -6853,6 +6859,53 @@ def applyDeviceMapping(data, Map mapping) {
 
 // ==================== SYSTEM TOOLS ====================
 
+// ===== /hub2/hubData diagnostics: pending platform update + hub health alerts =====
+// /hub2/hubData is the data the modern hub UI computes server-side. It carries the hub's OWN
+// authoritative health alerts plus the pending-platform-update flag (what the UI "bell" reads) --
+// neither is in hub.data or any /hub/advanced/* metric. The availability check is cloud-driven
+// (cloud.hubitat.com); the hub caches the result here so it is readable locally. Defensive: returns
+// null on any fetch/parse failure so callers degrade gracefully (older firmware may not serve it).
+def _getHub2HubData() {
+    try {
+        def raw = hubInternalGet("/hub2/hubData")
+        if (!raw) return null
+        def parsed = new groovy.json.JsonSlurper().parseText(raw)
+        return (parsed instanceof Map) ? parsed : null
+    } catch (Exception e) {
+        mcpLog("debug", "server", "_getHub2HubData read/parse failed: ${e.message}")
+        return null
+    }
+}
+
+// platformUpdate block: the pending HUB FIRMWARE update. Distinct from hub_get_update_status's
+// MCP-server-app version check. currentVersion is the hub firmware string; available +
+// availableVersion come from /hub2/hubData.alerts (platformUpdateAvailable / platformUpdateVersion).
+def _platformUpdateFromHub2(hub2) {
+    def fw = null
+    try { fw = location?.hub?.firmwareVersionString?.toString() } catch (Exception e) { }
+    if (!(hub2 instanceof Map)) {
+        return [available: null, currentVersion: fw,
+                note: "Pending-firmware status unavailable (/hub2/hubData unreadable -- older firmware or a transient read failure)."]
+    }
+    def alerts = (hub2.alerts instanceof Map) ? hub2.alerts : [:]
+    boolean avail = alerts.platformUpdateAvailable == true
+    def out = [available: avail, currentVersion: fw ?: hub2.version?.toString()]
+    if (avail) out.availableVersion = alerts.platformUpdateVersion?.toString()
+    return out
+}
+
+// healthAlerts block: the hub's own active health determinations from /hub2/hubData -- complementary
+// to, NOT duplicating, the locally-derived memory/temp/DB warnings. `active` lists the currently-
+// firing alert flags; `details` is the full alert map (every flag + the hub's message strings). The
+// platform-update fields are surfaced separately (platformUpdate), so they are dropped here.
+def _healthAlertsFromHub2(hub2) {
+    if (!(hub2 instanceof Map)) return null
+    def alerts = (hub2.alerts instanceof Map) ? ([:] + hub2.alerts) : [:]
+    alerts.remove("platformUpdateAvailable"); alerts.remove("platformUpdateVersion")
+    def active = alerts.findAll { k, v -> v == true }.collect { k, v -> k.toString() }.sort()
+    return [safeMode: hub2.safeMode == true, active: active, details: alerts]
+}
+
 def toolGetHubInfo(args = null) {
     def hub = location.hub
     def info = [
@@ -6982,6 +7035,17 @@ def toolGetHubInfo(args = null) {
             info.identifyHubError = msg
             mcpLog("warn", "server", "identifyHub blinkLED request failed [${e.class.simpleName}]: ${msg}")
         }
+    }
+
+    // Pending hub firmware update + hub health alerts from /hub2/hubData (one fetch; not PII-gated --
+    // these are hub-health, not location data). platformUpdate + safeMode always; the full alerts
+    // block only when asked (it is the diagnostics surface, lives in full on hub_get_metrics too).
+    def hub2 = _getHub2HubData()
+    info.platformUpdate = _platformUpdateFromHub2(hub2)
+    if (hub2 instanceof Map) info.safeMode = (hub2.safeMode == true)
+    if (args?.includeHealthAlerts == true) {
+        def ha = _healthAlertsFromHub2(hub2)
+        if (ha != null) info.healthAlerts = ha
     }
 
     return info
@@ -11551,6 +11615,11 @@ def toolGetHubPerformance(args) {
     mcpLog("info", "monitoring", "Hub performance snapshot recorded=${recordSnapshot}, trendPoints=${trends.size()}")
     return [
         current: current,
+        // The hub's OWN active health alerts (from /hub2/hubData) sit alongside the locally-derived
+        // memory/temp/DB warnings on `current` -- e.g. the hub's hubLargeDatabase/hubLowMemory flags
+        // complement (and may differ in threshold from) the databaseWarning/memoryWarning above. null
+        // when /hub2/hubData is unreadable.
+        healthAlerts: _healthAlertsFromHub2(_getHub2HubData()),
         trends: trends,
         trendPointsAvailable: history.size(),
         historyFile: csvFileName
@@ -26736,7 +26805,8 @@ def toolCheckForUpdate(args) {
             latestVersion: updateInfo.latestVersion ?: "unknown (check in progress)",
             updateAvailable: updateInfo.updateAvailable ?: false,
             lastChecked: updateInfo.checkedAt ? formatTimestamp(updateInfo.checkedAt) : "checking now",
-            note: "Version check is asynchronous. If latestVersion shows 'unknown', call this tool again in a few seconds to see the result."
+            platformUpdate: _platformUpdateFromHub2(_getHub2HubData()),
+            note: "Two distinct updates here. installedVersion/latestVersion/updateAvailable track the MCP Rule Server APP on GitHub (asynchronous -- if latestVersion is 'unknown', call again in a few seconds). platformUpdate is the SEPARATE pending HUBITAT FIRMWARE/platform update on the hub itself (from /hub2/hubData)."
         ]
     } catch (Exception e) {
         return [

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -2403,7 +2403,7 @@ Verify rule after creation.""",
                     readDisabledNote: [type: "string", description: "Present when the Read master is disabled; PII excluded"],
                     identifyHubTriggered: [type: "boolean", description: "Present when identifyHub requested; LED blink result"],
                     identifyHubError: [type: "string", description: "Present when identifyHub blink failed"],
-                    platformUpdate: [type: "object", description: "Pending HUB FIRMWARE/platform update from /hub2/hubData: {available (bool or null), currentVersion, availableVersion (when available)}. Distinct from hub_get_update_status's MCP-server-app check; available=null means /hub2/hubData was unreadable."],
+                    platformUpdate: [type: "object", description: "Pending HUB FIRMWARE/platform update from /hub2/hubData: {available (bool or null), currentVersion, availableVersion (when available), note (only when available=null)}. Distinct from hub_get_update_status's MCP-server-app check; available=null means /hub2/hubData was unreadable/unrecognized and the note explains why."],
                     safeMode: [type: "boolean", description: "Whether the hub is running in Safe Mode (from /hub2/hubData). Absent if /hub2/hubData was unreadable."],
                     healthAlerts: [type: "object", description: "Present only when includeHealthAlerts=true: the hub's health alerts from /hub2/hubData -- {safeMode, active (list of currently-firing alert flags), details (full alert map + message strings)}."]
                 ]
@@ -3045,7 +3045,7 @@ def _getAllToolDefinitions_part4() {
                     latestVersion: [type: "string", description: "Latest MCP server app version on GitHub; 'unknown' while async check pending"],
                     updateAvailable: [type: "boolean", description: "Whether a newer MCP server app version is available"],
                     lastChecked: [type: "string", description: "When the app-version check last completed"],
-                    platformUpdate: [type: "object", description: "Pending HUB FIRMWARE/platform update from /hub2/hubData: {available (bool or null), currentVersion, availableVersion (when available)}. Separate from the MCP server app check above; available=null when /hub2/hubData was unreadable."],
+                    platformUpdate: [type: "object", description: "Pending HUB FIRMWARE/platform update from /hub2/hubData: {available (bool or null), currentVersion, availableVersion (when available), note (only when available=null)}. Separate from the MCP server app check above; available=null when /hub2/hubData was unreadable/unrecognized and the note explains why."],
                     note: [type: "string", description: "Guidance distinguishing the two update types + async-check hint"]
                 ],
                 required: ["success", "installedVersion"]
@@ -6872,7 +6872,10 @@ def _getHub2HubData() {
         def parsed = new groovy.json.JsonSlurper().parseText(raw)
         return (parsed instanceof Map) ? parsed : null
     } catch (Exception e) {
-        mcpLog("debug", "server", "_getHub2HubData read/parse failed: ${e.message}")
+        // warn, not debug: the default log threshold is "error", so a debug line would be invisible --
+        // and a /hub2/hubData fetch/parse failure (transient 5xx, auth hiccup, or a firmware that
+        // changed the JSON shape) is exactly the cause an operator needs when platformUpdate degrades.
+        mcpLog("warn", "server", "_getHub2HubData read/parse failed: ${e.message}")
         return null
     }
 }
@@ -6883,13 +6886,19 @@ def _getHub2HubData() {
 def _platformUpdateFromHub2(hub2) {
     def fw = null
     try { fw = location?.hub?.firmwareVersionString?.toString() } catch (Exception e) { }
-    if (!(hub2 instanceof Map)) {
-        return [available: null, currentVersion: fw,
-                note: "Pending-firmware status unavailable (/hub2/hubData unreadable -- older firmware or a transient read failure)."]
+    def hubVer = (hub2 instanceof Map) ? hub2.version?.toString() : null
+    // available:null is the schema's documented "unreadable" signal -- honor it for BOTH a missing
+    // /hub2/hubData AND a present-but-unrecognized shape (alerts not a Map, or a non-Boolean
+    // platformUpdateAvailable), so a malformed/changed payload can never masquerade as a confident
+    // "no update available".
+    def alerts = (hub2 instanceof Map && hub2.alerts instanceof Map) ? hub2.alerts : null
+    def pa = alerts?.platformUpdateAvailable
+    if (alerts == null || (pa != null && !(pa instanceof Boolean))) {
+        return [available: null, currentVersion: fw ?: hubVer,
+                note: "Pending-firmware status unreadable (/hub2/hubData missing, or its alerts block has an unrecognized shape)."]
     }
-    def alerts = (hub2.alerts instanceof Map) ? hub2.alerts : [:]
-    boolean avail = alerts.platformUpdateAvailable == true
-    def out = [available: avail, currentVersion: fw ?: hub2.version?.toString()]
+    boolean avail = (pa == true)
+    def out = [available: avail, currentVersion: fw ?: hubVer]
     if (avail) out.availableVersion = alerts.platformUpdateVersion?.toString()
     return out
 }

--- a/src/test/groovy/server/Hub2DataDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/Hub2DataDiagnosticsSpec.groovy
@@ -16,7 +16,9 @@ import support.ToolSpecBase
  * And the defensive path: when /hub2/hubData is unreadable, callers degrade (available=null, no
  * safeMode, healthAlerts=null) rather than throwing.
  *
- * hubGet.register('/hub2/hubData') stubs hubInternalGet; an unregistered path returns null.
+ * hubGet.register('/hub2/hubData') stubs hubInternalGet; an unregistered path makes hubInternalGet
+ * THROW, which _getHub2HubData catches and degrades to null (so the "unreadable" specs exercise the
+ * real catch arm, not a benign no-op).
  */
 class Hub2DataDiagnosticsSpec extends ToolSpecBase {
 
@@ -39,6 +41,17 @@ class Hub2DataDiagnosticsSpec extends ToolSpecBase {
     @Shared String HUB2_NO_UPDATE_SAFEMODE = JsonOutput.toJson([
         version: '2.5.0.143', safeMode: true,
         alerts: [platformUpdateAvailable: false, hubLowMemory: false, zwaveOffline: false]
+    ])
+
+    // Safe Mode AND a pending update at once -- proves the two are read from independent fields.
+    @Shared String HUB2_UPDATE_AND_SAFEMODE = JsonOutput.toJson([
+        version: '2.5.0.143', safeMode: true,
+        alerts: [platformUpdateAvailable: true, platformUpdateVersion: '2.5.0.153', hubLowMemory: false]
+    ])
+
+    // Valid JSON object but the alerts block is the wrong shape (a list) -- a firmware shape change.
+    @Shared String HUB2_ALERTS_MALFORMED = JsonOutput.toJson([
+        version: '2.5.0.143', safeMode: false, alerts: ['not', 'a', 'map']
     ])
 
     def setupSpec() {
@@ -83,6 +96,49 @@ class Hub2DataDiagnosticsSpec extends ToolSpecBase {
         result.platformUpdate.available == false
         result.platformUpdate.currentVersion == '2.5.0.143'
         !result.platformUpdate.containsKey('availableVersion')
+        // the readable path must NOT carry the "unreadable" note
+        !result.platformUpdate.containsKey('note')
+    }
+
+    def "hub_get_info platformUpdate.available is null (not false) when /hub2/hubData has an unrecognized alerts shape"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        hubGet.register('/hub2/hubData') { params -> HUB2_ALERTS_MALFORMED }
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then: 'a present-but-malformed alerts block must NOT masquerade as a confident "no update"'
+        result.platformUpdate.available == null
+        result.platformUpdate.note?.toLowerCase()?.contains('unrecognized')
+    }
+
+    def "hub_get_info reads safeMode and platformUpdate from independent fields (Safe Mode WITH a pending update)"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        hubGet.register('/hub2/hubData') { params -> HUB2_UPDATE_AND_SAFEMODE }
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then:
+        result.safeMode == true
+        result.platformUpdate.available == true
+        result.platformUpdate.availableVersion == '2.5.0.153'
+    }
+
+    def "hub_get_info platformUpdate.currentVersion falls back to /hub2/hubData version when the hub firmware string is null"() {
+        given:
+        def h = new TestHub()
+        h.firmwareVersionString = null
+        sharedLocation.hub = h
+        hubGet.register('/hub2/hubData') { params -> HUB2_NO_UPDATE_SAFEMODE }   // carries version: '2.5.0.143'
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then: 'firmwareVersionString null -> currentVersion comes from hub2.version'
+        result.platformUpdate.currentVersion == '2.5.0.143'
     }
 
     def "hub_get_info degrades gracefully when /hub2/hubData is unreadable"() {
@@ -97,7 +153,9 @@ class Hub2DataDiagnosticsSpec extends ToolSpecBase {
         noExceptionThrown()
         result.platformUpdate.available == null
         result.platformUpdate.currentVersion == '2.5.0.143'   // still from the hub firmware string
-        result.platformUpdate.note?.toLowerCase()?.contains('unavailable')
+        // note is always set on the unreadable path -- assert it plainly (no safe-nav: a null note
+        // here would itself be a regression we want to fail on).
+        result.platformUpdate.note.toLowerCase().contains('unreadable')
         !result.containsKey('safeMode')
         !result.containsKey('healthAlerts')
     }
@@ -146,8 +204,10 @@ class Hub2DataDiagnosticsSpec extends ToolSpecBase {
         result.healthAlerts.safeMode == false
         // only the firing boolean flags, sorted
         result.healthAlerts.active == ['hubLowMemory']
-        // details carries the full alert map incl. messages...
+        // details carries the FULL alert map -- firing AND non-firing flags + messages (unlike
+        // `active`, which is filtered to the true ones)...
         result.healthAlerts.details.hubLowMemory == true
+        result.healthAlerts.details.hubHighLoad == false
         result.healthAlerts.details.headerMessages instanceof List
         // ...but the platform-update fields are surfaced separately, not duplicated here
         !result.healthAlerts.details.containsKey('platformUpdateAvailable')

--- a/src/test/groovy/server/Hub2DataDiagnosticsSpec.groovy
+++ b/src/test/groovy/server/Hub2DataDiagnosticsSpec.groovy
@@ -1,0 +1,185 @@
+package server
+
+import groovy.json.JsonOutput
+import spock.lang.Shared
+import support.TestHub
+import support.TestLocation
+import support.ToolSpecBase
+
+/**
+ * Contract spec for the /hub2/hubData surfacing (pending platform/firmware update + hub health
+ * alerts + safeMode). Asserts the three tools that fold it in behave correctly against the real
+ * endpoint shape captured from a C-8 on 2.5.0.143:
+ *   - hub_get_info        -> platformUpdate + safeMode always; healthAlerts only with the opt-in arg
+ *   - hub_get_update_status -> platformUpdate alongside the (preserved) MCP-app version check
+ *   - hub_get_metrics     -> the full healthAlerts block alongside the trend metrics
+ * And the defensive path: when /hub2/hubData is unreadable, callers degrade (available=null, no
+ * safeMode, healthAlerts=null) rather than throwing.
+ *
+ * hubGet.register('/hub2/hubData') stubs hubInternalGet; an unregistered path returns null.
+ */
+class Hub2DataDiagnosticsSpec extends ToolSpecBase {
+
+    @Shared private TestLocation sharedLocation = new TestLocation()
+
+    // Captured shape: pending update available + an active low-memory alert.
+    @Shared String HUB2_UPDATE_AND_ALERT = JsonOutput.toJson([
+        hubId: '811e21ba', version: '2.5.0.143', model: 'C-8', name: 'CrameHub', safeMode: false,
+        alerts: [
+            platformUpdateAvailable: true, platformUpdateVersion: '2.5.0.153',
+            hubLowMemory: true, hubHighLoad: false, hubLoadSevere: false,
+            zwaveOffline: false, zigbeeOffline: false, hubLargeDatabase: false,
+            localBackupFailed: false, cloudBackupFailed: false, weakZigbee: false,
+            databaseSize: 15,
+            headerMessages: ['Platform update 2.5.0.153 available', 'Hub is running low on memory.']
+        ]
+    ])
+
+    // No pending update, no firing alerts, hub in Safe Mode.
+    @Shared String HUB2_NO_UPDATE_SAFEMODE = JsonOutput.toJson([
+        version: '2.5.0.143', safeMode: true,
+        alerts: [platformUpdateAvailable: false, hubLowMemory: false, zwaveOffline: false]
+    ])
+
+    def setupSpec() {
+        appExecutor.getLocation() >> sharedLocation
+    }
+
+    def cleanup() {
+        sharedLocation.hub = null
+    }
+
+    private TestHub hubOnFirmware(String fw) {
+        def h = new TestHub()
+        h.firmwareVersionString = fw
+        return h
+    }
+
+    // -------- #12: pending platform/firmware update --------
+
+    def "hub_get_info surfaces platformUpdate when /hub2/hubData reports one available"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        hubGet.register('/hub2/hubData') { params -> HUB2_UPDATE_AND_ALERT }
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then:
+        result.platformUpdate.available == true
+        result.platformUpdate.currentVersion == '2.5.0.143'
+        result.platformUpdate.availableVersion == '2.5.0.153'
+    }
+
+    def "hub_get_info platformUpdate.available is false (no availableVersion) when none pending"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        hubGet.register('/hub2/hubData') { params -> HUB2_NO_UPDATE_SAFEMODE }
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then:
+        result.platformUpdate.available == false
+        result.platformUpdate.currentVersion == '2.5.0.143'
+        !result.platformUpdate.containsKey('availableVersion')
+    }
+
+    def "hub_get_info degrades gracefully when /hub2/hubData is unreadable"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        // /hub2/hubData not registered -> hubInternalGet returns null.
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then:
+        noExceptionThrown()
+        result.platformUpdate.available == null
+        result.platformUpdate.currentVersion == '2.5.0.143'   // still from the hub firmware string
+        result.platformUpdate.note?.toLowerCase()?.contains('unavailable')
+        !result.containsKey('safeMode')
+        !result.containsKey('healthAlerts')
+    }
+
+    def "hub_get_update_status surfaces platformUpdate while preserving the MCP-app version fields"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        hubGet.register('/hub2/hubData') { params -> HUB2_UPDATE_AND_ALERT }
+
+        when:
+        def result = script.toolCheckForUpdate([:])
+
+        then:
+        result.success == true
+        result.containsKey('installedVersion')      // MCP server app check preserved
+        result.containsKey('updateAvailable')
+        result.platformUpdate.available == true
+        result.platformUpdate.availableVersion == '2.5.0.153'
+    }
+
+    // -------- #13: health alerts + safeMode --------
+
+    def "hub_get_info surfaces safeMode but NOT the full alerts block by default"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        hubGet.register('/hub2/hubData') { params -> HUB2_NO_UPDATE_SAFEMODE }
+
+        when:
+        def result = script.toolGetHubInfo()
+
+        then:
+        result.safeMode == true
+        !result.containsKey('healthAlerts')
+    }
+
+    def "hub_get_info includes the full healthAlerts block only when includeHealthAlerts=true"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        hubGet.register('/hub2/hubData') { params -> HUB2_UPDATE_AND_ALERT }
+
+        when:
+        def result = script.toolGetHubInfo([includeHealthAlerts: true])
+
+        then:
+        result.healthAlerts != null
+        result.healthAlerts.safeMode == false
+        // only the firing boolean flags, sorted
+        result.healthAlerts.active == ['hubLowMemory']
+        // details carries the full alert map incl. messages...
+        result.healthAlerts.details.hubLowMemory == true
+        result.healthAlerts.details.headerMessages instanceof List
+        // ...but the platform-update fields are surfaced separately, not duplicated here
+        !result.healthAlerts.details.containsKey('platformUpdateAvailable')
+        !result.healthAlerts.details.containsKey('platformUpdateVersion')
+    }
+
+    def "hub_get_metrics folds in the full healthAlerts block alongside the trend metrics"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        hubGet.register('/hub2/hubData') { params -> HUB2_UPDATE_AND_ALERT }
+
+        when:
+        def result = script.toolGetHubPerformance([:])
+
+        then:
+        result.containsKey('current')
+        result.healthAlerts != null
+        result.healthAlerts.active == ['hubLowMemory']
+        result.healthAlerts.safeMode == false
+    }
+
+    def "hub_get_metrics healthAlerts is null when /hub2/hubData is unreadable"() {
+        given:
+        sharedLocation.hub = hubOnFirmware('2.5.0.143')
+        // /hub2/hubData not registered.
+
+        when:
+        def result = script.toolGetHubPerformance([:])
+
+        then:
+        noExceptionThrown()
+        result.containsKey('healthAlerts')
+        result.healthAlerts == null
+    }
+}

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -271,6 +271,26 @@ These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0
 
 **Expected**: Calls `hub_get_info`. Returns hub name, model, firmware version.
 
+### T14b — pending hub firmware/platform update
+
+```json
+{
+  "test_prompt": "Is there a Hubitat firmware/platform update available for my hub, and what version would it update to? Don't apply anything."
+}
+```
+
+**Expected**: Calls `hub_get_info` (or `hub_get_update_status`) and reports the `platformUpdate` block — whether a hub FIRMWARE update is pending and, if so, the `availableVersion` — keeping it distinct from any MCP server-app update. Makes no changes.
+
+### T14c — hub health alerts + safe mode
+
+```json
+{
+  "test_prompt": "Are there any health alerts on my hub right now — low memory, safe mode, radios offline, failed backups? Don't change anything."
+}
+```
+
+**Expected**: Surfaces the hub's own health alerts via `hub_get_info` with `includeHealthAlerts=true` (or `hub_get_metrics`'s `healthAlerts`). Reports `safeMode` and the active alert flags (e.g. `hubLowMemory`, `zwaveOffline`, `localBackupFailed`). Read-only — makes no changes.
+
 ### T15 — hub_list_modes
 
 ```json

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1352,6 +1352,7 @@ class TestRunner:
         for k in ("safeMode", "active", "details"):
             assert k in ha, f"healthAlerts missing '{k}': {ha}"
         assert isinstance(ha["active"], list), f"healthAlerts.active not a list: {ha['active']}"
+        assert isinstance(ha["details"], dict), f"healthAlerts.details not a dict: {ha['details']}"
         # platform-update fields are surfaced via platformUpdate, not duplicated in the alert details
         assert "platformUpdateAvailable" not in ha["details"], \
             f"platformUpdate leaked into healthAlerts.details: {sorted(ha['details'])}"

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1328,6 +1328,51 @@ class TestRunner:
         assert result is not None, "hub_get_metrics returned None"
 
     @test("system_tools")
+    def test_hub_get_info_platform_update_and_safemode(self) -> None:
+        # #12/#13: hub_get_info folds in the pending platform/firmware update + safeMode from
+        # /hub2/hubData. On a reachable hub the endpoint is readable, so these resolve (not the
+        # null degrade path); the full alerts block stays out unless opted in.
+        info = self.client.call_tool("hub_get_info", {})
+        assert "platformUpdate" in info, f"hub_get_info missing platformUpdate: {sorted(info)}"
+        pu = info["platformUpdate"]
+        assert "currentVersion" in pu, f"platformUpdate missing currentVersion: {pu}"
+        assert isinstance(pu.get("available"), bool), \
+            f"platformUpdate.available not resolved -- /hub2/hubData unreadable? {pu}"
+        if pu["available"]:
+            assert pu.get("availableVersion"), f"available=true but no availableVersion: {pu}"
+        assert "safeMode" in info, f"hub_get_info missing safeMode: {sorted(info)}"
+        assert "healthAlerts" not in info, "healthAlerts must be absent without includeHealthAlerts=true"
+
+    @test("system_tools")
+    def test_hub_get_info_health_alerts_opt_in(self) -> None:
+        # #13: the full alerts block appears only with includeHealthAlerts=true.
+        info = self.client.call_tool("hub_get_info", {"includeHealthAlerts": True})
+        ha = info.get("healthAlerts")
+        assert ha is not None, f"includeHealthAlerts=true but healthAlerts absent/null: {sorted(info)}"
+        for k in ("safeMode", "active", "details"):
+            assert k in ha, f"healthAlerts missing '{k}': {ha}"
+        assert isinstance(ha["active"], list), f"healthAlerts.active not a list: {ha['active']}"
+        # platform-update fields are surfaced via platformUpdate, not duplicated in the alert details
+        assert "platformUpdateAvailable" not in ha["details"], \
+            f"platformUpdate leaked into healthAlerts.details: {sorted(ha['details'])}"
+
+    @test("system_tools")
+    def test_hub_get_update_status_platform_update(self) -> None:
+        # #12: hub_get_update_status surfaces the hub firmware update separately from the MCP-app check.
+        res = self.client.call_tool("hub_get_update_status", {})
+        assert "installedVersion" in res, f"missing MCP-app installedVersion: {sorted(res)}"
+        assert "platformUpdate" in res, f"missing platformUpdate: {sorted(res)}"
+        assert "available" in res["platformUpdate"], f"platformUpdate shape wrong: {res['platformUpdate']}"
+
+    @test("system_tools")
+    def test_hub_get_metrics_health_alerts(self) -> None:
+        # #13: hub_get_metrics folds in the full healthAlerts block alongside the trend metrics.
+        res = self.client.call_tool("hub_manage_diagnostics", {"tool": "hub_get_metrics"})
+        assert "healthAlerts" in res, f"hub_get_metrics missing healthAlerts: {sorted(res)}"
+        ha = res["healthAlerts"]
+        assert ha is not None and "active" in ha and "safeMode" in ha, f"healthAlerts shape wrong: {ha}"
+
+    @test("system_tools")
     def test_get_memory_history(self) -> None:
         result = self.client.call_tool("hub_manage_diagnostics", {
             "tool": "hub_get_memory_history",


### PR DESCRIPTION
## Summary

Surface two things the hub computes but no MCP tool exposed, both read from `/hub2/hubData`: the pending **hub firmware/platform update** and the hub's own **health-alerts block + Safe Mode**. Until now `hub_get_info` only derived memory/temp/DB warnings locally, and `hub_get_update_status` only checked the MCP **server-app** version on GitHub — neither knew about a pending Hubitat firmware update or the hub's native alerts.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- New `_getHub2HubData()` helper: one defensive `hubInternalGet("/hub2/hubData")` + JSON parse, returns null on any failure so every caller degrades gracefully (the read failure is logged at `warn`).
- `platformUpdate {available, currentVersion, availableVersion}` added to **`hub_get_info`** + **`hub_get_update_status`**, kept distinct from the unrelated MCP-app version check. `available` is `null` (not a misleading `false`) when `/hub2/hubData` is missing or its `alerts` block has an unrecognized shape.
- `healthAlerts {safeMode, active[], details{}}` added to **`hub_get_metrics`** (full block, in the `hub_read_diagnostics` surface) and **`hub_get_info`** (`safeMode` always; full block via `includeHealthAlerts=true`).
- Refreshed `hub_get_metrics` description + gateway summaries/searchHints for discoverability; verbose prose wrapped in `[[FLAT_TRIM]]` so the flat `tools/list` catalog stays under its size budget. No new tools.

## Release Notes

- `hub_get_info` and `hub_get_update_status` now report a pending **Hubitat firmware/platform update** (separate from the MCP server-app update).
- `hub_get_info` now reports **Safe Mode** and, via `includeHealthAlerts=true`, the hub's full **health-alerts** block (radio offline, backup failures, low memory, DB bloat, weak mesh); `hub_get_metrics` returns the full block too.

## Testing

- `Hub2DataDiagnosticsSpec` — 11 contract cases incl. update-available, no-update, Safe Mode, opt-in vs default alerts, the malformed/missing-`alerts` degrade path, and the firmware-version fallback. Full Spock suite green (3384 tests).
- `tests/e2e_test.py` — 4 `system_tools` scenarios asserting the new blocks on a real hub.
- `tests/BAT-v2.md` — T14b (firmware update) + T14c (health alerts).
- Endpoint shape verified against a live C-8 (2.5.0.143).

## Checklist

- [x] Unit tests added for the changed tools
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally
- [x] Live-hub BAT tests updated (`tests/BAT-v2.md`)
- [x] Documentation updated (tool descriptions + schemas)
- [x] No new/renamed MCP tools (Tool Design Rules N/A); existing schemas updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
