### PR TITLE
feat: update app/driver code via saveOrUpdateJson instead of legacy ajax/update

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -579,7 +579,7 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 | `/hub/reboot` | none | Reboot hub |
 | `/hub/shutdown` | none | Shutdown hub |
 | `/hub/zwaveRepair` | none | Start Z-Wave network repair |
-| `/app/saveOrUpdateJson` | JSON: `{"id": <id\|null>, "source": "<code>", "version": <ver\|1>}` | Install (id=null) or update (id=N) app code. Returns `{success, id, message}`; compile errors ride verbatim in `message`. MUST use `Content-Type: application/json`. `version` echoes the current code version (hub-side stale-version enforcement unverified; see the library row for the verified lock behavior). |
+| `/app/saveOrUpdateJson` | JSON: `{"id": <id\|null>, "source": "<code>", "version": <ver\|1>}` | Install (id=null) or update (id=N) app code. Returns `{success, id, message}`; compile errors ride verbatim in `message`. MUST use `Content-Type: application/json`. `version` is enforced hub-side: a save carrying a stale version is rejected with a version-mismatch error (observed live — a web-UI save after an MCP-driven update errors out). |
 | `/driver/saveOrUpdateJson` | JSON: `{"id": <id\|null>, "source": "<code>", "version": <ver\|1>}` | Install (id=null) or update (id=N) driver code — same contract as the app endpoint. |
 | `/app/ajax/update` | `id=<id>, version=<ver>, source=<code>` | Legacy form-encoded app-code update; still works on fw 2.5.x (the e2e watchdog still uses it). Response: `{status, errorMessage}`. Same shape at `/driver/ajax/update`. |
 | `/library/saveOrUpdateJson` | JSON: `{"id": null, "source": "<code>", "version": null}` | Install new library (id=null creates; id=N updates with version=N for optimistic lock). Returns `{success, message, id, version}`. MUST use `Content-Type: application/json`. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -579,10 +579,8 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 | `/hub/reboot` | none | Reboot hub |
 | `/hub/shutdown` | none | Shutdown hub |
 | `/hub/zwaveRepair` | none | Start Z-Wave network repair |
-| `/app/save` | `id="", version="", create="", source=<code>` | Install new app |
-| `/driver/save` | `id="", version="", create="", source=<code>` | Install new driver |
-| `/app/ajax/update` | `id=<id>, version=<ver>, source=<code>` | Update app code |
-| `/driver/ajax/update` | `id=<id>, version=<ver>, source=<code>` | Update driver code |
+| `/app/saveOrUpdateJson` | JSON: `{"id": <id\|null>, "source": "<code>", "version": <ver\|1>}` | Install (id=null) or update (id=N, version for optimistic lock) app code. Returns `{success, id, message}`; compile errors ride verbatim in `message`. MUST use `Content-Type: application/json`. (Legacy `/app/save` and `/app/ajax/update` are no longer used.) |
+| `/driver/saveOrUpdateJson` | JSON: `{"id": <id\|null>, "source": "<code>", "version": <ver\|1>}` | Install (id=null) or update (id=N) driver code — same contract as the app endpoint. |
 | `/library/saveOrUpdateJson` | JSON: `{"id": null, "source": "<code>", "version": null}` | Install new library (id=null creates; id=N updates with version=N for optimistic lock). Returns `{success, message, id, version}`. MUST use `Content-Type: application/json`. |
 | `/login` | `username=<u>, password=<p>, submit=Login` | Hub Security login |
 | `/device/save` | `id=<deviceId>, label=<label>, name=<name>, deviceNetworkId=<dni>, type.id=<typeId>` | Update device properties (flat field names, Grails convention). NOTE: silently ignores `roomId` — use `/room/save` instead |

--- a/SKILL.md
+++ b/SKILL.md
@@ -579,8 +579,9 @@ These are undocumented endpoints on the Hubitat hub at `http://127.0.0.1:8080`:
 | `/hub/reboot` | none | Reboot hub |
 | `/hub/shutdown` | none | Shutdown hub |
 | `/hub/zwaveRepair` | none | Start Z-Wave network repair |
-| `/app/saveOrUpdateJson` | JSON: `{"id": <id\|null>, "source": "<code>", "version": <ver\|1>}` | Install (id=null) or update (id=N, version for optimistic lock) app code. Returns `{success, id, message}`; compile errors ride verbatim in `message`. MUST use `Content-Type: application/json`. (Legacy `/app/save` and `/app/ajax/update` are no longer used.) |
+| `/app/saveOrUpdateJson` | JSON: `{"id": <id\|null>, "source": "<code>", "version": <ver\|1>}` | Install (id=null) or update (id=N) app code. Returns `{success, id, message}`; compile errors ride verbatim in `message`. MUST use `Content-Type: application/json`. `version` echoes the current code version (hub-side stale-version enforcement unverified; see the library row for the verified lock behavior). |
 | `/driver/saveOrUpdateJson` | JSON: `{"id": <id\|null>, "source": "<code>", "version": <ver\|1>}` | Install (id=null) or update (id=N) driver code — same contract as the app endpoint. |
+| `/app/ajax/update` | `id=<id>, version=<ver>, source=<code>` | Legacy form-encoded app-code update; still works on fw 2.5.x (the e2e watchdog still uses it). Response: `{status, errorMessage}`. Same shape at `/driver/ajax/update`. |
 | `/library/saveOrUpdateJson` | JSON: `{"id": null, "source": "<code>", "version": null}` | Install new library (id=null creates; id=N updates with version=N for optimistic lock). Returns `{success, message, id, version}`. MUST use `Content-Type: application/json`. |
 | `/login` | `username=<u>, password=<p>, submit=Login` | Hub Security login |
 | `/device/save` | `id=<deviceId>, label=<label>, name=<name>, deviceNetworkId=<dni>, type.id=<typeId>` | Update device properties (flat field names, Grails convention). NOTE: silently ignores `roomId` — use `/room/save` instead |

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -9213,8 +9213,8 @@ def hubInternalPostForm(String path, Map body, int timeout = 420, boolean isRetr
 }
 
 /**
- * POST to the hub's internal API with a JSON body. Used by library management endpoints
- * which accept Content-Type: application/json (unlike app/driver endpoints that use form-encoded).
+ * POST to the hub's internal API with a JSON body. Used by the saveOrUpdateJson family
+ * (app/driver/library create and update) and other Content-Type: application/json endpoints.
  * Returns a parsed Map/List from the JSON response body, or null on empty response.
  */
 def hubInternalPostJson(String path, String jsonBody, int timeout = 420, boolean isRetry = false) {
@@ -9475,7 +9475,7 @@ def toolRestoreItemBackup(args) {
         ]
     }
 
-    // Library backups cannot be restored via the app/driver ajax/update endpoint.
+    // Library restores don't ride this path (libraries have their own save contract).
     // Direct the caller to use hub_create_library or hub_update_library with the backup source.
     if (entry.type == "library") {
         return [
@@ -9569,27 +9569,24 @@ def toolRestoreItemBackup(args) {
             } catch (Exception vErr) { /* proceed without version */ }
         }
 
-        def updatePath = (entryCopy.type == "app") ? "/app/ajax/update" : "/driver/ajax/update"
-        def result = hubInternalPostForm(updatePath, [
-            id: entryCopy.id,
-            version: currentVersion ?: entryCopy.version,
-            source: source
-        ])
+        // Same JSON save endpoint the update path uses; id present => in-place update.
+        def savePath = (entryCopy.type == "app") ? "/app/saveOrUpdateJson" : "/driver/saveOrUpdateJson"
+        def parsed = hubInternalPostJson(savePath, groovy.json.JsonOutput.toJson([
+            id: entryCopy.id as Integer,
+            source: source,
+            version: currentVersion ?: entryCopy.version
+        ]))
 
-        def responseData = result?.data
         def success = false
         def errorMsg = null
-        if (responseData) {
-            try {
-                def parsed = (responseData instanceof String) ? new groovy.json.JsonSlurper().parseText(responseData) : responseData
-                success = parsed.status == "success"
-                errorMsg = parsed.errorMessage
-            } catch (Exception parseErr) {
-                mcpLog("warn", "hub-admin", "Restore update response was not JSON: ${responseData?.toString()?.take(200)}")
-                errorMsg = "Unexpected response format — restore may have succeeded but could not be confirmed."
-            }
+        if (parsed instanceof Map) {
+            success = parsed.success == true
+            if (!success) errorMsg = parsed.message ?: parsed.errorMessage
+        } else if (parsed == null) {
+            // Fail closed on an empty/unparseable body: the write may or may not have landed.
+            errorMsg = "Empty or unparseable response from ${savePath} — restore may or may not have applied. Verify the ${entryCopy.type} source before retrying."
         } else {
-            success = true
+            errorMsg = "Unexpected response shape from ${savePath}: ${parsed.toString().take(200)}"
         }
 
         if (success) {
@@ -12932,7 +12929,7 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
     }
 
     def ajaxPath = (type == "app") ? "/app/ajax/code" : "/driver/ajax/code"
-    def updatePath = (type == "app") ? "/app/ajax/update" : "/driver/ajax/update"
+    def savePath = (type == "app") ? "/app/saveOrUpdateJson" : "/driver/saveOrUpdateJson"
 
     // Resolve source from one of three modes: source, sourceFile, or resave
     def sourceCode = null
@@ -13056,28 +13053,31 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
     }
     mcpLog("info", "hub-admin", "Updating ${type} ID: ${itemId} (version: ${currentVersion}, mode: ${sourceMode}, sourceLength: ${sourceCode.length()})")
     try {
-        def result = hubInternalPostForm(updatePath, [
-            id: itemId,
-            version: currentVersion,
-            source: sourceCode
-        ])
+        // Update rides POST /app|driver/saveOrUpdateJson (JSON) -- the same endpoint the Vue
+        // editor and the create path use; a non-null id means in-place update of the existing
+        // code class. Response is {success, id, message[, version]}; a compile failure rides
+        // verbatim in `message`. (Replaces the legacy form POST /app|driver/ajax/update.)
+        def parsed = hubInternalPostJson(savePath, groovy.json.JsonOutput.toJson([
+            id: itemId as Integer,
+            source: sourceCode,
+            version: currentVersion
+        ]))
 
-        def responseData = result?.data
         def success = false
         def errorMsg = null
 
-        if (responseData) {
-            try {
-                def responseStr = responseData?.toString()
-                def parsed = new groovy.json.JsonSlurper().parseText(responseStr)
-                success = parsed.status == "success"
-                errorMsg = parsed.errorMessage
-            } catch (Exception parseErr) {
-                mcpLog("warn", "hub-admin", "${type} update response was not JSON: ${responseData?.toString()?.take(200)}")
-                errorMsg = "Unexpected response format — update may have succeeded but could not be confirmed. Check the ${type} in the Hubitat web UI."
-            }
+        if (parsed instanceof Map) {
+            success = parsed.success == true
+            if (!success) errorMsg = parsed.message ?: parsed.errorMessage
+        } else if (parsed == null) {
+            // hubInternalPostJson returns null on an empty or unparseable body. A SELF-update can
+            // legitimately drop the response (the recompile kills the in-flight request -- the
+            // #237 lastSelfDeploy stash below covers that case); for anything else, fail closed
+            // rather than assume the write landed.
+            success = isSelfUpdate
+            if (!success) errorMsg = "Empty or unparseable response from ${savePath} -- the update may or may not have applied. Re-read the ${type} source to verify before retrying."
         } else {
-            success = true
+            errorMsg = "Unexpected response shape from ${savePath}: ${parsed.toString().take(200)}"
         }
 
         // Persist the self-deploy outcome (incl. the hub's verbatim errorMessage) so it survives the

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -9190,10 +9190,6 @@ def hubInternalPost(String path, Map body = null, int timeout = 30, boolean isRe
 }
 
 /**
- * Make an authenticated POST request to the hub's internal API with form-encoded body.
- * Used for app/driver management endpoints that require application/x-www-form-urlencoded.
- */
-/**
  * POST a pre-encoded form-urlencoded body to the hub's internal API. Use
  * this instead of `hubInternalPostForm` when the body contains values
  * HTTPBuilder's auto-encoder mangles (notably backslash + quote sequences
@@ -9206,6 +9202,11 @@ def hubInternalPostFormRaw(String path, String encodedBody, int timeout = 420, b
                               returnShape: 'struct', isRetry: isRetry])
 }
 
+/**
+ * Form-encoded POST to the hub's internal API. Used by the classic dynamicPage surfaces
+ * (/installedapp/* settings submits, button clicks, lifecycle fires) and other endpoints
+ * that require application/x-www-form-urlencoded.
+ */
 def hubInternalPostForm(String path, Map body, int timeout = 420, boolean isRetry = false) {
     _hubRequest('POST', path, [body: body, timeout: timeout,
                               requestContentType: "application/x-www-form-urlencoded", keepAlive: true,
@@ -9215,7 +9216,10 @@ def hubInternalPostForm(String path, Map body, int timeout = 420, boolean isRetr
 /**
  * POST to the hub's internal API with a JSON body. Used by the saveOrUpdateJson family
  * (app/driver/library create and update) and other Content-Type: application/json endpoints.
- * Returns a parsed Map/List from the JSON response body, or null on empty response.
+ * Returns a parsed Map/List from the JSON response body, null on an EMPTY body, or an
+ * [_unparseable: true, message: ...] sentinel Map when the body wasn't JSON (e.g. an HTML
+ * login page) -- callers must not conflate the last two: an empty body can be a legitimate
+ * dropped-response signature, a non-JSON body never is.
  */
 def hubInternalPostJson(String path, String jsonBody, int timeout = 420, boolean isRetry = false) {
     def bodyText = _hubRequest('POST', path, [body: jsonBody, timeout: timeout,
@@ -9225,8 +9229,8 @@ def hubInternalPostJson(String path, String jsonBody, int timeout = 420, boolean
         try {
             return new groovy.json.JsonSlurper().parseText(bodyText)
         } catch (Exception parseErr) {
-            mcpLog("error", "hub-admin", "hubInternalPostJson response not JSON: ${bodyText?.take(200)}")
-            return null
+            mcpLog("error", "hub-admin", "hubInternalPostJson ${path}: response not JSON: ${bodyText?.take(200)}")
+            return [_unparseable: true, message: "hub returned a non-JSON body from ${path}: ${bodyText?.take(200)}"]
         }
     }
     return null
@@ -9475,7 +9479,8 @@ def toolRestoreItemBackup(args) {
         ]
     }
 
-    // Library restores don't ride this path (libraries have their own save contract).
+    // Library restores don't ride this path -- the version fetch + pre-restore backup here
+    // are wired to /app|driver/ajax/code, which has no library twin.
     // Direct the caller to use hub_create_library or hub_update_library with the backup source.
     if (entry.type == "library") {
         return [
@@ -9555,6 +9560,16 @@ def toolRestoreItemBackup(args) {
         mcpLog("warn", "hub-admin", "Could not create pre-restore backup: ${preBackupErr.message} -- proceeding with restore anyway")
     }
 
+    // Restoring the MCP server's OWN code drops the response exactly like a self-update
+    // (the recompile kills the in-flight request), so it gets the same empty-body leniency
+    // and lastSelfDeploy stash the update path has. Computed before the try so the
+    // exception path can stash too.
+    boolean isSelfRestore = false
+    if (entryCopy.type == "app") {
+        def selfIds = [app?.id?.toString(), _resolveSelfAppClassId()?.toString()].findAll { it != null }
+        isSelfRestore = selfIds.contains(entryCopy.id?.toString())
+    }
+
     // Now push the backup source directly via the hub internal API (bypass toolUpdateAppCode to avoid
     // its backupItemSource call which would overwrite our original backup file)
     try {
@@ -9571,6 +9586,7 @@ def toolRestoreItemBackup(args) {
 
         // Same JSON save endpoint the update path uses; id present => in-place update.
         def savePath = (entryCopy.type == "app") ? "/app/saveOrUpdateJson" : "/driver/saveOrUpdateJson"
+
         def parsed = hubInternalPostJson(savePath, groovy.json.JsonOutput.toJson([
             id: entryCopy.id as Integer,
             source: source,
@@ -9581,17 +9597,41 @@ def toolRestoreItemBackup(args) {
         def errorMsg = null
         if (parsed instanceof Map) {
             success = parsed.success == true
-            if (!success) errorMsg = parsed.message ?: parsed.errorMessage
+            if (success && parsed.id != null && parsed.id.toString() != entryCopy.id.toString()) {
+                success = false
+                errorMsg = "Hub reported success but saved to ${entryCopy.type} id ${parsed.id} instead of the targeted id ${entryCopy.id} -- a duplicate code entry may have been created."
+            } else if (!success) {
+                errorMsg = parsed.message ?: parsed.errorMessage ?: "hub response lacked success=true: ${parsed.toString().take(200)}"
+            }
         } else if (parsed == null) {
-            // Fail closed on an empty/unparseable body: the write may or may not have landed.
-            errorMsg = "Empty or unparseable response from ${savePath} — restore may or may not have applied. Verify the ${entryCopy.type} source before retrying."
+            // null is strictly an EMPTY body (non-JSON bodies arrive as the _unparseable sentinel
+            // and fail above). Lenient only for a self-restore; otherwise fail closed.
+            success = isSelfRestore
+            if (!success) errorMsg = "Empty response from ${savePath} — restore may or may not have applied. Verify the ${entryCopy.type} source before retrying."
         } else {
             errorMsg = "Unexpected response shape from ${savePath}: ${parsed.toString().take(200)}"
         }
 
+        if (isSelfRestore) {
+            try {
+                def stash = [
+                    success: success,
+                    error: success ? null : (errorMsg ?: "Restore failed -- the hub returned an error"),
+                    sourceMode: "restore",
+                    importUrl: null,
+                    sourceLength: source.length(),
+                    at: now()
+                ]
+                if (success && parsed == null) stash.assumed = true
+                atomicState.lastSelfDeploy = stash
+            } catch (Exception stashErr) {
+                mcpLog("error", "hub-admin", "lastSelfDeploy stash write failed -- self-restore outcome record lost: ${stashErr}")
+            }
+        }
+
         if (success) {
             mcpLog("info", "hub-admin", "Restore succeeded: ${entryCopy.type} ID ${entryCopy.id} restored to version ${entryCopy.version}")
-            return [
+            def restoreResult = [
                 success: true,
                 message: "Restored ${entryCopy.type} ID ${entryCopy.id} to version ${entryCopy.version} (backup from ${formatTimestamp(entryCopy.timestamp)})",
                 type: entryCopy.type,
@@ -9601,6 +9641,11 @@ def toolRestoreItemBackup(args) {
                 preRestoreFile: preRestoreFileName,
                 undoHint: "To undo this restore, use 'hub_restore_backup' with backupKey='${preRestoreBackupKey}'"
             ]
+            if (isSelfRestore && parsed == null) {
+                restoreResult.assumed = true
+                restoreResult.note = "This restored the MCP server's own code, so the hub's response was dropped by the recompile -- success is inferred, not hub-confirmed. Verify via hub_get_info (lastSelfDeploy) or hub_get_source."
+            }
+            return restoreResult
         } else {
             mcpLog("error", "hub-admin", "Restore failed for ${entryCopy.type} ID ${entryCopy.id}: ${errorMsg ?: 'unknown error'}")
             return [
@@ -9613,6 +9658,20 @@ def toolRestoreItemBackup(args) {
         }
     } catch (Exception e) {
         mcpLogError("hub-admin", "Restore failed with exception for ${entryCopy.type} ID ${entryCopy.id}", e)
+        if (isSelfRestore) {
+            try {
+                atomicState.lastSelfDeploy = [
+                    success: false,
+                    error: "Restore failed: ${e.message}",
+                    sourceMode: "restore",
+                    importUrl: null,
+                    sourceLength: (source != null ? source.length() : 0),
+                    at: now()
+                ]
+            } catch (Exception stashErr) {
+                mcpLog("error", "hub-admin", "lastSelfDeploy stash write failed -- self-restore outcome record lost: ${stashErr}")
+            }
+        }
         return [
             success: false,
             error: "Restore failed: ${e.message}",
@@ -12910,6 +12969,15 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
         throw new IllegalArgumentException("expectedVersion was supplied as null. Omit the field entirely to skip the optimistic-lock check, or pass an integer.")
     }
 
+    // Validate id shape up front: bad args are caller-recoverable and belong on the
+    // IllegalArgumentException path, not in a runtime-failure envelope from the POST.
+    def itemIdInt
+    try {
+        itemIdInt = itemId as Integer
+    } catch (NumberFormatException | ClassCastException idErr) {
+        throw new IllegalArgumentException("${idParam} must be an integer ${type} code id (got '${itemId}')")
+    }
+
     // Self-update guard: blocks overwriting our own app source unless Developer Mode is on.
     // Runs before any I/O so blocked self-updates don't pull source. Fails closed when `app` is
     // unavailable -- can't verify it's not a self-update, so refuse rather than risk a silent brick.
@@ -13053,12 +13121,12 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
     }
     mcpLog("info", "hub-admin", "Updating ${type} ID: ${itemId} (version: ${currentVersion}, mode: ${sourceMode}, sourceLength: ${sourceCode.length()})")
     try {
-        // Update rides POST /app|driver/saveOrUpdateJson (JSON) -- the same endpoint the Vue
-        // editor and the create path use; a non-null id means in-place update of the existing
-        // code class. Response is {success, id, message[, version]}; a compile failure rides
-        // verbatim in `message`. (Replaces the legacy form POST /app|driver/ajax/update.)
+        // Update rides POST /app|driver/saveOrUpdateJson (JSON); a non-null id means in-place
+        // update of the existing code class. Response is {success, id, message[, version]}; a
+        // compile failure rides verbatim in `message`. (The old form /app|driver/ajax/update
+        // returns a different envelope entirely: {status, errorMessage}.)
         def parsed = hubInternalPostJson(savePath, groovy.json.JsonOutput.toJson([
-            id: itemId as Integer,
+            id: itemIdInt,
             source: sourceCode,
             version: currentVersion
         ]))
@@ -13068,14 +13136,21 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
 
         if (parsed instanceof Map) {
             success = parsed.success == true
-            if (!success) errorMsg = parsed.message ?: parsed.errorMessage
+            if (success && parsed.id != null && parsed.id.toString() != itemIdInt.toString()) {
+                // saveOrUpdateJson is an upsert: success echoing a DIFFERENT id means the hub
+                // saved somewhere other than the target -- likely a duplicate code entry.
+                success = false
+                errorMsg = "Hub reported success but saved to ${type} id ${parsed.id} instead of the targeted id ${itemIdInt} -- a duplicate code entry may have been created. Check Apps Code / Drivers Code before retrying."
+            } else if (!success) {
+                errorMsg = parsed.message ?: parsed.errorMessage ?: "hub response lacked success=true: ${parsed.toString().take(200)}"
+            }
         } else if (parsed == null) {
-            // hubInternalPostJson returns null on an empty or unparseable body. A SELF-update can
-            // legitimately drop the response (the recompile kills the in-flight request -- the
-            // #237 lastSelfDeploy stash below covers that case); for anything else, fail closed
-            // rather than assume the write landed.
+            // null is strictly an EMPTY body (a non-JSON body comes back as the _unparseable
+            // sentinel Map and fails above). A SELF-update legitimately drops the response --
+            // the recompile kills the in-flight request, and the lastSelfDeploy stash below
+            // covers recovery; for anything else, fail closed rather than assume the write landed.
             success = isSelfUpdate
-            if (!success) errorMsg = "Empty or unparseable response from ${savePath} -- the update may or may not have applied. Re-read the ${type} source to verify before retrying."
+            if (!success) errorMsg = "Empty response from ${savePath} -- the update may or may not have applied. Re-read the ${type} source to verify before retrying."
         } else {
             errorMsg = "Unexpected response shape from ${savePath}: ${parsed.toString().take(200)}"
         }
@@ -13084,7 +13159,7 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
         // post-success app reload AND the failure-case cloud 504 -- a later hub_get_info read recovers it.
         if (isSelfUpdate) {
             try {
-                atomicState.lastSelfDeploy = [
+                def stash = [
                     success: success,
                     error: success ? null : (errorMsg ?: "Update failed -- the hub returned an error"),
                     sourceMode: sourceMode,
@@ -13092,7 +13167,15 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
                     sourceLength: sourceCode.length(),
                     at: now()
                 ]
-            } catch (Exception ignore) { /* bookkeeping must never break the deploy */ }
+                // A dropped (empty) response is the expected self-update signature, but the success
+                // is inferred, not hub-confirmed -- mark it so consumers can choose to re-verify.
+                if (success && parsed == null) stash.assumed = true
+                atomicState.lastSelfDeploy = stash
+            } catch (Exception stashErr) {
+                // Never break the deploy over bookkeeping, but a lost stash means the self-deploy
+                // outcome is unrecoverable -- say so instead of failing silently.
+                mcpLog("error", "hub-admin", "lastSelfDeploy stash write failed -- self-deploy outcome record lost: ${stashErr}")
+            }
         }
 
         if (success) {
@@ -13173,7 +13256,9 @@ private Map toolUpdateItemCodeInner(String type, String idParam, args) {
                     sourceLength: (sourceCode != null ? sourceCode.length() : 0),
                     at: now()
                 ]
-            } catch (Exception ignore) { }
+            } catch (Exception stashErr) {
+                mcpLog("error", "hub-admin", "lastSelfDeploy stash write failed -- self-deploy outcome record lost: ${stashErr}")
+            }
         }
         return [
             success: false,

--- a/src/test/groovy/server/HubInternalRetrySpec.groovy
+++ b/src/test/groovy/server/HubInternalRetrySpec.groovy
@@ -378,4 +378,74 @@ class HubInternalRetrySpec extends ToolSpecBase {
         loginCalls == 0
         atomicStateMap.hubSecurityCookie == 'JSESSIONID=cached'
     }
+
+    // ---- hubInternalPostJson response-body contract (parsed Map / strict-empty null / sentinel) ----
+    // hubInternalPostJson has no metaClass shadow in the harness, so these run the real helper
+    // down to the httpPost dispatcher above. Callers key fail-open/fail-closed decisions on the
+    // three-way split, so each leg is pinned.
+
+    def "hubInternalPostJson parses a JSON response body into the response Map"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and:
+        httpPostHandler = { Map params, Closure cb ->
+            cb.call([status: 200, data: '{"success": true, "id": 7}'])
+        }
+
+        when:
+        def result = script.hubInternalPostJson('/app/saveOrUpdateJson', '{"id": 7, "source": "s"}')
+
+        then:
+        result instanceof Map
+        result.success == true
+        result.id == 7
+        !result.containsKey('_unparseable')
+    }
+
+    def "hubInternalPostJson returns null STRICTLY for an empty response body"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and: 'the POST commits but the response body is empty (the dropped-response signature)'
+        httpPostHandler = { Map params, Closure cb ->
+            cb.call([status: 200, data: ''])
+        }
+
+        when:
+        def result = script.hubInternalPostJson('/app/saveOrUpdateJson', '{"id": 1}')
+
+        then: 'null means empty body and nothing else -- the signal self-deploy callers treat leniently'
+        result == null
+    }
+
+    def "hubInternalPostJson returns the _unparseable sentinel (not null) on a non-JSON response body"() {
+        given:
+        enableHubSecurity()
+        seedCachedCookie('JSESSIONID=cached')
+
+        and: 'the hub answers the POST with an HTML body (e.g. a login or error page), not JSON'
+        httpPostHandler = { Map params, Closure cb ->
+            cb.call([status: 200, data: '<html>Hub Login</html>'])
+        }
+        def errorLogs = []
+        script.metaClass.mcpLog = { String level, String component, String msg ->
+            if (level == 'error') errorLogs << msg
+        }
+
+        when:
+        def result = script.hubInternalPostJson('/app/saveOrUpdateJson', '{"id": 1}')
+
+        then: 'callers can distinguish a non-JSON body from a legitimately empty (dropped) one'
+        result instanceof Map
+        result._unparseable == true
+        result.message.contains('non-JSON body')
+        result.message.contains('/app/saveOrUpdateJson')
+        result.message.contains('<html>Hub Login</html>')
+
+        and: 'the error log names the failing path'
+        errorLogs.any { it.contains('/app/saveOrUpdateJson') && it.contains('not JSON') }
+    }
 }

--- a/src/test/groovy/server/RegressionsFromHistorySpec.groovy
+++ b/src/test/groovy/server/RegressionsFromHistorySpec.groovy
@@ -377,10 +377,10 @@ class RegressionsFromHistorySpec extends ToolSpecBase {
 
         and: 'capture the version passed into the update POST'
         def posted = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             posted.path = path
-            posted.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            posted.body = new groovy.json.JsonSlurper().parseText(body)
+            [success: true]
         }
 
         when:
@@ -415,10 +415,10 @@ class RegressionsFromHistorySpec extends ToolSpecBase {
 
         and: 'capture the version passed into the update POST'
         def posted = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             posted.path = path
-            posted.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            posted.body = new groovy.json.JsonSlurper().parseText(body)
+            [success: true]
         }
 
         when:
@@ -518,9 +518,9 @@ class RegressionsFromHistorySpec extends ToolSpecBase {
 
         and: 'capture the version passed into the update POST'
         def posted = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            posted.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            posted.body = new groovy.json.JsonSlurper().parseText(body)
+            [success: true]
         }
 
         when:
@@ -553,9 +553,9 @@ class RegressionsFromHistorySpec extends ToolSpecBase {
 
         and: 'capture the version passed into the update POST'
         def posted = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            posted.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            posted.body = new groovy.json.JsonSlurper().parseText(body)
+            [success: true]
         }
 
         when:

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -25,8 +25,9 @@ import support.ToolSpecBase
  *   - hubInternalGet       -- routed by HarnessSpec via hubGet.register(path) closures.
  *   - hubInternalPostJson  -- create/update/restore POST helper (POST /app|driver/saveOrUpdateJson),
  *                            stubbed per-test on script.metaClass; takes (String path,
- *                            String body) and returns the PARSED response Map ({success, id, ...})
- *                            or null for an empty/unparseable body.
+ *                            String body) and returns the PARSED response Map ({success, id, ...}),
+ *                            null for an EMPTY body, or the [_unparseable: true, message: ...]
+ *                            sentinel Map for a non-JSON body.
  *   - uploadHubFile / downloadHubFile -- purely dynamic, stubbed per-test on script.metaClass.
  *
  * Each direct-call feature has a parallel "via dispatch" feature that fires
@@ -1825,6 +1826,33 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         useGateways << [true, false]
     }
 
+    def "hub_update_app rejects a non-numeric appId before any I/O"() {
+        given:
+        enableWrite()
+        def getCalls = 0
+        hubGet.register('/app/ajax/code') { params ->
+            getCalls++
+            '{"status": "ok", "version": 1, "source": "x"}'
+        }
+        def postCalls = 0
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            postCalls++
+            [success: true]
+        }
+
+        when:
+        script.toolUpdateAppCode([appId: 'abc', source: 'code', confirm: true])
+
+        then: 'a bad id is caller-recoverable: IllegalArgumentException, not a runtime envelope from the POST'
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('must be an integer')
+        ex.message.contains('abc')
+
+        and: 'validation fired before any I/O -- no backup fetch, no save POST'
+        getCalls == 0
+        postCalls == 0
+    }
+
     def "hub_update_app throws when none of source, sourceFile, or resave are supplied"() {
         given:
         enableWrite()
@@ -2191,7 +2219,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         errKey << ['message', 'errorMessage']
     }
 
-    def "hub_update_app fails closed on an empty/unparseable hub response (non-self update)"() {
+    def "hub_update_app fails closed on an empty hub response (non-self update)"() {
         given:
         enableWrite()
         hubGet.register('/app/ajax/code') { params ->
@@ -2205,8 +2233,51 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         then: 'a dropped response on a foreign app is NOT assumed to have landed'
         result.success == false
-        result.error.contains('Empty or unparseable response')
+        result.error.contains('Empty response from /app/saveOrUpdateJson')
         result.error.contains('verify')
+    }
+
+    def "hub_update_app fails closed when the hub echoes success for a DIFFERENT id (duplicate-save signature)"() {
+        given:
+        enableWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 1, "source": "old"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+
+        and: 'saveOrUpdateJson is an upsert: success with a different echoed id means it saved elsewhere'
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true, id: 999]
+        }
+
+        when:
+        def result = script.toolUpdateAppCode([appId: '50', source: 'new', confirm: true])
+
+        then: 'reported as failure naming both ids, not as a silent mis-targeted success'
+        result.success == false
+        result.error.contains('duplicate')
+        result.error.contains('999')
+        result.error.contains('50')
+    }
+
+    def "hub_update_app failure with neither message nor errorMessage still returns a concrete error"() {
+        given:
+        enableWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 1, "source": "old"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, foo: 'bar']
+        }
+
+        when:
+        def result = script.toolUpdateAppCode([appId: '80', source: 'new', confirm: true])
+
+        then: 'the raw response rides in the error instead of a null/blank message'
+        result.success == false
+        result.error.contains('hub response lacked success=true')
+        result.error.contains('foo')
     }
 
     def "hub_update_app reports failure on an unexpected response shape (hub returned a list)"() {
@@ -3324,14 +3395,19 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 3, "source": "current"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        def captured = [:]
         script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.path = path
             [success: false, message: 'bad code']
         }
 
         when:
         def result = script.toolRestoreItemBackup([backupKey: 'driver_88', confirm: true])
 
-        then: 'failure is reported, original manifest entry preserved for retry'
+        then: 'a driver restore rides the DRIVER save endpoint (a cross-write to /app/ would corrupt an app)'
+        captured.path == '/driver/saveOrUpdateJson'
+
+        and: 'failure is reported, original manifest entry preserved for retry'
         result.success == false
         result.error.contains('bad code')
         result.message.contains('preserved')
@@ -3352,7 +3428,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 3, "source": "current"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        def captured = [:]
         script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.path = path
             [success: false, message: 'bad code']
         }
 
@@ -3360,6 +3438,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         def response = mcpDriver.callTool('hub_restore_backup', [backupKey: 'driver_88', confirm: true])
 
         then:
+        captured.path == '/driver/saveOrUpdateJson'
         response.error == null
         !response.result.isError
         def inner = mcpDriver.parseInner(response)
@@ -3372,7 +3451,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         useGateways << [true, false]
     }
 
-    def "hub_restore_backup fails closed on an empty/unparseable hub response (restore has no self-update leniency)"() {
+    def "hub_restore_backup fails closed on an empty hub response (non-self restore)"() {
         given:
         enableWrite()
         atomicStateMap.itemBackupManifest = [
@@ -3391,8 +3470,72 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         then: 'failure is reported and the backup entry is preserved for retry'
         result.success == false
-        result.error.contains('Empty or unparseable response')
+        result.error.contains('Empty response from /app/saveOrUpdateJson')
         result.message.contains('preserved')
+        atomicStateMap.itemBackupManifest.containsKey('app_99')
+    }
+
+    def "hub_restore_backup self-restore treats an empty response as assumed success and stashes lastSelfDeploy"() {
+        // Restoring the MCP server's OWN code drops the response exactly like a self-update
+        // (the recompile kills the in-flight request), so the empty-body leniency applies and
+        // the outcome is recoverable from atomicState.lastSelfDeploy via hub_get_info.
+        given:
+        enableWrite()
+
+        and: 'backup entry id matches app.id (sharedAppStub id 1); class-id lookup resolves nothing'
+        atomicStateMap.itemBackupManifest = [
+            'app_1': [type: 'app', id: '1', fileName: 'mcp-backup-app-1.groovy',
+                      version: 4, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        script.metaClass._resolveSelfAppClassId = { -> null }
+        script.metaClass.downloadHubFile = { String fileName -> 'self backup source'.getBytes('UTF-8') }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 9, "source": "current self source"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body -> null }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'app_1', confirm: true])
+
+        then: 'success is inferred, flagged as assumed (not hub-confirmed) with a verification pointer'
+        result.success == true
+        result.assumed == true
+        result.note.contains('hub_get_info')
+
+        and: 'the lastSelfDeploy stash records the restore outcome for a follow-up read'
+        atomicStateMap.lastSelfDeploy?.success == true
+        atomicStateMap.lastSelfDeploy.assumed == true
+        atomicStateMap.lastSelfDeploy.sourceMode == 'restore'
+        atomicStateMap.lastSelfDeploy.error == null
+    }
+
+    def "hub_restore_backup fails closed when the hub echoes success for a DIFFERENT id (duplicate-save signature)"() {
+        given:
+        enableWrite()
+        atomicStateMap.itemBackupManifest = [
+            'app_99': [type: 'app', id: '99', fileName: 'mcp-backup-app-99.groovy',
+                       version: 4, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        script.metaClass.downloadHubFile = { String fileName -> 'old source v4'.getBytes('UTF-8') }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 9, "source": "current source on hub"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+
+        and: 'saveOrUpdateJson is an upsert: success with a different echoed id means it saved elsewhere'
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true, id: 777]
+        }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'app_99', confirm: true])
+
+        then: 'reported as failure naming both ids; backup entry preserved for retry'
+        result.success == false
+        result.error.contains('duplicate')
+        result.error.contains('777')
+        result.error.contains('99')
         atomicStateMap.itemBackupManifest.containsKey('app_99')
     }
 
@@ -3949,10 +4092,11 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         warnLogs.any { it.contains('ALLOWED') && it.contains('id=1') }
     }
 
-    def "hub_update_app self-update treats an empty/unparseable response as success and records lastSelfDeploy"() {
+    def "hub_update_app self-update treats an empty response as success and records lastSelfDeploy with assumed:true"() {
         // A self-update legitimately drops the response -- the recompile kills the in-flight
-        // request -- so a null parse is success here; the outcome is recovered later from
-        // atomicState.lastSelfDeploy via hub_get_info.
+        // request -- so an EMPTY body is success here; the outcome is recovered later from
+        // atomicState.lastSelfDeploy via hub_get_info. The success is inferred, not
+        // hub-confirmed, so the stash carries assumed:true.
         given:
         enableWrite()
         settingsMap.enableDeveloperMode = true
@@ -3969,6 +4113,34 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.success == true
         atomicStateMap.lastSelfDeploy?.success == true
         atomicStateMap.lastSelfDeploy.error == null
+        atomicStateMap.lastSelfDeploy.assumed == true
+    }
+
+    def "hub_update_app self-update fails closed on a non-JSON (unparseable-sentinel) response and stashes the failure"() {
+        // The empty-body leniency must NOT extend to a non-JSON body: an HTML login page or
+        // error page is never a legitimate dropped-response signature, even mid-self-update.
+        given:
+        enableWrite()
+        settingsMap.enableDeveloperMode = true
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 5, "source": "self source"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [_unparseable: true, message: 'hub returned a non-JSON body from /app/saveOrUpdateJson: <html>...']
+        }
+
+        when:
+        def result = script.toolUpdateAppCode([appId: '1', source: 'self-update v4', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('non-JSON body')
+
+        and: 'the stash records the failure with the sentinel message, not an assumed success'
+        atomicStateMap.lastSelfDeploy?.success == false
+        atomicStateMap.lastSelfDeploy.error.contains('non-JSON body')
+        !atomicStateMap.lastSelfDeploy.containsKey('assumed')
     }
 
     def "hub_update_app self-update guard blocks resave mode (most-likely real-world brick scenario)"() {

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -3539,6 +3539,218 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         atomicStateMap.itemBackupManifest.containsKey('app_99')
     }
 
+    def "hub_restore_backup self-restore is detected via the Apps Code CLASS id (the real CI deploy path), not just the instance id"() {
+        // A code restore targets the Apps Code CLASS id (e.g. 178), which differs from app.id
+        // (the running instance, 1). The REAL _resolveSelfAppClassId runs here against a stubbed
+        // /hub2/userAppTypes -- if detection only checked the instance id, this self-restore
+        // would fail closed instead of getting the empty-body leniency.
+        given:
+        enableWrite()
+        atomicStateMap.itemBackupManifest = [
+            'app_178': [type: 'app', id: '178', fileName: 'mcp-backup-app-178.groovy',
+                        version: 4, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        hubGet.register('/hub2/userAppTypes') { params -> '[{"id":178,"namespace":"mcp","name":"MCP Rule Server"}]' }
+        script.metaClass.downloadHubFile = { String fileName -> 'self backup source'.getBytes('UTF-8') }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 9, "source": "current self source"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body -> null }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'app_178', confirm: true])
+
+        then: 'empty-body leniency fires via the class-id match'
+        result.success == true
+        result.assumed == true
+        result.note.contains('hub_get_info')
+
+        and: 'the stash records the restore outcome'
+        atomicStateMap.lastSelfDeploy?.success == true
+        atomicStateMap.lastSelfDeploy.assumed == true
+        atomicStateMap.lastSelfDeploy.sourceMode == 'restore'
+    }
+
+    def "hub_restore_backup self-restore stashes lastSelfDeploy when the save THROWS (exception path)"() {
+        // A big self-restore can kill the connection before any response body exists. The catch
+        // block must still persist a failure record so a follow-up hub_get_info can recover it.
+        given:
+        enableWrite()
+        atomicStateMap.itemBackupManifest = [
+            'app_1': [type: 'app', id: '1', fileName: 'mcp-backup-app-1.groovy',
+                      version: 4, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        script.metaClass._resolveSelfAppClassId = { -> null }
+        script.metaClass.downloadHubFile = { String fileName -> 'self backup source'.getBytes('UTF-8') }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 9, "source": "current self source"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            throw new RuntimeException('connection reset mid-restore')
+        }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'app_1', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('Restore failed:')
+        result.error.contains('connection reset mid-restore')
+
+        and: 'the failure is stashed for a follow-up read, marked as a restore'
+        atomicStateMap.lastSelfDeploy?.success == false
+        atomicStateMap.lastSelfDeploy.sourceMode == 'restore'
+        atomicStateMap.lastSelfDeploy.error.contains('connection reset mid-restore')
+        !atomicStateMap.lastSelfDeploy.containsKey('assumed')
+    }
+
+    def "hub_restore_backup self-restore records the hub's VERBATIM error to lastSelfDeploy on a rejected save"() {
+        given:
+        enableWrite()
+        atomicStateMap.itemBackupManifest = [
+            'app_1': [type: 'app', id: '1', fileName: 'mcp-backup-app-1.groovy',
+                      version: 4, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        script.metaClass._resolveSelfAppClassId = { -> null }
+        script.metaClass.downloadHubFile = { String fileName -> 'self backup source'.getBytes('UTF-8') }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 9, "source": "current self source"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+
+        and: 'the hub rejects the save with its real compile error'
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'unable to resolve class Foo']
+        }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'app_1', confirm: true])
+
+        then: 'the result carries the verbatim message'
+        result.success == false
+        result.error.contains('unable to resolve class Foo')
+
+        and: 'the stash carries it verbatim (un-prefixed), the thing a follow-up read must recover'
+        atomicStateMap.lastSelfDeploy?.success == false
+        atomicStateMap.lastSelfDeploy.error == 'unable to resolve class Foo'
+        atomicStateMap.lastSelfDeploy.sourceMode == 'restore'
+    }
+
+    def "hub_restore_backup failure with neither message nor errorMessage still returns a concrete error"() {
+        given:
+        enableWrite()
+        atomicStateMap.itemBackupManifest = [
+            'app_99': [type: 'app', id: '99', fileName: 'mcp-backup-app-99.groovy',
+                       version: 4, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        script.metaClass.downloadHubFile = { String fileName -> 'old source v4'.getBytes('UTF-8') }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 9, "source": "current source on hub"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, foo: 'bar']
+        }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'app_99', confirm: true])
+
+        then: 'the raw response rides in the error instead of a null/blank message'
+        result.success == false
+        result.error.contains('hub response lacked success=true')
+        result.error.contains('foo')
+        atomicStateMap.itemBackupManifest.containsKey('app_99')
+    }
+
+    def "hub_restore_backup success without an echoed id is accepted (id-echo guard tolerates a missing id)"() {
+        given:
+        enableWrite()
+        atomicStateMap.itemBackupManifest = [
+            'app_99': [type: 'app', id: '99', fileName: 'mcp-backup-app-99.groovy',
+                       version: 4, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        script.metaClass.downloadHubFile = { String fileName -> 'old source v4'.getBytes('UTF-8') }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 9, "source": "current source on hub"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true]   // no id key at all
+        }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'app_99', confirm: true])
+
+        then: 'the duplicate-save guard only fires on a PRESENT mismatched id'
+        result.success == true
+        result.id == '99'
+        !result.containsKey('assumed')
+    }
+
+    def "hub_restore_backup driver restore fails closed on an empty response even when the driver id collides with app.id"() {
+        // isSelfRestore is keyed on type=='app'; a driver whose code id happens to equal the
+        // MCP server's instance id must NOT inherit the self-restore empty-body leniency.
+        given:
+        enableWrite()
+        atomicStateMap.itemBackupManifest = [
+            'driver_1': [type: 'driver', id: '1', fileName: 'mcp-backup-driver-1.groovy',
+                         version: 2, timestamp: 1_234_000_000_000L, sourceLength: 10]
+        ]
+        script.metaClass.downloadHubFile = { String fileName -> 'driver backup'.getBytes('UTF-8') }
+        hubGet.register('/driver/ajax/code') { params ->
+            '{"status": "ok", "version": 3, "source": "current"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body -> null }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'driver_1', confirm: true])
+
+        then: 'fails closed on the DRIVER save path -- no leniency bleed across types'
+        result.success == false
+        result.error.contains('Empty response from /driver/saveOrUpdateJson')
+        atomicStateMap.itemBackupManifest.containsKey('driver_1')
+
+        and: 'no self-deploy stash was written'
+        atomicStateMap.lastSelfDeploy == null
+    }
+
+    def "hub_restore_backup self-restore with a Map-confirmed success carries no assumed flag (hub-confirmed, not inferred)"() {
+        given:
+        enableWrite()
+        atomicStateMap.itemBackupManifest = [
+            'app_1': [type: 'app', id: '1', fileName: 'mcp-backup-app-1.groovy',
+                      version: 4, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        script.metaClass._resolveSelfAppClassId = { -> null }
+        script.metaClass.downloadHubFile = { String fileName -> 'self backup source'.getBytes('UTF-8') }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 9, "source": "current self source"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+
+        and: 'the response survived the recompile and confirms the save (matching echoed id)'
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true, id: 1]
+        }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'app_1', confirm: true])
+
+        then: 'a hub-confirmed self-restore is a plain success -- no assumed flag, no verification note'
+        result.success == true
+        !result.containsKey('assumed')
+        !result.containsKey('note')
+
+        and: 'the stash records the confirmed outcome without assumed'
+        atomicStateMap.lastSelfDeploy?.success == true
+        atomicStateMap.lastSelfDeploy.error == null
+        atomicStateMap.lastSelfDeploy.sourceMode == 'restore'
+        !atomicStateMap.lastSelfDeploy.containsKey('assumed')
+    }
+
     def "hub_restore_backup returns clear error for library type and directs user to hub_update_library"() {
         given:
         enableWrite()

--- a/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
+++ b/src/test/groovy/server/ToolAppDriverCodeSpec.groovy
@@ -23,11 +23,10 @@ import support.ToolSpecBase
  *
  * Mocking strategy (see docs/testing.md):
  *   - hubInternalGet       -- routed by HarnessSpec via hubGet.register(path) closures.
- *   - hubInternalPostJson  -- create POST helper (POST /app|driver/saveOrUpdateJson),
+ *   - hubInternalPostJson  -- create/update/restore POST helper (POST /app|driver/saveOrUpdateJson),
  *                            stubbed per-test on script.metaClass; takes (String path,
- *                            String body) and returns the PARSED response Map ({success, id, ...}).
- *   - hubInternalPostForm  -- update/restore POST helper, stubbed per-test on script.metaClass
- *                            (takes (String path, Map body); returns [status, location, data]).
+ *                            String body) and returns the PARSED response Map ({success, id, ...})
+ *                            or null for an empty/unparseable body.
  *   - uploadHubFile / downloadHubFile -- purely dynamic, stubbed per-test on script.metaClass.
  *
  * Each direct-call feature has a parallel "via dispatch" feature that fires
@@ -1859,7 +1858,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         useGateways << [true, false]
     }
 
-    def "hub_update_app (source mode) backs up, fetches version, POSTs to /app/ajax/update"() {
+    def "hub_update_app (source mode) backs up, fetches version, POSTs to /app/saveOrUpdateJson"() {
         given:
         enableWrite()
 
@@ -1872,22 +1871,23 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             uploads << name
         }
 
-        and: 'hubInternalPostForm returns a success response'
+        and: 'hubInternalPostJson returns a success response'
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.path = path
             captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 50]
         }
 
         when:
         def result = script.toolUpdateAppCode([appId: '50', source: 'new source', confirm: true])
 
         then: 'update path and body match the hub contract'
-        captured.path == '/app/ajax/update'
-        captured.body.id == '50'
-        captured.body.version == 12
-        captured.body.source == 'new source'
+        captured.path == '/app/saveOrUpdateJson'
+        def sent = new groovy.json.JsonSlurper().parseText(captured.body)
+        sent.id == 50
+        sent.version == 12
+        sent.source == 'new source'
 
         and: 'pre-edit backup written to File Manager'
         uploads.size() == 1
@@ -1905,7 +1905,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_update_app via dispatch (source mode) backs up and POSTs to /app/ajax/update (useGateways=#useGateways)"() {
+    def "hub_update_app via dispatch (source mode) backs up and POSTs to /app/saveOrUpdateJson (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         enableWrite()
@@ -1915,20 +1915,21 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         def uploads = []
         script.metaClass.uploadHubFile = { String name, byte[] content -> uploads << name }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.path = path
             captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 50]
         }
 
         when:
         def response = mcpDriver.callTool('hub_update_app', [appId: '50', source: 'new source', confirm: true])
 
         then:
-        captured.path == '/app/ajax/update'
-        captured.body.id == '50'
-        captured.body.version == 12
-        captured.body.source == 'new source'
+        captured.path == '/app/saveOrUpdateJson'
+        def sent = new groovy.json.JsonSlurper().parseText(captured.body)
+        sent.id == 50
+        sent.version == 12
+        sent.source == 'new source'
         uploads.size() == 1
         uploads[0] == 'mcp-backup-app-50.groovy'
         response.error == null
@@ -1945,6 +1946,31 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         useGateways << [true, false]
     }
 
+    def "hub_update_app sends a JSON body whose id is an Integer (string appId arg is coerced for the endpoint)"() {
+        given:
+        enableWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 12, "source": "old source"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        def captured = [:]
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.json = body
+            [success: true, id: 123]
+        }
+
+        when: 'appId arrives as a String, the way MCP args always do'
+        def result = script.toolUpdateAppCode([appId: '123', source: 'new source', confirm: true])
+
+        then: 'the wire body carries id as a JSON number, with version and source forwarded'
+        def sent = new groovy.json.JsonSlurper().parseText(captured.json)
+        sent.id == 123
+        sent.id instanceof Integer
+        sent.version == 12
+        sent.source == 'new source'
+        result.success == true
+    }
+
     def "hub_update_app (sourceFile mode) reads source from File Manager"() {
         given:
         enableWrite()
@@ -1956,16 +1982,16 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             fileName == 'my-app.groovy' ? 'source from file'.getBytes('UTF-8') : null
         }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 60]
         }
 
         when:
         def result = script.toolUpdateAppCode([appId: '60', sourceFile: 'my-app.groovy', confirm: true])
 
         then:
-        captured.body.source == 'source from file'
+        new groovy.json.JsonSlurper().parseText(captured.body).source == 'source from file'
         result.success == true
         result.sourceMode == 'sourceFile'
         result.note.contains('File Manager')
@@ -1984,16 +2010,16 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             fileName == 'my-app.groovy' ? 'source from file'.getBytes('UTF-8') : null
         }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 60]
         }
 
         when:
         def response = mcpDriver.callTool('hub_update_app', [appId: '60', sourceFile: 'my-app.groovy', confirm: true])
 
         then:
-        captured.body.source == 'source from file'
+        new groovy.json.JsonSlurper().parseText(captured.body).source == 'source from file'
         response.error == null
         !response.result.isError
         def inner = mcpDriver.parseInner(response)
@@ -2044,17 +2070,18 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 70]
         }
 
         when:
         def result = script.toolUpdateAppCode([appId: '70', resave: true, confirm: true])
 
         then: 'submitted source matches fetched source; version captured from the fresh fetch'
-        captured.body.source == 'current source'
-        captured.body.version == 7
+        def sent = new groovy.json.JsonSlurper().parseText(captured.body)
+        sent.source == 'current source'
+        sent.version == 7
         result.success == true
         result.sourceMode == 'resave'
         result.note.contains('no cloud round-trip')
@@ -2070,17 +2097,18 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 70]
         }
 
         when:
         def response = mcpDriver.callTool('hub_update_app', [appId: '70', resave: true, confirm: true])
 
         then:
-        captured.body.source == 'current source'
-        captured.body.version == 7
+        def sent = new groovy.json.JsonSlurper().parseText(captured.body)
+        sent.source == 'current source'
+        sent.version == 7
         response.error == null
         !response.result.isError
         def inner = mcpDriver.parseInner(response)
@@ -2092,15 +2120,15 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         useGateways << [true, false]
     }
 
-    def "hub_update_app reports failure when the hub response parses to status=error"() {
+    def "hub_update_app reports failure when the hub response carries success=false"() {
         given:
         enableWrite()
         hubGet.register('/app/ajax/code') { params ->
             '{"status": "ok", "version": 1, "source": "old"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status": "error", "errorMessage": "Compilation failed"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'Compilation failed']
         }
 
         when:
@@ -2113,7 +2141,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
     }
 
     @spock.lang.Unroll
-    def "hub_update_app via dispatch reports failure envelope when hub response status=error (useGateways=#useGateways)"() {
+    def "hub_update_app via dispatch reports failure envelope when hub response carries success=false (useGateways=#useGateways)"() {
         given:
         settingsMap.useGateways = useGateways
         enableWrite()
@@ -2121,8 +2149,8 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 1, "source": "old"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status": "error", "errorMessage": "Compilation failed"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'Compilation failed']
         }
 
         when:
@@ -2138,6 +2166,64 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         where:
         useGateways << [true, false]
+    }
+
+    @spock.lang.Unroll
+    def "hub_update_app failure surfaces the hub's verbatim compile error from the '#errKey' field"() {
+        given:
+        enableWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 1, "source": "old"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, (errKey): 'unable to resolve class Foo']
+        }
+
+        when:
+        def result = script.toolUpdateAppCode([appId: '80', source: 'broken', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('unable to resolve class Foo')
+
+        where:
+        errKey << ['message', 'errorMessage']
+    }
+
+    def "hub_update_app fails closed on an empty/unparseable hub response (non-self update)"() {
+        given:
+        enableWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 1, "source": "old"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body -> null }
+
+        when:
+        def result = script.toolUpdateAppCode([appId: '80', source: 'new', confirm: true])
+
+        then: 'a dropped response on a foreign app is NOT assumed to have landed'
+        result.success == false
+        result.error.contains('Empty or unparseable response')
+        result.error.contains('verify')
+    }
+
+    def "hub_update_app reports failure on an unexpected response shape (hub returned a list)"() {
+        given:
+        enableWrite()
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 1, "source": "old"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body -> [[odd: 'list']] }
+
+        when:
+        def result = script.toolUpdateAppCode([appId: '80', source: 'new', confirm: true])
+
+        then:
+        result.success == false
+        result.error.contains('Unexpected response shape')
     }
 
     def "hub_update_app rejects bulk-mode args (updates[] not supported on apps)"() {
@@ -2185,16 +2271,16 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.path = path
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 55]
         }
 
         when:
         def result = script.toolUpdateDriverCode([driverId: '55', source: 'metadata { v2 }', confirm: true])
 
         then:
-        captured.path == '/driver/ajax/update'
+        captured.path == '/driver/saveOrUpdateJson'
         result.success == true
         result.driverId == '55'
         result.sourceMode == 'source'
@@ -2210,16 +2296,16 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.path = path
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 55]
         }
 
         when:
         def response = mcpDriver.callTool('hub_update_driver', [driverId: '55', source: 'metadata { v2 }', confirm: true])
 
         then:
-        captured.path == '/driver/ajax/update'
+        captured.path == '/driver/saveOrUpdateJson'
         response.error == null
         !response.result.isError
         def inner = mcpDriver.parseInner(response)
@@ -2332,10 +2418,10 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         script.metaClass.downloadHubFile = { String fileName -> 'metadata { }'.getBytes('UTF-8') }
         def updatePaths = []
         def updateIds = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             updatePaths << path
-            updateIds << body.id?.toString()
-            [status: 200, location: null, data: '{"status": "success"}']
+            updateIds << new groovy.json.JsonSlurper().parseText(body).id?.toString()
+            [success: true]
         }
 
         when:
@@ -2356,7 +2442,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         result.updates*.driverId == ['101', '102', '103']
 
         and: 'each driver was independently posted to the update path'
-        updatePaths.every { it == '/driver/ajax/update' }
+        updatePaths.every { it == '/driver/saveOrUpdateJson' }
         updateIds as Set == ['101', '102', '103'] as Set
     }
 
@@ -2372,10 +2458,10 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         script.metaClass.downloadHubFile = { String fileName -> 'metadata { }'.getBytes('UTF-8') }
         def updatePaths = []
         def updateIds = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             updatePaths << path
-            updateIds << body.id?.toString()
-            [status: 200, location: null, data: '{"status": "success"}']
+            updateIds << new groovy.json.JsonSlurper().parseText(body).id?.toString()
+            [success: true]
         }
 
         when:
@@ -2397,7 +2483,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         inner.updates.size() == 3
         inner.updates.every { it.success == true }
         inner.updates*.driverId == ['101', '102', '103']
-        updatePaths.every { it == '/driver/ajax/update' }
+        updatePaths.every { it == '/driver/saveOrUpdateJson' }
         updateIds as Set == ['101', '102', '103'] as Set
 
         where:
@@ -2418,9 +2504,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             fileName == 'driver-202.groovy' ? null : 'metadata { }'.getBytes('UTF-8')
         }
         def postedIds = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            postedIds << body.id?.toString()
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            postedIds << new groovy.json.JsonSlurper().parseText(body).id?.toString()
+            [success: true]
         }
 
         when:
@@ -2463,9 +2549,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             fileName == 'driver-202.groovy' ? null : 'metadata { }'.getBytes('UTF-8')
         }
         def postedIds = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            postedIds << body.id?.toString()
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            postedIds << new groovy.json.JsonSlurper().parseText(body).id?.toString()
+            [success: true]
         }
 
         when:
@@ -2508,9 +2594,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 1, "source": "metadata { name \\"existing\\" }"}'
         }
         def postedSources = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            postedSources << body.source
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            postedSources << new groovy.json.JsonSlurper().parseText(body).source
+            [success: true]
         }
 
         when:
@@ -2550,9 +2636,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 1, "source": "metadata { name \\"existing\\" }"}'
         }
         def postedSources = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            postedSources << body.source
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            postedSources << new groovy.json.JsonSlurper().parseText(body).source
+            [success: true]
         }
 
         when:
@@ -2590,13 +2676,13 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 1, "source": "metadata { }"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
-        // Middle item's hub POST returns status=failure body — reaches toolUpdateItemCodeInner's
-        // else branch (now carrying note + lastBackup after this PR's symmetry fix).
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            if (body.id == '402') {
-                [status: 200, location: null, data: '{"status": "failure", "errorMessage": "version conflict"}']
+        // Middle item's hub POST returns success:false — reaches toolUpdateItemCodeInner's
+        // failure branch (which carries note + lastBackup).
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            if (new groovy.json.JsonSlurper().parseText(body).id == 402) {
+                [success: false, message: 'version conflict']
             } else {
-                [status: 200, location: null, data: '{"status": "success"}']
+                [success: true]
             }
         }
 
@@ -2634,11 +2720,11 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 1, "source": "metadata { }"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            if (body.id == '402') {
-                [status: 200, location: null, data: '{"status": "failure", "errorMessage": "version conflict"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            if (new groovy.json.JsonSlurper().parseText(body).id == 402) {
+                [success: false, message: 'version conflict']
             } else {
-                [status: 200, location: null, data: '{"status": "success"}']
+                [success: true]
             }
         }
 
@@ -3142,12 +3228,12 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             uploads << name
         }
 
-        and: 'hubInternalPostForm captures the update call and returns success'
+        and: 'hubInternalPostJson captures the save call and returns success'
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.path = path
             captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 99]
         }
 
         when:
@@ -3156,11 +3242,12 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         then: 'pre-restore backup file was created with the current-source contents'
         uploads == ['mcp-prerestore-app-99.groovy']
 
-        and: 'update hits /app/ajax/update with the backup source and the fresh version'
-        captured.path == '/app/ajax/update'
-        captured.body.id == '99'
-        captured.body.version == 9
-        captured.body.source == 'old source v4'
+        and: 'restore hits /app/saveOrUpdateJson with the backup source and the fresh version'
+        captured.path == '/app/saveOrUpdateJson'
+        def sent = new groovy.json.JsonSlurper().parseText(captured.body)
+        sent.id == 99
+        sent.version == 9
+        sent.source == 'old source v4'
 
         and: 'result carries undo info and reports success'
         result.success == true
@@ -3193,10 +3280,10 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         def uploads = []
         script.metaClass.uploadHubFile = { String name, byte[] content -> uploads << name }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.path = path
             captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 99]
         }
 
         when:
@@ -3204,10 +3291,11 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         then:
         uploads == ['mcp-prerestore-app-99.groovy']
-        captured.path == '/app/ajax/update'
-        captured.body.id == '99'
-        captured.body.version == 9
-        captured.body.source == 'old source v4'
+        captured.path == '/app/saveOrUpdateJson'
+        def sent = new groovy.json.JsonSlurper().parseText(captured.body)
+        sent.id == 99
+        sent.version == 9
+        sent.source == 'old source v4'
         response.error == null
         !response.result.isError
         def inner = mcpDriver.parseInner(response)
@@ -3236,8 +3324,8 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 3, "source": "current"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status": "error", "errorMessage": "bad code"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'bad code']
         }
 
         when:
@@ -3264,8 +3352,8 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 3, "source": "current"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status": "error", "errorMessage": "bad code"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'bad code']
         }
 
         when:
@@ -3282,6 +3370,30 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         where:
         useGateways << [true, false]
+    }
+
+    def "hub_restore_backup fails closed on an empty/unparseable hub response (restore has no self-update leniency)"() {
+        given:
+        enableWrite()
+        atomicStateMap.itemBackupManifest = [
+            'app_99': [type: 'app', id: '99', fileName: 'mcp-backup-app-99.groovy',
+                       version: 4, timestamp: 1_234_000_000_000L, sourceLength: 50]
+        ]
+        script.metaClass.downloadHubFile = { String fileName -> 'old source v4'.getBytes('UTF-8') }
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 9, "source": "current source on hub"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body -> null }
+
+        when:
+        def result = script.toolRestoreItemBackup([backupKey: 'app_99', confirm: true])
+
+        then: 'failure is reported and the backup entry is preserved for retry'
+        result.success == false
+        result.error.contains('Empty or unparseable response')
+        result.message.contains('preserved')
+        atomicStateMap.itemBackupManifest.containsKey('app_99')
     }
 
     def "hub_restore_backup returns clear error for library type and directs user to hub_update_library"() {
@@ -3304,7 +3416,7 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
     // -------- hub_update_app: expectedVersion optimistic-lock --------
 
-    def "hub_update_app with matching expectedVersion proceeds and POSTs to /app/ajax/update"() {
+    def "hub_update_app with matching expectedVersion proceeds and POSTs to /app/saveOrUpdateJson"() {
         given:
         enableWrite()
         hubGet.register('/app/ajax/code') { params ->
@@ -3312,18 +3424,18 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.path = path
             captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true, id: 50]
         }
 
         when:
         def result = script.toolUpdateAppCode([appId: '50', source: 'new source', expectedVersion: 42, confirm: true])
 
         then:
-        captured.path == '/app/ajax/update'
-        captured.body.version == 42
+        captured.path == '/app/saveOrUpdateJson'
+        new groovy.json.JsonSlurper().parseText(captured.body).version == 42
         result.success == true
         result.previousVersion == 42
     }
@@ -3337,9 +3449,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         def uploads = []
         script.metaClass.uploadHubFile = { String name, byte[] content -> uploads << name }
         def postCount = 0
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             postCount++
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true]
         }
 
         when:
@@ -3370,9 +3482,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def postCount = 0
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             postCount++
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true]
         }
 
         when:
@@ -3402,9 +3514,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def postCount = 0
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             postCount++
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true]
         }
 
         when: 'caller sends "8" (string) and hub is at 7'
@@ -3457,9 +3569,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.body = new groovy.json.JsonSlurper().parseText(body)
+            [success: true]
         }
 
         when:
@@ -3478,9 +3590,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def postCount = 0
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             postCount++
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true]
         }
 
         when:
@@ -3503,9 +3615,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.body = new groovy.json.JsonSlurper().parseText(body)
+            [success: true]
         }
 
         when:
@@ -3536,9 +3648,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def postCount = 0
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             postCount++
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true]
         }
 
         when:
@@ -3557,8 +3669,8 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 1, "source": "old"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status": "error", "errorMessage": "compile failed"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'compile failed']
         }
 
         when:
@@ -3582,9 +3694,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def postCount = 0
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             postCount++
-            [status: 200, location: null, data: '{"status": "success"}']
+            [success: true]
         }
 
         when:
@@ -3613,9 +3725,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         and: 'every update POST that does happen returns success'
         def postedIds = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            postedIds << body.id
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            postedIds << new groovy.json.JsonSlurper().parseText(body).id?.toString()
+            [success: true]
         }
 
         when: 'caller asserts wrong version on the middle entry only'
@@ -3669,9 +3781,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             null
         }
         def postedIds = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            postedIds << body.id
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            postedIds << new groovy.json.JsonSlurper().parseText(body).id?.toString()
+            [success: true]
         }
 
         when:
@@ -3701,8 +3813,8 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             if (id == '203') return '{"status": "ok", "version": 8, "source": "c"}'   // success
             null
         }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true]
         }
 
         when: 'item 0 conflicts, item 1 has no driverId (throws), item 2 succeeds'
@@ -3735,9 +3847,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.body = new groovy.json.JsonSlurper().parseText(body)
+            [success: true]
         }
 
         when: 'caller passes a Long (e.g. parser produced Long for an integer JSON literal)'
@@ -3817,9 +3929,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.body = new groovy.json.JsonSlurper().parseText(body)
+            [success: true]
         }
         def warnLogs = []
         script.metaClass.mcpLog = { String level, String component, String msg ->
@@ -3835,6 +3947,28 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
 
         and: 'security-relevant ALLOWED audit log fires'
         warnLogs.any { it.contains('ALLOWED') && it.contains('id=1') }
+    }
+
+    def "hub_update_app self-update treats an empty/unparseable response as success and records lastSelfDeploy"() {
+        // A self-update legitimately drops the response -- the recompile kills the in-flight
+        // request -- so a null parse is success here; the outcome is recovered later from
+        // atomicState.lastSelfDeploy via hub_get_info.
+        given:
+        enableWrite()
+        settingsMap.enableDeveloperMode = true
+        hubGet.register('/app/ajax/code') { params ->
+            '{"status": "ok", "version": 5, "source": "self source"}'
+        }
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.hubInternalPostJson = { String path, String body -> null }
+
+        when:
+        def result = script.toolUpdateAppCode([appId: '1', source: 'self-update v3', confirm: true])
+
+        then:
+        result.success == true
+        atomicStateMap.lastSelfDeploy?.success == true
+        atomicStateMap.lastSelfDeploy.error == null
     }
 
     def "hub_update_app self-update guard blocks resave mode (most-likely real-world brick scenario)"() {
@@ -3885,9 +4019,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            captured.body = body
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            captured.body = new groovy.json.JsonSlurper().parseText(body)
+            [success: true]
         }
 
         when:
@@ -3906,8 +4040,8 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 1, "source": "other app"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true]
         }
 
         when:
@@ -3925,8 +4059,8 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 1, "source": "driver src"}'
         }
         script.metaClass.uploadHubFile = { String name, byte[] content -> }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true]
         }
 
         when:
@@ -3968,9 +4102,9 @@ class ToolAppDriverCodeSpec extends ToolSpecBase {
             '{"status": "ok", "version": 1, "source": "drv"}'
         }
         def postedIds = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            postedIds << body.id
-            [status: 200, location: null, data: '{"status": "success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            postedIds << new groovy.json.JsonSlurper().parseText(body).id?.toString()
+            [success: true]
         }
 
         when: 'bulk update of two drivers, one of which has id==app.id'

--- a/src/test/groovy/server/ToolImportUrlSpec.groovy
+++ b/src/test/groovy/server/ToolImportUrlSpec.groovy
@@ -213,10 +213,10 @@ class ToolImportUrlSpec extends ToolSpecBase {
             '{"status": "ok", "source": "old-source", "version": 7}'
         }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.path = path
             captured.body = body
-            [status: 200, location: null, data: '{"status":"success"}']
+            [success: true, id: 42]
         }
         // backup helper is a no-op stub
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 7, fileName: 'b.json'] }
@@ -233,8 +233,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
         result.sourceMode == 'importUrl'
         result.sourceLength == 'fetched-source-here'.length()
         result.note?.contains('hub-side fetch')  // pins the "no agent transcript" semantic, not just the substring
-        captured.path == '/app/ajax/update'
-        captured.body.source == 'fetched-source-here'
+        captured.path == '/app/saveOrUpdateJson'
+        new groovy.json.JsonSlurper().parseText(captured.body).source == 'fetched-source-here'
     }
 
     // -------- importUrl integration: hub_create_app --------
@@ -570,11 +570,16 @@ class ToolImportUrlSpec extends ToolSpecBase {
         hubGet.register('/app/ajax/code') { params ->
             '{"status": "ok", "source": "old", "version": 5}'
         }
+        // The code save rides hubInternalPostJson; the lifecycle fire rides hubInternalPostForm.
+        // Both append to one list so the save-then-fire ordering stays pinned.
         def posts = []
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            posts << [helper: 'json', path: path]
+            [success: true]
+        }
         script.metaClass.hubInternalPostForm = { String path, Map body ->
-            posts << [path: path, body: body]
-            // first POST: code update; second POST: trigger updated
-            [status: 200, location: null, data: '{"status":"success"}']
+            posts << [helper: 'form', path: path]
+            [status: 200, location: null, data: '']
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
@@ -591,8 +596,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
         result.triggerUpdated == 194
         result.updatedFired == true
         posts.size() == 2
-        posts[0].path == '/app/ajax/update'
-        posts[1].path == '/installedapp/configure/194/mainPage'
+        posts[0] == [helper: 'json', path: '/app/saveOrUpdateJson']
+        posts[1] == [helper: 'form', path: '/installedapp/configure/194/mainPage']
     }
 
     def "hub_update_app with triggerUpdated reports updatedFired=false + repairHints when lifecycle POST throws"() {
@@ -601,13 +606,15 @@ class ToolImportUrlSpec extends ToolSpecBase {
         hubGet.register('/app/ajax/code') { params ->
             '{"status": "ok", "source": "old", "version": 5}'
         }
-        def postCount = 0
+        def savePostCount = 0
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            savePostCount++
+            [success: true]
+        }
+        def lifecyclePaths = []
         script.metaClass.hubInternalPostForm = { String path, Map body ->
-            postCount++
-            if (path.startsWith('/installedapp/configure/')) {
-                throw new RuntimeException('hub rejected lifecycle POST')
-            }
-            [status: 200, location: null, data: '{"status":"success"}']
+            lifecyclePaths << path
+            throw new RuntimeException('hub rejected lifecycle POST')
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
@@ -625,10 +632,11 @@ class ToolImportUrlSpec extends ToolSpecBase {
         result.triggerUpdated == 194
         result.updatedFired == false
         result.repairHints?.any { it.toString().contains('lifecycle-fire POST failed') }
-        // Pins that BOTH posts were attempted -- the save (1) + the lifecycle fire (2).
+        // Pins that BOTH posts were attempted -- the save + the lifecycle fire.
         // Without this, a regression that throws before reaching the lifecycle POST
         // could produce the same envelope shape while never trying the second POST.
-        postCount == 2
+        savePostCount == 1
+        lifecyclePaths == ['/installedapp/configure/194/mainPage']
     }
 
     def "hub_update_app without triggerUpdated does NOT fire updated() (negative pin matches UI behavior)"() {
@@ -637,10 +645,15 @@ class ToolImportUrlSpec extends ToolSpecBase {
         hubGet.register('/app/ajax/code') { params ->
             '{"status": "ok", "source": "old", "version": 5}'
         }
-        def posts = []
+        def savePaths = []
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            savePaths << path
+            [success: true]
+        }
+        def lifecyclePaths = []
         script.metaClass.hubInternalPostForm = { String path, Map body ->
-            posts << [path: path]
-            [status: 200, location: null, data: '{"status":"success"}']
+            lifecyclePaths << path
+            [status: 200, location: null, data: '']
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
@@ -655,8 +668,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
         result.success == true
         result.containsKey('triggerUpdated') == false
         result.containsKey('updatedFired') == false
-        posts.size() == 1
-        posts[0].path == '/app/ajax/update'  // only the code-save POST, no lifecycle POST
+        savePaths == ['/app/saveOrUpdateJson']  // only the code-save POST...
+        lifecyclePaths.isEmpty()                // ...no lifecycle POST
     }
 
     def "hub_update_app with triggerUpdated lifecycle failure also sets partial:true"() {
@@ -667,9 +680,9 @@ class ToolImportUrlSpec extends ToolSpecBase {
         hubGet.register('/app/ajax/code') { params ->
             '{"status": "ok", "source": "old", "version": 5}'
         }
+        script.metaClass.hubInternalPostJson = { String path, String body -> [success: true] }
         script.metaClass.hubInternalPostForm = { String path, Map body ->
-            if (path.startsWith('/installedapp/configure/')) throw new RuntimeException('hub rejected lifecycle POST')
-            [status: 200, location: null, data: '{"status":"success"}']
+            throw new RuntimeException('hub rejected lifecycle POST')
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
@@ -754,8 +767,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
         settingsMap.enableDeveloperMode = true
         stubHttpGet(200, 'fetched-self-source')
         hubGet.register('/app/ajax/code') { params -> '{"status":"ok","source":"old","version":5}' }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status":"success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true]
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
@@ -777,8 +790,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
         stubHttpGet(200, 'broken-self-source')
         hubGet.register('/app/ajax/code') { params -> '{"status":"ok","source":"old","version":5}' }
         // Hub rejects the save with its real validation message (the exact thing CI must recover).
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status":"error","errorMessage":"name cannot be empty in definition section"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'name cannot be empty in definition section']
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
@@ -802,8 +815,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
         // app.id is 1; the self CLASS id resolves to 178. appId 42 matches neither -> not a self-update.
         hubGet.register('/hub2/userAppTypes') { params -> '[{"id":178,"namespace":"mcp","name":"MCP Rule Server"}]' }
         hubGet.register('/app/ajax/code') { params -> '{"status":"ok","source":"old","version":5}' }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status":"success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true]
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
@@ -826,8 +839,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
         stubHttpGet(200, 'class-id-self-source')
         hubGet.register('/hub2/userAppTypes') { params -> '[{"id":178,"namespace":"mcp","name":"MCP Rule Server"}]' }
         hubGet.register('/app/ajax/code') { params -> '{"status":"ok","source":"old","version":5}' }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status":"error","errorMessage":"name cannot be empty in definition section"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: false, message: 'name cannot be empty in definition section']
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
@@ -843,17 +856,17 @@ class ToolImportUrlSpec extends ToolSpecBase {
     }
 
     def "hub_update_app self-update records lastSelfDeploy when the save THROWS (cloud 504 / exception path)"() {
-        // The big-source importUrl deploy can 504 at the cloud relay: hubInternalPostForm throws
+        // The big-source importUrl deploy can 504 at the cloud relay: hubInternalPostJson throws
         // before any parseable 200 body. The catch block must still persist a failure record so a
         // follow-up hub_get_info can recover it; the message is the exception text (not the hub's
-        // verbatim compiler error -- that only exists on the synchronous 200+errorMessage path).
+        // verbatim compiler error -- that only exists on the synchronous success=false path).
         given:
         enableWrite()
         settingsMap.enableDeveloperMode = true
         atomicStateMap.lastSelfDeploy = null
         stubHttpGet(200, 'self-source-that-504s')
         hubGet.register('/app/ajax/code') { params -> '{"status":"ok","source":"old","version":5}' }
-        script.metaClass.hubInternalPostForm = { String path, Map body -> throw new RuntimeException('cloud 504') }
+        script.metaClass.hubInternalPostJson = { String path, String body -> throw new RuntimeException('cloud 504') }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
         when:
@@ -910,10 +923,11 @@ class ToolImportUrlSpec extends ToolSpecBase {
         given:
         enableWrite()
         hubGet.register('/app/ajax/code') { params -> '{"status":"ok","source":"old","version":5}' }
+        script.metaClass.hubInternalPostJson = { String path, String body -> [success: true] }
         def lifecyclePostCount = 0
         script.metaClass.hubInternalPostForm = { String path, Map body ->
-            if (path.startsWith('/installedapp/configure/')) lifecyclePostCount++
-            [status: 200, location: null, data: '{"status":"success"}']
+            lifecyclePostCount++
+            [status: 200, location: null, data: '']
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 5, fileName: 'b.json'] }
 
@@ -957,15 +971,15 @@ class ToolImportUrlSpec extends ToolSpecBase {
         captured.path == '/driver/saveOrUpdateJson'
     }
 
-    def "hub_update_driver with importUrl POSTs the fetched source to /driver/ajax/update"() {
+    def "hub_update_driver with importUrl POSTs the fetched source to /driver/saveOrUpdateJson"() {
         given:
         enableWrite()
         stubHttpGet(200, 'updated-driver-source')
         hubGet.register('/driver/ajax/code') { params -> '{"status":"ok","source":"old","version":3}' }
         def captured = [:]
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             captured.path = path; captured.body = body
-            [status: 200, location: null, data: '{"status":"success"}']
+            [success: true, id: 55]
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 3, fileName: 'b.json'] }
 
@@ -975,8 +989,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
         then:
         result.success == true
         result.sourceMode == 'importUrl'
-        captured.path == '/driver/ajax/update'
-        captured.body.source == 'updated-driver-source'
+        captured.path == '/driver/saveOrUpdateJson'
+        new groovy.json.JsonSlurper().parseText(captured.body).source == 'updated-driver-source'
     }
 
     def "hub_update_library with importUrl posts to /library/saveOrUpdateJson"() {
@@ -1036,9 +1050,9 @@ class ToolImportUrlSpec extends ToolSpecBase {
         stubHttpGet(200, 'updated-bulk-driver')
         hubGet.register('/driver/ajax/code') { params -> '{"status":"ok","source":"old","version":2}' }
         def postPaths = []
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
+        script.metaClass.hubInternalPostJson = { String path, String body ->
             postPaths << path
-            [status: 200, location: null, data: '{"status":"success"}']
+            [success: true]
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 2, fileName: 'b.json'] }
 
@@ -1054,7 +1068,7 @@ class ToolImportUrlSpec extends ToolSpecBase {
         result.updates[0].success == true
         result.updates[0].sourceMode == 'importUrl'
         nextHttpGetCaptured.uri == 'https://raw.example/d.groovy'
-        postPaths.contains('/driver/ajax/update')
+        postPaths.contains('/driver/saveOrUpdateJson')
     }
 
     // -------- JSON-RPC dispatch envelope (-32602 on mutex, success on happy path) --------
@@ -1112,8 +1126,8 @@ class ToolImportUrlSpec extends ToolSpecBase {
         enableWrite()
         stubHttpGet(200, 'dispatch-fetched-source')
         hubGet.register('/app/ajax/code') { params -> '{"status":"ok","source":"old","version":9}' }
-        script.metaClass.hubInternalPostForm = { String path, Map body ->
-            [status: 200, location: null, data: '{"status":"success"}']
+        script.metaClass.hubInternalPostJson = { String path, String body ->
+            [success: true]
         }
         script.metaClass.backupItemSource = { String type, String itemId -> [version: 9, fileName: 'b.json'] }
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1445,8 +1445,7 @@ class TestRunner:
 
     # -----------------------------------------------------------------------
     # GROUP 4d: app_code_update (1 test) -- the hub_update_app code-deploy path
-    # (POST /app/saveOrUpdateJson, the same endpoint the Vue editor and the
-    # create path use). One throwaway code class, three legs before its delete:
+    # (POST /app/saveOrUpdateJson). One throwaway code class, three legs before its delete:
     # a real round-trip edit (success + version advance + source landed), the
     # hub's verbatim compile error on broken Groovy (not our generic fallback),
     # and the client-side expectedVersion optimistic lock (refused, no write).

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1444,6 +1444,133 @@ class TestRunner:
                     print(f"  [WARN] deadman cleanup: delete code class {code_app_id} failed: {exc}")
 
     # -----------------------------------------------------------------------
+    # GROUP 4d: app_code_update (1 test) -- the hub_update_app code-deploy path
+    # (POST /app/saveOrUpdateJson, the same endpoint the Vue editor and the
+    # create path use). One throwaway code class, three legs before its delete:
+    # a real round-trip edit (success + version advance + source landed), the
+    # hub's verbatim compile error on broken Groovy (not our generic fallback),
+    # and the client-side expectedVersion optimistic lock (refused, no write).
+    # -----------------------------------------------------------------------
+
+    @test("app_code_update")
+    def test_update_app_code_lifecycle(self) -> None:
+        # Throwaway Apps Code class (code only, never installed as an instance). The name
+        # deliberately starts with "Deadman Test Target" (namespace mcptest) so the cleanup
+        # Layer 5 startswith sweep reclaims a stranded copy if a crash skips the finally below.
+        source_v1 = '''\
+definition(
+    name: "Deadman Test Target Update",
+    namespace: "mcptest",
+    author: "ci",
+    description: "Throwaway e2e app-code update-leg target",
+    category: "Utility",
+    iconUrl: "https://raw.githubusercontent.com/hubitat/HubitatPublic/master/app-dev/icon.png",
+    iconX2Url: "https://raw.githubusercontent.com/hubitat/HubitatPublic/master/app-dev/icon.png"
+)
+
+preferences {
+    page(name: "p", title: "Update Leg Target", install: true, uninstall: true) {
+        section { paragraph "Throwaway update-leg target. Marker: ${updateLegMarker()}" }
+    }
+}
+
+def installed() {}
+def updated() {}
+
+def updateLegMarker() { return "UPDATE-LEG-MARKER-V1" }
+'''
+        code_app_id = None
+        try:
+            created = self.client.call_tool("hub_manage_code", {
+                "tool": "hub_create_app",
+                "args": {"source": source_v1, "confirm": True},
+            })
+            code_app_id = created.get("appId")
+            assert code_app_id, f"hub_create_app(source) did not return an appId (code class): {created}"
+
+            before = self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_source",
+                "args": {"type": "app", "id": code_app_id},
+            })
+            assert before.get("success") is True and before.get("version") is not None \
+                and "UPDATE-LEG-MARKER-V1" in (before.get("source") or ""), \
+                f"could not read back the created code class: {before}"
+            version_before = int(before["version"])
+
+            # Leg 1: round-trip edit -- valid modified source must save, advance the hub's
+            # version counter, and be readable back via hub_get_source.
+            source_v2 = source_v1.replace("UPDATE-LEG-MARKER-V1", "UPDATE-LEG-MARKER-V2")
+            updated = self.client.call_tool("hub_manage_code", {
+                "tool": "hub_update_app",
+                "args": {"appId": code_app_id, "source": source_v2, "confirm": True},
+            })
+            assert updated.get("success") is True, f"hub_update_app round-trip failed: {updated}"
+            assert updated.get("previousVersion") is not None, \
+                f"hub_update_app success carries no previousVersion: {updated}"
+            after = self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_source",
+                "args": {"type": "app", "id": code_app_id},
+            })
+            assert "UPDATE-LEG-MARKER-V2" in (after.get("source") or ""), \
+                f"updated source did not land on the hub: {after}"
+            version_after = int(after["version"])
+            assert version_after > version_before, \
+                f"version did not advance after update ({version_before} -> {version_after})"
+
+            # Leg 2: compile error -- the hub's verbatim compiler text must ride back in
+            # `error`, not our generic fallback string.
+            source_broken = source_v2.replace(
+                "def updated() {}",
+                "def updated() { new ClassThatDoesNotExistBatE2e() }",
+            )
+            failed = self.client.call_tool("hub_manage_code", {
+                "tool": "hub_update_app",
+                "args": {"appId": code_app_id, "source": source_broken, "confirm": True},
+            })
+            assert failed.get("success") is False, f"broken Groovy was accepted: {failed}"
+            err = str(failed.get("error") or "")
+            assert err and err != "Update failed - the hub returned an error", \
+                f"compile failure did not surface the hub's error text: {failed}"
+            assert "unable to resolve" in err.lower() or "ClassThatDoesNotExistBatE2e" in err, \
+                f"error text is not the hub's compiler output: {err!r}"
+
+            # Leg 3: optimistic lock -- a stale expectedVersion must be refused client-side
+            # with conflict:true, before anything is written.
+            source_v3 = source_v2.replace("UPDATE-LEG-MARKER-V2", "UPDATE-LEG-MARKER-V3")
+            conflicted = self.client.call_tool("hub_manage_code", {
+                "tool": "hub_update_app",
+                "args": {"appId": code_app_id, "source": source_v3,
+                         "expectedVersion": 99999, "confirm": True},
+            })
+            assert conflicted.get("success") is False, \
+                f"stale expectedVersion was accepted: {conflicted}"
+            assert conflicted.get("conflict") is True, \
+                f"conflict flag missing on optimistic-lock refusal: {conflicted}"
+
+            # One re-read proves NEITHER refused leg wrote anything: still V2, no V3 marker,
+            # version unchanged since the round-trip edit.
+            final = self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_source",
+                "args": {"type": "app", "id": code_app_id},
+            })
+            final_src = final.get("source") or ""
+            assert "UPDATE-LEG-MARKER-V2" in final_src and "UPDATE-LEG-MARKER-V3" not in final_src, \
+                f"a refused update mutated the stored source: {final}"
+            assert int(final["version"]) == version_after, \
+                f"a refused update advanced the version ({version_after} -> {final.get('version')})"
+
+            print(f"    APP_CODE_UPDATE ok -- v{version_before}->v{version_after}; compile error + lock conflict both refused with no write")
+        finally:
+            if code_app_id:
+                try:
+                    self.client.call_tool("hub_manage_code", {
+                        "tool": "hub_delete_item",
+                        "args": {"type": "app", "id": code_app_id, "confirm": True},
+                    })
+                except Exception as exc:
+                    print(f"  [WARN] app-code update cleanup: delete code class {code_app_id} failed: {exc}")
+
+    # -----------------------------------------------------------------------
     # GROUP 5: trigger_types (1 batched test -- all trigger types in one rule)
     # -----------------------------------------------------------------------
 
@@ -2786,10 +2913,12 @@ class TestRunner:
             except Exception as exc:
                 print(f"  [WARN] Native rule sweep failed: {exc}")
 
-        # Layer 5: stranded deadman install-fix throwaway. The @test("deadman") test installs
-        # 'Deadman Test Target' (namespace mcptest) + its code class; neither carries the BAT_E2E_
-        # prefix, so a crash/kill between its create and finally would strand it past the other
-        # sweeps. Reclaim instance(s) + code class by namespace+name (idempotent across runs).
+        # Layer 5: stranded mcptest throwaways. The @test("deadman") test installs 'Deadman Test
+        # Target' (instance + code class) and the @test("app_code_update") test creates the
+        # 'Deadman Test Target Update' code class (named to ride this same startswith match);
+        # none carry the BAT_E2E_ prefix, so a crash/kill between a create and its finally would
+        # strand them past the other sweeps. Reclaim instance(s) + code class by namespace+name
+        # (idempotent across runs).
         try:
             dtypes = self.client.call_tool("hub_read_apps_code",
                                            {"tool": "hub_list_apps", "args": {"scope": "types"}})


### PR DESCRIPTION
## Summary

- Unifies the app/driver code **update** wire onto `POST /app|driver/saveOrUpdateJson` (`{id, source, version}` JSON) — the same endpoint the create path, the library path, and the hub's own editor use — replacing the legacy form POST `/app|driver/ajax/update` in `hub_update_app`, `hub_update_driver`, and the app/driver leg of `hub_restore_backup`.
- Hardens the save/restore response handling: empty and non-JSON hub responses are now distinguished and fail closed (with one deliberate exception for self-deploys, whose dropped response is the expected recompile signature), the upsert id echo is verified, and `hub_restore_backup` gets the same self-deploy handling the update path has.

## Type of change

- [x] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

Part of #212 (the remaining #212 endpoint adoptions land in separate PRs).

- `toolUpdateItemCodeInner`: the update POST rides `hubInternalPostJson` to `/app|driver/saveOrUpdateJson`; response parsing matches the create path (`{success, id, message}` — compile errors ride verbatim in `message`). Preserved unchanged: version/source pre-fetch via `/app|driver/ajax/code`, the client-side `expectedVersion` conflict envelope, pre-update auto-backup, the `lastSelfDeploy` stash, the self-update Developer-Mode guard, and `triggerUpdated`. Non-numeric ids are rejected up front as validation errors.
- `hubInternalPostJson` distinguishes an **empty** response body (`null`) from a **non-JSON** one (an `[_unparseable, message]` sentinel carrying the body snippet, with the request path logged). A garbage body — e.g. a stale-cookie HTML page — can no longer be mistaken for a successful self-deploy or poison the `lastSelfDeploy` record; every caller surfaces the snippet through its existing message fallbacks.
- Fail-closed semantics: an empty response now fails a non-self update (previously assumed success); only a self-deploy keeps the leniency (the recompile kills the in-flight request), and such successes are marked `assumed: true` in `lastSelfDeploy`. Stash write failures are logged instead of swallowed.
- Upsert id-echo guard: a success reported for a different id than targeted fails with a duplicate-entry warning (update and restore).
- `toolRestoreItemBackup`: same wire flip, plus full self-restore handling — restoring the MCP server's own code gets the empty-body leniency, an `assumed`/`note` envelope, and a `lastSelfDeploy` stash (`sourceMode: "restore"`) on all outcomes; failure envelopes keep a diagnostic breadcrumb when the hub's response carries no message.
- The e2e watchdog (`e2e-deadman-watchdog-v2.groovy`) deliberately stays on `ajax/update` — it is the e2e recovery mechanism and keeps the battle-tested path.
- SKILL.md endpoint table: dead `/app/save` rows replaced with the `saveOrUpdateJson` contract (hub-side `version` enforcement confirmed by live observation: a web-UI save after an MCP-driven update errors with a version mismatch); a legacy `ajax/update` row is kept since the watchdog still uses it.
- Specs: every stub/assertion pinning the old form wire flipped (`ToolAppDriverCodeSpec`, `ToolImportUrlSpec`, `RegressionsFromHistorySpec`); new coverage for the helper's three-way response contract, verbatim compile-error surfacing (both `message` and `errorMessage` keys), fail-closed empty/unparseable paths, self-deploy leniency + `assumed` stashes (update and restore, including the class-id detection leg and the exception/rejected-save stash paths), id-echo guards, missing-message breadcrumbs, the driver-restore path pin, and pre-flight id validation.
- e2e: new `app_code_update` scenario — round-trip edit (version advance + source landed), broken-Groovy update surfacing the hub's verbatim compiler text, and a stale `expectedVersion` refusal proving no write occurred.

## Release Notes

- App and driver code updates now use the same modern hub endpoint as code creation, with compile errors reported verbatim
  - An update that gets no response from the hub is now reported as unverified instead of assumed successful
  - Restoring a code backup of the MCP server itself now reports its outcome honestly and records it for later inspection

## Testing

- `./gradlew test` green locally (full Spock suite) and across the CI matrix; `python tests/sandbox_lint.py` clean.
- New e2e scenario `app_code_update` proved the new wire on the live test hub: create a throwaway Apps Code class → valid update (success, version advance, source landed) → broken-Groovy update (the hub's verbatim compiler text, not the generic fallback) → stale `expectedVersion` (`conflict: true`, no write) → delete.
- Reviewed via the PR review toolkit (code, tests, error handling, comments); all findings fixed in-PR or explicitly dismissed with reasoning.

## Checklist

- [x] **Unit tests added for any new MCP tools** (no new tools; changed behaviour covered by new/updated unit + dispatch cases)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms)
- [x] Live-hub BAT tests updated if tool behaviour changed (verified: `tests/BAT-v2.md` references `hub_update_app` only in a tool-inventory table; no endpoint contract pinned, no change needed)
- [x] Documentation updated if user-facing behaviour or tool surface changed (SKILL.md endpoint table)
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (no tool surface changes)
