### PR TITLE
docs: list string/decimal for runCommand parameter types

### DIFF
--- a/docs/rm_action_subtype_schemas.md
+++ b/docs/rm_action_subtype_schemas.md
@@ -141,7 +141,7 @@ Calls any device-driver command not exposed by higher-level capability mappings 
 | `command` | String | Required. Driver command name (e.g. 'flashOff', 'refresh', 'setLevel') |
 | `deviceIds` | List\<Integer\> | Required |
 | `capabilityFilter` | String | Default 'Switch' |
-| `parameters` | List | Literal: `[{type: 'number', value: 75}]`. Variable-sourced: `[{type: 'number', variable: 'myVar'}]`. Mix literal and variable entries across slots. Fails loud (success=false with descriptive error) if the hub does not reveal the xVar enum after enabling variable mode for a slot. |
+| `parameters` | List | Each slot is `{type, value}` (literal) or `{type, variable}` (variable-sourced). `type` is one of `'number'`, `'decimal'`, or `'string'` (lowercase) -- it maps to RM's per-parameter `cpType` selector. Literal: `[{type: 'number', value: 75}]` or `[{type: 'string', value: 'auto'}]`. Variable-sourced: `[{type: 'number', variable: 'myVar'}]`. Mix literal and variable entries across slots. Fails loud (success=false with descriptive error) if the hub does not reveal the xVar enum after enabling variable mode for a slot. |
 | `useLastEventDevice` | Boolean | |
 | `delay` | Map | |
 | `rawSettings` | Map | |


### PR DESCRIPTION
## Summary

The `runCommand` row in `docs/rm_action_subtype_schemas.md` documented only `number` for `parameters[].type`, but the `_rmAddAction` validator accepts `number` / `decimal` / `string` (lowercase) — and the in-tool `get_tool_guide(section='set_rule_reference')` already lists all three. This syncs the standalone schema reference: the full type set, a `string` example, and the `cpType` mapping note.

## Type of change

- [x] `docs` — documentation only

## Changes

- `docs/rm_action_subtype_schemas.md`: the `runCommand` `parameters[].type` cell now documents the accepted set (`number` / `decimal` / `string`, lowercase) with a string example, matching the `_rmAddAction` validator + the in-tool guide.
- Part of #195 (addAction reference doc accuracy).

## Release Notes

- Docs: the RM action-subtype reference now lists `string`/`decimal` (in addition to `number`) for Run Custom Action parameter types.

## Testing

- `python tests/sandbox_lint.py` — passes (0 errors / 0 warnings).
- Accuracy: the `_rmAddAction` validator throws unless the type is exactly `number`/`decimal`/`string` (lowercase); the note matches that + the already-shipped in-tool `get_tool_guide` content.
- Doc-only — no Spock/e2e behaviour change.

## Checklist

- [ ] Unit tests added for any new MCP tools — N/A (doc-only)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms) — CI confirms
- [ ] Live-hub BAT tests updated if tool behaviour changed — N/A (no behaviour change)
- [x] Documentation updated if user-facing behaviour or tool surface changed
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules — N/A