### PR TITLE
feat: add walkStep drive mode and pare hub_set_rule prose into the tool guide

### DIFF
--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -4956,6 +4956,12 @@ NOTE: this section describes the LEGACY custom MCP rule engine (the custom_* too
 - days_of_week: Specific days
 - sun_position: Sun above/below horizon
 - hsm_status: Current HSM state
+- presence: Presence sensor state (deviceId)
+- lock: Lock state (deviceId)
+- thermostat_mode: Thermostat mode (deviceId)
+- thermostat_state: Thermostat operating state (deviceId)
+- illuminance: Illuminance threshold (deviceId + operator + value)
+- power: Power-meter threshold (deviceId + operator + value)
 
 ### Actions
 - device_command: Send command to device
@@ -4977,6 +4983,13 @@ NOTE: this section describes the LEGACY custom MCP rule engine (the custom_* too
 - set_valve: Open/close valve
 - set_fan_speed: Set fan to low/medium/high/auto
 - set_shade: Open/close/position shade
+- set_level: Set dimmer level — {deviceId, level (0-100)}
+- set_color: Set RGBW color — {deviceId, color}
+- set_color_temperature: Set color temperature — {deviceId, temperature (Kelvin)}
+- lock / unlock: Lock or unlock a lock — {deviceId}
+- capture_state: Capture device states for later restore — {deviceIds}
+- restore_state: Restore previously captured states (no fields)
+- send_notification: Send a notification to a device — {deviceId, message}
 - variable_math: Arithmetic on variables — {variableName, operation: add|subtract|multiply|divide|modulo|set, operand, scope: local|global}''',
 
         backup: '''## Backup System
@@ -5269,16 +5282,26 @@ Also a valid `patches[]` op (reported as `op: 'replaceRequiredExpression'`). Ins
 
 ### `walkStep` schema-aware wizard walker
 
-`walkStep` is the lowest-level escape hatch: drive one wizard page/operation at a time when the high-level `addTrigger`/`addAction` helpers don't cover the capability you need (Periodic Schedule sub-pages, conditional-trigger binding, IF/THEN/ELSE flow control, features added in a later firmware). Each call returns a structured snapshot -- schema before/after, schema diff (inputs appeared/disappeared), value-echo (catches silent enum case normalization), sub-page hrefs, action/trigger list-count change (disambiguates 'committed' from 'broke and lost the row'), and a health check.
+`walkStep` is the lowest-level escape hatch: drive the RM wizard when the high-level `addTrigger`/`addAction` helpers don't cover the capability you need (Periodic Schedule sub-pages, conditional-trigger binding, IF/THEN/ELSE flow control, features added in a later firmware). Each single-step call returns a structured snapshot -- schema before/after, schema diff (inputs appeared/disappeared), value-echo (catches silent enum case normalization), sub-page hrefs, action/trigger list-count change (disambiguates 'committed' from 'broke and lost the row'), and a health check.
 
-Spec: `{page, operation, write?:{<field>:<value>}, click?:{name,stateAttribute?}, navigate?:{targetPage}, validateEnum?:<bool>, hrefContext?:{fromPage,hrefName,hrefParams?,hrefIndex?}}` where `page` is e.g. `selectTriggers`/`selectActions`/`doActPage`/`mainPage`/`periodic` and `operation` is one of:
+Spec: `{page, operation, write?:{<field>:<value>}, click?:{name,stateAttribute?}, navigate?:{targetPage}, validateEnum?:<bool>, hrefContext?:{fromPage,hrefName,hrefParams?,hrefIndex?}, steps?:[...]}` where `page` is e.g. `selectTriggers`/`selectActions`/`doActPage`/`mainPage`/`periodic` and `operation` is one of:
+- `drive` -- **preferred**: run an ordered `steps=[...]` list (each item a single-step spec) in ONE call. The tool performs them in sequence, carrying the page forward across `navigate`/`done`, and stops at the first failed step (`stopOnError=false` to continue). A step that omits `page` inherits the page the previous step ended on. Returns `{steps:[{step, operation, page, success, diff, valueEcho, silentRejection, commitSignal, health}, ...], stepsRequested, stepsRun, lastStepOperation, success, health}`; a trailing `done` step gets the same mainPage Done finalize a single-step `done` does. This automates the manual loop below.
 - `introspect` -- fetch schema; no mutation.
 - `write` -- write one field's value (exactly one key per call; `hrefContext` for sub-pages).
 - `click` -- click a regular button (`cancelCapab`, `hasAll`, `moreCond`, ...).
 - `navigate` -- forward into a sub-page via its href.
 - `done` -- BACK-navigate from a sub-page to its parent (`_action_previous=Done`), carrying ALL the sub-page's current settings. REQUIRED for sub-pages (Periodic, etc.) whose parent row otherwise renders `?`. Pass `hrefContext={fromPage:<parent>, hrefParams:{n:<idx>}}`.
 
-Recommended driving loop: `introspect` to see the page's fields -> `navigate` into a sub-page if one is exposed -> `write` each required field (with `hrefContext` on sub-pages) -> inspect `diff.appeared`/`valueEcho.match`/`silentRejection` between writes -> `done` to back out of a sub-page (this bakes the trigger/action description) -> `click` `hasAll`/`actionDone` on the parent to finalize the row. Always check `silentRejection`, `valueEcho.match`, and `health.ok` in the response -- they are the fail-loud signals.
+The loop `drive` automates (and the sequence to put in `steps[]`): `introspect` to see the page's fields -> `navigate` into a sub-page if one is exposed -> `write` each required field (with `hrefContext` on sub-pages) -> inspect `diff.appeared`/`valueEcho.match`/`silentRejection` between writes -> `done` to back out of a sub-page (this bakes the trigger/action description) -> `click` `hasAll`/`actionDone` on the parent to finalize the row. Always check `silentRejection`, `valueEcho.match`, and `health.ok` in each step's snapshot -- they are the fail-loud signals.
+
+Worked `drive` example (a multi-device switch trigger committed in one call, the `steps[]` form of the raw-mode example above):
+```
+hub_set_rule(appId=N, confirm=true, walkStep={operation:'drive', steps:[
+  {page:'selectTriggers', operation:'write', write:{tCapab1:'Switch'}},
+  {page:'selectTriggers', operation:'write', write:{tDev1:[<deviceId>, ...]}},
+  {page:'selectTriggers', operation:'write', write:{tstate1:'on'}},
+  {page:'selectTriggers', operation:'click', click:{name:'hasAll'}}]})
+```
 
 ### Raw `settings`/`button` mode (manual wizard flow)
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -4956,10 +4956,10 @@ NOTE: this section describes the LEGACY custom MCP rule engine (the custom_* too
 - days_of_week: Specific days
 - sun_position: Sun above/below horizon
 - hsm_status: Current HSM state
-- presence: Presence sensor state (deviceId)
-- lock: Lock state (deviceId)
-- thermostat_mode: Thermostat mode (deviceId)
-- thermostat_state: Thermostat operating state (deviceId)
+- presence: Presence sensor state (deviceId + status: present|not present)
+- lock: Lock state (deviceId + status: locked|unlocked)
+- thermostat_mode: Thermostat mode (deviceId + mode: auto|cool|heat|off|emergency heat)
+- thermostat_state: Thermostat operating state (deviceId + state: idle|heating|cooling|fan only|pending heat|pending cool)
 - illuminance: Illuminance threshold (deviceId + operator + value)
 - power: Power-meter threshold (deviceId + operator + value)
 
@@ -4984,11 +4984,11 @@ NOTE: this section describes the LEGACY custom MCP rule engine (the custom_* too
 - set_fan_speed: Set fan to low/medium/high/auto
 - set_shade: Open/close/position shade
 - set_level: Set dimmer level — {deviceId, level (0-100)}
-- set_color: Set RGBW color — {deviceId, color}
+- set_color: Set color via hue/saturation/level — {deviceId, hue (0-100), saturation (0-100), level (0-100, optional)}
 - set_color_temperature: Set color temperature — {deviceId, temperature (Kelvin)}
 - lock / unlock: Lock or unlock a lock — {deviceId}
-- capture_state: Capture device states for later restore — {deviceIds}
-- restore_state: Restore previously captured states (no fields)
+- capture_state: Capture device states for later restore — {deviceIds, stateId? (optional, default "default")}
+- restore_state: Restore previously captured states — {stateId? (optional, default "default")}
 - send_notification: Send a notification to a device — {deviceId, message}
 - variable_math: Arithmetic on variables — {variableName, operation: add|subtract|multiply|divide|modulo|set, operand, scope: local|global}''',
 
@@ -5285,7 +5285,7 @@ Also a valid `patches[]` op (reported as `op: 'replaceRequiredExpression'`). Ins
 `walkStep` is the lowest-level escape hatch: drive the RM wizard when the high-level `addTrigger`/`addAction` helpers don't cover the capability you need (Periodic Schedule sub-pages, conditional-trigger binding, IF/THEN/ELSE flow control, features added in a later firmware). Each single-step call returns a structured snapshot -- schema before/after, schema diff (inputs appeared/disappeared), value-echo (catches silent enum case normalization), sub-page hrefs, action/trigger list-count change (disambiguates 'committed' from 'broke and lost the row'), and a health check.
 
 Spec: `{page, operation, write?:{<field>:<value>}, click?:{name,stateAttribute?}, navigate?:{targetPage}, validateEnum?:<bool>, hrefContext?:{fromPage,hrefName,hrefParams?,hrefIndex?}, steps?:[...]}` where `page` is e.g. `selectTriggers`/`selectActions`/`doActPage`/`mainPage`/`periodic` and `operation` is one of:
-- `drive` -- **preferred**: run an ordered `steps=[...]` list (each item a single-step spec) in ONE call. The tool performs them in sequence, carrying the page forward across `navigate`/`done`, and stops at the first failed step (`stopOnError=false` to continue). A step that omits `page` inherits the page the previous step ended on. Returns `{steps:[{step, operation, page, success, diff, valueEcho, silentRejection, commitSignal, health}, ...], stepsRequested, stepsRun, lastStepOperation, success, health}`; a trailing `done` step gets the same mainPage Done finalize a single-step `done` does. This automates the manual loop below.
+- `drive` -- **preferred**: run an ordered `steps=[...]` list (each item a single-step spec) in ONE call. The tool performs them in sequence, carrying the page forward across `navigate`/`done`, and stops at the first failed step (`stopOnError=false` to continue). A step that omits `page` inherits the page the previous step ended on. Returns `{steps:[{step, operation, page, success, diff, valueEcho, silentRejection, commitSignal, opResult, health}, ...], stepsRequested, stepsRun, lastStepOperation, success, health}`; on a halt the aggregate also carries a top-level `error` + `repairHints` naming the failed step. End the drive with a `done` step to fire the mainPage Done finalize (the `updateRule`-equivalent that re-initializes subscriptions) — the same finalize a single-step `done` gets. This automates the manual loop below.
 - `introspect` -- fetch schema; no mutation.
 - `write` -- write one field's value (exactly one key per call; `hrefContext` for sub-pages).
 - `click` -- click a regular button (`cancelCapab`, `hasAll`, `moreCond`, ...).
@@ -5294,13 +5294,15 @@ Spec: `{page, operation, write?:{<field>:<value>}, click?:{name,stateAttribute?}
 
 The loop `drive` automates (and the sequence to put in `steps[]`): `introspect` to see the page's fields -> `navigate` into a sub-page if one is exposed -> `write` each required field (with `hrefContext` on sub-pages) -> inspect `diff.appeared`/`valueEcho.match`/`silentRejection` between writes -> `done` to back out of a sub-page (this bakes the trigger/action description) -> `click` `hasAll`/`actionDone` on the parent to finalize the row. Always check `silentRejection`, `valueEcho.match`, and `health.ok` in each step's snapshot -- they are the fail-loud signals.
 
-Worked `drive` example (a multi-device switch trigger committed in one call, the `steps[]` form of the raw-mode example above):
+Worked `drive` example (a multi-device switch trigger committed in one call, the `steps[]` form of the raw-mode example below). The trailing `done` is what runs the mainPage Done finalize (raw-mode step 6, `updateRule`); without it the trigger is written to settings but never subscribed, so the rule looks created yet never fires:
 ```
 hub_set_rule(appId=N, confirm=true, walkStep={operation:'drive', steps:[
+  {page:'selectTriggers', operation:'click', click:{name:'true', stateAttribute:'moreCond'}},
   {page:'selectTriggers', operation:'write', write:{tCapab1:'Switch'}},
   {page:'selectTriggers', operation:'write', write:{tDev1:[<deviceId>, ...]}},
   {page:'selectTriggers', operation:'write', write:{tstate1:'on'}},
-  {page:'selectTriggers', operation:'click', click:{name:'hasAll'}}]})
+  {page:'selectTriggers', operation:'click', click:{name:'hasAll'}},
+  {page:'selectTriggers', operation:'done'}]})
 ```
 
 ### Raw `settings`/`button` mode (manual wizard flow)

--- a/libraries/mcp-code-management-lib.groovy
+++ b/libraries/mcp-code-management-lib.groovy
@@ -2749,13 +2749,7 @@ Auto-backs up before modifying. Requires Write master + confirm + backup <24h.""
 
 Returns the app's identity (label, type, parent, disabled state) and its current config page: sections, inputs (name, type, title, description, options, current value), and `embeddedActions` — clickable button affordances embedded in paragraph HTML[[FLAT_TRIM]] (RM 5.1 wizards expose "Create New Trigger", "Edit Trigger", "Delete Trigger" etc. as `<div class='submitOnChange'>` elements rather than schema inputs; this field surfaces them with their button name + stateAttribute so hub_set_rule can drive them)[[/FLAT_TRIM]]. Multi-page apps (e.g. RM 5.1) expose sub-pages by name — pass pageName to navigate into them. Read-only; does not modify anything. summary=true: fast identity-only mode.
 
-[[FLAT_TRIM]]
-Use to: understand what an existing automation actually does, audit rules for best-practice issues, diff two similar apps, generate human-readable summaries, or answer "which app is doing X" after hub_list_apps (scope='instances') / hub_list_device_dependents narrows the field.
-[[/FLAT_TRIM]]
-
-[[FLAT_TRIM]]
-Workflow: (1) Get the appId from hub_list_apps (scope='instances', all apps), hub_list_rules (RM rules specifically -- these are Rule-5.x appIds under parent Rule Machine; use this, not hub_get_custom_rule, which only handles MCP-native rules), or hub_list_apps (scope='instances') with filter=parents to explore app hierarchy. (2) Call hub_get_app_config with the appId. (3) For multi-page apps, optionally pass pageName -- call hub_list_app_pages first to discover available page names (the pageName param lists the common HPM / RM / Room Lighting pages).
-[[/FLAT_TRIM]]
+Get the appId from hub_list_apps (scope='instances') or hub_list_rules (RM rules -- use this, not hub_get_custom_rule, which only handles MCP-native rules); for multi-page apps pass pageName (hub_list_app_pages discovers available names).
 
 Requires Read master.""",
             inputSchema: [

--- a/libraries/mcp-custom-rules-lib.groovy
+++ b/libraries/mcp-custom-rules-lib.groovy
@@ -820,13 +820,7 @@ def _getAllToolDefinitions_partCustomRules() {
             name: "hub_create_custom_rule",
             description: """*** LEGACY: the custom MCP rule engine is now considered legacy. Existing custom rules continue to fire and this engine will receive bug fixes if reported, but new feature work goes to native Rule Machine. For default rule creation requests ("create a Rule Machine rule," "Hubitat rule," anything the user wants visible in Hubitat's RM app list / web UI), use hub_manage_rule_machine hub_set_rule instead. THIS tool creates MCP-managed sandbox rules that fire as installed apps but are NOT visible in Hubitat's RM UI; only use when explicitly asked for that or for backward compatibility with existing custom_* rules. ***
 
-Create a new automation rule (MCP sandbox engine). Call `hub_get_tool_guide(section='rules')` for structure, syntax, and examples.
-
-[[FLAT_TRIM]]
-Trigger types: device_event (supports duration, multi-device), button_event, time (HH:mm/sunrise/sunset+offset), periodic, mode_change, hsm_change
-Condition types: device_state, device_was, time_range, mode, variable, days_of_week, sun_position, hsm_status
-Action types: device_command, toggle_device, activate_scene, set_variable, set_local_variable, set_mode, set_hsm, delay, if_then_else, cancel_delayed, repeat, stop, log, set_thermostat, http_request, speak, comment, set_valve, set_fan_speed, set_shade, variable_math
-[[/FLAT_TRIM]]
+Create a new automation rule (MCP sandbox engine). Call `hub_get_tool_guide(section='rules')` for the trigger/condition/action type lists, per-type fields, structure, syntax, and examples.
 
 Verify rule after creation.""",
             inputSchema: [
@@ -836,10 +830,10 @@ Verify rule after creation.""",
                     description: [type: "string", description: "Optional human-readable rule description"],
                     enabled: [type: "boolean", description: "Enable rule immediately on creation", default: true],
                     testRule: [type: "boolean", description: "Mark as test rule - will NOT be backed up on deletion. Use for temporary/experimental rules.", default: false],
-                    triggers: [type: "array", description: "Trigger objects (at least one required), each a {type, ...} object. See the type list in the tool description and hub_get_tool_guide(section='rules') for per-type fields, e.g. {\"type\":\"time\",\"time\":\"sunset\"}."],
-                    conditions: [type: "array", description: "Optional condition objects gating the actions, each {type, ...}. See type list above and the rules guide, e.g. {\"type\":\"mode\",\"mode\":\"Night\"}."],
+                    triggers: [type: "array", items: [type: "object", properties: [type: [type: "string", enum: ["device_event", "button_event", "time", "sunrise", "sunset", "sun", "periodic", "mode_change", "hsm_change"]]]], description: "Trigger objects (at least one required), each a {type, ...} object — the `type` enum lists the kinds (sunrise/sunset/sun are shortcuts for a time trigger). Per-type fields + examples: hub_get_tool_guide(section='rules'). e.g. {\"type\":\"time\",\"time\":\"sunset\"}."],
+                    conditions: [type: "array", items: [type: "object", properties: [type: [type: "string", enum: ["device_state", "device_was", "time_range", "mode", "variable", "days_of_week", "sun_position", "hsm_status", "presence", "lock", "thermostat_mode", "thermostat_state", "illuminance", "power"]]]], description: "Optional condition objects gating the actions, each {type, ...}. Per-type fields: hub_get_tool_guide(section='rules'). e.g. {\"type\":\"mode\",\"mode\":\"Night\"}."],
                     conditionLogic: [type: "string", enum: ["all", "any"], description: "How to combine multiple conditions: 'all' = AND, 'any' = OR.", default: "all"],
-                    actions: [type: "array", description: "Action objects to run when triggered (at least one required), each {type, ...}. See type list above and the rules guide, e.g. {\"type\":\"device_command\",\"deviceId\":\"42\",\"command\":\"on\"}."]
+                    actions: [type: "array", items: [type: "object", properties: [type: [type: "string", enum: ["device_command", "toggle_device", "activate_scene", "set_variable", "set_local_variable", "set_mode", "set_hsm", "delay", "if_then_else", "cancel_delayed", "repeat", "stop", "log", "set_level", "set_color", "set_color_temperature", "lock", "unlock", "capture_state", "restore_state", "send_notification", "set_thermostat", "http_request", "speak", "comment", "set_valve", "set_fan_speed", "set_shade", "variable_math"]]]], description: "Action objects to run when triggered (at least one required), each {type, ...}. Per-type fields: hub_get_tool_guide(section='rules'). e.g. {\"type\":\"device_command\",\"deviceId\":\"42\",\"command\":\"on\"}."]
                 ],
                 required: ["name", "triggers", "actions"]
             ],

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -6894,21 +6894,54 @@ private Map _rmDriveWalkSteps(Integer appId, Map spec) {
     def currentPage = spec?.page?.toString()?.trim()
     def allOk = true
     def lastStepOperation = null
+    // Pre-flight: validate every step's SHAPE before issuing ANY live POST. A drive is
+    // partial-commit by nature (each write/click is a live POST), so a structural mistake
+    // -- a non-object step, or a nested drive -- must reject the whole drive up front,
+    // never after steps 1..N-1 have already mutated the rule. (Runtime errors that surface
+    // only on execution are handled per-step inside the loop, where the partial trace of
+    // the steps that already committed is preserved.)
+    steps.eachWithIndex { rawStep, i ->
+        if (!(rawStep instanceof Map)) {
+            throw new IllegalArgumentException("walkStep.drive step ${i + 1} must be an object {operation, ...}")
+        }
+        if (((Map) rawStep).operation?.toString()?.trim() == "drive") {
+            throw new IllegalArgumentException("walkStep.drive steps cannot nest operation='drive' (step ${i + 1})")
+        }
+    }
     int idx = 0
     for (def rawStep : steps) {
         idx++
-        if (!(rawStep instanceof Map)) {
-            throw new IllegalArgumentException("walkStep.drive step ${idx} must be an object {operation, ...}")
-        }
         def step = new LinkedHashMap((Map) rawStep)
         def stepOp = step.operation?.toString()?.trim() ?: "introspect"
-        if (stepOp == "drive") {
-            throw new IllegalArgumentException("walkStep.drive steps cannot nest operation='drive' (step ${idx})")
-        }
         // Inherit the page the previous step ended on when this step omits one.
         if (!step.page && currentPage) step.page = currentPage
-        def r = _rmWalkStep(appId, step)
         lastStepOperation = stepOp
+        def r
+        try {
+            r = _rmWalkStep(appId, step)
+        } catch (Exception stepExc) {
+            // A step that THROWS at runtime (bad input mid-sequence, a hub error) would
+            // otherwise unwind the whole drive and discard the per-step trace of the steps
+            // that already ran. Capture the throw as a failed step so the partial-run record
+            // + a health verdict survive, identical in quality to a success=false step. Record
+            // the step's OWN page (step.page is set by the inherit line above), not currentPage
+            // -- currentPage only advances on a SUCCESSFUL step, so it would mis-name the page
+            // the failing op actually targeted.
+            mcpLogError("rm-native", "walkStep drive: step ${idx} (${stepOp}) threw for app ${appId}", stepExc)
+            def stepHealth = null
+            try { stepHealth = _rmCheckRuleHealth(appId) } catch (Exception ignored) { /* best effort -- never mask the real error */ }
+            stepResults << [
+                step: idx,
+                operation: stepOp,
+                page: (step.page ?: currentPage),
+                success: false,
+                error: stepExc.message ?: stepExc.toString(),
+                health: stepHealth
+            ]
+            allOk = false
+            if (stopOnError) break
+            else continue
+        }
         if (r?.page) currentPage = r.page.toString()
         stepResults << [
             step: idx,
@@ -6928,7 +6961,7 @@ private Map _rmDriveWalkSteps(Integer appId, Map spec) {
         }
     }
     def finalHealth = _rmCheckRuleHealth(appId)
-    return [
+    def result = [
         success: allOk && finalHealth.ok,
         operation: "drive",
         page: currentPage,
@@ -6938,6 +6971,19 @@ private Map _rmDriveWalkSteps(Integer appId, Map spec) {
         steps: stepResults,
         health: finalHealth
     ]
+    // Fail-loud rollup: a success:false drive must ALWAYS carry a top-level reason. A step
+    // error caught per-step otherwise lives only in steps[].error -- a weak signal for an
+    // LLM caller that sees success:false with no top-level `error`. Surface the first failed
+    // step's error (and a repairHint naming it); if every step passed but the rule ended
+    // unhealthy, surface the finalHealth.ok gate's reason instead.
+    def firstFailed = stepResults.find { it.success == false }
+    if (firstFailed != null) {
+        result.error = "drive halted at step ${firstFailed.step} (${firstFailed.operation}): ${firstFailed.error ?: 'step reported success:false -- inspect its valueEcho/silentRejection/health'}".toString()
+        result.repairHints = (result.repairHints ?: []) + ["Drive stopped at step ${firstFailed.step}. Inspect steps[${firstFailed.step - 1}] for the failure detail, correct it, and re-run the drive from that step.".toString()]
+    } else if (!finalHealth.ok) {
+        result.error = "drive completed all ${stepResults.size()} step(s) but the rule is unhealthy: ${(finalHealth.issues ?: ['see health']).join('; ')}".toString()
+    }
+    return result
 }
 
 // Commit a value-write as a FULL page-form submit to /installedapp/update/json,
@@ -7062,7 +7108,7 @@ private Map _rmBackupRuleSnapshot(Integer ruleId, String reason) {
         // config JSON alone is enough to restore. Record the failure in
         // the snapshot so post-mortem sees why status was absent.
         mcpLog("warn", "rm-native", "Backup for rule ${ruleId}: statusJson failed -- ${e.message}")
-        status = [error: e.message]
+        status = [error: e.message ?: e.toString()]
     }
 
     // Detect appType from the config's appType.name so the restore path
@@ -7663,6 +7709,14 @@ def _createNativeAppShell(args) {
         if (createDone?.done == false) {
             result.mainPageDoneFailed = true
             result.mainPageDoneError = createDone.reason
+            // Flip success ONLY for commitButton:null app types (Basic Rule, Button Controller),
+            // where this Done is the session's ONLY lifecycle event -- a miss there means the app
+            // never initialized (a false-clean create). RM-family creates already fired updateRule
+            // above to commit each section, so a missed trailing Done there is a state-marker
+            // cleanup caveat (surfaced via the repairHint), not a creation failure.
+            if (_resolveCommitButton(_appTypeRegistry()[appType]?.appName) == null) {
+                result.success = false
+            }
             result.repairHints = (result.repairHints ?: []) + ["The session-end mainPage Done click did not commit (${createDone.reason}). Settings are already written, but the app's update lifecycle did not run -- verify via hub_get_app_config(appId=${newId}) and re-commit via hub_set_native_app(appId=${newId}, button='updateRule') for RM-family apps.".toString()]
         }
         if (triggerSpecs) result.triggers = triggerResults
@@ -7696,7 +7750,7 @@ def _createNativeAppShell(args) {
         try { _rmForceDeleteApp(newId) } catch (Exception ce) {
             mcpLog("warn", "rm-native", "Orphan cleanup failed for ${newId}: ${ce.message}")
         }
-        return [success: false, error: "${appType} create failed: ${e.message}", orphanCleanup: "attempted", note: "No partial app left behind."]
+        return [success: false, error: "${appType} create failed: ${e.message ?: e.toString()}", orphanCleanup: "attempted", note: "No partial app left behind."]
     }
 }
 
@@ -10431,6 +10485,12 @@ def _applyNativeAppEdit(args) {
                 if (walkDone?.done == false) {
                     result.mainPageDoneFailed = true
                     result.mainPageDoneError = walkDone.reason
+                    // The Done click drives the app's update lifecycle; a miss means subscriptions
+                    // / schedules did not re-initialize even though settings are written, so the
+                    // result is NOT clean -- flip success so callers branching on it don't treat a
+                    // half-committed edit as done.
+                    result.success = false
+                    result.repairHints = (result.repairHints ?: []) + ["The session-end mainPage Done click did not commit (${walkDone.reason}). Settings are already written, but the app's update lifecycle did not run -- verify via hub_get_app_config(appId=${appId}) and re-commit via hub_set_native_app(appId=${appId}, button='updateRule') for RM-family apps.".toString()]
                 }
             }
             return result
@@ -10439,7 +10499,7 @@ def _applyNativeAppEdit(args) {
             return [
                 success: false,
                 appId: appId,
-                error: e.message,
+                error: e.message ?: e.toString(),
                 backup: backup,
                 restoreHint: "Backup saved before write. Call hub_restore_backup with backupKey='${backup.backupKey}' to roll back."
             ]
@@ -10786,7 +10846,7 @@ def _applyNativeAppEdit(args) {
             def trigResult = [
                 success: false,
                 appId: appId,
-                error: e.message,
+                error: e.message ?: e.toString(),
                 backup: backup,
                 restoreHint: isRetryExhaustion ?
                     "If hub_get_app_config confirms the operation did NOT commit, roll back via hub_restore_backup(backupKey='${backup.backupKey}')." :
@@ -11038,7 +11098,7 @@ def _applyNativeAppEdit(args) {
                         def innerResults = []
                         (pm.addTriggers as List).each { tspec ->
                             try { innerResults << _rmAddTrigger(appId, tspec as Map) }
-                            catch (Exception e) { innerResults << [success: false, error: e.message] }
+                            catch (Exception e) { innerResults << [success: false, error: e.message ?: e.toString()] }
                         }
                         // Outer success rolls up inner success — mark the
                         // outer entry as failed if ANY inner item failed,
@@ -11052,7 +11112,7 @@ def _applyNativeAppEdit(args) {
                         def innerResults = []
                         (pm.addActions as List).each { aspec ->
                             try { innerResults << _rmAddAction(appId, aspec as Map, true) }
-                            catch (Exception e) { innerResults << [success: false, error: e.message] }
+                            catch (Exception e) { innerResults << [success: false, error: e.message ?: e.toString()] }
                         }
                         def innerOk = innerResults.every { (it instanceof Map) && (it.success != false) && (it.partial != true) }
                         patchResults << [success: innerOk, op: "addActions", results: innerResults]
@@ -11191,7 +11251,7 @@ def _applyNativeAppEdit(args) {
                         def innerResults = []
                         (pm.replaceActions as List).each { aspec ->
                             try { innerResults << _rmAddAction(appId, aspec as Map, true) }
-                            catch (Exception e) { innerResults << [success: false, error: e.message] }
+                            catch (Exception e) { innerResults << [success: false, error: e.message ?: e.toString()] }
                         }
                         def innerOk = innerResults.every { (it instanceof Map) && (it.success != false) && (it.partial != true) }
                         patchResults << [success: innerOk, op: "replaceActions", removedIndices: cleared, addedResults: innerResults]
@@ -11756,6 +11816,19 @@ def _applyNativeAppEdit(args) {
         if (editDone?.done == false) {
             result.mainPageDoneFailed = true
             result.mainPageDoneError = editDone.reason
+            // Flip success ONLY for commitButton:null app types (Basic Rule, Button Controller),
+            // where this Done is the edit's ONLY commit channel -- a miss means nothing committed.
+            // For RM-family apps the edit already committed through another channel (a button click
+            // like pausRule via /installedapp/btn, or a main-page settings write's auto-updateRule),
+            // so a missed trailing Done is a state-marker-cleanup caveat (surfaced via the
+            // repairHint), NOT a failure -- flipping success there would be a false negative for a
+            // completed action. (finalConfig.app.appType.name is live-confirmed populated on the
+            // base configure/json endpoint; _resolveCommitButton fails safe to non-null on a
+            // degraded/absent name, i.e. toward NOT flipping.)
+            if (_resolveCommitButton(finalConfig?.app?.appType?.name?.toString()) == null) {
+                result.success = false
+            }
+            result.repairHints = (result.repairHints ?: []) + ["The session-end mainPage Done click did not commit (${editDone.reason}). Settings are already written, but the app's update lifecycle did not run -- verify via hub_get_app_config(appId=${appId}) and re-commit via hub_set_native_app(appId=${appId}, button='updateRule') for RM-family apps.".toString()]
         }
         return result
     } catch (Exception e) {
@@ -11816,7 +11889,7 @@ def toolDeleteNativeApp(args) {
         return [
             success: false,
             appId: appId,
-            error: e.message,
+            error: e.message ?: e.toString(),
             backup: backup
         ]
     }

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -136,7 +136,7 @@ Requires the Write master + confirm=true + recent hub backup.""",
                     pageName: [type: "string", description: "Optional sub-page for schema introspection + settings POST."],
                     stateAttribute: [type: "string", description: "Optional state attribute value for the button click."],
                     buttonRule: [type: "object", description: "Create a Button Rule under an existing Button Controller.[[FLAT_TRIM]] Routes through the controller's add-button flow; returns buttonRuleId with the Button trigger auto-seeded — author its actions via hub_set_rule(appId=buttonRuleId, addAction=...). The controller must already have a button device assigned.[[/FLAT_TRIM]]", properties: [controllerId: [type: "integer", description: "Button Controller-5.1 appId"], buttonNumber: [type: "integer", description: "button number (>=1)"], event: [type: "string", enum: ["pushed", "held", "doubleTapped", "released"]]]],
-                    walkStep: [type: "object", description: "Generic classic-dynamicPage walker.[[FLAT_TRIM]] introspect/write/click/done, one step per call, for stateful multi-page classic apps; same shape as hub_set_rule's walkStep — see hub_get_tool_guide(section='set_rule_reference'). For Rule Machine RULES use hub_set_rule.[[/FLAT_TRIM]]"],
+                    walkStep: [type: "object", description: "Generic classic-dynamicPage walker for stateful multi-page classic apps -- introspect/write/click/navigate/done one step per call, or operation='drive' with steps=[...] to run the whole sequence in one call. Same shape as hub_set_rule's walkStep (see hub_get_tool_guide(section='set_rule_reference')). For Rule Machine RULES use hub_set_rule."],
                     confirm: [type: "boolean", description: "Must be true. Safety gate for Write master operations."]
                 ],
                 required: ["confirm"]
@@ -194,74 +194,47 @@ Requires the Write master + confirm=true + recent hub backup.""",
                     stateAttribute: [type: "string", description: "Optional state attribute value for the button click (e.g. trigger/action index for RM editCond/editAct)."],
                     addTrigger: [
                         type: "object",
-                        description: """Add a Rule Machine TRIGGER to the rule via the high-level structured API. DISCRIMINATOR: use `capability` (NOT `type`) -- callers passing `{type: 'switch', ...}` will get "addTrigger.capability is required. Common values: Switch, Motion, Contact, Time, Periodic Schedule, Mode, Custom Attribute. Pass {discover: true} to get the full structured schema.". Pass `addTrigger: {discover: true}` for the live per-capability schema, or call `hub_get_tool_guide(section='set_rule_reference')` for the `addTrigger` families reference. The tool orchestrates the full RM 5.1 wizard internally -- discovers next index, opens editor, walks the schema-aware writes, commits via hasAll, and auto-finalizes the residual isCondTrig prompt. Returns the assigned trigger index in result.triggerIndex. updateRule fires automatically after the commit so subscriptions populate immediately -- no separate button call needed.[[FLAT_TRIM]] (Exception: if updateRule itself is rejected the response carries `subscriptionsNotLive: true` -- see PARTIAL-SUCCESS HANDLING for the recovery path.)[[/FLAT_TRIM]] (Bulk addTriggers[] fires updateRule once at the end of the batch.)
+                        description: """Add a Rule Machine TRIGGER via the high-level structured API. DISCRIMINATOR: use `capability` (NOT `type`) -- `{type: 'switch', ...}` is rejected with "addTrigger.capability is required". Pass `addTrigger: {discover: true}` for the live per-capability schema, or `hub_get_tool_guide(section='set_rule_reference')` for the `addTrigger` families reference. The tool orchestrates the full RM 5.1 wizard internally (discover index, walk the schema-aware writes, commit, auto-finalize the residual isCondTrig prompt) and fires updateRule so subscriptions populate; returns result.triggerIndex. Bulk addTriggers[] fires updateRule once at the end.
 
-[[FLAT_TRIM]]
-Capability families (NAMES here; full per-field specs via addTrigger:{discover:true} or hub_get_tool_guide(section='set_rule_reference')): Device-state (Switch / Motion / Contact / Lock / Garage / Door / Valve / Window Shade / Presence / Power source) = capability + deviceIds + state, optional allOfThese for "all of these"; Numeric (Temperature / Humidity / Battery / Illuminance / Power / Energy / CO2 / Dimmer / Thermostat setpoints) = capability + deviceIds + comparator + value; Button = capability='Button' + deviceIds + buttonNumber + state; Custom Attribute = capability='Custom Attribute' + deviceIds + attribute + comparator + value; Time / Sunrise / Sunset = capability='Certain Time (and optional date)' + time + atTime ('HH:mm' = daily-recurring, full ISO datetime = one-shot dated) + offset; Mode = capability='Mode' + state (name) or modeIds; Periodic Schedule = capability='Periodic Schedule' + periodic={frequency, everyN, ...}. Modifier: andStays={hours,minutes,seconds} on any device-state/numeric trigger.
-[[/FLAT_TRIM]]
+Capability families (NAMES; full per-field specs via discover:true or the guide): Device-state (Switch / Motion / Contact / Lock / Garage / Door / Valve / Window Shade / Presence / Power source), Numeric (Temperature / Humidity / Battery / Illuminance / Power / Energy / CO2 / Dimmer / Thermostat setpoints), Button, Custom Attribute, Time / Sunrise / Sunset, Mode, Periodic Schedule. Modifiers: andStays, allOfThese.
 
-Optional fields on every spec:
-  - conditional (default false) — sets isCondTrig.<N>=true. Combine with `condition` below to bind the conditional-trigger gate in one call; or set conditional=true alone to leave the gate empty for later.
-  - condition — Map driving the conditional-trigger sub-wizard: {capability, deviceIds?, variable?, compareToVariable?, state?, comparator?, value?, attribute?, not?, rawSettings?} (handled inline; no separate call). `conditional` is implied true when set. Custom Attribute needs attribute+comparator[[FLAT_TRIM]] (for an enum-recognized attribute RM routes the value to the picker and omits the comparator -- correct, not a lost value)[[/FLAT_TRIM]]; Variable needs variable (+ compareToVariable for a variable-vs-variable RHS, mutually exclusive with value).[[FLAT_TRIM]] NOTE: trigger.condition supports a NARROWER set than addRequiredExpression/addAction — Variable, Custom Attribute, and enum/numeric device-state only; Mode-via-picker, Between two times, and compareToDevice are NOT supported here (use addRequiredExpression for those).[[/FLAT_TRIM]] Wire-format details: guide:true.
-  - rawSettings — escape hatch dict {fieldName: value} for advanced fields not yet mapped (e.g. ButtontDev<N> overrides, alternative attribute pickers, etc.). Use `@N` token to substitute the auto-assigned trigger/condition index — e.g. {'xVar@N': 'myVar'} writes `xVar1` when the trigger lands at index 1.
+Optional on every spec:
+  - conditional — sets isCondTrig.<N>; combine with `condition` to bind the conditional-trigger gate in one call, or set alone to leave it empty.
+  - condition — Map {capability, deviceIds?, variable?, compareToVariable?, state?, comparator?, value?, attribute?, not?, rawSettings?} (selectTriggers supports a NARROWER set than addRequiredExpression/addAction — see guide).
+  - rawSettings — escape hatch {fieldName: value} using the `@N` token for the auto-assigned index, e.g. {'xVar@N': 'myVar'} writes `xVar1` when the trigger lands at index 1.
 
-Trigger index is auto-assigned (next available). The wizard's auto-finalize via isCondTrig.<N>=false fires unless conditional=true. One add_trigger call replaces the 6-8 calls of the manual wizard flow.
-
-PARTIAL-SUCCESS: success:true can come with partial:true -- check partial/repairHints in the response (full protocol: guide:true).[[FLAT_TRIM]] DETAIL: success:true = the call completed and the trigger skeleton was written; partial:true (orthogonal) = some fields didn't land or the row carries a *BROKEN* marker — the trigger exists but needs repair via repairHints. Common repair: pass missing fields via rawSettings and re-add, or walkStep introspect on selectTriggers to see the live fields. Don't treat partial as failure — exhaust tool-only repair first. On a rejected trailing updateRule the trigger is written but not subscribed (subscriptionsNotLive:true) — retry hub_set_rule(button='updateRule', confirm=true). Full slot reference: guide:true.[[/FLAT_TRIM]]"""
+PARTIAL-SUCCESS: success:true can come with partial:true — check partial/repairHints; on a rejected trailing updateRule the trigger is written but not subscribed (subscriptionsNotLive:true), retry hub_set_rule(button='updateRule', confirm=true). Full protocol: guide:true or hub_get_tool_guide(section='set_rule_reference')."""
                     ],
                     addTriggers: [
                         type: "array",
-                        description: "Bulk-add multiple triggers in one tool call. Each item is the same shape as addTrigger. updateRule fires ONCE at the end (not after each trigger), so subscriptions populate from a fully-loaded rule. Pairs naturally with addActions for building a complete rule in a single call. Empty/omitted falls back to the single addTrigger path. On a rejected post-bulk updateRule the adds are committed but not subscribed (subscriptionsNotLive:true) — retry hub_set_rule(button='updateRule', confirm=true); full slot reference: guide:true.",
+                        description: "Bulk-add multiple triggers in one call (each item the same shape as addTrigger). updateRule fires ONCE at the end, so subscriptions populate from a fully-loaded rule; pairs with addActions to build a whole rule in one call. Empty/omitted falls back to single addTrigger. On a rejected post-bulk updateRule: subscriptionsNotLive:true — retry hub_set_rule(button='updateRule', confirm=true).",
                         items: [type: "object"]
                     ],
                     addRequiredExpression: [
                         type: "object",
-                        description: """Add a Rule Machine 5.1 Required Expression (RM's pre-trigger gate that conditions whether the rule is allowed to fire) via the high-level structured API. The tool orchestrates STPage's full wizard internally (per-condition reveal walk, hasAll/hasRule commit, back-nav Done) and fires updateRule. Returns the assigned condition indices in result.conditionIndices.
+                        description: """Add a Rule Machine 5.1 Required Expression (RM's pre-trigger gate conditioning whether the rule may fire) via the high-level structured API. The tool orchestrates STPage's full wizard internally and fires updateRule; returns result.conditionIndices.
 
-Spec: {conditions:[{capability, deviceIds?, state?, comparator?, value?, attribute?, not?}, ...], operator:'AND'|'OR'|'XOR' OR operators:[...] (one per gap)}. For per-condition field rules, all extended per-capability shapes (Mode, Between two times, Variable incl. compareToVariable, device-relative compareToDevice, nested subExpression), the full STPage capability list, and the partial-success/failure contract, pass guide:true or hub_get_tool_guide(section='set_rule_reference').
-[[FLAT_TRIM]]
-RM 5.1 spec: AND/OR/XOR have equal precedence, evaluated left-to-right. Use `operators` (list) for mixed-operator expressions like 'P1 AND P2 OR P3 XOR P4'.
+Spec: {conditions:[{capability, deviceIds?, state?, comparator?, value?, attribute?, not?, rawSettings?}, ...], operator:'AND'|'OR'|'XOR' OR operators:[...] (one per gap, for mixed expressions; equal precedence, left-to-right)}. comparator is REQUIRED with attribute for Custom Attribute, and with variable+value for Variable (ASCII !=/<>/== auto-map to RM glyphs). For the full STPage capability list, all extended per-capability shapes (Mode, Between two times, Variable incl. compareToVariable, device-relative compareToDevice, nested subExpression) and the partial-success/failure contract, pass guide:true or hub_get_tool_guide(section='set_rule_reference').
 
-Per-condition spec fields:
-  - capability — required (full STPage capability list: guide:true).
-  - deviceIds — required for device capabilities (Switch / Motion / Contact / Lock / Temperature / etc.); omit for non-device capabilities (Mode, Private Boolean, Last Event Device, time-based).
-  - state — enum value matching the capability ('on'/'off' Switch, 'active'/'inactive' Motion, 'open'/'closed' Contact, 'locked'/'unlocked' Lock, etc.); omit for numeric.
-  - comparator — numeric capabilities ('=', '<', '>', '<=', '>=', '!='); REQUIRED together with attribute for Custom Attribute, and with variable+value for Variable (ASCII !=/<>/== auto-map to RM glyphs).
-  - value — numeric threshold paired with comparator.
-  - attribute — Custom Attribute name (e.g. 'humidity'); REQUIRED and paired with comparator. Example: {capability:'Custom Attribute', deviceIds:[N], attribute:'water', comparator:'=', state:'empty'}. For an attribute the hub recognizes as an ENUM (switch/motion/contact/lock/...), RM routes the value to the enum picker and omits the comparator -- that is correct for a value comparator, not a lost value. A no-RHS state-change comparator (`*changed*`/`*became*`) cannot be represented on an enum attribute (no comparator slot, no value); use the device's native capability instead (e.g. capability:'Switch'), or a non-built-in attribute name (see hub_get_tool_guide section='set_rule_reference').
-  - not — boolean (default false), inverts the condition.
-  - rawSettings — escape hatch {fieldName: value} for fields not yet mapped.
-
-The wizard walks each condition's reveal sequence (cond=a -> rCapab_<N> -> rDev_<N> -> state_<N> / numeric comparator -> optional NOT), commits via hasAll, writes the joining operator between conditions, finalizes via hasRule, and submits the back-nav Done. The expression text on mainPage renders as e.g. "Switch1 is on" (single) or "Switch1 is on AND Motion1 is active" (multi). updateRule fires after the expression commits so the rule's evaluator picks up the gate immediately. The cond counter is shared at the Rule Machine parent app's atomicState level (the parent app's id varies per hub) -- condition indices may not start at 1 (verified live on the second rule of a session: cond=['2'] is normal, not a bug).
-
-PARTIAL-SUCCESS: partial:true / expressionNotLive / wizardStuck can accompany success -- check repairHints. partial:true means some condition fields didn't land (settingsSkipped names them); repairHints names the next step -- pass missing fields via rawSettings on the affected condition. On a rejected trailing updateRule the expression is committed but not live (expressionNotLive:true) -- retry hub_set_rule(button='updateRule', confirm=true). If wizardStuck:true the wizard couldn't auto-cancel -- call hub_set_rule(button='cancelCapab', pageName='STPage', confirm=true) first (restoreHint has the exact command). Discrete-event sensor state names (wet/dry, detected/clear, etc.) and the full settingsSkipped-sentinel reference: guide:true.[[/FLAT_TRIM]]"""
+PARTIAL-SUCCESS: partial:true / expressionNotLive / wizardStuck can accompany success — check repairHints; on a rejected trailing updateRule the expression is committed but not live (expressionNotLive:true), retry hub_set_rule(button='updateRule', confirm=true). If wizardStuck:true call hub_set_rule(button='cancelCapab', pageName='STPage', confirm=true) first (restoreHint has the exact command)."""
                     ],
                     replaceRequiredExpression: [
                         type: "object",
-                        description: """Replace an existing RM 5.1 Required Expression in place (same appId, no clone) -- whole-expression replace. Same spec as addRequiredExpression ({conditions:[...], operator|operators}); use addRequiredExpression to ADD one when the rule has none (this refuses with requiredExpressionMissing if there is nothing to replace). For per-capability condition shapes and the full partial-success/failure contract pass guide:true or hub_get_tool_guide(section='set_rule_reference').[[FLAT_TRIM]]
-
-Replace an EXISTING Rule Machine 5.1 Required Expression IN PLACE (same appId, no clone). Same spec shape as addRequiredExpression -- {conditions:[...], operator|operators} -- so the new expression can be single-condition, multi-condition, or nested. Use this when a rule ALREADY has a Required Expression and you want to change it; to ADD one to a rule that has none, use addRequiredExpression instead. The tool deletes the whole committed expression, then builds the new condition(s) through the same validated walker addRequiredExpression uses, and fires updateRule. Semantics are WHOLE-expression replace, matching addRequiredExpression's add semantics. Per-condition spec fields and extended capability shapes are identical to addRequiredExpression (guide:true for the full reference).
-
-replaceRequiredExpression refuses (success:false, requiredExpressionMissing:true) when there is no committed expression to replace, so the replace-vs-add intent is never silently swapped. On a clean success returns requiredExpressionReplaced:true plus the same conditionIndices / settingsApplied / settingsSkipped / partial envelope as addRequiredExpression. The delete is destructive, but the entire spec is validated BEFORE it so a malformed spec leaves the existing expression intact; UNLIKE addRequiredExpression the replace path never leaves a committed-but-not-live result -- any failure AFTER the delete (including a rejected trailing updateRule) auto-restores the pre-op backup and returns requiredExpressionReplaced:false. Auto-restore reports requiredExpressionRestored:true when the original expression was put back in place, or false when it could not be (no backup / unconfirmed replay, rule may be left ungated / recreated under requiredExpressionRestoredAs). A failed replace is always reported, never silent data loss.[[/FLAT_TRIM]]"""
+                        description: """Replace an existing RM 5.1 Required Expression in place (same appId, no clone) -- whole-expression replace. Same spec as addRequiredExpression ({conditions:[...], operator|operators}); use addRequiredExpression to ADD one when the rule has none (this refuses with requiredExpressionMissing if there is nothing to replace). The delete is destructive, but the entire spec is validated BEFORE it (a malformed spec leaves the existing expression intact) and any failure after the delete -- including a rejected trailing updateRule -- auto-restores the pre-op backup (requiredExpressionRestored): a failed replace is always reported, never silent data loss. Per-condition shapes and the full partial-success/failure contract: guide:true or hub_get_tool_guide(section='set_rule_reference')."""
                     ],
 
                     addActions: [
                         type: "array",
-                        description: "Bulk-add multiple actions in one tool call. Each item is the same shape as addAction. updateRule fires ONCE at the end (not after each action), so subscriptions populate from a fully-loaded rule (actions self-bake via doActPage->selectActions per-item). Pairs naturally with addTriggers -- pass both to add many triggers + many actions in a single tool call. On a rejected post-bulk updateRule the adds are committed but not subscribed (subscriptionsNotLive:true) — retry hub_set_rule(button='updateRule', confirm=true); full slot reference: guide:true.",
+                        description: "Bulk-add multiple actions in one call (each item the same shape as addAction; actions self-bake via doActPage). updateRule fires ONCE at the end. Pairs with addTriggers to add many triggers + actions in one call. On a rejected post-bulk updateRule: subscriptionsNotLive:true — retry hub_set_rule(button='updateRule', confirm=true).",
                         items: [type: "object"]
                     ],
                     addLocalVariable: [
                         type: "object",
-                        description: """Add a local variable to the rule. Spec: {name, type, value} where:
-  - name: variable name (used as %name% in actions/expressions)
-  - type: 'Number' | 'Decimal' | 'String' | 'Boolean' | 'DateTime' (case-insensitive)
-  - value: initial value matching the type (Number/Decimal want numeric; String wants text; Boolean wants true/false; DateTime wants ISO timestamp)
-
-Variables live in state.allLocalVars (NOT appSettings); read via /installedapp/statusJson/<appId>'s appState.allLocalVars to verify. Returns success=false with repair hints if value/type mismatch causes RM to silently reject. Verified live for all 5 types."""
+                        description: "Add a local variable. Spec: {name, type, value} where type is one of Number/Decimal/String/Boolean/DateTime (case-insensitive) and value matches the type (DateTime wants an ISO timestamp). Used as %name% in actions/expressions; stored in state.allLocalVars (verify via statusJson appState.allLocalVars, not appSettings). Returns success=false with repair hints if a value/type mismatch makes RM silently reject."
                     ],
                     patches: [
                         type: "array",
-                        description: """Atomic multi-mutation. Each item is a sub-spec dict with one operation key chosen from: settings, button, addTrigger, addTriggers, addAction, addActions, addRequiredExpression, replaceRequiredExpression, addLocalVariable, removeAction, clearActions, replaceActions, moveAction. Operations run sequentially; updateRule fires ONCE at the end. Useful for combined "add RE + add action + edit local var" patterns. Each patch's result is reported in patches[i] with its op name and outcome — failures on individual ops don't abort the rest.""",
+                        description: "Atomic multi-mutation: each item is a sub-spec with ONE operation key (settings, button, addTrigger(s), addAction(s), addRequiredExpression, replaceRequiredExpression, addLocalVariable, removeAction, clearActions, replaceActions, moveAction). Operations run sequentially; updateRule fires ONCE at the end. Per-op outcome in patches[i]; an individual op failing doesn't abort the rest.",
                         items: [type: "object"]
                     ],
                     removeAction: [
@@ -270,11 +243,11 @@ Variables live in state.allLocalVars (NOT appSettings); read via /installedapp/s
                     ],
                     clearActions: [
                         type: "boolean",
-                        description: "Pass true to delete every action on the rule (highest index first). Useful for the 'wipe and rebuild' pattern. The delete commits synchronously (a full selectActions page-form submit runs RM's trashActs handler in-band), so the actions are gone when the call returns. updateRule fires after the clear. Defensive recovery (rare): if the response carries asyncCommitLikely:true the clear may have committed late — verify via hub_get_app_config(appId) and do NOT call cancelTrash (it can commit pending deletes); full protocol: guide:true."
+                        description: "Pass true to delete every action (highest index first) -- the 'wipe and rebuild' pattern. The delete commits synchronously; updateRule fires after. Rare late-commit recovery (asyncCommitLikely:true): verify via hub_get_app_config(appId), do NOT call cancelTrash (it can commit pending deletes); full protocol: guide:true."
                     ],
                     replaceActions: [
                         type: "array",
-                        description: "Atomically replace the rule's entire action list. Internally: clears all existing actions (synchronous trashActs submit), then bulk-adds every spec in this list (same shape as addAction items), then fires updateRule once. Useful for updating existing actions or reordering by passing actions in the new order. Pass [] to clear all actions without adding new ones (equivalent to clearActions=true). Defensive recovery (rare): if the response carries asyncCommitLikely:true the inner clear may have committed late and the add half is skipped (original specs echoed as pendingActionsToAdd) — verify via hub_get_app_config(appId), re-add the echoed specs if the clear committed, and do NOT call cancelTrash; full protocol: guide:true.",
+                        description: "Atomically replace the rule's entire action list: clears all existing actions, bulk-adds every spec here (same shape as addAction items), then fires updateRule once. Useful for editing or reordering; pass [] to clear all (equivalent to clearActions=true). Rare late-commit recovery (asyncCommitLikely:true): verify via hub_get_app_config(appId), re-add the echoed pendingActionsToAdd, do NOT call cancelTrash; full protocol: guide:true.",
                         items: [type: "object"]
                     ],
                     moveAction: [
@@ -287,56 +260,29 @@ Variables live in state.allLocalVars (NOT appSettings); read via /installedapp/s
                     ],
                     modifyTrigger: [
                         type: "object",
-                        description: "Change the state field of an existing trigger. Pass {index: <N>, mods: {state: '<new-state>'}}. Opens the editCond wizard for that trigger, writes tstate<N>, commits via hasAll, and fires updateRule. Scope: only the 'state' field is supported. To change a trigger's capability or deviceIds, use removeTrigger + addTrigger instead. Note: only device-state triggers (Switch, Motion, Contact, Lock, Presence, etc.) expose a state field. Time, Periodic Schedule, and Mode triggers don't have a state value -- attempting modifyTrigger on those will throw with a descriptive error suggesting removeTrigger + addTrigger as the workaround."
+                        description: "Change the state field of an existing trigger: {index: <N>, mods: {state: '<new-state>'}}. Opens editCond, writes tstate<N>, commits, fires updateRule. Only the 'state' field is supported, and only device-state triggers (Switch, Motion, Contact, Lock, Presence, ...) expose one -- Time/Periodic/Mode triggers throw with a removeTrigger+addTrigger workaround hint. To change capability or deviceIds, use removeTrigger + addTrigger."
                     ],
                     walkStep: [
                         type: "object",
-                        description: """Schema-aware single-step wizard walker. Use this when the high-level addAction/addTrigger helpers don't cover the capability you need (e.g. Periodic Schedule sub-pages, conditional trigger binding, IF/THEN/ELSE flow control, RM features added in a later firmware). Each call performs one operation on one wizard page and returns a structured snapshot — schema before/after, schema diff (which inputs appeared/disappeared), value-echo (catches silent enum case normalization), sub-page hrefs, list-count change for actions/triggers (disambiguates 'committed' from 'broke and lost the row'), full health check.
+                        description: """Schema-aware wizard walker -- the escape hatch when the high-level addAction/addTrigger helpers don't cover the capability (Periodic Schedule sub-pages, conditional-trigger binding, IF/THEN/ELSE flow control, later-firmware features).
 
-Spec shape:
-  {
-    page: <page name>,           // e.g. "selectTriggers", "selectActions", "doActPage", "mainPage", "periodic"
-    operation: "introspect" | "write" | "click" | "navigate" | "done",
-    write?: {<schemaFieldName>: <value>},          // exactly one key per call
-    click?: {name: <btnName>, stateAttribute?},    // for buttons
-    navigate?: {targetPage: <page>},               // forward sub-page entry via href
-    validateEnum?: <bool>,                         // when true, reject writes whose value isn't in the input's options list
-    hrefContext?: {fromPage, hrefName, hrefParams?, hrefIndex?}  // sub-page state + back-nav target
-  }
+PREFERRED -- operation='drive' runs the whole loop in ONE call: pass steps=[ {operation, page?, write?/click?/navigate?/done?, hrefContext?}, ... ] and the tool performs them in order (introspect → navigate into a sub-page → write each field → done → finalize), carrying the page forward across navigate/done and stopping at the first failed step (stopOnError=false to continue). Returns {steps:[per-step diff/valueEcho/health], success, health}. This does the progressive loop for you instead of issuing N separate calls.
 
-Operations:
+Single-step operations (the primitives drive composes; call directly for fine control): introspect (fetch schema, no mutation) | write (one field, exactly one key per call) | click (a regular button: cancelCapab, hasAll, moreCond, ...) | navigate (forward into a sub-page via its href) | done (BACK-navigate to the parent via _action_previous=Done, carrying the sub-page's settings; REQUIRED for sub-pages like Periodic whose parent row otherwise renders "?" -- pass hrefContext={fromPage:<parent>, hrefParams:{n:<idx>}}).
 
-[[FLAT_TRIM]]
-  - introspect: fetch schema; no mutation
-  - write: write one field's value (with hrefContext for sub-pages)
-  - click: click a regular button (cancelCapab, hasAll, moreCond, etc.)
-  - navigate: forward into a sub-page via its href
-[[/FLAT_TRIM]]
-  - done: BACK-NAVIGATE from a sub-page to its parent via _action_previous=Done. Carries ALL the sub-page's current settings in the form. REQUIRED for sub-pages (Periodic Schedule, etc.) whose parent's row description otherwise renders as "?". Pass hrefContext={fromPage: <parent>, hrefParams: {n: <idx>}} so RM routes correctly.
-
-Recommended driving loop (introspect to see fields -> navigate into a sub-page if exposed -> write each required field -> inspect diff.appeared/valueEcho.match/silentRejection -> done to bake the row -> click hasAll/actionDone to finalize): full walkthrough via guide:true or hub_get_tool_guide(section='set_rule_reference').
-
-Always check `silentRejection`, `valueEcho.match`, and `health.ok` in the response — these are the fail-loud signals."""
+Spec: {page, operation, write?:{<field>:<value>}, click?:{name, stateAttribute?}, navigate?:{targetPage}, validateEnum?, hrefContext?:{fromPage, hrefName, hrefParams?, hrefIndex?}, steps?:[...] (drive)}; page is e.g. selectTriggers/selectActions/doActPage/mainPage/periodic. Always check `silentRejection`, `valueEcho.match`, `health.ok` -- the fail-loud signals. Full reference: guide:true or hub_get_tool_guide(section='set_rule_reference')."""
                     ],
                     addAction: [
                         type: "object",
-                        description: """Add a Rule Machine ACTION to the rule via the high-level structured API. DISCRIMINATOR: use `capability` (NOT `type`) -- callers passing `{type: 'log', ...}` will get "addAction.capability is required (e.g. 'switch'). Common values: switch, dimmer, color, log, notification, mode, setVariable, runCommand, delay, repeat, ifThen. Pass {discover: true} to get the full structured schema.". Per-capability field specs: docs/rm_action_subtype_schemas.md (or pass `addAction: {discover: true}` for the live structured schema -- returns immediately, no hub mutation). Parallel to addTrigger but for the doActPage wizard. The tool orchestrates the full RM 5.1 action-wizard internally -- initializes state.actNdx, discovers the next action index, opens the editor (button=N with the correctly-concatenated stateAttribute=doActN), walks the schema-aware writes for category-specific fields, and commits via actionDone. Returns the assigned action index in result.actionIndex. No trailing updateRule call is needed from the caller: doActPage->selectActions navigation self-bakes the action into the rule's actions[] map.
+                        description: """Add a Rule Machine ACTION via the high-level structured API. DISCRIMINATOR: use `capability` (NOT `type`) -- `{type: 'log', ...}` is rejected with "addAction.capability is required (e.g. 'switch')". Pass `addAction: {discover: true}` for the live per-field schema (returns immediately, no hub mutation), or see docs/rm_action_subtype_schemas.md / hub_get_tool_guide(section='set_rule_reference'). The tool orchestrates the full RM 5.1 action wizard internally; returns result.actionIndex (no trailing updateRule needed -- doActPage self-bakes the action).
 
-[[FLAT_TRIM]]
-Capability families (NAMES here; full per-field specs via addAction:{discover:true} or hub_get_tool_guide(section='set_rule_reference')): switch (on/off/toggle/flash, setPerMode/choosePerMode); dimmer (setLevel/toggle/adjust/fade/stopFade/startRaiseLower/stopChanging/setLevelPerMode); color; colorTemp; button (push/pushPerMode/choosePerMode); runCommand (any driver command + deviceIds + parameters, literal or hub-variable-sourced); lock; thermostat; shade; fan; mode (setMode + modeName or modeId); setVariable (variable + value or sourceVariable); log / notification / httpGet / httpPost / ping; volume / mute / chime / siren; privateBoolean / runRule / cancelTimers / pauseRule (+ ruleIds); capture / restore / refresh / poll / disableDevice; fileWrite / fileAppend / fileDelete; zwavePoll; flow control (delay [hours/minutes/seconds or a variable-sourced seconds] / delayPerMode / cancelDelay / repeat / stopRepeat / repeatWhile / waitExpression / waitEvents / ifThen / elseIf / else / endIf / exitRule / comment). Most take deviceIds + action + fields; the expression-based ones (ifThen / elseIf / repeatWhile / waitExpression) take expression={conditions:[...], operator|operators}.
-[[/FLAT_TRIM]] LIMIT: only ONE waitEvents action per rule (RM stores wait events globally, not per-action).
+Capability families (NAMES; full per-field specs via discover:true or the guide): switch, dimmer, color, colorTemp, button, runCommand, lock, thermostat, shade, fan, mode, setVariable, log / notification / httpGet / httpPost / ping, volume / mute / chime / siren, privateBoolean / runRule / cancelTimers / pauseRule, capture / restore / refresh / poll / disableDevice, fileWrite / fileAppend / fileDelete, zwavePoll, and flow control (delay / delayPerMode / cancelDelay / repeat / stopRepeat / repeatWhile / waitExpression / waitEvents / ifThen / elseIf / else / endIf / exitRule / comment). The expression-based ones (ifThen / elseIf / repeatWhile / waitExpression) take expression={conditions:[...], operator|operators}. LIMIT: only ONE waitEvents action per rule (RM stores wait events globally, not per-action).
 
-  Per-condition shape inside any expression:
-    {capability: <RM-condition-cap>, deviceIds?: [<id>], state?: <enum-value>, comparator?: <op>, value?: <num>, attribute?: <name>, not?: true, rawSettings?: {...}}[[FLAT_TRIM]]
-    Convenience: pass singular deviceId: N instead of deviceIds: [N] -- the dispatcher normalizes because RM 5.1 expects the array form in rDev_<N> (bare integer bypasses pre-validation and silently stores {N: null}, rule renders but never fires). If both are provided, deviceIds wins.[[/FLAT_TRIM]]
-    [[FLAT_TRIM]]Nested subExpression: NOT supported on addAction -- rejected with a targeted error. Use addRequiredExpression for nested expressions, or flatten. The doActPage walker rejects nested subExpression with the message "nested subExpression on this row is not yet supported"; the addAction pre-pass also rejects to surface a clear error before any wizard write. addRequiredExpression supports nesting of arbitrary depth today.[[/FLAT_TRIM]]
-    Extended per-capability shapes (Mode, Between two times, Variable, Custom Attribute, compareToDevice) and discrete-event sensor state names: pass guide:true or hub_get_tool_guide(section='set_rule_reference') -- the shared walker _rmWalkConditionReveal handles all per-capability reveal sequences here; result envelopes differ per tool (see PARTIAL-SUCCESS HANDLING below).
+Per-condition shape inside any expression: {capability, deviceIds?, state?, comparator?, value?, attribute?, not?, rawSettings?}. Pass singular deviceId:N or deviceIds:[N] (array form preferred -- a bare integer silently stores {N: null}). Nested subExpression is NOT supported here (use addRequiredExpression). Extended per-capability shapes (Mode, Between two times, Variable, Custom Attribute, compareToDevice) and discrete-event state names: guide:true.
 
-Optional on any spec: delay {hours, minutes, seconds, cancelable}; rawSettings {fieldName: value, ...} escape hatch — use the '@N' token for the auto-assigned action index (e.g. {'flashRate.@N': 750}). Action index is auto-assigned. Variable-sourced values (dimmer setLevel levelVariable, delay variable), the HSM/Garage/Valve "not yet mapped" rawSettings workarounds, and the doActPage wire-format quirks the helper handles are in the guide (guide:true).
+Optional on any spec: delay {hours, minutes, seconds, cancelable}; rawSettings {fieldName: value} escape hatch using the '@N' token for the auto-assigned action index (e.g. {'flashRate.@N': 750}). Variable-sourced values and the not-yet-mapped capability workarounds (HSM/Garage/Valve): guide:true.
 
-PARTIAL-SUCCESS HANDLING: partial:true is orthogonal to success — the action row exists but needs repair; repairHints names next steps. Common repair: walkStep introspect on doActPage to see the live schema, then write the missing fields; for unrecoverable rows (hubRenderError=true) use removeAction(index:N) then retry. Full settingsSkipped-sentinel + not-live slot reference: guide:true.
-
-On failure, wizardStuck: true means the wizard could not be auto-cancelled -- call hub_set_rule(button='cancelCapab', pageName='doActPage', confirm=true) before retry; restoreHint has the exact command."""
+PARTIAL-SUCCESS: partial:true is orthogonal to success — the action row exists but needs repair (repairHints names next steps); for unrecoverable rows (hubRenderError=true) use removeAction(index:N) then retry. On failure wizardStuck:true means call hub_set_rule(button='cancelCapab', pageName='doActPage', confirm=true) before retry (restoreHint has the exact command). Full protocol: guide:true."""
                     ],
                     guide: [type: "boolean", description: "Set true to return the full hub_set_rule capability reference (trigger/action/expression families, extended condition shapes, the raw settings/button wizard flow, and walkStep) inline — same content as hub_get_tool_guide(section='set_rule_reference'), without a separate tool call. Makes NO change to any rule."],
                     buttonRule: [type: "object", description: "Create a Button Rule under an existing Button Controller (RM-family).[[FLAT_TRIM]] Routes through the controller's add-button flow; returns buttonRuleId with the Button trigger auto-seeded — then author actions with addAction on that appId. Controller must already have a button device. Same handler as hub_set_native_app.buttonRule.[[/FLAT_TRIM]]", properties: [controllerId: [type: "integer", description: "Button Controller-5.1 appId"], buttonNumber: [type: "integer", description: "button number (>=1)"], event: [type: "string", enum: ["pushed", "held", "doubleTapped", "released"]]]],
@@ -427,20 +373,7 @@ On failure, wizardStuck: true means the wizard could not be auto-cancelled -- ca
         ],
         [
             name: "hub_get_rule_health",
-            description: """Inspect a rule's current state and return a structured health report — the LLM uses this to detect broken rules without having to investigate via curl. Works for Rule Machine, Visual Rules Builder, and other classic apps (Button Controller, Basic Rule) — which share RM's configPage protocol, so the configPage checks (e.g. configPage.error, multiple-flag poison) cover them.[[FLAT_TRIM]] Preferred source is the rule's compiled state: the classic RM `broken` boolean (GET /app/ruleBuilderJson), or a graph Visual Rule's validationErrors (GET /app/ruleBuilder20Json) — VRB rules are rules too, validationErrors is their broken-equivalent. For classic RM the HTML render scan is retained as cross-check + fallback. `ruleFormat` says which engine answered. Surfaces:
-
-  - broken: authoritative compiled-state boolean — RM compiled `broken`, or (graph VRB) validationErrors non-empty; null when no boolean applies (classic VRB, or the source is unavailable)
-  - validationErrors: graph Visual Rule validation problems
-  - configPage.error: page render failures (often caused by multi-flag DB poisoning)
-  - label markers: '*BROKEN*' suffix RM appends when a rule has a malformed trigger or action
-  - paragraph markers: '**Broken Trigger**', '**Broken Action**', '**Broken Condition**'
-  - multiple-flag corruption: lists settings whose statusJson .multiple flag has been flipped to false despite the schema declaring multiple=true
-  - structural imbalance: walks actType.<N>/actSubType.<N> and flags IF/ELSE-IF/ELSE/END-IF or Repeat/End-Repeat blocks left unmatched by a false-failed mutation that committed post-response; RM does NOT surface this via the paragraph markers above
-  - cross-check: flags when the compiled-state boolean and the HTML markers disagree
-
-ruleFormat (rm / vrb-graph / vrb-classic / basic-rule / button-controller / classic-app) says what was inspected. Run after every mutation to confirm the change didn't leave the rule broken. Per-app event history: hub_list_device_events with appId.
-
-hub_set_rule attaches this report as `health` on every response (success AND error); hub_set_visual_rule attaches it on every response that resolves to a rule id (early CREATE failures carry no appId). brokenMarkerCounts gives per-marker occurrence counts (the replace/restore gate uses a count increase to spot a new broken instance).[[/FLAT_TRIM]] ok=false means at least one issue was found; the issues list explains what.""",
+            description: """Inspect a rule's current state and return a structured health report -- detect broken rules without curl. Works for Rule Machine, Visual Rules Builder, and other classic apps (Button Controller, Basic Rule), which share RM's configPage protocol. Prefers the rule's compiled state (RM `broken` via /app/ruleBuilderJson, or a graph VRB's validationErrors via /app/ruleBuilder20Json) with the HTML render scan as cross-check + fallback; `ruleFormat` (rm / vrb-graph / vrb-classic / basic-rule / button-controller / classic-app) says which engine answered. The report surfaces the compiled-state broken verdict, validationErrors, config-page render errors, RM *BROKEN* / **Broken Trigger|Action|Condition** markers, multiple-flag corruption, structural IF/Repeat imbalance, and a compiled-vs-HTML cross-check (full key list + brokenMarkerCounts: outputSchema below). Run after every mutation to confirm the change didn't leave the rule broken; hub_set_rule attaches it as `health` on every response. ok=false means at least one issue was found; the issues list explains what.""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -6637,6 +6570,14 @@ private Map _rmCollectWalkSchema(Map configPage, Map liveSettings = null) {
 // For "introspect" the call only fetches the schema — no mutation. The
 // `before` snapshot is the same as `after` and `diff` is empty.
 private Map _rmWalkStep(Integer appId, Map spec) {
+    // "drive" runs an ordered sequence of single-step operations in ONE call --
+    // the progressive flow that replaces the manual introspect -> navigate ->
+    // write each field -> done -> finalize loop the caller used to issue as N
+    // separate calls. Handled before the single-step page check because a drive
+    // carries its page per step, not at the top level.
+    if (spec?.operation?.toString()?.trim() == "drive") {
+        return _rmDriveWalkSteps(appId, spec)
+    }
     def page = spec?.page?.toString()?.trim()
     if (!page) throw new IllegalArgumentException("walkStep.page is required (e.g. 'selectTriggers', 'selectActions', 'doActPage', 'mainPage', 'periodic')")
     if (!page.matches(/[A-Za-z0-9_]+/)) throw new IllegalArgumentException("walkStep.page must be alphanumeric/underscore")
@@ -6929,6 +6870,73 @@ private Map _rmWalkStep(Integer appId, Map spec) {
         commitSignal: commitSignal,
         silentRejection: silentRejection,
         health: health
+    ]
+}
+
+// Auto-driver for walkStep (operation='drive'): run an ordered list of
+// single-step operations in one call, composing _rmWalkStep per step. Each
+// step is a normal walkStep spec ({operation, page?, write?/click?/navigate?/
+// done?, hrefContext?, validateEnum?}); a step that omits `page` inherits the
+// page the previous step left off on, because navigate moves to the target
+// page and done moves back to the parent. The drive stops at the first failed
+// step unless stopOnError=false, and returns an aggregate {steps:[...],
+// success, health} -- the per-step before/after schemas are omitted to keep
+// the envelope small; each step keeps its diff/valueEcho/health fail-loud
+// signals. This is the progressive flow that does the loop the LLM used to
+// drive by hand across N separate calls.
+private Map _rmDriveWalkSteps(Integer appId, Map spec) {
+    if (!(spec?.steps instanceof List) || ((List) spec.steps).isEmpty()) {
+        throw new IllegalArgumentException("walkStep operation='drive' requires a non-empty steps=[...] list, each item a single-step spec {operation, page?, write?/click?/navigate?/done?, hrefContext?}")
+    }
+    def steps = (List) spec.steps
+    def stopOnError = spec?.stopOnError != false   // default: stop at the first failed step
+    def stepResults = []
+    def currentPage = spec?.page?.toString()?.trim()
+    def allOk = true
+    def lastStepOperation = null
+    int idx = 0
+    for (def rawStep : steps) {
+        idx++
+        if (!(rawStep instanceof Map)) {
+            throw new IllegalArgumentException("walkStep.drive step ${idx} must be an object {operation, ...}")
+        }
+        def step = new LinkedHashMap((Map) rawStep)
+        def stepOp = step.operation?.toString()?.trim() ?: "introspect"
+        if (stepOp == "drive") {
+            throw new IllegalArgumentException("walkStep.drive steps cannot nest operation='drive' (step ${idx})")
+        }
+        // Inherit the page the previous step ended on when this step omits one.
+        if (!step.page && currentPage) step.page = currentPage
+        def r = _rmWalkStep(appId, step)
+        lastStepOperation = stepOp
+        if (r?.page) currentPage = r.page.toString()
+        stepResults << [
+            step: idx,
+            operation: stepOp,
+            page: r?.page,
+            success: r?.success,
+            diff: r?.diff,
+            valueEcho: r?.valueEcho,
+            silentRejection: r?.silentRejection,
+            commitSignal: r?.commitSignal,
+            opResult: r?.opResult,
+            health: r?.health
+        ]
+        if (r?.success == false) {
+            allOk = false
+            if (stopOnError) break
+        }
+    }
+    def finalHealth = _rmCheckRuleHealth(appId)
+    return [
+        success: allOk && finalHealth.ok,
+        operation: "drive",
+        page: currentPage,
+        stepsRequested: steps.size(),
+        stepsRun: stepResults.size(),
+        lastStepOperation: lastStepOperation,
+        steps: stepResults,
+        health: finalHealth
     ]
 }
 
@@ -10410,11 +10418,13 @@ def _applyNativeAppEdit(args) {
             def result = _rmWalkStep(appId, walkStepSpec)
             result.appId = appId
             result.backup = backup
-            // Click mainPage Done as the final step — only if walkStep
-            // operation was 'done' (meaning the wizard flow is complete).
+            // Click mainPage Done as the final step — only if the walk's
+            // final operation was 'done' (meaning the wizard flow is complete):
+            // a single-step 'done', or a 'drive' whose last step was 'done'.
             // For introspect/write/click/navigate ops in the middle of a
             // multi-step walk, skip Done since the caller is mid-flow.
-            if (walkStepSpec?.operation?.toString() == "done") {
+            def wsOp = walkStepSpec?.operation?.toString()
+            if (wsOp == "done" || (wsOp == "drive" && result?.lastStepOperation == "done")) {
                 def walkDone = null
                 try { walkDone = _rmSubmitMainPageDone(appId) }
                 catch (Exception doneExc) { mcpLog("warn", "rm-native", "walkStep: trailing mainPage Done click failed for app ${appId}: ${doneExc.message} -- in-flight state markers may linger and corrupt subsequent edits") }

--- a/libraries/mcp-self-admin-lib.groovy
+++ b/libraries/mcp-self-admin-lib.groovy
@@ -519,9 +519,7 @@ def _getAllToolDefinitions_partSelfAdmin() {
             name: "hub_update_package",
             description: """Developer Mode self-deploy: full HPM-repair of the MCP package at a git ref in one call -- OVERRIDES whatever is installed, the same way Hubitat Package Manager's Repair does, but anchored to packageManifest.json AT `ref` so an UNMERGED PR installs (HPM repair only reads the published manifest).
 
-[[FLAT_TRIM]]
-Flow: fetch packageManifest.json at `ref` -> install every declared library BUNDLE first (the hub fetches + unpacks the .zip, overwriting libraries in place) -> then deploy every declared app, the SELF app (mcp / "MCP Rule Server", the running parent) LAST so its recompile (which can drop the response, #237) is the final act. Deploys the parent app code class, the child app (mcp / "MCP Rule"), AND the library bundle -- each app's Apps Code class id is resolved at runtime from /hub2/userAppTypes by namespace+name (not hard-coded). Does NOT touch app INSTANCES, undeclared drivers, or anything outside this package's manifest.
-[[/FLAT_TRIM]]
+Deploys every declared library bundle + app from the manifest at `ref`, saving the running self app LAST (its recompile can drop the response, #237). Does NOT touch app instances, undeclared drivers, or anything outside this package's manifest.
 
 Brick-safe: if ANYTHING before the self app save fails (app/manifest fetch, an unresolved app class, a bundle install, a non-self app), it aborts BEFORE touching the self app -- the running server is left exactly as-is and still updatable via hub_update_app, the always-available escape hatch. Self-modification is gated by this tool's own enableDeveloperMode check (it deploys by Apps Code CLASS id, so hub_update_app's instance-id self-update guard does not fire here).
 

--- a/src/test/groovy/server/ToolCustomRuleLifecycleSpec.groovy
+++ b/src/test/groovy/server/ToolCustomRuleLifecycleSpec.groovy
@@ -17,6 +17,55 @@ import support.ToolSpecBase
  */
 class ToolCustomRuleLifecycleSpec extends ToolSpecBase {
 
+    // ---- schema: type enums (issue #258) ------------------------------------
+
+    def "hub_create_custom_rule schema enums stay in lockstep with the create-path validators"() {
+        // Issue #258 moved the trigger/condition/action type lists OUT of the description
+        // prose and INTO items.properties.type.enum (the structural home per AGENTS.md "use
+        // enum for a fixed set"). The create path (toolCreateRule/toolUpdateRule in this lib)
+        // gates every type through validateTrigger/validateCondition/validateAction in
+        // hubitat-mcp-server.groovy. This guard reads those validators' ACTUAL `case` labels
+        // from source and asserts each enum equals the accepted set -- so a strict client can
+        // never reject a type the create path accepts (the exact regression caught in review,
+        // where the enum was derived from runtime dispatch and missed validator-only cases),
+        // and a newly-added validator case can't silently drift from the enum.
+        // Exceptions: 'expression' is validate-REJECTED (Eval.me banned in the sandbox) so it
+        // is excluded from conditions; sunrise/sunset/sun are normalizeTrigger INPUT aliases
+        // (normalized to type:'time' before validateTrigger) added on top of the trigger cases;
+        // minutes/hours/days are the nested periodic-UNIT switch inside validateTrigger, not
+        // trigger types.
+        given:
+        settingsMap.enableCustomRuleEngine = true
+        def src = new File('hubitat-mcp-server.groovy').text
+        def caseLabels = { String fnSig ->
+            int start = src.indexOf(fnSig)
+            assert start >= 0 : "could not find ${fnSig} in hubitat-mcp-server.groovy -- validator moved/renamed?"
+            int end = src.indexOf('\ndef ', start + fnSig.length())
+            def body = src.substring(start, end < 0 ? src.length() : end)
+            (body =~ /case\s+"([a-z_]+)"/).collect { it[1] } as Set
+        }
+        def triggerCases = caseLabels('def validateTrigger(trigger) {') - ['minutes', 'hours', 'days']
+        def conditionCases = caseLabels('def validateCondition(condition) {') - ['expression']
+        def actionCases = caseLabels('def validateAction(action) {')
+
+        def def_ = script.getAllToolDefinitions().find { it.name == 'hub_create_custom_rule' }
+        def triggerEnum = def_.inputSchema.properties.triggers.items.properties.type.enum as Set
+        def conditionEnum = def_.inputSchema.properties.conditions.items.properties.type.enum as Set
+        def actionEnum = def_.inputSchema.properties.actions.items.properties.type.enum as Set
+
+        expect: 'the validators actually parsed (guard is not vacuous)'
+        triggerCases.contains('device_event') && conditionCases.contains('device_state') && actionCases.contains('device_command')
+
+        and: 'trigger enum = validateTrigger cases + the normalizeTrigger sun aliases'
+        triggerEnum == (triggerCases + ['sunrise', 'sunset', 'sun'])
+
+        and: 'condition enum = validateCondition cases (minus the rejected expression type)'
+        conditionEnum == conditionCases
+
+        and: 'action enum = validateAction cases exactly'
+        actionEnum == actionCases
+    }
+
     // ---- toolCreateRule -----------------------------------------------------
 
     def "toolCreateRule creates rule via addChildApp and returns the child app id"() {

--- a/src/test/groovy/server/ToolCustomRuleLifecycleSpec.groovy
+++ b/src/test/groovy/server/ToolCustomRuleLifecycleSpec.groovy
@@ -42,6 +42,10 @@ class ToolCustomRuleLifecycleSpec extends ToolSpecBase {
             assert start >= 0 : "could not find ${fnSig} in hubitat-mcp-server.groovy -- validator moved/renamed?"
             int end = src.indexOf('\ndef ', start + fnSig.length())
             def body = src.substring(start, end < 0 ? src.length() : end)
+            // /[a-z_]+/ matches the lowercase_underscore type labels the validators use. A future
+            // label with a digit/uppercase (e.g. "set_hvac2") would be missed here -- but then the
+            // guard fails in the SAFE direction (the enum carries it, the parsed set doesn't =>
+            // inequality => RED), so it degrades to a loud failure, never a silent miss.
             (body =~ /case\s+"([a-z_]+)"/).collect { it[1] } as Set
         }
         def triggerCases = caseLabels('def validateTrigger(trigger) {') - ['minutes', 'hours', 'days']

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -5013,6 +5013,241 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.opResult?.done?.parent == null
     }
 
+    // ---- walkStep operation='drive': the auto-driver that runs an ordered
+    // sequence of single-step operations in one call (issue #258). It composes
+    // _rmWalkStep per step, carries the page forward across navigate/done, and
+    // stops at the first failed step unless stopOnError=false.
+
+    def "walkStep drive runs an ordered sequence in one call and aggregates per-step results"() {
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [
+                [name: "tCapab1", type: "enum", options: ["Switch", "Motion"]],
+                [name: "hasAll", type: "button"]
+            ])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+
+        when: "drive an introspect + click sequence in a single call"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "selectTriggers", operation: "introspect"],
+                [page: "selectTriggers", operation: "click", click: [name: "hasAll"]]
+            ]],
+            confirm: true
+        ])
+
+        then: "the aggregate envelope reports both steps with their per-step operation + page"
+        result.operation == "drive"
+        result.stepsRequested == 2
+        result.stepsRun == 2
+        result.steps.size() == 2
+        result.steps[0].operation == "introspect"
+        result.steps[0].page == "selectTriggers"
+        result.steps[1].operation == "click"
+        result.lastStepOperation == "click"
+        result.success == true
+
+        and: "the click step actually executed through the real walker (a /installedapp/btn POST fired for hasAll)"
+        posts.any { it.path == "/installedapp/btn" && it.body?.name == "hasAll" }
+
+        and: "each per-step result carries the documented fail-loud signal fields (diff/valueEcho/silentRejection/health)"
+        result.steps.every { it.containsKey('diff') && it.containsKey('valueEcho') && it.containsKey('silentRejection') && it.health != null }
+        result.steps[0].diff?.containsKey('appeared')
+        result.steps[0].health?.containsKey('ok')
+
+        and: "no trailing mainPage Done finalize fires when the drive's last step is NOT 'done'"
+        // The conditional finalize must NOT run unless lastStepOperation=='done' -- guards the
+        // negative side of the drive-done-finalize test below.
+        !posts.any { it.path == "/installedapp/update/json" && it.body?._action_update == "Done" && it.body?.currentPage == "mainPage" }
+    }
+
+    def "walkStep drive stops at the first failed step by default (stopOnError)"() {
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [
+                [name: "tCapab1", type: "enum", options: ["Switch"]],
+                [name: "hasAll", type: "button"]
+            ])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        // Non-echoing post: the write never round-trips, so valueEcho.match=false
+        // and that step fails -- the trailing click step must NOT run.
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "selectTriggers", operation: "write", write: [tCapab1: "Switch"]],
+                [page: "selectTriggers", operation: "click", click: [name: "hasAll"]]
+            ]],
+            confirm: true
+        ])
+
+        then: "only the first (failing) step ran; the drive halted before the click"
+        result.stepsRequested == 2
+        result.stepsRun == 1
+        result.success == false
+        result.steps[0].operation == "write"
+        !posts.any { it.path == "/installedapp/btn" && it.body?.name == "hasAll" }
+    }
+
+    def "walkStep drive with stopOnError=false continues past a failed step"() {
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [
+                [name: "tCapab1", type: "enum", options: ["Switch"]],
+                [name: "hasAll", type: "button"]
+            ])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", stopOnError: false, steps: [
+                [page: "selectTriggers", operation: "write", write: [tCapab1: "Switch"]],
+                [page: "selectTriggers", operation: "click", click: [name: "hasAll"]]
+            ]],
+            confirm: true
+        ])
+
+        then: "both steps ran despite the first failing; overall success is still false"
+        result.stepsRun == 2
+        result.success == false
+        posts.any { it.path == "/installedapp/btn" && it.body?.name == "hasAll" }
+    }
+
+    def "walkStep drive rejects a missing or empty steps list with an actionable error"() {
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when: "drive without a steps list"
+        def missing = script.toolSetRule([appId: 100, walkStep: [operation: "drive"], confirm: true])
+
+        then:
+        missing.success == false
+        missing.error?.toString()?.contains("steps")
+
+        when: "drive with an empty steps list"
+        def empty = script.toolSetRule([appId: 100, walkStep: [operation: "drive", steps: []], confirm: true])
+
+        then:
+        empty.success == false
+        empty.error?.toString()?.contains("steps")
+    }
+
+    def "walkStep drive whose final step is done gets the trailing mainPage Done finalize"() {
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        // The trailing finalize fetches the mainPage sub-page path explicitly.
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [[name: "tCapab1", type: "enum", options: ["Switch"], value: "Switch"]])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            statusJson(100, [[name: "tCapab1", type: "enum", value: "Switch"]])
+        }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "selectTriggers", operation: "introspect"],
+                [page: "selectTriggers", operation: "done"]
+            ]],
+            confirm: true
+        ])
+
+        then: "the drive's last step was done, so the dispatcher fired the trailing mainPage Done finalize"
+        // The trailing finalize is _rmSubmitMainPageDone -- it POSTs the mainPage form
+        // with _action_update='Done' + currentPage='mainPage', distinct from the done
+        // STEP's sub-page Done (_action_previous='Done', currentPage='selectTriggers'). A
+        // single-step done gets the same finalize; this pins that a drive ending in done does too.
+        result.lastStepOperation == "done"
+        posts.any { it.path == "/installedapp/update/json" && it.body?._action_update == "Done" && it.body?.currentPage == "mainPage" }
+    }
+
+    def "walkStep drive carries the page forward: a step omitting page inherits the navigate target"() {
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true, version: 7,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "selectTriggers", title: "T", install: false, error: null,
+                             sections: [[title: "", input: [],
+                                         body: [[element: "href", name: "periodic1", page: "periodic", params: [n: 1]]]]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/periodic') { params ->
+            JsonOutput.toJson([
+                app: [id: 100, version: 7], configPage: [name: "periodic", sections: [[input: [[name: "whichPeriod1", type: "enum"]]]]], settings: [:]
+            ])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            [status: 200, location: null, data: JsonOutput.toJson([
+                app: [id: 100, version: 7], configPage: [name: "periodic", sections: [[input: [[name: "whichPeriod1", type: "enum"]]]]]
+            ])]
+        }
+
+        when: "step 1 navigates to the periodic sub-page; step 2 omits page entirely"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "selectTriggers", operation: "navigate", navigate: [targetPage: "periodic"]],
+                [operation: "introspect"]
+            ]],
+            confirm: true
+        ])
+
+        then: "step 2 inherited the navigate target page rather than failing on a missing page"
+        result.stepsRun == 2
+        result.steps[0].operation == "navigate"
+        result.steps[1].operation == "introspect"
+        result.steps[1].page == "periodic"
+    }
+
     def "addTriggers bulk shortcut returns partial: true when one inner spec fails"() {
         given:
         enableWrite()

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -934,6 +934,45 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.buttonClicked == "pausRule"
     }
 
+    def "edit Done-miss flips success:false for a commitButton:null app but NOT for an RM app"() {
+        // The edit-path Done-miss flip is gated on _resolveCommitButton(appType.name)==null. For a
+        // Button Controller / Basic Rule the trailing Done is the ONLY commit channel, so a miss is
+        // a real failure (success:false). For an RM app the edit already committed (the button click
+        // via /installedapp/btn, or a main-page settings write's auto-updateRule), so a missed Done
+        // is only a state-marker-cleanup caveat -> success stays true. Neither registers a mainPage
+        // sub-page, so the trailing _rmSubmitMainPageDone fetch fails -> done:false on both.
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params ->
+            JsonOutput.toJson([
+                app: [id: 100, name: "Button Controller-5.1", label: "BC", installed: true,
+                      appType: [name: "Button Controller-5.1", namespace: "hubitat"]],
+                configPage: [name: "mainPage", title: "Button Controller", install: true, error: null,
+                             sections: [[title: "", input: []]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/101') { params -> ruleConfigJson(101, "RM", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        hubGet.register('/installedapp/statusJson/101') { params -> statusJson(101) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when: "a button edit on the Button Controller (commitButton:null), trailing Done can't commit"
+        def bc = script.toolSetRule([appId: 100, button: "pausRule", confirm: true])
+
+        then: "the missed Done is a real failure -- the Done was the only commit channel"
+        bc.mainPageDoneFailed == true
+        bc.success == false
+
+        when: "the same edit on an RM rule, whose trailing Done also can't commit"
+        def rm = script.toolSetRule([appId: 101, button: "pausRule", confirm: true])
+
+        then: "RM committed via the button click, so the missed Done does NOT flip success"
+        rm.mainPageDoneFailed == true
+        rm.success == true
+    }
+
     // ---------- delete_rm_rule ----------
 
     def "delete_rm_rule snapshots, then force-deletes when force=true"() {
@@ -4861,6 +4900,9 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
                 configPage: [name: "periodic", sections: [[input: [[name: "whichPeriod1", type: "enum", value: "Hourly"]]]]]
             ])]
         }
+        // walkStep done routes through the dispatcher's trailing mainPage Done finalize; stub the
+        // mainPage so it commits (an unstubbed fetch would fail it and correctly flip success:false).
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
 
         when:
         def result = script.toolSetRule([
@@ -4987,6 +5029,9 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
                 configPage: [name: "selectTriggers", sections: [[input: [[name: "tCapab1", type: "enum", value: "Switch"]]]]]
             ])]
         }
+        // walkStep done fires the dispatcher's trailing mainPage Done finalize; stub the mainPage
+        // so it commits (an unstubbed fetch would fail it and correctly flip success:false).
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
 
         when: "Done on selectTriggers (no hrefContext — top-level page Done)"
         def result = script.toolSetRule([
@@ -5139,6 +5184,8 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
         then: "both steps ran despite the first failing; overall success is still false"
         result.stepsRun == 2
+        result.steps.size() == 2
+        result.steps[1].operation == "click"   // the post-failure step is present in the aggregate, not just its POST
         result.success == false
         posts.any { it.path == "/installedapp/btn" && it.body?.name == "hasAll" }
     }
@@ -5204,6 +5251,46 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         posts.any { it.path == "/installedapp/update/json" && it.body?._action_update == "Done" && it.body?.currentPage == "mainPage" }
     }
 
+    def "walkStep drive whose trailing mainPage Done fails flips success:false with a repairHint"() {
+        // The trailing mainPage Done drives the app's update lifecycle (subscriptions/schedules
+        // re-init). If it does not commit, the edit is half-applied -- success must flip to false
+        // and carry a repairHint, NOT report a false-clean done. Fail ONLY the trailing mainPage
+        // Done (_action_update=Done + currentPage=mainPage); the in-drive steps commit fine.
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [[name: "tCapab1", type: "enum", options: ["Switch"], value: "Switch"]])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params ->
+            statusJson(100, [[name: "tCapab1", type: "enum", value: "Switch"]])
+        }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/update/json" && body?._action_update == "Done" && body?.currentPage == "mainPage") {
+                return [status: 500, location: null, data: '']
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when: "a drive ending in done, whose trailing mainPage Done POST returns 500"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "selectTriggers", operation: "introspect"],
+                [page: "selectTriggers", operation: "done"]
+            ]],
+            confirm: true
+        ])
+
+        then: "the missed Done flips success:false and surfaces the failure reason + a repairHint"
+        result.mainPageDoneFailed == true
+        result.success == false
+        result.mainPageDoneError?.toString()?.contains("500")
+        (result.repairHints as List)?.any { it.toString().contains("updateRule") }
+    }
+
     def "walkStep drive carries the page forward: a step omitting page inherits the navigate target"() {
         given:
         enableWrite()
@@ -5246,6 +5333,242 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         result.steps[0].operation == "navigate"
         result.steps[1].operation == "introspect"
         result.steps[1].page == "periodic"
+    }
+
+    def "walkStep drive carries the parent page forward after a done step"() {
+        // After a 'done' step the walker is back on the sub-page's PARENT page; a following
+        // step that omits `page` must inherit that parent. This is the done-op analog of the
+        // navigate page-carry test above -- it pins the r.page(=parent) -> currentPage threading
+        // for done specifically (done sets page=parentPage, unlike navigate's page=target).
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/periodic') { params ->
+            ruleConfigJson(100, "r", [[name: "whichPeriod1", type: "enum", options: ["Hourly"]]])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params ->
+            ruleConfigJson(100, "r", [[name: "ruleLabel", type: "text"]])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when: "step 1 done returns from the periodic sub-page to parent mainPage; step 2 omits page"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "periodic", operation: "done", hrefContext: [fromPage: "mainPage", hrefName: "name", hrefParams: [n: 1]]],
+                [operation: "introspect"]
+            ]],
+            confirm: true
+        ])
+
+        then: "the done step reports the parent page, and step 2 inherited it rather than failing on a missing page"
+        result.stepsRun == 2
+        result.steps[0].operation == "done"
+        result.steps[0].page == "mainPage"
+        result.steps[1].operation == "introspect"
+        result.steps[1].page == "mainPage"
+    }
+
+    def "walkStep drive reports success=false when the rule ends unhealthy even though every step passed"() {
+        // The drive success gate is `allOk && finalHealth.ok`. A drive whose steps ALL pass
+        // (allOk=true) but whose post-run health check comes back broken must still report
+        // success:false. The compiled-state read (/app/ruleBuilderJson, hit exactly once per
+        // _rmCheckRuleHealth and nowhere else) is the lever: healthy for the step's own health
+        // check, broken on the trailing finalHealth read -- which isolates the finalHealth.ok
+        // conjunct (a step's own success is also health-gated, so a uniformly-broken rule
+        // couldn't distinguish the two AND-operands).
+        given:
+        enableWrite()
+        def rb = [n: 0]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [[name: "tCapab1", type: "enum", options: ["Switch"]]])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        // 1-step drive => two health checks total: the step's own (read #1, clean) and the
+        // post-loop finalHealth (read #2, broken). Flip broken:true on read #2+.
+        hubGet.register('/app/ruleBuilderJson/100') { params ->
+            rb.n = rb.n + 1
+            JsonOutput.toJson([broken: (rb.n >= 2)])
+        }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when: "the introspect step passes, but the rule reads broken on the final health check"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "selectTriggers", operation: "introspect"]
+            ]],
+            confirm: true
+        ])
+
+        then: "the step itself succeeded, but the unhealthy finalHealth.ok gates overall success to false"
+        result.stepsRun == 1
+        result.steps[0].success == true
+        result.health.ok == false
+        result.health.broken == true
+        result.success == false
+    }
+
+    def "walkStep drive captures a step that THROWS into the per-step trace instead of unwinding the run"() {
+        // A drive step that throws (here: a write with no write map -> _rmWalkStep throws) must be
+        // recorded as a failed step so the partial-run trace of the steps that already ran survives,
+        // rather than being discarded into the bare dispatcher error envelope. The failed step must
+        // record its OWN page (the throwing step is on selectTriggers, distinct from step 1's
+        // mainPage, so a regression that recorded currentPage would show mainPage and be caught),
+        // and the drive aggregate must roll the failure up to a top-level error + repairHints.
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [[name: "tCapab1", type: "enum", options: ["Switch"]]])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when: "step 2 is a write with no write map on a DIFFERENT page than step 1 -> the walker throws mid-drive"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "mainPage", operation: "introspect"],
+                [page: "selectTriggers", operation: "write"],
+                [page: "mainPage", operation: "introspect"]
+            ]],
+            confirm: true
+        ])
+
+        then: "the throw is captured as a failed step; the aggregate (with step 1) survives, step 3 is skipped"
+        result.operation == "drive"
+        result.success == false
+        result.stepsRun == 2
+        result.steps.size() == 2
+        result.steps[0].operation == "introspect" && result.steps[0].success == true
+        result.steps[1].operation == "write"
+        result.steps[1].success == false
+        result.steps[1].error?.toString()?.contains("write")
+
+        and: "the failed step records its OWN page, not the previous step's"
+        result.steps[1].page == "selectTriggers"
+
+        and: "the drive rolls the first failed step up to a top-level error + repairHints (fail-loud for an LLM caller)"
+        result.error?.toString()?.contains("step 2")
+        result.error?.toString()?.contains("write")
+        (result.repairHints as List)?.any { it.toString().contains("step 2") }
+    }
+
+    def "walkStep drive rejects a nested drive step"() {
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when: "a drive step is itself an operation='drive'"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [operation: "drive", steps: [[page: "mainPage", operation: "introspect"]]]
+            ]],
+            confirm: true
+        ])
+
+        then: "nesting is rejected"
+        result.success == false
+        result.error?.toString()?.toLowerCase()?.contains("nest")
+    }
+
+    def "walkStep drive rejects a non-object step"() {
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when: "a step is a bare string, not an object"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: ["introspect"]],
+            confirm: true
+        ])
+
+        then: "each step must be an object"
+        result.success == false
+        result.error?.toString()?.contains("object")
+    }
+
+    def "walkStep drive validates step shapes up front so a malformed step at index >1 commits nothing"() {
+        // Structural mistakes (non-object step, nested drive) are caught in a PRE-FLIGHT pass over
+        // all steps BEFORE the loop issues any live POST. So a malformed step after a valid live
+        // write rejects the whole drive with NOTHING committed, rather than running step 1's write
+        // and then unwinding (which would strand a half-applied mutation with no trace).
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [[name: "tCapab1", type: "enum", options: ["Switch"]]])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+
+        when: "a valid live write is followed by a non-object step"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "selectTriggers", operation: "write", write: [tCapab1: "Switch"]],
+                "garbage"
+            ]],
+            confirm: true
+        ])
+
+        then: "the whole drive is rejected pre-flight; step 1's write never issued a POST"
+        result.success == false
+        result.error?.toString()?.contains("object")
+        posts.isEmpty()
+    }
+
+    def "walkStep drive leaves a following step on the SAME page after a plain (no-hrefContext) done"() {
+        // A done WITHOUT hrefContext has no parent to return to (parentPage=null), so _rmWalkStep
+        // leaves page on the sub-page (page = parentPage ?: page). A following step that omits page
+        // must therefore inherit the SAME sub-page -- the negative of the hrefContext-done parent
+        // carry above, pinning the `parentPage ?: page` fallback branch.
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [[name: "tCapab1", type: "enum", options: ["Switch"]]])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when: "a plain done on selectTriggers (no hrefContext), then a step that omits page"
+        def result = script.toolSetRule([
+            appId: 100,
+            walkStep: [operation: "drive", steps: [
+                [page: "selectTriggers", operation: "done"],
+                [operation: "introspect"]
+            ]],
+            confirm: true
+        ])
+
+        then: "the done kept the page on selectTriggers, and step 2 inherited it"
+        result.stepsRun == 2
+        result.steps[0].operation == "done"
+        result.steps[0].page == "selectTriggers"
+        result.steps[1].operation == "introspect"
+        result.steps[1].page == "selectTriggers"
     }
 
     def "addTriggers bulk shortcut returns partial: true when one inner spec fails"() {

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1838,6 +1838,86 @@ class TestRunner:
             })
             assert wsn.get("page") == "mainPage", \
                 f"walkStep should route through the native-app tool, got: {wsn}"
+
+            # issue #258 added operation='drive' WITHOUT changing the single-step path; prove
+            # the old mode still drives a write end-to-end via SEPARATE calls (open the editor,
+            # then pick a capability) -- the same click+write the drive composes, step by step.
+            self._set_rule(app_id, {"walkStep": {"page": "selectTriggers", "operation": "click",
+                                                 "click": {"name": "true", "stateAttribute": "moreCond"}}}, strict=True)
+            sw = self._set_rule(app_id, {"walkStep": {"page": "selectTriggers", "operation": "write",
+                                                      "write": {"tCapab1": "Switch"}}}, strict=True)
+            assert (sw.get("valueEcho") or {}).get("match") is True, \
+                f"single-step write should still round-trip as before: {sw}"
+        finally:
+            self._delete_native(app_id)
+
+    @test("native_apps")
+    def test_set_rule_walkstep_drive(self) -> None:
+        # issue #258: walkStep operation='drive' runs an ordered steps[] sequence in ONE
+        # call -- the progressive flow that replaces the manual introspect -> ... -> finalize
+        # loop the LLM used to issue as N separate calls. This pins the drive orchestration
+        # surface end-to-end against a live hub across four facets:
+        #   (1) read composition  -- multi-page introspect returns the aggregate
+        #                            {operation:'drive', steps:[...], stepsRun, success} with
+        #                            each step's page + fail-loud health snapshot;
+        #   (2) WRITE composition -- a click (open trigger editor) + a capability write in one
+        #                            call, with the write proven to land live via valueEcho;
+        #   (3) failure halt      -- a bad step aborts the drive (success:false) without
+        #                            corrupting the rule.
+        # Each live drive is kept to <=2 steps on purpose: a drive does a full
+        # introspect+op+introspect+health per step, so a long drive is ONE heavy tool call
+        # that risks the cloud relay's ~10s 504 ceiling. The stopOnError step-success=false
+        # branch and the >2-step commit sequence are covered deterministically by the Spock
+        # unit tests; here we prove the drive layer works against the real wizard.
+        app_id = self._create_native_rule("WalkDrive")
+        try:
+            # (1) read composition + page-carry + per-step health
+            res = self._set_rule(app_id, {"walkStep": {"operation": "drive", "steps": [
+                {"page": "selectTriggers", "operation": "introspect"},
+                {"page": "mainPage", "operation": "introspect"},
+            ]}}, strict=True)
+            assert isinstance(res, dict), f"walkStep drive returned non-dict: {res}"
+            assert res.get("operation") == "drive", f"drive should echo operation='drive': {res}"
+            steps = res.get("steps")
+            assert isinstance(steps, list) and len(steps) == 2, f"drive should report 2 per-step results: {res}"
+            assert res.get("stepsRun") == 2, f"both steps should run on a healthy rule: {res}"
+            assert steps[0].get("operation") == "introspect" and steps[0].get("page") == "selectTriggers", \
+                f"step 1 should introspect selectTriggers: {steps[0]}"
+            assert steps[1].get("page") == "mainPage", f"step 2 should land on mainPage: {steps[1]}"
+            assert all(isinstance(s.get("health"), dict) for s in steps), \
+                f"each drive step should carry its health snapshot: {steps}"
+            self._assert_rule_healthy(app_id)
+
+            # (2) WRITE composition: open the trigger editor then pick a capability, in ONE
+            #     drive call. Mirrors _rmAddTrigger's proven wire format (click name='true'/
+            #     stateAttribute='moreCond' opens the editor; tCapab1 is the capability picker).
+            #     The drive's own valueEcho proves the write round-tripped on the live hub.
+            wr = self._set_rule(app_id, {"walkStep": {"operation": "drive", "steps": [
+                {"page": "selectTriggers", "operation": "click", "click": {"name": "true", "stateAttribute": "moreCond"}},
+                {"page": "selectTriggers", "operation": "write", "write": {"tCapab1": "Switch"}},
+            ]}}, strict=True)
+            assert wr.get("stepsRun") == 2, f"both drive steps should run (click + write): {wr}"
+            write_step = next((s for s in (wr.get("steps") or []) if s.get("operation") == "write"), None)
+            assert write_step is not None, f"the write step should be reported in the aggregate: {wr}"
+            assert (write_step.get("valueEcho") or {}).get("match") is True, \
+                f"the driven tCapab1='Switch' write should round-trip live (valueEcho.match): {write_step}"
+            # A half-built (uncommitted) trigger is scratch wizard state, not a broken rule.
+            self._assert_rule_renders(app_id)
+
+            # (3) failure halt: an invalid step operation aborts the drive (success:false,
+            #     the step throws) and must NOT corrupt the rule.
+            bad = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": {
+                "appId": app_id, "confirm": True,
+                "walkStep": {"operation": "drive", "steps": [
+                    {"page": "mainPage", "operation": "introspect"},
+                    {"page": "mainPage", "operation": "bogus_op"},
+                ]},
+            }})
+            assert bad.get("success") is False, \
+                f"a drive with an invalid step operation must halt with success:false: {bad}"
+            assert "operation" in str(bad.get("error") or "").lower(), \
+                f"the halt error should name the bad operation: {bad}"
+            self._assert_rule_renders(app_id)
         finally:
             self._delete_native(app_id)
 


### PR DESCRIPTION
## Summary

- Pare `hub_set_rule`'s oversized inputSchema prose down to load-bearing inline content (purpose, the `capability`-not-`type` discriminator, spec shapes, the `@N` rawSettings token, safety/`confirm`, partial-success recovery, guide pointers); the exhaustive per-field reference already lives in `hub_get_tool_guide(section='set_rule_reference')`. The flat `tools/list` now passes its size guards with margin — it was **over** the 124,000-byte cap in Developer Mode.
- Replace the PR #264 `[[FLAT_TRIM]]` blocks (capability-family summaries, `hub_create_custom_rule` types, `hub_get_app_config`, `hub_update_package`, `hub_get_rule_health`) with lean inline content or proper schema/guide homes, so descriptions no longer depend on the flat-mode strip.
- Add `walkStep operation='drive'`: a progressive auto-driver that runs an ordered `steps[]` sequence (introspect→write→done→finalize) in one call, composing the existing single-step `_rmWalkStep` per step. The single-step operations are unchanged.

## Type of change

- [x] `feat` — new feature or capability

## Changes

- `hub_set_rule`: trimmed `addTrigger` / `addAction` / `addRequiredExpression` / `replaceRequiredExpression` / `walkStep` and the action-mutation properties (`addTriggers`/`addActions`/`addLocalVariable`/`patches`/`clearActions`/`replaceActions`/`modifyTrigger`) to a lean inline summary + guide pointer, keeping all load-bearing tokens (discriminators, spec shapes, `@N`, capability names, the `waitEvents` LIMIT, partial-success recovery).
- `hub_get_rule_health`: dropped the `Surfaces:` bullet list (duplicated in `outputSchema`).
- `hub_create_custom_rule`: moved the trigger/condition/action type lists from prose into formal `items.properties.type.enum`, matched to the create-path validators (`validateTrigger`/`validateCondition`/`validateAction`) — 9 trigger / 14 condition / 29 action types — with per-type fields in `hub_get_tool_guide(section='rules')`.
- `hub_update_package` / `hub_get_app_config`: condensed Flow / use-case prose to lean inline.
- New `walkStep operation='drive'` (+ `steps[]`, `stopOnError`); documented in `set_rule_reference`.
- Closes #258.

## Release Notes

- `hub_set_rule` descriptions are leaner — the full trigger/action/expression reference now lives in `hub_get_tool_guide(section='set_rule_reference')` (fetch inline with `guide:true`), keeping the tool catalog under the response cap.
- New `walkStep` drive mode: pass `{operation:'drive', steps:[...]}` to run a whole wizard sequence in one call instead of step by step.
- `hub_create_custom_rule` now declares its trigger/condition/action types as schema enums for better validation hints.

## Testing

- `python tests/sandbox_lint.py` — passes.
- `./gradlew test` — full Spock suite passes (incl. the new drive tests, the source-derived `hub_create_custom_rule` enum guard, and the flat/gateway catalog-size guards; dev-mode flat catalog stays under the 123,500-byte guard, well below the 124,000 cap).
- `tests/e2e_test.py`: `test_set_rule_walkstep_drive` (live read-composition + a live write verified via `valueEcho` + bad-step-halt) and `test_set_rule_walkstep_introspect` extended to cover the single-step write path live.

## Checklist

- [x] **Unit tests added** (drive composition/stopOnError/validation/finalize/page-carry; source-derived custom_rule enum guard)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally
- [ ] Live-hub BAT tests updated — not added; the `tests/e2e_test.py` drive scenario covers the live flow
- [x] Documentation updated (guide sections)
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules
