### PR TITLE
refactor: route the variable-name enum pickers through the canonical reader

### DIFF
--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -5754,11 +5754,13 @@ private Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = fal
                 if (!xVarInput) {
                     throw new IllegalArgumentException("runCommand: xVar field not revealed after enabling variable mode for param slot ${pNumStr} (expected '${xVarField}') -- hub may not support variable-sourced parameters for command '${actionSpec.command}'")
                 }
-                def xVarOpts = (xVarInput.options instanceof Map) ? xVarInput.options.keySet().collect { it?.toString() } :
-                               (xVarInput.options instanceof List) ? xVarInput.options.collect { it?.toString() } : null
+                // Canonical reader handles every option shape (Map container, scalar, List-of-value-Maps),
+                // shared with the setVariable source-variable + fromDevice/math modes so all enum reads match.
+                def xVarOpts = _rmReadPickerOptionStrings(xVarInput)
                 // Fail loud when options are absent or unreadable: writing an unvalidated
-                // variable name would produce a silently-broken action.
-                if (xVarOpts == null || xVarOpts.isEmpty()) {
+                // variable name would produce a silently-broken action. The canonical reader
+                // returns a non-null list, so the idiomatic truthiness check covers empty/absent.
+                if (!xVarOpts) {
                     throw new IllegalArgumentException("runCommand: xVar${pNumStr}.${idx} revealed but has no enumerable options -- cannot validate variable name '${pVariable}'. Hub may not expose variable list for command '${actionSpec.command}'")
                 }
                 if (!xVarOpts.any { it == pVariable.toString() }) {
@@ -8397,16 +8399,11 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
             throw new IllegalStateException("conditions[${condIdx}]: Variable: variable-name picker not revealed after rCapab='Variable'. Visible fields: ${visible}")
         }
         def varPickerField = varPickerReveal.input.name.toString()
-        // Validate variable name against the schema's option list.
-        // Hub options for variable pickers are Maps keyed by variable name (the throw
-        // in the Variable-picker validation branch below emits "hub variable
-        // '${varName}' not in the revealed picker" -- varName IS the key).
-        // Map.Entry.toString() would produce "key=value" strings
-        // that never match a bare name; use .keySet() to extract the names.
-        def varOptsRaw = varPickerReveal.input.options
-        def varOpts = (varOptsRaw instanceof Map)
-            ? (varOptsRaw as Map).keySet().collect { it?.toString() }.findAll { it }
-            : (varOptsRaw ?: []).collect { it?.toString() }.findAll { it }
+        // Validate variable name against the schema's option list via the canonical
+        // reader. Variable-picker options are Maps keyed by variable name, so the reader's
+        // Map branch extracts the keys (the names); it also normalizes the scalar and
+        // List-of-{value:...} shapes a hand-rolled Map?keySet:List?collect reader mishandled.
+        def varOpts = _rmReadPickerOptionStrings(varPickerReveal.input)
         if (!varOpts) {
             // Schema's option list came back empty -- could be a hub with no variables defined,
             // a firmware version that lazily-populates the enum, or a probe-timing race. The
@@ -8462,11 +8459,9 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
                 throw new IllegalStateException("conditions[${condIdx}]: Variable: right-hand variable picker not revealed after isVar_<N>=true (compareToVariable='${rhsVarName}'). Without it the condition would render '${varName} ${cond.comparator} 0' (numeric default) instead of variable-vs-variable. Visible fields: ${visible}")
             }
             def rhsVarField = rhsVarReveal.input.name.toString()
-            // Validate the RHS variable name against the revealed picker's options.
-            def rhsOptsRaw = rhsVarReveal.input.options
-            def rhsOpts = (rhsOptsRaw instanceof Map)
-                ? (rhsOptsRaw as Map).keySet().collect { it?.toString() }.findAll { it }
-                : (rhsOptsRaw ?: []).collect { it?.toString() }.findAll { it }
+            // Validate the RHS variable name against the revealed picker's options via the
+            // canonical reader (same Map-keyed-by-name contract as the LHS variable picker).
+            def rhsOpts = _rmReadPickerOptionStrings(rhsVarReveal.input)
             if (!rhsOpts) {
                 // Empty option list -- same ambiguity as the LHS variable picker: a hub with
                 // no variables, a lazily-populated enum, or a probe-timing race. The walker

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -13856,6 +13856,90 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         !posts.any { it.path == "/installedapp/update/json" && it.body.containsKey("settings[state_1]") }
     }
 
+    def "addAction ifThen Variable compareToVariable: LHS+RHS pickers validate List-of-{value:...} options (canonical reader)"() {
+        // Regression guard: the condition reveal-walker validates the LHS variable name and the
+        // RHS compareToVariable name through the canonical _rmReadPickerOptionStrings. When the
+        // hub renders the variable pickers as a List of {value:...} option maps (rather than a
+        // Map keyed by name), the reader extracts .value. The prior hand-rolled List branch
+        // stringified each option to "[value:A]" and rejected the valid variable name. Both
+        // pickers use the value-map shape here so the walker must route both reads correctly.
+        given:
+        enableWrite()
+        def isVarWritten = false
+        def daSeq = 0
+        def posts = []
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            if (path == "/installedapp/update/json" && body["_action_previous"] != "Done") {
+                body.each { k, v -> if (_settingKeyOf(k) == "isVar_1") isVarWritten = true }
+            }
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params ->
+            ruleConfigJson(100, "r", [[name: "actType.1", type: "enum",
+                options: ["condActs": "Conditional Actions"]]])
+        }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params ->
+            daSeq++
+            def inputs = [
+                [name: "actType.1", type: "enum", options: ["condActs": "Conditional Actions"]],
+                [name: "actSubType.1", type: "enum", options: ["getIfThen": "IF Expression THEN"]],
+                [name: "cond", type: "enum", options: ["a": "New condition"]],
+                [name: "rCapab_1", type: "enum", options: ["Variable", "Switch"]],
+                // LHS variable picker delivered as a List of {value:...} option maps.
+                [name: "lVar_1", type: "enum", options: [[value: "A"], [value: "B"]]],
+                [name: "RelrDev_1", type: "enum", options: ["=", "≠", "<", ">"]],
+                [name: "isVar_1", type: "bool"],
+                [name: "state_1", type: "number"],
+                [name: "hasAll", type: "button"]
+            ]
+            if (isVarWritten) {
+                // RHS variable picker likewise a List of {value:...} maps.
+                inputs = inputs + [[name: "xVarR_1", type: "enum", options: [[value: "A"], [value: "B"]]]]
+            }
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "doActPage", title: "T", install: false, error: null,
+                             sections: [[title: "", input: inputs,
+                                         paragraphs: ["IF A > B THEN (seq ${daSeq})".toString()]]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params ->
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "mainPage", title: "Edit Rule", install: true, error: null,
+                             sections: [[title: "", input: [], paragraphs: ["IF A > B THEN"]]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+
+        when:
+        def result = script.toolSetRule([
+            appId: 100,
+            addAction: [
+                capability: "ifThen",
+                expression: [conditions: [[
+                    capability: "Variable", variable: "A",
+                    comparator: ">", compareToVariable: "B"
+                ]]]
+            ],
+            confirm: true
+        ])
+
+        then: "both variable names validate against the {value:...} option lists -- not rejected"
+        result.success == true
+
+        and: "isVar_1=true revealed the RHS picker and the RHS variable name landed at xVarR_1"
+        posts.any { it.path == "/installedapp/update/json" && it.body["settings[isVar_1]"]?.toString() == "true" }
+        posts.any { it.path == "/installedapp/update/json" && it.body["settings[xVarR_1]"]?.toString() == "B" }
+    }
+
     def "addAction ifThen Variable compareToVariable: empty RHS-picker option list emits api_unavailable sentinel and flips partial"() {
         // LOAD-BEARING guard for the RHS empty-options degradation path. When the revealed
         // right-hand picker has NO options (hub with no vars / lazily-populated enum / probe
@@ -17677,6 +17761,97 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         and: "xVar2.1 was absent from the schema at the pre-uVar fetch (gating is production-observable)"
         fieldNamesAtPreUVarFetch != null
         !fieldNamesAtPreUVarFetch.contains("xVar2.1")
+    }
+
+    def "addAction runCommand variable parameter: canonical reader validates a List-of-value-Maps xVar enum shape"() {
+        // Regression guard for the picker-read consistency fix. The variable-param path now reads
+        // its xVar enum via the canonical _rmReadPickerOptionStrings (shared with the setVariable /
+        // fromDevice / math source modes) instead of a hand-rolled Map?keySet : List?collect. The
+        // old reader stringified a List-of-{value:...} option ([[value:'myVar']] -> "[value:myVar]")
+        // and then rejected the valid variable name; the canonical reader extracts .value. This pins
+        // the corrected read on the discriminating option shape.
+        given:
+        enableWrite()
+        def writtenFields = [:]
+        def moreParamsFired = false
+        def uVar2Written = false
+
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/btn" && body?.name == "moreParams") moreParamsFired = true
+            if (path == "/installedapp/update/json") {
+                body?.each { k, v ->
+                    def key = _settingKeyOf(k)
+                    if (key != null) {
+                        writtenFields[key] = v
+                        if (key == "uVar2.1") uVar2Written = true
+                    }
+                }
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params ->
+            ruleConfigJson(100, "r", [[name: "actType.1", type: "enum",
+                options: ["modeActs": "Run Custom Action"]]])
+        }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params ->
+            def inputs = [
+                [name: "actType.1", type: "enum", options: ["modeActs": "Run Custom Action"]],
+                [name: "actSubType.1", type: "enum", options: ["getDefinedAction": "Run Custom Action"]],
+                [name: "myCapab.1", type: "enum", options: ["Switch": "Switch"]],
+                [name: "devices.1", type: "capability.switch", multiple: true],
+                [name: "cCmd.1", type: "text"],
+                [name: "moreParams", type: "button"],
+                [name: "actionDone", type: "button"]
+            ]
+            if (moreParamsFired && !uVar2Written) {
+                inputs = inputs + [
+                    [name: "cpType2.1", type: "enum",
+                     options: ["string": "String", "number": "Number", "decimal": "Decimal"]],
+                    [name: "uVar2.1", type: "bool"],
+                    [name: "cpVal2.1", type: "text"]
+                ]
+            } else if (uVar2Written) {
+                // xVar enum delivered as a List of {value:...} option maps -- the shape the old
+                // hand-rolled reader mishandled. The canonical reader extracts .value.
+                inputs = inputs + [
+                    [name: "cpType2.1", type: "enum",
+                     options: ["string": "String", "number": "Number", "decimal": "Decimal"]],
+                    [name: "uVar2.1", type: "bool"],
+                    [name: "xVar2.1", type: "enum",
+                     options: [[value: "myVar"], [value: "counter"], [value: "temp"]]]
+                ]
+            }
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "doActPage", title: "T", install: false, error: null,
+                             sections: [[title: "", input: inputs, paragraphs: ["seq"]]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        hubGet.register('/device/fullJson/42') { params -> '{"id":"42","name":"Device1"}' }
+
+        when:
+        def result = script.toolSetRule([
+            appId: 100,
+            addAction: [
+                capability: "runCommand",
+                command: "setLevel",
+                deviceIds: [42],
+                parameters: [[type: "NUMBER", variable: "myVar"]]
+            ],
+            confirm: true
+        ])
+
+        then: "the variable name validates against the List-of-{value:...} enum and lands at xVar2.1"
+        result.success == true
+        writtenFields["uVar2.1"] == "true"
+        writtenFields["xVar2.1"] == "myVar"
     }
 
     def "addAction runCommand literal parameter: moreParams+P-discovery writes cpVal at P=2"() {


### PR DESCRIPTION
## What this does

Rule Machine's variable-name pickers (used when a rule reads a hub variable -- e.g. a `runCommand` action parameter sourced from a variable, or a "Variable A vs Variable B" condition) return their option lists in a few different shapes depending on context. Three of these read sites each had their own small hand-written parser for those shapes, and one shape was parsed wrong -- it turned a valid variable name into a stringified map and then rejected it. This routes all three through the single shared reader the rest of the code already uses, so they all handle every shape the same, correct way.

## Summary

- Route the `runCommand` variable-parameter picker and the LHS/RHS `compareToVariable` condition pickers through the shared `_rmReadPickerOptionStrings` reader, instead of three separate hand-rolled `Map?keySet : List?collect` parsers.
- The shared reader additionally handles the `List-of-{value:...}` option shape the hand-rolled readers mishandled (it stringified a value-map to `"[value:foo]"` and then rejected the valid variable name).
- Behaviour-preserving on the shapes the old readers already handled (Map keys, list-of-strings); the value-map handling is the only added behaviour.

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [x] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- `libraries/mcp-native-rules-lib.groovy`: the runCommand `xVar` picker, the condition LHS variable picker, and the RHS `compareToVariable` picker now call `_rmReadPickerOptionStrings` (the same reader the setVariable copy-from-variable / fromDevice / math source modes already use).
- Deliberately left hand-rolled: `walkStep`'s `validateEnum` (its options are pre-normalised to `{value, label}` upstream by `_rmCollectWalkSchema`, so the swap would be behaviour-identical) and the device-reference picker (it reads the Map **key** as the reference -- a different contract than the reader's `.value` extraction).
- Spock regression specs for the `List-of-{value:...}` shape on the runCommand and compareToVariable pickers.

## Release Notes

- Internal refactor: Rule Machine variable-name pickers now share a single option-list reader. No user-facing behaviour change.

## Testing

- `python tests/sandbox_lint.py` — passes.
- `./gradlew test` — full Spock suite passes.
- The new regression specs were verified both ways: they fail if the picker reads are reverted to the old hand-rolled parsers, confirming they pin the corrected behaviour.
- Live smoke on a test hub: created a rule with a `Variable A > Variable B` (`compareToVariable`) condition; both variable names validated against the live picker and wrote correctly, confirming the change preserves behaviour on the option shape the hub actually returns.
- No `tests/e2e_test.py` scenario added: the change is behaviour-identical on the shape the live hub returns (confirmed by the smoke above), so there is no client-observable difference to cover; the added value-map shape handling is covered by the Spock specs.

## Checklist

- [ ] **Unit tests added for any new MCP tools** — N/A (no new tools); regression specs added for the changed reads.
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed — N/A (behaviour-identical on the live path)
- [ ] Documentation updated if user-facing behaviour or tool surface changed — N/A (no tool-surface change)
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules — N/A (no new/renamed tools)
