### PR TITLE
ci: stop the e2e required check from blocking docs-only PRs (also completes hub2-source inventory)

### DIFF
--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -22,26 +22,14 @@ name: Hub E2E (test hub)
 on:
   pull_request_target:
     branches: [main]
-    # Skip when only docs / non-test files change. Cuts CI cost on
-    # README-only / SKILL-only PRs that can't break the hub-side surface.
-    paths:
-      - 'hubitat-mcp-server.groovy'
-      - 'hubitat-mcp-rule.groovy'
-      - 'e2e-deadman-watchdog.groovy'
-      - 'e2e-deadman-watchdog-v2.groovy'
-      - 'tests/e2e_test.py'
-      - '.github/workflows/hub-e2e.yml'
-      - '.github/scripts/lease_acquire.sh'
-      - '.github/scripts/lease_release.sh'
-      - '.github/scripts/mcp_setup_env.sh'
-      - '.github/scripts/mcp_restore_env.sh'
-      - '.github/scripts/mcp_validate_package_tool.sh'
-      - '.github/scripts/mcp_watchdog_lib.sh'
-      - '.github/scripts/mcp_watchdog_deploy.sh'
-      - '.github/scripts/mcp_arm_watchdog.sh'
-      - '.github/scripts/mcp_disarm_watchdog.sh'
-      - 'libraries/**'
-      - 'bundles/**'
+    # Deliberately NO `paths:` filter. `e2e` is a REQUIRED status check, and a paths-filtered
+    # required check never reports on a PR that doesn't touch those paths -- it sits at
+    # "Expected -- waiting for status to be reported" forever, so a docs-only PR can never
+    # merge. Instead the workflow always triggers and the e2e job's `gate` step detects whether
+    # any hub-relevant file changed: none changed (docs-only / non-hub PR) -> report green
+    # WITHOUT running the suite; any changed -> run the real suite. The hub-relevant allowlist
+    # lives in that gate step and is the source of truth for "what must exercise e2e" -- do NOT
+    # reintroduce a workflow-level paths: filter here (it recreates the never-reports deadlock).
   workflow_dispatch:
     inputs:
       pr_number:
@@ -208,26 +196,66 @@ jobs:
         with:
           ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || github.event.pull_request.head.sha || github.ref }}
 
-      - name: Check secret availability + skip if absent
-        # MCP_URL / WATCHDOG_URL are empty only when the secrets aren't configured at all --
-        # e.g. someone forked the whole project to a repo without the donated test hub, or
-        # @level99 has not yet provisioned the separate watchdog endpoint. (Under
-        # pull_request_target on the upstream repo the run is in trusted context, so the
-        # secrets ARE present for both trusted and approved fork PRs; fork-PR secret
-        # stripping does NOT apply here the way it does to a plain pull_request trigger.)
-        # In the no-secret case we skip cleanly rather than fail red -- e2e must not go red
-        # before WATCHDOG_MCP_URL exists. GitHub doesn't allow `secrets` in job-level `if:`
-        # conditions, so the check happens here as a step output and gates everything below.
+      - name: Gate — secret availability + hub-relevant change detection
+        # Two independent reasons to report green WITHOUT running the hub suite. Both write a
+        # line to the run summary so a skip-green is never mistaken for a real pass.
+        #
+        # 1) Secrets absent. MCP_URL / WATCHDOG_URL are empty only when the secrets aren't
+        #    configured at all -- e.g. someone forked the project without the donated test hub,
+        #    or @level99 has not provisioned the watchdog endpoint. (Under pull_request_target on
+        #    the upstream repo the run is in trusted context, so the secrets ARE present for
+        #    trusted and approved fork PRs.) GitHub doesn't allow `secrets` in a job-level `if:`,
+        #    so the check happens here as a step output that gates every step below.
+        # 2) No hub-relevant file changed (docs-only / non-hub PR). The workflow-level `paths:`
+        #    filter was removed because `e2e` is a REQUIRED check and a paths-filtered required
+        #    check never reports on a docs-only PR (it hangs at "Expected -- waiting" and blocks
+        #    merge). So the workflow always triggers and relevance is detected HERE against the
+        #    same allowlist. A PR touching ANY allowlist path takes the real-run branch, so this
+        #    cannot green-wash a change e2e should test; detection fails SAFE (run on any doubt);
+        #    workflow_dispatch always runs the real suite.
         id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -z "$MCP_URL" ]; then
             echo "::notice::LEVEL99_TEST_HUB_MCP_URL secret not available — skipping E2E (expected on repos without the test hub configured)"
+            echo "E2E NOT RUN — test-hub secret (LEVEL99_TEST_HUB_MCP_URL) not configured." >> "$GITHUB_STEP_SUMMARY"
             echo "available=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "$WATCHDOG_URL" ]; then
-            echo "::notice::WATCHDOG_MCP_URL secret not available — skipping E2E (the v2 dead-man watchdog endpoint is not provisioned yet; this is expected until @level99 sets WATCHDOG_MCP_URL)"
+            exit 0
+          fi
+          if [ -z "$WATCHDOG_URL" ]; then
+            echo "::notice::WATCHDOG_MCP_URL secret not available — skipping E2E (the v2 dead-man watchdog endpoint is not provisioned yet; expected until @level99 sets WATCHDOG_MCP_URL)"
+            echo "E2E NOT RUN — watchdog secret (WATCHDOG_MCP_URL) not configured." >> "$GITHUB_STEP_SUMMARY"
             echo "available=false" >> "$GITHUB_OUTPUT"
-          else
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"   # manual dispatch always runs the real suite
+            exit 0
+          fi
+          # Fetch the PR's changed-file list. Fail SAFE: if it can't be read, run the full suite
+          # rather than risk green-washing a code PR.
+          files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename')" || {
+            echo "::warning::Could not list changed files — running the full E2E suite to be safe."
             echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+          # Hub-relevant allowlist — the source of truth for "what must exercise e2e".
+          # (`case` patterns: `*` matches `/`, so `libraries/*` covers nested paths too.)
+          relevant=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              hubitat-mcp-server.groovy|hubitat-mcp-rule.groovy|e2e-deadman-watchdog.groovy|e2e-deadman-watchdog-v2.groovy|tests/e2e_test.py|.github/workflows/hub-e2e.yml|.github/scripts/lease_acquire.sh|.github/scripts/lease_release.sh|.github/scripts/mcp_setup_env.sh|.github/scripts/mcp_restore_env.sh|.github/scripts/mcp_validate_package_tool.sh|.github/scripts/mcp_watchdog_lib.sh|.github/scripts/mcp_watchdog_deploy.sh|.github/scripts/mcp_arm_watchdog.sh|.github/scripts/mcp_disarm_watchdog.sh|libraries/*|bundles/*)
+                relevant=true ;;
+            esac
+          done <<< "$files"
+          if [ "$relevant" = "true" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::No hub-relevant files changed — reporting E2E green WITHOUT running the suite (docs-only / non-hub PR)."
+            echo "E2E NOT RUN — no hub-relevant files changed (docs-only / non-hub PR). Skipped on purpose; this green does NOT mean the e2e suite executed." >> "$GITHUB_STEP_SUMMARY"
+            echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: actions/setup-python@v6

--- a/resources/hub2-source/README.md
+++ b/resources/hub2-source/README.md
@@ -46,7 +46,7 @@ two load-bearing files:
   button encoding. Endpoints it calls: `/installedapp/update/json` (settings
   POST), `/installedapp/btn` (button click), `/installedapp/ssr/` (server-side
   page render), `/installedapp/collapseCallback/`, `/installedapp/configure/`.
-- **`main.js`** (148 KB) — the broader classic app-list / app-config UI logic:
+- **`main.js`** (145 KB) — the broader classic app-list / app-config UI logic:
   `submitOnChange`, `formAction`, `nextPage` / `btnNext` page navigation,
   `AppButtons`, plus `/installedapp/status/`, `/installedapp/createchild/`,
   `/installedapp/disable`, `/installedapp/configure/`.
@@ -54,13 +54,13 @@ two load-bearing files:
 Supporting files:
 
 - **`helpers.js`** (16 KB) — shared UI helpers (`/installedapp/list`).
-- **`hub2utils.js`** (3.6 KB) — small shared utility shims.
+- **`hub2utils.js`** (3.7 KB) — small shared utility shims.
 - **`hubitat.min.js`** (33 KB) — **not** the dynamicPage engine: the Handlebars
   template runtime (`registerPartial`/`registerHelper`/`unregisterDecorator`),
   modal / z-index helpers (`showModal`, `updateZIndex`), and the hub-control
   toolbar (`reboot`/`shutdown`/`zwaveRepair` via jQuery `.ajax`). Vendored for
   completeness of the classic `/ui2/js` set.
-- **`success-compiled.js`** (833 B) — tiny precompiled Handlebars template bundle.
+- **`success-compiled.js`** (842 B) — tiny precompiled Handlebars template bundle.
 
 ### On the "Rule Machine is a black box" note
 
@@ -106,6 +106,7 @@ user-facing app type ("Visual Rules Builder" parent; children are hidden type
 | `GET  /app/ruleBuilderGenerateRule?appId=&prompt=` | VRB AI generate (Gemini cloud) → `{success, whenNodes, thenNodes, elseNodes}` |
 | `GET  /app/ruleBuilderSuggestions` | Prompt suggestions for the VRB AI-generate dialog |
 | `GET  /device/listWithCapabilities/json` | Device list with capabilities — feeds the VRB device pickers |
+| `GET  /device/listJson?capability=<cap>` | Classic `dynamicPage` device-input picker feed (`appUI.js` line 209 `$.getJSON('/device/listJson?capability='…)`, `main.js`) — a capability-filtered device list. The MCP server reaches the same data via `/device/fullJson` + `hub_list_devices`; this is the older classic-engine path, distinct from the Vue `listWithCapabilities/json` above |
 | `GET  /modes/list/json` | Location modes list — feeds the VRB mode trigger/condition/action dialogs |
 | `GET  /appui/createBasicRulesChild` | Server-creates a new Basic Rules child → `{success, appId}` |
 | `GET  /appui/clearEmptyBasicRules` | Sweeps empty (never-saved) Basic Rules children |
@@ -118,6 +119,8 @@ user-facing app type ("Visual Rules Builder" parent; children are hidden type
 | `GET  /installedapp/statusJson/<id>` | App status JSON |
 | `GET  /installedapp/eventsJson/<id>` | Events history JSON |
 | `POST /installedapp/forcedelete/<id>/quiet` | Force-delete, no prompts |
+| `GET  /installedapp/createchild/<ns>/<appName>/parent/<parentId>` | Server-creates a child app instance under a parent — a raw GET that 302-redirects to the new child's `configure/<id>` page. Used by the MCP server (`_rmCreateChildApp`) to instantiate classic child apps (Basic Rule, RM child, etc.) |
+| `POST /installedapp/disable` | Enable/disable an installed app — body `{id, disable:<bool>}` (`true` disables, `false` enables). Posted by `main.js` `enableApp()`/`disableApp()`. Not currently called by the MCP server |
 | `GET  /installedapp/direct/<alias>` | NOT a Vue CRUD endpoint — a name-addressed 302 redirect chain: `direct/<alias>` → `create/<typeId>` → `configure/<instanceId>` (type ids vary per hub; the alias is the stable key). Get-or-create, so it doubles as a stable name→id resolver (fw 2.5.0.143) |
 | `GET  /installedapp/direct/hubVariables` | Singleton: the chain lands on the SAME instance every visit. The Vue `HubVariables` component is a non-functional stub — the classic `hubVar` wizard is the real variable-CRUD contract |
 | `GET  /installedapp/direct/swapDevice` | Transient: every visit CREATES a fresh instance (1802, then 1803 observed) — callers own cleanup of instances they don't drive to completion. The swap flow itself is the classic `mainPage` wizard; its pickers offer only free-standing devices (app-owned child/component devices are excluded from both `oldDev` and `newDev`); `oldDev` additionally lists only devices referenced by at least one app, while `newDev` offers any compatible free-standing device (fw 2.5.0.143) |

--- a/resources/hub2-source/README.md
+++ b/resources/hub2-source/README.md
@@ -119,7 +119,7 @@ user-facing app type ("Visual Rules Builder" parent; children are hidden type
 | `GET  /installedapp/statusJson/<id>` | App status JSON |
 | `GET  /installedapp/eventsJson/<id>` | Events history JSON |
 | `POST /installedapp/forcedelete/<id>/quiet` | Force-delete, no prompts |
-| `GET  /installedapp/createchild/<ns>/<appName>/parent/<parentId>` | Server-creates a child app instance under a parent — a raw GET that 302-redirects to the new child's `configure/<id>` page. Used by the MCP server (`_rmCreateChildApp`) to instantiate classic child apps (Basic Rule, RM child, etc.) |
+| `GET  /installedapp/createchild/<namespace>/<appName>/parent/<parentId>` | Server-creates a child app instance under a parent — a raw GET that 302-redirects to the new child's `configure/<id>` page. Used by the MCP server (`_rmCreateChildApp`) to instantiate classic child apps (Basic Rule, RM child, etc.) |
 | `POST /installedapp/disable` | Enable/disable an installed app — body `{id, disable:<bool>}` (`true` disables, `false` enables). Posted by `main.js` `enableApp()`/`disableApp()`. Not currently called by the MCP server |
 | `GET  /installedapp/direct/<alias>` | NOT a Vue CRUD endpoint — a name-addressed 302 redirect chain: `direct/<alias>` → `create/<typeId>` → `configure/<instanceId>` (type ids vary per hub; the alias is the stable key). Get-or-create, so it doubles as a stable name→id resolver (fw 2.5.0.143) |
 | `GET  /installedapp/direct/hubVariables` | Singleton: the chain lands on the SAME instance every visit. The Vue `HubVariables` component is a non-functional stub — the classic `hubVar` wizard is the real variable-CRUD contract |


### PR DESCRIPTION
## Summary

- Fix a merge-blocking CI deadlock: the required `e2e` status check never reported on docs-only
  PRs. `hub-e2e.yml` had a workflow-level `paths:` filter, so on a PR touching none of those paths
  the workflow never triggered — and a *required* check that never runs hangs at "Expected —
  waiting for status" forever, blocking the merge.
- Also completes the `resources/hub2-source/` endpoint inventory (the original purpose of this PR):
  three missing/prose-only endpoints and three corrected file sizes.

## Type of change

- [x] `ci` — CI/CD pipeline change
- (also contains `docs` changes — see Changes)

## Changes

**CI — `.github/workflows/hub-e2e.yml`:**
- Remove the workflow-level `paths:` filter so the workflow always triggers (a paths-filtered
  *required* check can never report on a PR outside those paths).
- Move the same hub-relevant allowlist into the `e2e` job's `gate` step:
  - **No hub-relevant file changed** (docs-only / non-hub PR) → report **green without running the
    hub suite**, and write an "E2E NOT RUN — docs-only" line to the run summary so a skip-green is
    never mistaken for a real pass.
  - **Any allowlist path changed** → run the real suite exactly as before.
- Detection **fails safe**: if the changed-file list can't be fetched, the full suite runs — so a
  code PR can never be green-washed.

**Docs — `resources/hub2-source/README.md`:**
- Add `GET /device/listJson?capability=` (classic device-input picker feed; server uses `/device/fullJson`).
- Promote `GET /installedapp/createchild/<namespace>/<appName>/parent/<parentId>` to a table row
  (used by `_rmCreateChildApp`).
- Add `POST /installedapp/disable` (body `{id, disable:<bool>}`; not yet called by the server).
- Correct file sizes: `main.js` 148→145 KB, `success-compiled.js` 833→842 B, `hub2utils.js` 3.6→3.7 KB.

- Part of #257 (does **not** close it — the umbrella stays open until every finding is addressed).

## Release Notes

- No user-facing change — internal CI reliability (docs-only PRs are no longer blocked by the e2e
  required check) and reverse-engineering reference docs (`resources/hub2-source/` inventory).

## Testing

- `hub-e2e.yml` YAML validated. The real e2e suite ran on this PR (run 27620412049) and passed —
  the PR edits a hub-relevant path, so it exercised the real-run branch. The docs-only auto-green
  branch takes effect for future pure-docs PRs once this is on `main` (pull_request_target reads the
  workflow from the base branch).
- In-job allowlist is identical to the removed `paths:` list; detection fails safe to running the
  full suite.

## Checklist

- [ ] Unit tests for new MCP tools — N/A (no tool)
- [ ] Sandbox lint — N/A (no `.groovy` change)
- [ ] `./gradlew test` — N/A (no code change)
- [ ] Live-hub BAT tests — N/A
- [x] Documentation updated
- [ ] New/renamed MCP tools follow AGENTS.md — N/A
