### PR TITLE
feat: bulk form for hub_create_variable + RM variable-source doc notes

### DIFF
--- a/agent-skill/hubitat-mcp/tool-reference.md
+++ b/agent-skill/hubitat-mcp/tool-reference.md
@@ -184,7 +184,7 @@ Manage hub variables (every type — Number, Decimal, String, Boolean, DateTime)
 | `hub_list_variables` | List all hub variables (with type/connector linkage) and rule-engine variables. | None |
 | `hub_get_variable` | Get a variable's value + metadata (type, deviceId, attribute). | None |
 | `hub_set_variable` | Set an existing variable's value. Falls back to rule_engine namespace when no hub var matches. | None |
-| `hub_create_variable` | Create a new hub variable. Type enum: Number / Decimal / String / Boolean / DateTime. | Write master |
+| `hub_create_variable` | Create a new hub variable, or several at once via `variables=[{name,type,value},...]` (mutually exclusive with the single name/type/value form). Type enum: Number / Decimal / String / Boolean / DateTime. String values must be non-empty. | Write master |
 | `hub_delete_variable` | Permanently delete a variable (DESTRUCTIVE — also removes its connector if any). `force=true` if rules reference it. | Write master + recent backup |
 | `hub_create_connector` | Create a virtual-device connector for an existing hub variable. | Write master |
 | `hub_delete_connector` | Remove the connector device for a hub variable (the variable itself is unchanged). | Write master |

--- a/docs/rm_action_subtype_schemas.md
+++ b/docs/rm_action_subtype_schemas.md
@@ -122,6 +122,8 @@ Actions: `setSpeed`, `cycle`
 | `delay` | Map | |
 | `rawSettings` | Map | |
 
+Note: fan `setSpeed` takes a fixed enum speed only (low / medium-low / medium / medium-high / high / on / off / auto); RM has no variable-sourced fan speed because the classic wizard exposes a variable toggle only for numeric/text value fields, not enum pickers. For a variable-driven speed, use `runCommand` with `command='setSpeed'` and `parameters=[{type:'string', variable:'<varName>'}]` (per-parameter variable sourcing).
+
 ### button
 Actions: `push`, `pushPerMode`, `choosePerMode`
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1037,7 +1037,7 @@ def getGatewayConfig() {
                 hub_list_variables: "List all hub variables (with type/connector linkage) and rule-engine variables.",
                 hub_get_variable: "Get a variable's value + metadata (type, deviceId, attribute). Args: name",
                 hub_set_variable: "Set an existing variable's value. Falls back to rule_engine namespace when no hub var matches. Args: name, value",
-                hub_create_variable: "Create a new hub variable. Args: name, type (Number|Decimal|String|Boolean|DateTime), value, confirm=true",
+                hub_create_variable: "Create a new hub variable, or several at once. Single: name, type (Number|Decimal|String|Boolean|DateTime), value, confirm=true. Bulk: variables=[{name,type,value},...], confirm=true (mutually exclusive with the single form). A String value must be non-empty",
                 hub_delete_variable: "Permanently delete a variable (DESTRUCTIVE — also removes its connector if any). Args: name, confirm=true, [force=true if rules reference it]",
                 hub_create_connector: "Create a virtual-device connector for an existing hub variable. For Number/Decimal vars, connectorType picks the device type (Dimmer|Variable|Volume|ColorTemp|Humidity|Illuminance, default Variable). Args: name, connectorType?, confirm=true",
                 hub_delete_connector: "Remove the connector device for a hub variable (variable itself unchanged). Args: name, confirm=true",
@@ -5223,6 +5223,7 @@ For the live machine-readable per-field schema (action enums, required and optio
 - **Thermostat** (`capability='thermostat'`): `action=(any)` + `deviceIds` + optional `mode`/`fanMode`/`heatingSetpoint`/`coolingSetpoint`/`adjustHeating`/`adjustCooling`.
 - **Shade/blind** (`capability='shade'`): `open`/`close`/`stop` + `deviceIds`. `setPosition` + `deviceIds` + `position` (0–100).
 - **Fan** (`capability='fan'`): `setSpeed` + `deviceIds` + `speed` (low/med/high/auto/etc.). `cycle` + `deviceIds`.
+  - **NOTE:** fan `setSpeed` takes a fixed enum speed only (low / medium-low / medium / medium-high / high / on / off / auto); RM has no variable-sourced fan speed (unlike dimmer `setLevel`'s `levelVariable`) because the classic wizard exposes a variable toggle only for numeric/text value fields, not enum pickers. For a variable-driven speed, use `capability='runCommand'` with `command='setSpeed'` + `parameters=[{type:'string', variable:'<varName>'}]` (per-parameter variable sourcing).
 - **Mode** (`capability='mode'`): `action='setMode'` + `modeId` (Integer) OR `modeName` (String, case-insensitive). When `modeName` is supplied it is resolved to the numeric mode ID via `location.modes` before the write; an unknown name fails fast with the list of valid mode names. Use `hub_list_modes` to inspect available modes first. Note: `addAction` mode uses the `modeName` field for explicit name-based resolution; `addTrigger` mode uses the generic `state` field instead because triggers cover a superset of device-state events where a single field serves multiple capability types -- `modeName` vs `state` is an intentional surface difference, not a typo.
 - **Hub Variable** (`capability='setVariable'`, alias `'variable'`): `variable` (target) + exactly ONE source mode -- `value` (numeric constant), `sourceVariable` (copy from another hub variable), `fromDevice` (`{deviceId, attribute}` -- read a device attribute), or `math` (`{left, op, right}` -- structured variable math). All variable names (`variable`, `sourceVariable`, `math` var-operands) must be existing hub variable names -- unknown names are rejected before any write. The four source modes are mutually exclusive; providing more than one is rejected. `math` binary operators (`+ - * / %`) require `right`; unary operators (`negate absolute round random sqrt sin cos tan asin acos atan log toRadians toDegrees`) reject `right`. A `math` operand that is a number becomes a literal constant; a string operand is a variable name. `fromDevice` reads from any hub device (not just MCP-selected); an attribute not in the device's filtered enum is rejected with `success=false` and the device's available-attribute list. See `addAction setVariable` in `docs/rm_action_subtype_schemas.md` for the full field reference.
 - **Logging / Messaging**: `capability='log' + message`. `capability='notification' + deviceIds + message`. `capability='httpGet' + url`. `capability='httpPost' + url + body + optional contentType`. `capability='ping' + ip`.
@@ -5270,6 +5271,16 @@ Applies to `addRequiredExpression.conditions[]` (STPage) and `addAction.expressi
 - **Sub-expression (parens) -- addRequiredExpression-only**: `{subExpression:{conditions:[...], operator?:'AND'|'OR'|'XOR', operators?:[...]}}`. The STPage walker recursively handles nesting of arbitrary depth. **`addAction` (ifThen/elseIf/repeatWhile/waitExpression) REJECTS nested subExpression** with `"nested subExpression on this row is not yet supported"`. Flatten the conditions list, or move the nested expression to a Required Expression.
 
 `addTrigger.condition` supports a narrower subset: Variable (incl. `compareToVariable`), Custom Attribute, and enum/numeric device-state. Mode-via-picker / Between two times / compareToDevice are NOT yet supported on `selectTriggers` -- the `_rmBuildCondition` helper is a static direct-write path, not the shared `_rmWalkConditionReveal` walker.
+
+### Supported comparison shapes for a numeric condition
+
+A numeric device condition's right-hand side can be one of these shapes (the RM 5.1 wizard exposes the `isDev_` device-RHS toggle but no `isVar_` toggle on a numeric device condition, so "device attribute vs a hub variable" is NOT a directly-supported shape):
+
+- a) **Device attribute vs literal value** -- `{capability:'Temperature', deviceIds:[N], comparator:'>', value:72}`.
+- b) **Device attribute vs another device's same attribute** (`compareToDevice`, numeric capabilities only) -- `{capability:'Temperature', deviceIds:[N], comparator:'>', compareToDevice:{deviceId:M, offset?:-2}}`. The reference reads the SAME capability; `offset` is optional.
+- c) **Variable vs variable** (`compareToVariable`, Variable-capability LHS only) -- `{capability:'Variable', variable:'<hubVarName>', comparator:'=', compareToVariable:'<otherHubVarName>'}`.
+
+To compare a **device attribute against a hub variable**, there is no direct shape -- read the attribute into a variable first with an `addAction setVariable` using `fromDevice` (`{deviceId, attribute}`), then compare variable-vs-variable per shape (c).
 
 ### `addRequiredExpression` operator contract
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1781,11 +1781,12 @@ def handleGateway(gatewayName, toolName, toolArgs) {
 
     // Option D: Pre-validate required parameters and return a helpful error.
     def safeArgs = toolArgs ?: [:]
-    // Read this tool's required-param list from the small memoized map instead of
-    // rebuilding the whole ~111-tool catalog on every gateway call. A missing key
-    // means the tool has no required params. The full catalog (with the
-    // [[FLAT_TRIM]]-stripped param descriptions for the hint) is rebuilt lazily
-    // only inside the if (missing) branch below, which fires rarely.
+    // Read this tool's required-param list from the memoized map. Computing the
+    // memo key walks the catalog once per gateway call; the memo saves the per-tool
+    // map re-derivation, not the catalog walk. A missing key means the tool has no
+    // required params. The full catalog (with the [[FLAT_TRIM]]-stripped param
+    // descriptions for the hint) is rebuilt lazily only inside the if (missing)
+    // branch below, which fires rarely.
     def required = requiredParamsByTool()[toolName]
     // Gate-bypassing meta-calls return pure static content with NO hub mutation and
     // short-circuit at the very top of their handler (before any gate / appId check),
@@ -2012,11 +2013,12 @@ def getAllToolDefinitions() {
 // hub_update_app) recompiles the class without firing updated() or bumping
 // currentVersion() (PRs ride the same version), so neither updated() invalidation
 // nor a version stamp catches a same-version required-array change -- a content
-// fingerprint does. Cheap append pass, no per-tool allocation; kept as the raw
-// string (no sandbox digest API assumed, String equality is cheap).
-def requiredParamsCatalogFingerprint() {
+// fingerprint does. Operates on a pre-fetched defs list so the caller can build
+// both the key and the memo from one catalog walk; kept as the raw string (no
+// sandbox digest API assumed, String equality is cheap).
+def requiredParamsCatalogFingerprint(List defs) {
     def sb = new StringBuilder()
-    getAllToolDefinitions().each { tool ->
+    defs.each { tool ->
         def req = tool?.inputSchema?.required
         if (req instanceof List && !req.isEmpty()) {
             sb.append(tool.name as String).append(':').append(req.join(',')).append(';')
@@ -2026,19 +2028,21 @@ def requiredParamsCatalogFingerprint() {
 }
 
 // Memo of each tool's required-params array (fresh String copies, never the
-// mutable raw def list) for the gateway missing-param pre-check, so handleGateway
-// need not rebuild the full catalog per call. Keyed on the catalog fingerprint so
-// it self-heals on a same-version code deploy, and cleared in updated() alongside
-// the BM25 corpus. Tools with no/empty inputSchema.required are omitted, so a
-// miss == "no required params".
+// mutable raw def list) for the gateway missing-param pre-check. The full catalog
+// is walked once per call to compute the fingerprint key; the memo saves the
+// per-tool map re-derivation (the String-copy allocation), not the catalog build.
+// Keyed on the catalog fingerprint so it self-heals on a same-version code deploy,
+// and cleared in updated() alongside the BM25 corpus. Tools with no/empty
+// inputSchema.required are omitted, so a miss == "no required params".
 def requiredParamsByTool() {
-    def fp = requiredParamsCatalogFingerprint()
+    def defs = getAllToolDefinitions()
+    def fp = requiredParamsCatalogFingerprint(defs)
     def cached = atomicState.requiredParamsByTool
     if (cached instanceof Map && atomicState.requiredParamsByToolFingerprint == fp) {
         return cached
     }
     def built = [:]
-    getAllToolDefinitions().each { tool ->
+    defs.each { tool ->
         def req = tool?.inputSchema?.required
         if (req instanceof List && !req.isEmpty()) {
             built[tool.name as String] = req.collect { it as String }

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -473,6 +473,7 @@ def updated() {
     atomicState.remove("toolSearchTokens")        // ...and the paired BM25 token cache in lockstep
     atomicState.remove("toolSearchCorpusVersion")  // ...and the corpus version stamp
     atomicState.remove("requiredParamsByTool")    // ...and the gateway required-param memo
+    atomicState.remove("requiredParamsByToolFingerprint")  // ...and its content fingerprint in lockstep
     initialize()
 
     // ===== One-time custom-engine rename migration =====
@@ -2006,19 +2007,34 @@ def getAllToolDefinitions() {
     return _getAllToolDefinitions_partNativeRM() + _getAllToolDefinitions_partRooms() + _getAllToolDefinitions_partBundles() + _getAllToolDefinitions_partVisualRules() + _getAllToolDefinitions_partDiscovery() + _getAllToolDefinitions_partAppCloner() + _getAllToolDefinitions_partSelfAdmin() + _getAllToolDefinitions_partHpm() + _getAllToolDefinitions_partCodeManagement() + _getAllToolDefinitions_partCustomRules() + _getAllToolDefinitions_partVariables() + _getAllToolDefinitions_partVirtualDevices() + _getAllToolDefinitions_partDevices() + _getAllToolDefinitions_partSystem() + _getAllToolDefinitions_partDiagnostics() + _getAllToolDefinitions_partDebugLogging() + _getAllToolDefinitions_partItemBackups() + _getAllToolDefinitions_partFiles()
 }
 
-// Lightweight memoized name -> inputSchema.required map for the gateway
-// dispatch-path missing-param pre-check. handleGateway used to rebuild the
-// entire ~111-tool catalog (applyDescriptionTransform(getAllToolDefinitions())
-// + collectEntries) on EVERY gateway call just to read one tool's required
-// array. required arrays carry no [[FLAT_TRIM]] markers and applyDescriptionTransform
-// never touches them (it only rewrites descriptions), and required is identical
-// in flat and gateway mode -- so no transform is needed here. Stored as a plain
-// Map<String,List<String>> (fresh String copies, never the mutable raw def list)
-// in atomicState; invalidated in updated() alongside the BM25 corpus. Tools with
-// no/empty inputSchema.required are omitted, so a miss == "no required params".
+// Content fingerprint of the catalog's name -> required-params shape, used as
+// the memo key in requiredParamsByTool(). A code deploy (HPM update,
+// hub_update_app) recompiles the class without firing updated() or bumping
+// currentVersion() (PRs ride the same version), so neither updated() invalidation
+// nor a version stamp catches a same-version required-array change -- a content
+// fingerprint does. Cheap append pass, no per-tool allocation; kept as the raw
+// string (no sandbox digest API assumed, String equality is cheap).
+def requiredParamsCatalogFingerprint() {
+    def sb = new StringBuilder()
+    getAllToolDefinitions().each { tool ->
+        def req = tool?.inputSchema?.required
+        if (req instanceof List && !req.isEmpty()) {
+            sb.append(tool.name as String).append(':').append(req.join(',')).append(';')
+        }
+    }
+    return sb.toString()
+}
+
+// Memo of each tool's required-params array (fresh String copies, never the
+// mutable raw def list) for the gateway missing-param pre-check, so handleGateway
+// need not rebuild the full catalog per call. Keyed on the catalog fingerprint so
+// it self-heals on a same-version code deploy, and cleared in updated() alongside
+// the BM25 corpus. Tools with no/empty inputSchema.required are omitted, so a
+// miss == "no required params".
 def requiredParamsByTool() {
+    def fp = requiredParamsCatalogFingerprint()
     def cached = atomicState.requiredParamsByTool
-    if (cached instanceof Map) {
+    if (cached instanceof Map && atomicState.requiredParamsByToolFingerprint == fp) {
         return cached
     }
     def built = [:]
@@ -2029,6 +2045,7 @@ def requiredParamsByTool() {
         }
     }
     atomicState.requiredParamsByTool = built
+    atomicState.requiredParamsByToolFingerprint = fp
     return built
 }
 

--- a/libraries/mcp-self-admin-lib.groovy
+++ b/libraries/mcp-self-admin-lib.groovy
@@ -519,11 +519,11 @@ def _getAllToolDefinitions_partSelfAdmin() {
         ],
         [
             name: "hub_update_package",
-            description: """Developer Mode self-deploy: full HPM-repair of the MCP package at a git ref in one call -- OVERRIDES whatever is installed, the same way Hubitat Package Manager's Repair does, but anchored to packageManifest.json AT `ref` so an UNMERGED PR installs (HPM repair only reads the published manifest).
+            description: """Developer Mode self-deploy: full HPM-repair of the MCP package at a git ref in one call -- OVERRIDES whatever is installed, the same way Hubitat Package Manager's Repair does, but anchored to packageManifest.json AT `ref` so an UNMERGED PR installs (HPM repair only reads the published manifest).[[FLAT_TRIM]]
 
 Deploys every declared library bundle + app from the manifest at `ref`, saving the running self app LAST (its recompile can drop the response, #237). Does NOT touch app instances, undeclared drivers, or anything outside this package's manifest.
 
-Brick-safe: if ANYTHING before the self app save fails (app/manifest fetch, an unresolved app class, a bundle install, a non-self app), it aborts BEFORE touching the self app -- the running server is left exactly as-is and still updatable via hub_update_app, the always-available escape hatch. Self-modification is gated by this tool's own enableDeveloperMode check (it deploys by Apps Code CLASS id, so hub_update_app's instance-id self-update guard does not fire here).
+Brick-safe: if ANYTHING before the self app save fails (app/manifest fetch, an unresolved app class, a bundle install, a non-self app), it aborts BEFORE touching the self app -- the running server is left exactly as-is and still updatable via hub_update_app, the always-available escape hatch. Self-modification is gated by this tool's own enableDeveloperMode check (it deploys by Apps Code CLASS id, so hub_update_app's instance-id self-update guard does not fire here).[[/FLAT_TRIM]]
 
 Gated on enableDeveloperMode (the tool is hidden from tools/list when Developer Mode is off) + the Write master + confirm=true + a recent backup. Use dryRun=true to fetch + parse + plan with ZERO writes (no confirm/backup needed) and see exactly which bundles and apps would deploy.""",
             inputSchema: [

--- a/libraries/mcp-variables-lib.groovy
+++ b/libraries/mcp-variables-lib.groovy
@@ -428,17 +428,13 @@ def toolCreateVariable(args) {
     return _createOneVariable(appId, name, type, value)
 }
 
-// Bulk create driver: validates the array shape, resolves the Hub Variables
-// app id ONCE, then creates each item sequentially. Per-item try/catch so one
-// failure never aborts the rest -- a failed item carries its own `error`.
+// Bulk create driver: requires a non-empty List at the batch level, resolves the
+// Hub Variables app id ONCE, then creates each item sequentially. Per-item
+// try/catch so one failure never aborts the rest -- a malformed (non-Map) item or
+// a bad name/type/value fails only itself and carries its own `error`.
 private Map _createVariablesBulk(variables) {
     if (!(variables instanceof List) || variables.isEmpty()) {
         throw new IllegalArgumentException("variables must be a non-empty array of {name, type, value} objects.")
-    }
-    variables.eachWithIndex { item, idx ->
-        if (!(item instanceof Map)) {
-            throw new IllegalArgumentException("variables[${idx}] must be an object with name, type, and value.")
-        }
     }
 
     def appId = _findHubVariablesAppId()
@@ -447,8 +443,13 @@ private Map _createVariablesBulk(variables) {
     int failedCount = 0
 
     variables.eachWithIndex { item, idx ->
-        def itemName = item.name?.toString()?.trim()
+        // A malformed (non-Map) item fails only itself, never the whole batch --
+        // same per-item isolation as a bad name/type/value below.
+        def itemName = (item instanceof Map) ? item.name?.toString()?.trim() : null
         try {
+            if (!(item instanceof Map)) {
+                throw new IllegalArgumentException("variables[${idx}] must be an object with name, type, and value.")
+            }
             _validateHubVarName(itemName)
             def itemType = _validateHubVarType(item.type?.toString())
             _validateInitialValue(itemName, itemType, item.value)
@@ -468,8 +469,10 @@ private Map _createVariablesBulk(variables) {
             createdCount++
         } catch (Exception e) {
             // Fall back to the array index when the item carried no usable name, so
-            // every failed entry is traceable to its request position.
-            results << [name: (itemName ?: item?.name ?: "variables[${idx}]"), success: false, error: e.message ?: e.toString()]
+            // every failed entry is traceable to its request position. Guard the
+            // .name read behind the Map check -- a non-Map item has no name property.
+            def rawName = (item instanceof Map) ? item.name : null
+            results << [name: (itemName ?: rawName ?: "variables[${idx}]"), success: false, error: e.message ?: e.toString()]
             failedCount++
         }
     }
@@ -939,14 +942,14 @@ def _getAllToolDefinitions_partVariables() {
         ],
         [
             name: "hub_create_variable",
-            description: "Create a new hub variable (global variable visible to apps and Rule Machine), one at a time or several in one call. Use this before hub_set_variable for a name that doesn't exist yet — Hubitat's setGlobalVar cannot create, only update.[[FLAT_TRIM]] Drives the Settings → Hub Variables wizard, since creation isn't exposed via the public app API. Name must not contain any of these characters: ' \" \\ ~ [ : ] < >.[[/FLAT_TRIM]] A String variable's initial value must be non-empty (an empty String reports success but never persists). Single form: name + type + value. Bulk form: variables=[{name,type,value}, ...] -- mutually exclusive with the single form.[[FLAT_TRIM]] Bulk items are created sequentially; each succeeds or fails independently and the result reports per-item status. To also expose the variable to device-only apps, follow up with hub_create_connector.[[/FLAT_TRIM]]",
+            description: "Create a new hub variable (global variable visible to apps and Rule Machine), one at a time or several in one call. Single form: name + type + value.[[FLAT_TRIM]] Bulk form: variables=[{name,type,value}, ...] -- mutually exclusive with the single form. Use this before hub_set_variable for a name that doesn't exist yet -- Hubitat's setGlobalVar cannot create, only update. Drives the Settings -> Hub Variables wizard, since creation isn't exposed via the public app API. Name must not contain any of these characters: ' \" \\ ~ [ : ] < >. A String variable's initial value must be non-empty (an empty String reports success but never persists). Bulk items are created sequentially; each succeeds or fails independently and the result reports per-item status. To also expose the variable to device-only apps, follow up with hub_create_connector.[[/FLAT_TRIM]]",
             inputSchema: [
                 type: "object",
                 properties: [
-                    name: [type: "string", description: "Single form: new variable name, e.g. \"vacationMode\".[[FLAT_TRIM]] Must not contain: ' \" \\ ~ [ : ] < >.[[/FLAT_TRIM]] Omit when using variables."],
-                    type: [type: "string", enum: ["Number", "Decimal", "String", "Boolean", "DateTime"], description: "Single form: variable type.[[FLAT_TRIM]] Omit when using variables.[[/FLAT_TRIM]]"],
-                    value: [description: "Single form: initial value, must match the type.[[FLAT_TRIM]] Omit when using variables.[[/FLAT_TRIM]]"],
-                    variables: [type: "array", description: "Bulk form: several variables in one call (mutually exclusive with name/type/value).", items: [
+                    name: [type: "string", description: "New variable name, e.g. \"vacationMode\". Omit when using variables.[[FLAT_TRIM]] Must not contain: ' \" \\ ~ [ : ] < >.[[/FLAT_TRIM]]"],
+                    type: [type: "string", enum: ["Number", "Decimal", "String", "Boolean", "DateTime"], description: "Variable type. Omit when using variables."],
+                    value: [description: "Initial value, must match the type. Omit when using variables."],
+                    variables: [type: "array", description: "Bulk form: several variables in one call.[[FLAT_TRIM]] Mutually exclusive with name/type/value.[[/FLAT_TRIM]]", items: [
                         type: "object",
                         properties: [
                             name: [type: "string", description: "New variable name (same character rules as the single form)"],

--- a/libraries/mcp-variables-lib.groovy
+++ b/libraries/mcp-variables-lib.groovy
@@ -390,13 +390,26 @@ def _findHubVariablesAppId() {
 
 def toolCreateVariable(args) {
     requireDestructiveConfirm(args.confirm)
+
+    // Bulk form: variables=[{name,type,value}, ...]. Mutually exclusive with
+    // the single name/type/value form. Each item is created SEQUENTIALLY
+    // through the shared Hub Variables system app -- the create wizard has a
+    // known post-write race that makes rapid/parallel creates spuriously fail,
+    // so the loop never parallelizes.
+    if (args.variables != null) {
+        if (args.name != null || args.type != null || args.value != null) {
+            throw new IllegalArgumentException(
+                "Provide EITHER the single name/type/value form OR the bulk variables array -- not both.")
+        }
+        return _createVariablesBulk(args.variables)
+    }
+
     def name = args.name?.toString()?.trim()
     _validateHubVarName(name)
     def type = _validateHubVarType(args.type?.toString())
     def value = args.value
-    if (value == null) {
-        throw new IllegalArgumentException("Initial value is required")
-    }
+    _validateInitialValue(name, type, value)
+
     // Refuse to silently overwrite an existing variable — the UI's "Create"
     // path can't either; the wizard only progresses when the name is novel.
     try {
@@ -412,6 +425,85 @@ def toolCreateVariable(args) {
     }
 
     def appId = _findHubVariablesAppId()
+    return _createOneVariable(appId, name, type, value)
+}
+
+// Bulk create driver: validates the array shape, resolves the Hub Variables
+// app id ONCE, then creates each item sequentially. Per-item try/catch so one
+// failure never aborts the rest -- a failed item carries its own `error`.
+private Map _createVariablesBulk(variables) {
+    if (!(variables instanceof List) || variables.isEmpty()) {
+        throw new IllegalArgumentException("variables must be a non-empty array of {name, type, value} objects.")
+    }
+    variables.eachWithIndex { item, idx ->
+        if (!(item instanceof Map)) {
+            throw new IllegalArgumentException("variables[${idx}] must be an object with name, type, and value.")
+        }
+    }
+
+    def appId = _findHubVariablesAppId()
+    def results = []
+    int createdCount = 0
+    int failedCount = 0
+
+    variables.eachWithIndex { item, idx ->
+        def itemName = item.name?.toString()?.trim()
+        try {
+            _validateHubVarName(itemName)
+            def itemType = _validateHubVarType(item.type?.toString())
+            _validateInitialValue(itemName, itemType, item.value)
+
+            // Pre-flight existence check (matches the single-create refusal).
+            def existing = null
+            try { existing = getGlobalVar(itemName) } catch (Exception e) {
+                logDebug("hub_create_variable bulk: getGlobalVar('${itemName}') threw ${e.class.simpleName}: ${e.message}")
+            }
+            if (existing != null) {
+                throw new IllegalArgumentException(
+                    "Hub variable '${itemName}' already exists (type=${existing.type}). Use set_variable to change the value, or pick a different name.")
+            }
+
+            def created = _createOneVariable(appId, itemName, itemType, item.value)
+            results << [name: itemName, success: true, type: created.type, value: created.value]
+            createdCount++
+        } catch (Exception e) {
+            // Fall back to the array index when the item carried no usable name, so
+            // every failed entry is traceable to its request position.
+            results << [name: (itemName ?: item?.name ?: "variables[${idx}]"), success: false, error: e.message ?: e.toString()]
+            failedCount++
+        }
+    }
+
+    return [
+        success: failedCount == 0,
+        results: results,
+        createdCount: createdCount,
+        failedCount: failedCount
+    ]
+}
+
+// Validate the initial value for a hub variable create. A null value is always
+// rejected; additionally a String variable created with an empty/blank value
+// reports success but never actually persists (getGlobalVar stays null --
+// deterministic), so reject that up front with an actionable error.
+private void _validateInitialValue(String name, String type, value) {
+    if (value == null) {
+        throw new IllegalArgumentException("Initial value is required")
+    }
+    if (type == "String" && !value.toString().trim()) {
+        throw new IllegalArgumentException(
+            "String variable '${name}' requires a non-empty initial value. " +
+            "Hubitat reports success for an empty String value but the variable never persists; supply any non-empty initial value.")
+    }
+}
+
+// Shared per-variable create core: drives the Hub Variables system app wizard
+// (prime -> moreVar -> write name/type/value or DateTime date/time + Done),
+// verifies the variable landed with a verify-backoff, and subscribes to its
+// change event. Returns the single-create success map; throws on validation
+// or verification failure. Both the single and bulk paths call this; `appId`
+// is resolved once by the caller and reused.
+private Map _createOneVariable(Integer appId, String name, String type, value) {
     def applied = []
     def skipped = []
 
@@ -847,28 +939,46 @@ def _getAllToolDefinitions_partVariables() {
         ],
         [
             name: "hub_create_variable",
-            description: "Create a new hub variable (global variable visible to apps and Rule Machine). Use this before hub_set_variable for a name that doesn't exist yet — Hubitat's setGlobalVar cannot create, only update.[[FLAT_TRIM]] Drives the Settings → Hub Variables wizard, since creation isn't exposed via the public app API. Name must not contain any of these characters: ' \" \\ ~ [ : ] < >.[[/FLAT_TRIM]] To also expose the variable to device-only apps, follow up with hub_create_connector.",
+            description: "Create a new hub variable (global variable visible to apps and Rule Machine), one at a time or several in one call. Use this before hub_set_variable for a name that doesn't exist yet — Hubitat's setGlobalVar cannot create, only update.[[FLAT_TRIM]] Drives the Settings → Hub Variables wizard, since creation isn't exposed via the public app API. Name must not contain any of these characters: ' \" \\ ~ [ : ] < >.[[/FLAT_TRIM]] A String variable's initial value must be non-empty (an empty String reports success but never persists). Single form: name + type + value. Bulk form: variables=[{name,type,value}, ...] -- mutually exclusive with the single form.[[FLAT_TRIM]] Bulk items are created sequentially; each succeeds or fails independently and the result reports per-item status. To also expose the variable to device-only apps, follow up with hub_create_connector.[[/FLAT_TRIM]]",
             inputSchema: [
                 type: "object",
                 properties: [
-                    name: [type: "string", description: "New variable name, e.g. \"vacationMode\". Must not contain: ' \" \\ ~ [ : ] < >"],
-                    type: [type: "string", description: "Variable type — one of: Number, Decimal, String, Boolean, DateTime"],
-                    value: [description: "Initial value, must match the chosen type (e.g. 72 for Number, true for Boolean, \"away\" for String, a DateTime string for DateTime)"],
+                    name: [type: "string", description: "Single form: new variable name, e.g. \"vacationMode\".[[FLAT_TRIM]] Must not contain: ' \" \\ ~ [ : ] < >.[[/FLAT_TRIM]] Omit when using variables."],
+                    type: [type: "string", enum: ["Number", "Decimal", "String", "Boolean", "DateTime"], description: "Single form: variable type.[[FLAT_TRIM]] Omit when using variables.[[/FLAT_TRIM]]"],
+                    value: [description: "Single form: initial value, must match the type.[[FLAT_TRIM]] Omit when using variables.[[/FLAT_TRIM]]"],
+                    variables: [type: "array", description: "Bulk form: several variables in one call (mutually exclusive with name/type/value).", items: [
+                        type: "object",
+                        properties: [
+                            name: [type: "string", description: "New variable name (same character rules as the single form)"],
+                            type: [type: "string", enum: ["Number", "Decimal", "String", "Boolean", "DateTime"], description: "Variable type"],
+                            value: [description: "Initial value, must match the type"]
+                        ],
+                        required: ["name", "type", "value"]
+                    ]],
                     confirm: [type: "boolean", description: "REQUIRED: must be true to perform the creation"]
                 ],
-                required: ["name", "type", "value", "confirm"]
+                required: ["confirm"]
             ],
             outputSchema: [
                 type: "object",
                 properties: [
-                    success: [type: "boolean", description: "Whether creation succeeded"],
-                    name: [type: "string", description: "Variable name"],
-                    type: [type: "string", description: "Variable type"],
-                    value: [description: "Initial value after creation"],
-                    source: [type: "string", description: "Always 'hub'"],
-                    message: [type: "string", description: "Human-readable result"]
+                    success: [type: "boolean", description: "Single form: whether creation succeeded. Bulk form: true only when every item was created."],
+                    name: [type: "string", description: "Single form: variable name"],
+                    type: [type: "string", description: "Single form: variable type"],
+                    value: [description: "Single form: initial value after creation"],
+                    source: [type: "string", description: "Single form: always 'hub'"],
+                    message: [type: "string", description: "Single form: human-readable result"],
+                    results: [type: "array", description: "Bulk form: per-item result, one entry per requested variable", items: [type: "object", properties: [
+                        name: [type: "string", description: "Variable name"],
+                        success: [type: "boolean", description: "Whether this item was created"],
+                        type: [type: "string", description: "Variable type (created items)"],
+                        value: [description: "Initial value after creation (created items)"],
+                        error: [type: "string", description: "Failure reason (failed items)"]
+                    ]]],
+                    createdCount: [type: "integer", description: "Bulk form: number of items created"],
+                    failedCount: [type: "integer", description: "Bulk form: number of items that failed"]
                 ],
-                required: ["success", "name", "type", "source"]
+                required: ["success"]
             ]
         ],
         [

--- a/libraries/mcp-variables-lib.groovy
+++ b/libraries/mcp-variables-lib.groovy
@@ -417,7 +417,7 @@ def toolCreateVariable(args) {
         if (existing != null) {
             throw new IllegalArgumentException(
                 "Hub variable '${name}' already exists (type=${existing.type}, value=${existing.value}). " +
-                "Use set_variable to change the value, or pick a different name.")
+                "Use hub_set_variable to change the value, or pick a different name.")
         }
     } catch (IllegalArgumentException reraise) { throw reraise }
     catch (Exception e) {
@@ -460,7 +460,7 @@ private Map _createVariablesBulk(variables) {
             }
             if (existing != null) {
                 throw new IllegalArgumentException(
-                    "Hub variable '${itemName}' already exists (type=${existing.type}). Use set_variable to change the value, or pick a different name.")
+                    "Hub variable '${itemName}' already exists (type=${existing.type}). Use hub_set_variable to change the value, or pick a different name.")
             }
 
             def created = _createOneVariable(appId, itemName, itemType, item.value)

--- a/src/test/groovy/server/HandleGatewaySpec.groovy
+++ b/src/test/groovy/server/HandleGatewaySpec.groovy
@@ -316,7 +316,7 @@ class HandleGatewaySpec extends ToolSpecBase {
         !result.error.contains('legacy_param')
 
         and: 'the memo + fingerprint were healed to the live catalog (live required restored)'
-        atomicStateMap.requiredParamsByToolFingerprint == script.requiredParamsCatalogFingerprint()
+        atomicStateMap.requiredParamsByToolFingerprint == script.requiredParamsCatalogFingerprint(script.getAllToolDefinitions())
         atomicStateMap.requiredParamsByTool['hub_get_room'] == ['room']
     }
 
@@ -345,12 +345,32 @@ class HandleGatewaySpec extends ToolSpecBase {
         atomicStateMap.requiredParamsByTool['hub_get_room'] == ['room']
     }
 
+    def "the fingerprint discriminates: two catalogs with different required shapes produce different fingerprints"() {
+        given: 'two catalogs identical except for one tool required array -- the only property the self-heal rests on'
+        // If requiredParamsCatalogFingerprint() returned a constant, the three tests
+        // above would all still pass (each seeds a deliberately-mismatched literal). This
+        // proves the fingerprint is actually a function of the required shape, so a
+        // same-version required-array change yields a fresh key and forces a rebuild.
+        def catalogA = [[name: 'hub_get_room', inputSchema: [required: ['room']]]]
+        def catalogB = [[name: 'hub_get_room', inputSchema: [required: ['room', 'extra_param']]]]
+
+        when:
+        def fpA = script.requiredParamsCatalogFingerprint(catalogA)
+        def fpB = script.requiredParamsCatalogFingerprint(catalogB)
+
+        then: 'a changed required array yields a different fingerprint (a constant return would make these equal)'
+        fpA != fpB
+
+        and: 'the fingerprint is stable for an unchanged shape'
+        fpA == script.requiredParamsCatalogFingerprint([[name: 'hub_get_room', inputSchema: [required: ['room']]]])
+    }
+
     def "a memo whose fingerprint matches the live catalog is served as-is (no rebuild)"() {
         given: 'a memo carrying a deliberately wrong required list but stamped with the LIVE fingerprint'
         // Proves the fingerprint is the gate: a matching fingerprint trusts the cached
         // value verbatim (the build-once/read-many fast path the memo exists for).
         atomicStateMap.requiredParamsByTool = ['hub_get_room': ['sentinel_param']]
-        atomicStateMap.requiredParamsByToolFingerprint = script.requiredParamsCatalogFingerprint()
+        atomicStateMap.requiredParamsByToolFingerprint = script.requiredParamsCatalogFingerprint(script.getAllToolDefinitions())
 
         when: 'omit the sentinel param the cached (matching-fingerprint) memo lists as required'
         def result = script.handleGateway('hub_manage_rooms', 'hub_get_room', [:])

--- a/src/test/groovy/server/HandleGatewaySpec.groovy
+++ b/src/test/groovy/server/HandleGatewaySpec.groovy
@@ -283,4 +283,82 @@ class HandleGatewaySpec extends ToolSpecBase {
         result.error.contains('confirm')
         (atomicStateMap.requiredParamsByTool['hub_create_room'] as Set) == (['name', 'confirm'] as Set)
     }
+
+    // ---- content-fingerprint self-heal of the required-param memo ----
+    // A code-update deploy (HPM update, hub_update_app, the e2e HPM-repair install)
+    // recompiles the class but does NOT fire updated() (the memo's only other
+    // invalidation) AND rides the SAME currentVersion() (PRs don't bump version), so
+    // neither updated() nor a version stamp catches a same-version required-array change.
+    // The memo is keyed on requiredParamsCatalogFingerprint() -- a content signature of
+    // the live name->required shape -- so a memo whose fingerprint != the live catalog's
+    // is rebuilt from the live definitions. The discriminator is that fingerprint check:
+    // reverting it makes the stale memo authoritative, so the load-bearing spec below
+    // rejects on the stale `legacy_param` (RED) instead of the live `room` (GREEN). The
+    // pre-check rejects before any tool impl runs, so the spec needs no hub-method stubs.
+
+    def "a same-version stale memo is rebuilt from live definitions (live required honored, not the stale entry)"() {
+        given: 'an old build memoized a different required list for hub_get_room; version is UNCHANGED but the catalog fingerprint no longer matches'
+        // hub_get_room requires ['room'] in the live (current) catalog. The seeded memo
+        // simulates an older same-version build that required `legacy_param` instead. The
+        // stamped fingerprint is a stale string that cannot match the live fingerprint --
+        // the exact same-version code-deploy scenario the e2e caught (a relaxed required
+        // array served stale because currentVersion() did not change).
+        atomicStateMap.requiredParamsByTool = ['hub_get_room': ['legacy_param']]
+        atomicStateMap.requiredParamsByToolFingerprint = 'stale-fingerprint-from-an-older-same-version-build'
+
+        when: 'a gateway call omits everything'
+        def result = script.handleGateway('hub_manage_rooms', 'hub_get_room', [:])
+
+        then: 'the fingerprint mismatch forces a rebuild -- rejection names the LIVE required param, never the stale one'
+        result.isError == true
+        result.tool == 'hub_get_room'
+        result.error.contains('room')
+        !result.error.contains('legacy_param')
+
+        and: 'the memo + fingerprint were healed to the live catalog (live required restored)'
+        atomicStateMap.requiredParamsByToolFingerprint == script.requiredParamsCatalogFingerprint()
+        atomicStateMap.requiredParamsByTool['hub_get_room'] == ['room']
+    }
+
+    def "a relaxed-required tool with a stale fingerprint is NOT rejected for the now-optional params (the e2e failure, abstracted)"() {
+        given: 'a stale memo lists params as required that the live build relaxed away; fingerprint is stale (same-version deploy)'
+        // Directly models the failing e2e: a tool whose required array was relaxed (here
+        // hub_get_room, whose live required is only ['room']) must not be rejected for a
+        // param the OLD build still listed. With the fix, supplying the live-required
+        // `room` passes the pre-check and dispatch reaches the impl; reverting the
+        // fingerprint guard would reject on the stale `extra_param` before dispatch even
+        // though `room` was supplied. Stub getRooms() to return a matching room so the
+        // impl resolves cleanly to a real result (bucket-1 per-test metaClass stub;
+        // setup() wipes it next test).
+        script.metaClass.getRooms = { [[id: 7, name: 'Kitchen', deviceIds: []]] }
+        atomicStateMap.requiredParamsByTool = ['hub_get_room': ['room', 'extra_param']]
+        atomicStateMap.requiredParamsByToolFingerprint = 'stale-fingerprint'
+
+        when: 'supply only the live-required param, omitting the stale extra'
+        def result = script.handleGateway('hub_manage_rooms', 'hub_get_room', [room: 'Kitchen'])
+
+        then: 'the pre-check passes (no missing-param rejection) -- dispatch reached the impl and returned the room'
+        !(result instanceof Map && result.isError == true && result.error?.toString()?.startsWith('Missing required'))
+        result.name == 'Kitchen'
+
+        and: 'the memo healed to the live shape (the stale extra param is gone)'
+        atomicStateMap.requiredParamsByTool['hub_get_room'] == ['room']
+    }
+
+    def "a memo whose fingerprint matches the live catalog is served as-is (no rebuild)"() {
+        given: 'a memo carrying a deliberately wrong required list but stamped with the LIVE fingerprint'
+        // Proves the fingerprint is the gate: a matching fingerprint trusts the cached
+        // value verbatim (the build-once/read-many fast path the memo exists for).
+        atomicStateMap.requiredParamsByTool = ['hub_get_room': ['sentinel_param']]
+        atomicStateMap.requiredParamsByToolFingerprint = script.requiredParamsCatalogFingerprint()
+
+        when: 'omit the sentinel param the cached (matching-fingerprint) memo lists as required'
+        def result = script.handleGateway('hub_manage_rooms', 'hub_get_room', [:])
+
+        then: 'the matching-fingerprint cache is honored verbatim -- the sentinel rejection fires (no rebuild)'
+        result.isError == true
+        result.tool == 'hub_get_room'
+        result.error.contains('sentinel_param')
+        atomicStateMap.requiredParamsByTool['hub_get_room'] == ['sentinel_param']
+    }
 }

--- a/src/test/groovy/server/ToolHubVariablesSpec.groovy
+++ b/src/test/groovy/server/ToolHubVariablesSpec.groovy
@@ -596,6 +596,20 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         ex.message.contains('Initial value is required')
     }
 
+    def "hub_create_variable rejects an empty-string value for a String variable"() {
+        // A String variable created with an empty value reports success but never
+        // persists (getGlobalVar stays null -- deterministic). Reject up front.
+        given:
+        enableWrite()
+
+        when:
+        script.toolCreateVariable([name: 'emptyStr', type: 'String', value: '', confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('non-empty initial value')
+    }
+
     def "hub_create_variable refuses to overwrite an existing hub variable"() {
         given:
         enableWrite()
@@ -766,6 +780,120 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         def ex = thrown(IllegalStateException)
         ex.message.contains('wizard completed but')
         ex.message.contains('ghostVar')
+    }
+
+    def "hub_create_variable bulk form creates every item and reports per-item success"() {
+        given:
+        enableWrite()
+
+        and: 'getGlobalVar echoes the requested name so each item round-trips its OWN name/type/value (not item-0 for all)'
+        def seen = [:]
+        def postWrite = [:]   // populated by the varValue write, keyed by name
+        script.metaClass.getGlobalVar = { String n ->
+            // First lookup per name = pre-flight (null); subsequent = post-write.
+            if (!seen[n]) { seen[n] = true; return null }
+            return [name: n, type: postWrite[n]?.type ?: 'Number', value: postWrite[n]?.value, deviceId: null, attribute: null]
+        }
+
+        and: 'wizard primitives recorded -- capture the per-item name/type/value the wizard actually wrote'
+        def buttonClicks = []
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName ->
+            buttonClicks << [appId: appId, btn: btnName]
+            return [status: 200]
+        }
+        def pending = [:]
+        def settingWrites = []
+        script.metaClass._rmWriteSettingOnPage = { Integer appId, String pageName, String key, Object value, List applied, String typeHint = null, List skipped = null ->
+            settingWrites << [key: key, value: value]
+            // hbVar -> varType -> varValue write order per item; stash so the post-write
+            // getGlobalVar can echo the value that THIS item just wrote.
+            if (key == 'hbVar')   pending.name  = value
+            if (key == 'varType') pending.type  = value
+            if (key == 'varValue') { postWrite[pending.name] = [type: pending.type, value: value]; pending.clear() }
+            if (applied != null) applied << key
+        }
+        def appIdLookups = 0
+        script.metaClass._findHubVariablesAppId = { -> appIdLookups++; 1424 }
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
+
+        when:
+        def result = script.toolCreateVariable([confirm: true, variables: [
+            [name: 'bulkA', type: 'Number', value: 1],
+            [name: 'bulkB', type: 'String', value: 'two']
+        ]])
+
+        then: 'overall success with both items created'
+        result.success == true
+        result.createdCount == 2
+        result.failedCount == 0
+        result.results.size() == 2
+
+        and: 'each result carries ITS OWN name/type/value -- a regression that wrote item-0 for every entry would fail here'
+        result.results[0].name == 'bulkA'
+        result.results[0].success == true
+        result.results[0].type == 'Number'
+        result.results[0].value == 1
+        result.results[1].name == 'bulkB'
+        result.results[1].success == true
+        result.results[1].type == 'String'
+        result.results[1].value == 'two'
+
+        and: 'and the wizard received each item distinct name/type/value (not item-0 twice)'
+        settingWrites.findAll { it.key == 'hbVar' }*.value == ['bulkA', 'bulkB']
+        settingWrites.findAll { it.key == 'varType' }*.value == ['Number', 'String']
+        settingWrites.findAll { it.key == 'varValue' }*.value == [1, 'two']
+
+        and: 'the Hub Variables app id was resolved ONCE and reused across the batch'
+        appIdLookups == 1
+    }
+
+    def "hub_create_variable bulk form: one bad item fails while the others still create"() {
+        given:
+        enableWrite()
+
+        and: 'getGlobalVar: null pre-flight, populated after commit (good names only)'
+        def seen = [:]
+        script.metaClass.getGlobalVar = { String n ->
+            if (!seen[n]) { seen[n] = true; return null }
+            return [name: n, type: 'Number', value: 1, deviceId: null, attribute: null]
+        }
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName -> [status: 200] }
+        script.metaClass._rmWriteSettingOnPage = { Integer appId, String pageName, String key, Object value, List applied, String typeHint = null, List skipped = null ->
+            if (applied != null) applied << key
+        }
+        script.metaClass._findHubVariablesAppId = { -> 1424 }
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
+
+        when: 'the middle item has a forbidden character in its name'
+        def result = script.toolCreateVariable([confirm: true, variables: [
+            [name: 'goodOne', type: 'Number', value: 1],
+            [name: 'bad[name]', type: 'Number', value: 2],
+            [name: 'goodTwo', type: 'Number', value: 3]
+        ]])
+
+        then: 'overall failure, but the two good items still created'
+        result.success == false
+        result.createdCount == 2
+        result.failedCount == 1
+        result.results.size() == 3
+        result.results[0].success == true
+        result.results[1].name == 'bad[name]'
+        result.results[1].success == false
+        result.results[1].error.contains('forbidden character')
+        result.results[2].success == true
+    }
+
+    def "hub_create_variable rejects supplying both the single form and the bulk array"() {
+        given:
+        enableWrite()
+
+        when:
+        script.toolCreateVariable([name: 'single', type: 'Number', value: 1, confirm: true,
+                                   variables: [[name: 'bulk', type: 'Number', value: 2]]])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('not both')
     }
 
     def "hub_delete_variable hub-namespace wizard sequence: deleteGV then delConfirm"() {
@@ -1415,6 +1543,48 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         then:
         response.error?.code == -32602
         response.error.message.contains('already exists')
+
+        where:
+        useGateways << [true, false]
+    }
+
+    @spock.lang.Unroll
+    def "hub_create_variable via dispatch creates the bulk array and reports per-item status (useGateways=#useGateways)"() {
+        given: 'the gateway must route the variables arg + the relaxed required:["confirm"]'
+        settingsMap.useGateways = useGateways
+        enableWrite()
+
+        and: 'getGlobalVar: null pre-flight per name, populated after each wizard commits'
+        def seen = [:]
+        script.metaClass.getGlobalVar = { String n ->
+            if (!seen[n]) { seen[n] = true; return null }
+            return [name: n, type: 'Number', value: 1, deviceId: null, attribute: null]
+        }
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName -> [status: 200] }
+        script.metaClass._rmWriteSettingOnPage = { Integer appId, String pageName, String key, Object value, List applied, String typeHint = null, List skipped = null ->
+            if (applied != null) applied << key
+        }
+        script.metaClass._findHubVariablesAppId = { -> 1424 }
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_variable', [confirm: true, variables: [
+            [name: 'dispBulkA', type: 'Number', value: 1],
+            [name: 'dispBulkB', type: 'Number', value: 2]
+        ]])
+
+        then:
+        response.error == null
+        !response.result.isError
+        def inner = mcpDriver.parseInner(response)
+        inner.success == true
+        inner.createdCount == 2
+        inner.failedCount == 0
+        inner.results.size() == 2
+        inner.results[0].name == 'dispBulkA'
+        inner.results[0].success == true
+        inner.results[1].name == 'dispBulkB'
+        inner.results[1].success == true
 
         where:
         useGateways << [true, false]

--- a/src/test/groovy/server/ToolHubVariablesSpec.groovy
+++ b/src/test/groovy/server/ToolHubVariablesSpec.groovy
@@ -883,6 +883,105 @@ class ToolHubVariablesSpec extends ToolSpecBase {
         result.results[2].success == true
     }
 
+    def "hub_create_variable bulk form: a non-Map item fails only itself while the others still create"() {
+        given:
+        enableWrite()
+
+        and: 'getGlobalVar: null pre-flight, populated after commit (good names only)'
+        def seen = [:]
+        script.metaClass.getGlobalVar = { String n ->
+            if (!seen[n]) { seen[n] = true; return null }
+            return [name: n, type: 'Number', value: 1, deviceId: null, attribute: null]
+        }
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName -> [status: 200] }
+        script.metaClass._rmWriteSettingOnPage = { Integer appId, String pageName, String key, Object value, List applied, String typeHint = null, List skipped = null ->
+            if (applied != null) applied << key
+        }
+        script.metaClass._findHubVariablesAppId = { -> 1424 }
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
+
+        when: 'the middle item is a bare integer, not a {name,type,value} object'
+        def result = script.toolCreateVariable([confirm: true, variables: [
+            [name: 'goodOne', type: 'Number', value: 1],
+            42,
+            [name: 'goodTwo', type: 'Number', value: 3]
+        ]])
+
+        then: 'the malformed item is isolated to its own entry -- both good items still create (a top-level throw would have lost them)'
+        result.success == false
+        result.createdCount == 2
+        result.failedCount == 1
+        result.results.size() == 3
+        result.results[0].name == 'goodOne'
+        result.results[0].success == true
+        result.results[1].success == false
+        result.results[1].name == 'variables[1]'
+        result.results[1].error.contains('must be an object')
+        result.results[2].name == 'goodTwo'
+        result.results[2].success == true
+    }
+
+    def "hub_create_variable bulk form: an empty variables array is a batch-level rejection"() {
+        given:
+        enableWrite()
+
+        when: 'variables is present but empty -- nothing to create'
+        script.toolCreateVariable([confirm: true, variables: []])
+
+        then: 'rejected at the batch level (a non-empty List is a genuine precondition, not a per-item failure)'
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('non-empty')
+    }
+
+    def "hub_create_variable bulk form: a per-item verify timeout is isolated, others still create"() {
+        given:
+        enableWrite()
+
+        and: 'getGlobalVar drives the REAL _createOneVariable verify-backoff: null pre-flight for all, then visible for the good names AFTER their wizard but null PERSISTENTLY for timesOut (the verify-backoff exhausts and throws for that one item only)'
+        // Models the genuine mid-wizard runtime failure (verify timeout) that validation
+        // never catches -- exercising the REAL _createOneVariable, not a private-method
+        // stub (a private call dispatches in-class and bypasses a metaClass override).
+        def committed = [:]   // name -> visible, flipped on this item's varValue write
+        script.metaClass.getGlobalVar = { String n ->
+            // timesOut never becomes visible; the others appear once their wizard committed.
+            if (n == 'timesOut') return null
+            return committed[n] ? [name: n, type: 'Number', value: 1, deviceId: null, attribute: null] : null
+        }
+
+        and: 'wizard primitives stubbed; the varValue write marks the (good) item visible to the verify-read'
+        script.metaClass._rmClickAppButton = { Integer appId, String btnName, String stateAttr, String pageName -> [status: 200] }
+        def pendingName = null
+        script.metaClass._rmWriteSettingOnPage = { Integer appId, String pageName, String key, Object value, List applied, String typeHint = null, List skipped = null ->
+            if (key == 'hbVar') pendingName = value
+            if (key == 'varValue' && pendingName != 'timesOut') committed[pendingName] = true
+            if (applied != null) applied << key
+        }
+        script.metaClass._findHubVariablesAppId = { -> 1424 }
+        script.metaClass.backupItemSource = { String type, String id -> [:] }
+        // Keep the verify-backoff loop instant (real code sleeps 500ms/attempt).
+        script.metaClass.pauseExecution = { long ms -> }
+
+        when: 'three valid-shaped items but the middle one never becomes visible (wizard runtime failure, not validation)'
+        def result = script.toolCreateVariable([confirm: true, variables: [
+            [name: 'createsA', type: 'Number', value: 1],
+            [name: 'timesOut', type: 'Number', value: 2],
+            [name: 'createsB', type: 'Number', value: 3]
+        ]])
+
+        then: 'the verify timeout is isolated to its own entry -- the other two still create'
+        result.success == false
+        result.createdCount == 2
+        result.failedCount == 1
+        result.results.size() == 3
+        result.results[0].name == 'createsA'
+        result.results[0].success == true
+        result.results[1].name == 'timesOut'
+        result.results[1].success == false
+        result.results[1].error.contains('not visible via getGlobalVar')
+        result.results[2].name == 'createsB'
+        result.results[2].success == true
+    }
+
     def "hub_create_variable rejects supplying both the single form and the bulk array"() {
         given:
         enableWrite()

--- a/src/test/groovy/server/ToolSearchToolsSpec.groovy
+++ b/src/test/groovy/server/ToolSearchToolsSpec.groovy
@@ -119,6 +119,7 @@ class ToolSearchToolsSpec extends ToolSpecBase {
         atomicStateMap.toolSearchTokens = [['x']]
         atomicStateMap.toolSearchCorpusVersion = 'v-test'
         atomicStateMap.requiredParamsByTool = [hub_get_room: ['room']]
+        atomicStateMap.requiredParamsByToolFingerprint = 'fp-test'
         script.metaClass.initialize = { -> }
 
         when:
@@ -129,6 +130,9 @@ class ToolSearchToolsSpec extends ToolSpecBase {
         atomicStateMap.toolSearchTokens == null
         atomicStateMap.toolSearchCorpusVersion == null
         atomicStateMap.requiredParamsByTool == null
+
+        and: 'the memo fingerprint is cleared in lockstep -- a stranded fingerprint would let the next rebuild miscompare'
+        atomicStateMap.requiredParamsByToolFingerprint == null
 
         and: 'the legacy state entry is never reintroduced'
         !stateMap.containsKey('toolSearchCorpus')

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -4191,6 +4191,64 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         if var_name in self.created_variable_names:
             self.created_variable_names.remove(var_name)
 
+    @test("hub_variables")
+    def test_hub_variable_bulk_create_round_trip(self) -> None:
+        # The bulk form (variables=[...]) creates several vars sequentially in one call
+        # and reports per-item status. A green round-trip proves the gateway routes the
+        # variables array, each item's wizard write landed in the real namespace, and the
+        # response carries per-item success + the value that actually persisted.
+        names = [f"{PREFIX}BulkVar_A", f"{PREFIX}BulkVar_B", f"{PREFIX}BulkVar_C"]
+        items = [
+            {"name": names[0], "type": "Number", "value": 1},
+            {"name": names[1], "type": "String", "value": "two"},
+            {"name": names[2], "type": "Boolean", "value": True},
+        ]
+        # Track BEFORE creating -- no prefix sweep for variables, so a crash between the
+        # create landing and a later append would strand the entities.
+        for n in names:
+            self.created_variable_names.append(n)
+        try:
+            cw = self._soft_write(
+                lambda: self.client.call_tool("hub_manage_variables", {
+                    "tool": "hub_create_variable",
+                    "args": {"variables": items, "confirm": True}}),
+                lambda: all(self._hub_variable_visible_in_bulk(n) for n in names),
+                "hub_create_variable (bulk)",
+            )
+            if cw["relayDropped"]:
+                assert cw["committed"], \
+                    f"bulk create lost to relay 504 and never committed: {names}"
+                print("    hub_create_variable (bulk): per-item assertions skipped (relay 504); verified via read-back")
+            else:
+                created = cw["response"]
+                assert created.get("success") is True, f"bulk create did not fully succeed: {created}"
+                assert created.get("createdCount") == 3 and created.get("failedCount") == 0, \
+                    f"bulk create count mismatch: {created}"
+                results = created.get("results") or []
+                assert len(results) == 3, f"bulk create did not report one result per item: {created}"
+                by_name = {r.get("name"): r for r in results}
+                for it in items:
+                    r = by_name.get(it["name"])
+                    assert r and r.get("success") is True, f"bulk item {it['name']} not created: {created}"
+                    # Per-item value round-trips -- a regression that wrote item-0 for every
+                    # entry would surface here (value/type would not match the requested item).
+                    assert r.get("value") == it["value"], \
+                        f"bulk item {it['name']} value mismatch: got {r.get('value')!r}, expected {it['value']!r}"
+                    assert r.get("type") == it["type"], \
+                        f"bulk item {it['name']} type mismatch: got {r.get('type')!r}, expected {it['type']!r}"
+
+            # Independently confirm each landed in the hub namespace and read back its value.
+            for it in items:
+                got = self.client.call_tool("hub_manage_variables", {
+                    "tool": "hub_get_variable", "args": {"name": it["name"]},
+                })
+                assert got.get("source") == "hub", f"bulk var {it['name']} not in the hub namespace: {got}"
+                assert got.get("value") == it["value"], \
+                    f"bulk var {it['name']} value mismatch on read-back: {got}"
+        finally:
+            for n in names:
+                self._delete_variable_safe(n)
+
     # -----------------------------------------------------------------------
     # GROUP 5: trigger_types (1 batched test -- all trigger types in one rule)
     # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a bulk form to `hub_create_variable` so several hub variables can be created in one call (`variables=[{name,type,value}, ...]`), alongside the existing single-variable form.
- Document two RM authoring constraints surfaced while building it: fan `setSpeed` is enum-only (no variable source), and the supported numeric-condition comparison shapes.
- Closes #285.

## Type of change

- [x] `feat` — new feature or capability

## Changes

- **`hub_create_variable` bulk form** — optional `variables=[{name,type,value}, ...]` array, mutually exclusive with the single `name/type/value` form. Items are created **sequentially** through the shared Hub Variables wizard app (its create path has a known post-write race that makes parallel creates spuriously fail); each succeeds or fails independently, and the result reports per-item status + `createdCount`/`failedCount`. The single-create core is factored into a shared `_createOneVariable` helper; the Hub Variables app id is resolved once and reused across the batch.
- **Empty-String guard** — reject an empty/blank initial value for a `String` variable up front (Hubitat reports success for an empty String but the variable never persists). Applies to both forms.
- **`type` enum** added to the schema (single + bulk-item).
- **Docs** — fan `setSpeed` is enum-only (RM only renders a variable toggle for numeric/text fields, not enum pickers; for a variable-driven speed use `runCommand` with `command='setSpeed'` + `parameters=[{type:'string', variable:'<var>'}]`); plus the supported numeric-condition comparison-shape matrix + the read-into-a-variable pattern for device-attribute-vs-variable.
- Verbose bulk-form description prose is `[[FLAT_TRIM]]`-wrapped so the flat `tools/list` catalog stays under the 124,000-byte cap.
- Closes #285.

## Release Notes

- `hub_create_variable` can now create several variables in one call — pass `variables=[{name, type, value}, ...]` (the single form still works). Each item succeeds or fails independently, with per-item status in the result.
- `hub_create_variable` now rejects an empty initial value for a String variable (an empty String silently fails to persist on the hub).
- Clarified RM docs: fan speed is a fixed enum (use `runCommand` for a variable-driven speed), and the supported numeric-condition comparison shapes (device-vs-value, device-vs-another-device, variable-vs-variable).

## Testing

- `python tests/sandbox_lint.py` — passes.
- `./gradlew test` — full Spock suite passes (incl. new direct-call + dispatch-envelope bulk specs with per-item value/type assertions, the empty-String guard, and the flat/gateway catalog-size guards).
- `tests/e2e_test.py` — new `test_hub_variable_bulk_create_round_trip` (bulk-create + per-item read-back + delete).
- Single-form create + the empty-String guard verified live on a test hub.

## Checklist

- [x] **Unit tests added for any new MCP tools** (no new tool — new arg on `hub_create_variable`; direct-call + dispatch-envelope bulk specs added)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`) — covered by the new `tests/e2e_test.py` bulk scenario instead
- [x] Documentation updated if user-facing behaviour or tool surface changed
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema)
