### PR TITLE
docs: choose the Claude Desktop bridge proxy by OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Alternatively, some people have had luck just simply giving Claude access to its
 <details>
 <summary><b>Claude Desktop</b></summary>
 
-Claude Desktop only launches **stdio** MCP servers from its config file — it does **not** accept a plain `"url"`/`"type": "url"` entry (those are silently ignored). Because this server speaks HTTP, you bridge it to stdio with [`mcp-remote`](https://www.npmjs.com/package/mcp-remote). This requires [Node.js](https://nodejs.org) installed (it provides the `npx` command).
+Claude Desktop only launches **stdio** MCP servers from its config file — it does **not** accept a plain `"url"`/`"type": "url"` entry (those are silently ignored). Because this server speaks HTTP, you bridge it to stdio with a small proxy. Use the one that matches your OS: **`mcp-proxy` on Windows** (via [`uv`](https://docs.astral.sh/uv/getting-started/installation/)'s `uvx`), **`mcp-remote` on macOS** (via [Node.js](https://nodejs.org)'s `npx`). Install the matching runtime first.
 
 > **Easiest option:** skip the config file entirely and add the server in **Claude.ai** instead (see the *Claude.ai* section below). Connectors you add there automatically show up in Claude Desktop when signed in to the same account — no JSON editing, and it works from any chat.
 
@@ -144,27 +144,26 @@ To edit the config file manually, open Claude Desktop > **Settings** > **Develop
 > ```
 > The regular installer (`.exe`) build does use `%APPDATA%\Claude\…`. ([tracking bug](https://github.com/anthropics/claude-code/issues/26073))
 
-Add **one** of the following — if you already have other MCP servers configured, merge the `hubitat` block into your existing `mcpServers` object instead of pasting over the whole file:
+Add the block for your OS — use your **local** URL (`http://YOUR_HUB_IP/apps/api/123/mcp?access_token=YOUR_TOKEN`) or your **cloud** URL (`https://cloud.hubitat.com/api/YOUR_HUB_ID/apps/123/mcp?access_token=YOUR_TOKEN`) where shown. If you already have other MCP servers configured, merge the `hubitat` block into your existing `mcpServers` object instead of pasting over the whole file.
 
-**Cloud endpoint (HTTPS):**
+**Windows — [`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy) (via `uvx`).** Same block for the local or cloud URL:
 ```json
 {
   "mcpServers": {
     "hubitat": {
-      "command": "npx",
+      "command": "uvx",
       "args": [
-        "-y",
-        "mcp-remote",
-        "https://cloud.hubitat.com/api/YOUR_HUB_ID/apps/123/mcp?access_token=YOUR_TOKEN",
+        "mcp-proxy",
         "--transport",
-        "http-only"
+        "streamablehttp",
+        "http://YOUR_HUB_IP/apps/api/123/mcp?access_token=YOUR_TOKEN"
       ]
     }
   }
 }
 ```
 
-**Local endpoint (HTTP)** — note the extra `--allow-http`, since `mcp-remote` blocks plain-HTTP URLs by default:
+**macOS — [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) (via `npx`).** Add `--allow-http` for a **local** (plain-HTTP) URL; omit it for the **cloud** (HTTPS) URL:
 ```json
 {
   "mcpServers": {


### PR DESCRIPTION
## Summary

- Splits Claude Desktop setup by OS: **Windows → `uvx mcp-proxy`**, **macOS → `npx mcp-remote`**. The `mcp-remote` method shipped in #288 works on macOS, but its tool calls fail in Claude Desktop on Windows, where `mcp-proxy` connects and calls tools cleanly.

## Type of change

- [x] `docs` — documentation only

## Changes

- Claude Desktop section intro now routes Windows users to `mcp-proxy` (via `uvx`) and macOS users to `mcp-remote` (via `npx`), each with its runtime prerequisite.
- Replaced the single cloud/local `mcp-remote` pair with one block per OS; consolidated the local-vs-cloud URL guidance up front. macOS block keeps the `--allow-http` note for local URLs.

## Release Notes

- Clarified Claude Desktop setup: use `mcp-proxy` (via `uvx`) on **Windows** and `mcp-remote` (via `npx`) on **macOS**. The previous instructions only documented `mcp-remote`, whose tool calls fail in Claude Desktop on Windows.

## Testing

- Windows: confirmed `uvx mcp-proxy --transport streamablehttp` connects and Claude Desktop successfully calls `hub_get_info` through it.
- macOS: `mcp-remote` path is the method already verified working by a macOS user.

## Checklist

- Documentation-only — no MCP tools, tests, or sandbox-lint surface affected.
- [x] Documentation updated
