### PR TITLE
fix: lean hub_update_mcp_settings description to restore flat tools/list budget

### DIFF
--- a/libraries/mcp-self-admin-lib.groovy
+++ b/libraries/mcp-self-admin-lib.groovy
@@ -498,11 +498,11 @@ def _getAllToolDefinitions_partSelfAdmin() {
     return [
         [
             name: "hub_update_mcp_settings",
-            description: "Update one or more of the MCP rule app's own settings (toggles, log levels, tuning parameters) in place. Use this to self-administer the MCP app without the Hubitat UI. Gated on enableDeveloperMode + the Write master + confirm=true + a recent backup; every successful write is logged at WARN for audit. Allowlisted keys only: mcpLogLevel, debugLogging, maxCapturedStates, loopGuardMax, loopGuardWindowSec, enableRead, enableCustomRuleEngine, useGateways, publishOutputSchemas — any other key is rejected. After changing any enable* toggle, useGateways, or publishOutputSchemas, MCP clients (Claude Code, etc.) may need to restart their connection to refresh the cached tool schema. [[FLAT_TRIM]]Deliberately NOT allowlisted: enableWrite (would disable the tool's own write path mid-session), enableDeveloperMode (lockout protection — must stay UI-only to disable), selectedDevices (different wire format, has its own tool), and disabled_tools/disabled_gateways (could self-disable this tool).[[/FLAT_TRIM]]",
+            description: "Update one or more of the MCP rule app's own settings (toggles, log levels, tuning) in place — self-administer the app without the Hubitat UI. Gated on enableDeveloperMode + the Write master + confirm=true + a recent backup; every successful write is logged at WARN for audit. Changing an enable* toggle, useGateways, or publishOutputSchemas reshapes tools/list, so MCP clients may need to reconnect to refresh cached schemas.",
             inputSchema: [
                 type: "object",
                 properties: [
-                    settings: [type: "object", description: "Map of setting key → new value (e.g., {\"mcpLogLevel\":\"warn\",\"enableCustomRuleEngine\":true})"],
+                    settings: [type: "object", description: "Map of setting key → new value (e.g. {\"mcpLogLevel\":\"warn\",\"enableCustomRuleEngine\":true}). Allowlisted keys: mcpLogLevel, debugLogging, maxCapturedStates, loopGuardMax, loopGuardWindowSec, enableRead, enableCustomRuleEngine, useGateways, publishOutputSchemas — any other key is rejected.[[FLAT_TRIM]] Deliberately NOT allowlisted: enableWrite (would disable this tool's own write path mid-session), enableDeveloperMode (lockout protection — must stay UI-only to disable), selectedDevices (different wire format, has its own tool), disabled_tools/disabled_gateways (could self-disable this tool).[[/FLAT_TRIM]]"],
                     confirm: [type: "boolean", description: "REQUIRED: must be true to confirm the operation"]
                 ],
                 required: ["settings", "confirm"]


### PR DESCRIPTION
## Summary

- `main` went red right after #289 merged: the flat + Developer-Mode `tools/list` catalog is
  **123,501 B — 1 byte over** the `< 123_500` guard (the 124 KB hub response cap).
- Root cause is accumulation, not one PR: **#291** (`outputSchema` opt-in) added the
  `publishOutputSchemas` key + a reconnect note to `hub_update_mcp_settings`'s already-long
  description; **#289**'s new `hub_set_app_disabled` tool tipped the combination over. Neither PR's
  CI tested both together (the #289 branch forked before #291 landed).

## Type of change

- [x] `fix`

## Changes

- `hub_update_mcp_settings`: trim the description to three sentences and move the allowlisted-keys
  enumeration into the `settings` param (where AGENTS.md says key lists belong; the "not allowlisted"
  rationale stays as FLAT_TRIM deep reference). Reclaims ~300 B from the flat catalog — back under the
  `< 123_500` guard with margin. Pure description/schema-text change; no behavior change.

## Release Notes

- No user-facing change — internal: keeps the flat `tools/list` under the hub's 124 KB response cap
  (a strict-MCP-client safety guard) after the v2.6.0 additions.

## Testing

- Full `./gradlew test` green — `UpdateNativeAppSchemaTrimSpec` dev-mode flat-size now passes;
  `ToolUpdateMcpSettingsSpec` + annotation/search specs unaffected. Sandbox lint green.

## Checklist

- [x] Sandbox lint passes
- [x] `./gradlew test` passes
- [x] Documentation updated (the tool description *is* the change)
- [ ] Unit/e2e for new tools — N/A (no new tool; description-only, no behavior change)
