### PR TITLE
fix: e2e-surfaced tool fixes (404 degrade, button-rule page, zigbee, watchdog jobs) + e2e runner/suite refactor

### DIFF
--- a/.github/scripts/mcp_arm_watchdog.sh
+++ b/.github/scripts/mcp_arm_watchdog.sh
@@ -156,11 +156,11 @@ echo "Asserting the watchdog's checkDeadman schedule is live (hub_get_jobs)..."
 if watchdog_schedule_alive; then
   echo "WATCHDOG_SCHEDULE_ALIVE checkDeadman=scheduled"
 else
-  # WARN, not HALT: hub_get_jobs is an unverified endpoint (the /hub/scheduledJobs/json shape may differ
-  # by firmware), and the disarm-restore poll later is the REAL proof the timer fires. The health check
-  # already proved the watchdog is serving, and it was freshly installed (initialize() ran its
-  # runEvery1Minute), so proceed to arm rather than block on a possibly-false-negative schedule read.
-  echo "::warning::Could not confirm a live 'checkDeadman' scheduled job via hub_get_jobs (the /hub/scheduledJobs/json shape may differ on this firmware). Proceeding to arm -- the disarm-restore poll will surface a genuinely-dead timer. If the dead-man never fires, re-check the watchdog's runEvery1Minute schedule."
+  # WARN, not HALT: hub_get_jobs reads the verified /logs/json endpoint, but the disarm-restore poll
+  # later is the REAL proof the timer fires. The health check already proved the watchdog is serving,
+  # and it was freshly installed (initialize() ran its runEvery1Minute), so a transient empty/slow jobs
+  # read shouldn't block the arm -- proceed rather than block on a possibly-false-negative schedule read.
+  echo "::warning::Could not confirm a live 'checkDeadman' scheduled job via hub_get_jobs (read from /logs/json). Proceeding to arm -- the disarm-restore poll will surface a genuinely-dead timer. If the dead-man never fires, re-check the watchdog's runEvery1Minute schedule."
 fi
 
 # --- 2c) Record canonical-main install URLs + identities into the restore manifest (no hub install) ---

--- a/.github/scripts/mcp_disarm_watchdog.sh
+++ b/.github/scripts/mcp_disarm_watchdog.sh
@@ -269,63 +269,24 @@ if [ -z "$RB_CLASS" ] || [ "$RB_CLASS" = "null" ] || { [ -n "$EXPECT_CLASS" ] &&
   exit 1
 fi
 
-# --- 2.5) Reap DEFERRED native rules (E2E_DEFER_NATIVE_DELETES) over WATCHDOG_URL -------------------
-# If the test step deferred its per-test native-rule fixture deletes, it wrote the EXACT tracked instance
-# ids to 'e2e-deferred-native-rules.json'. Force-delete each (the INSTANCE, via the watchdog's
-# hub_force_delete_app) NOW -- the round-trips overlap the wall-clock the restore poll below spends
-# sleeping. Precise ids only (no /hub2/appsList shape-guessing -> no wrong-app risk). Best-effort +
-# SEQUENTIAL (RM concurrency rule): a hiccup NEVER fails the step (the post-restore --cleanup-only step
-# is the idempotent prefix backstop). Absent file / deferral-off -> clean no-op.
-DEFERRED_FILE="e2e-deferred-native-rules.json"
-if DEF_TEXT=$(mcp_tool_call_text "hub_read_file (deferred native rules)" \
-    "$(jq -nc --arg fn "$DEFERRED_FILE" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_read_file",arguments:{fileName:$fn}}}')" 2>/dev/null); then
-  # Split a parse failure from a valid (possibly empty) array. hub_read_file returns the file body
-  # under .content; jq '.[]' errors (exit != 0) on truncated/corrupt JSON but yields empty output on a
-  # valid []. A SWALLOWED parse error must NOT collapse to "nothing to reap" -- that would silently
-  # skip the exact-id sweep and leave the rules to only the non-gating prefix backstop.
-  DEF_CONTENT=$(printf '%s' "$DEF_TEXT" | jq -r '.content // ""' 2>/dev/null || true)
-  if [ -z "$DEF_CONTENT" ]; then
-    echo "Deferred-rule sweep: deferred-id file had no content (deferral off, or no native fixtures left behind)."
-  elif ! DEF_IDS=$(printf '%s' "$DEF_CONTENT" | jq -r '.[]' 2>/dev/null); then
-    echo "::error::Deferred-rule sweep: ${DEFERRED_FILE} is not a valid JSON array (truncated/corrupt write?) -- exact-id sweep SKIPPED; the post-restore --cleanup-only prefix sweep is now the ONLY backstop for these ids. Raw head: $(printf '%s' "$DEF_CONTENT" | head -c 200 | tr '\n' ' ')"
-  elif [ -z "$DEF_IDS" ]; then
-    echo "Deferred-rule sweep: deferred-id list is an empty array -- nothing to reap (no native fixtures left behind)."
-  else
-    def_n=0
-    def_fail=0
-    while IFS= read -r rid; do
-      [ -z "$rid" ] && continue
-      def_n=$((def_n + 1))
-      echo "Deferred-rule sweep: force-deleting native rule instance ${rid} (overlapping the restore)..."
-      # mcp_tool_call_text PARSES the JSON-RPC result so we can check tool-level success -- force-delete is
-      # idempotent (deleting a gone rule is a no-op), so its retry is safe. Raw mcp_call would discard a
-      # tool-level error (tool missing, auth fail, 4xx/5xx) and look fine, masking a real failure.
-      if FD_TEXT=$(mcp_tool_call_text "hub_force_delete_app ${rid}" \
-          "$(jq -nc --arg id "$rid" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_force_delete_app",arguments:{id:$id,confirm:true}}}')" 2>/dev/null); then
-        # mcp_tool_call_text already unwraps .result.content[0].text, which the watchdog builds by
-        # JSON-serializing the tool's return map directly -- so success is TOP-LEVEL here ('.success'),
-        # NOT under a '.content' key. (The '.content | fromjson' shape applies only to hub_read_file,
-        # whose payload IS a file body under .content -- see the DEF_IDS read above.)
-        if [ "$(printf '%s' "$FD_TEXT" | jq -r '.success' 2>/dev/null)" = "true" ]; then
-          continue
-        fi
-        echo "::warning::Deferred-rule sweep: hub_force_delete_app(${rid}) did not report success: $(printf '%s' "$FD_TEXT" | jq -c '{success,error}' 2>/dev/null | head -c 200)"
-      else
-        echo "::warning::Deferred-rule sweep: hub_force_delete_app(${rid}) returned no parseable result (tool missing on the watchdog / endpoint down?)."
-      fi
-      def_fail=$((def_fail + 1))
-    done <<< "$DEF_IDS"
-    if [ "$def_fail" -eq 0 ]; then
-      echo "Deferred-rule sweep: force-deleted ${def_n} native rule instance(s); clearing the deferred-id list."
-      mcp_tool_call_text "hub_write_file (clear deferred list)" \
-        "$(jq -nc --arg fn "$DEFERRED_FILE" '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_write_file",arguments:{fileName:$fn,content:"[]",confirm:true}}}')" >/dev/null 2>&1 \
-        || echo "::warning::Deferred-rule sweep: could not clear ${DEFERRED_FILE} (the arm step truncates it next run; re-deleting already-gone ids is a harmless no-op)."
-    else
-      echo "::warning::Deferred-rule sweep: ${def_fail}/${def_n} force-delete(s) did NOT confirm -- KEEPING ${DEFERRED_FILE} so the post-restore --cleanup-only prefix sweep (and the next run) can still reap them. Not failing the restore (best-effort)."
-    fi
+# --- 2.5) Purge BAT_E2E_ fixtures (rules + variables) LOCALLY over WATCHDOG_URL --------------------
+# ONE call to the watchdog's hub_purge_e2e_artifacts enumerates every BAT_E2E_ app instance + hub
+# variable and deletes them LOOPBACK-LOCAL on the hub -- no per-item cloud round-trips, so this
+# replaces the old per-id force-delete loop (and now also reaps vars). Prefix-scoped, which is safe on
+# the sacrificial test hub (BAT_E2E_ == test fixtures by convention). Best-effort + SEQUENTIAL: a
+# hiccup NEVER fails the restore -- the post-restore --cleanup-only step is the idempotent prefix
+# backstop (and is what reaps BAT_E2E_ DEVICES, which the watchdog can't delete). The test step still
+# defers rule deletes (E2E_DEFER_NATIVE_DELETES) so they stay off the test critical path; this one
+# call cleans the whole accumulation at once.
+if PURGE_TEXT=$(mcp_tool_call_text "hub_purge_e2e_artifacts" \
+    "$(jq -nc '{jsonrpc:"2.0",id:1,method:"tools/call",params:{name:"hub_purge_e2e_artifacts",arguments:{confirm:true}}}')" 2>/dev/null); then
+  echo "Local purge: $(printf '%s' "$PURGE_TEXT" | jq -c '{deletedCount,failedCount,variablesDeletedCount,variablesFailedCount}' 2>/dev/null | head -c 200)"
+  PURGE_FAILS=$(printf '%s' "$PURGE_TEXT" | jq -r '((.failedCount // 0) + (.variablesFailedCount // 0))' 2>/dev/null || echo "?")
+  if [ "$PURGE_FAILS" != "0" ]; then
+    echo "::warning::Local purge reported ${PURGE_FAILS} failure(s) -- the post-restore --cleanup-only prefix sweep is the backstop. Detail: $(printf '%s' "$PURGE_TEXT" | jq -c '{failed,variablesFailed}' 2>/dev/null | head -c 300)"
   fi
 else
-  echo "::warning::Deferred-rule sweep: could not READ ${DEFERRED_FILE} after retries (transient transport, NOT necessarily deferral-off) -- relying on the post-restore --cleanup-only prefix sweep to reap any BAT_E2E_ rules."
+  echo "::warning::Local purge (hub_purge_e2e_artifacts) returned no parseable result (tool missing on the watchdog / endpoint down?) -- relying on the post-restore --cleanup-only prefix sweep to reap BAT_E2E_ fixtures."
 fi
 
 # --- 3) Fire-and-forget: the watchdog restores main asynchronously --------------------------------

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -468,6 +468,7 @@ jobs:
         run: bash .github/scripts/mcp_watchdog_deploy.sh
 
       - name: Run E2E tests
+        id: run_e2e
         if: steps.gate.outputs.available == 'true'
         env:
           # Defer per-test native-rule fixture deletes to the disarm step's force sweep (over
@@ -523,7 +524,9 @@ jobs:
         run: bash .github/scripts/mcp_restore_env.sh
 
       - name: Post-run hub status probe
-        if: always() && steps.gate.outputs.available == 'true'
+        # Diagnostic-only forensics worth the ~22s ONLY on a red run -- on a green run nobody reads it,
+        # so skip it (gated on run_e2e failure) to keep the held-lease teardown short.
+        if: always() && steps.gate.outputs.available == 'true' && steps.run_e2e.outcome == 'failure'
         # The pre-run probe's counterpart: capture what the run LEFT BEHIND (stranded artifacts,
         # load-limiter trips in the error log, memory descent, watchdog flag state) while we still
         # hold the lease. Runs after the cleanup step's restore-completion gate, so the hub is

--- a/e2e-deadman-watchdog-v2.groovy
+++ b/e2e-deadman-watchdog-v2.groovy
@@ -1547,11 +1547,11 @@ def adminListLibraries(args) {
     return result
 }
 
-// hub_get_jobs: condensed from toolGetHubJobs (hubitat-mcp-server.groovy). Reads the
-// scheduled-jobs JSON over loopback. (The main server's toolGetHubJobs reads jobs a different way;
-// this app reads /hub/scheduledJobs/json directly -- verify the path + shape on the test hub firmware.)
+// hub_get_jobs: condensed from toolGetHubJobs (hubitat-mcp-server.groovy). Reads jobs over loopback
+// from the verified /logs/json endpoint (jobs / runningJobs / hubCommands, keyed by methodName) --
+// the same shape the main server's toolGetHubJobs consumes via fetchLogsJson().
 def adminGetJobs(args) {
-    def responseText = hubGet("/hub/scheduledJobs/json", [:])
+    def responseText = hubGet("/logs/json", [:])
     if (!responseText) return [error: "Empty response from hub jobs endpoint"]
     def data
     try { data = new groovy.json.JsonSlurper().parseText(responseText) }
@@ -1566,7 +1566,8 @@ def adminGetJobs(args) {
     return [
         uptime: data?.uptime,
         scheduledJobs: [count: scheduledJobs.size(), jobs: scheduledJobs],
-        runningJobs: [count: runningJobs.size(), jobs: runningJobs]
+        runningJobs: [count: runningJobs.size(), jobs: runningJobs],
+        hubActions: [count: (data?.hubCommands ?: []).size(), actions: data?.hubCommands ?: []]
     ]
 }
 

--- a/e2e-deadman-watchdog-v2.groovy
+++ b/e2e-deadman-watchdog-v2.groovy
@@ -586,6 +586,7 @@ def executeAdminTool(String toolName, Map args) {
         case "hub_update_library":  return adminUpdateLibrary(args)
         case "hub_delete_item":     return adminDeleteItem(args)
         case "hub_force_delete_app": return adminForceDeleteInstalledApp(args)
+        case "hub_purge_e2e_artifacts": return adminPurgeE2eArtifacts(args)
         case "hub_set_app_disabled": return adminSetAppDisabled(args)
         case "hub_get_metrics":      return adminGetMetrics(args)
         case "hub_update_platform":  return adminUpdatePlatform(args)
@@ -1064,6 +1065,65 @@ def adminForceDeleteInstalledApp(args) {
         return [success: true, message: "Force-deleted installed app ${id} (HTTP ${st}; verified gone).", id: id]
     }
     return [success: false, error: "Force-delete of installed app ${id} returned HTTP ${st} but the gone-check could not read /installedapp/json (status=${cst ?: 'none'}) -- keep the id and re-delete to be safe.", id: id]
+}
+
+// hub_purge_e2e_artifacts: ONE-call LOCAL sweep of leftover test fixtures. Enumerates every installed-app
+// instance whose name starts with the BAT_E2E_ test prefix (via /hub2/appsList, the same read
+// adminListAppInstances uses) and force-deletes each by reusing adminForceDeleteInstalledApp's
+// forcedelete+verify-gone path. The whole loop runs loopback-local on the hub, so CI makes ONE cloud
+// round-trip instead of N -- replacing the disarm's per-item reap loop and the post-restore
+// --cleanup-only RM sweep. Hard-scoped to the prefix (never a real app); confirm:true required.
+def adminPurgeE2eArtifacts(args) {
+    requireConfirm(args)
+    String prefix = (args?.prefix instanceof String && args.prefix.trim()) ? args.prefix.trim() : "BAT_E2E_"
+    String raw = hubGet("/hub2/appsList", [:])
+    if (!raw) return [success: false, error: "empty response from /hub2/appsList -- cannot enumerate to purge"]
+    def parsed
+    try { parsed = new groovy.json.JsonSlurper().parseText(raw) }
+    catch (Exception e) { return [success: false, error: "unparseable /hub2/appsList: ${e.message}"] }
+    def targets = []
+    def recurse
+    recurse = { Map node ->
+        def d = node?.data ?: [:]
+        if ((d.name instanceof String) && d.name.startsWith(prefix) && d.id != null) {
+            targets << [id: d.id, name: d.name]
+        }
+        node?.children?.each { c -> recurse(c) }
+    }
+    (parsed?.apps ?: []).each { a -> recurse(a) }
+    mcpAdminLog "Purging ${targets.size()} ${prefix}* installed-app instance(s) locally."
+    def deleted = []
+    def failed = []
+    targets.each { t ->
+        def r
+        try { r = adminForceDeleteInstalledApp([id: t.id, confirm: true]) }
+        catch (Exception e) { r = [success: false, error: e.message] }
+        if (r?.success) { deleted << [id: t.id, name: t.name] }
+        else { failed << [id: t.id, name: t.name, error: r?.error] }
+    }
+    // Variables are hub-GLOBAL, so the watchdog (any app) can enumerate + remove them via DSL --
+    // local, no relay, no classic-wizard (the main server's wizard exists only for in-use/connector
+    // safety, which is moot for a BAT_E2E_ purge that runs AFTER the referencing rules are gone).
+    def varsDeleted = []
+    def varsFailed = []
+    try {
+        def allVars = getAllGlobalVars() ?: [:]
+        allVars.keySet().findAll { (it instanceof String) && it.startsWith(prefix) }.each { vn ->
+            try {
+                if (removeGlobalVariable(vn)) { varsDeleted << vn }
+                else { varsFailed << [name: vn, error: "removeGlobalVariable returned false (in use or already gone)"] }
+            } catch (Exception e) { varsFailed << [name: vn, error: e.message] }
+        }
+    } catch (Exception e) {
+        varsFailed << [name: "*", error: "getAllGlobalVars failed: ${e.message}"]
+    }
+    mcpAdminLog "Purge complete: ${deleted.size()} app(s), ${varsDeleted.size()} variable(s) deleted; " +
+                "${failed.size()} app + ${varsFailed.size()} var failure(s)."
+    return [success: failed.isEmpty() && varsFailed.isEmpty(), prefix: prefix,
+            deletedCount: deleted.size(), failedCount: failed.size(), deleted: deleted, failed: failed,
+            variablesDeletedCount: varsDeleted.size(), variablesFailedCount: varsFailed.size(),
+            variablesDeleted: varsDeleted, variablesFailed: varsFailed,
+            note: "Virtual DEVICES are NOT purged here (they are child devices of the main app and the hub's admin device-delete endpoint is not yet mirrored into the watchdog); the post-restore --cleanup-only sweep still reaps BAT_E2E_ devices."]
 }
 
 // hub_set_app_disabled: toggle an installed app's disabled flag (the admin UI's red-X) via
@@ -1733,6 +1793,8 @@ def getAdminToolDefinitions() {
          inputSchema: [type: "object", properties: [type: [type: "string", enum: ["app", "driver", "library"]], id: [type: "string"], confirm: [type: "boolean"]], required: ["type", "id", "confirm"]]],
         [name: "hub_force_delete_app", description: "Force-delete an INSTALLED-APP instance (e.g. an RM rule) via /installedapp/forcedelete/<id>/quiet. confirm:true required.",
          inputSchema: [type: "object", properties: [id: [type: "string"], confirm: [type: "boolean"]], required: ["id", "confirm"]]],
+        [name: "hub_purge_e2e_artifacts", description: "One-call LOCAL sweep of leftover test fixtures: force-delete every installed-app instance whose name starts with prefix (default BAT_E2E_) AND removeGlobalVariable every matching hub variable, all loopback-local on the hub so CI pays ONE cloud round-trip instead of N. Virtual devices are NOT covered (child devices of the main app). Returns per-class {deleted/failed} counts. confirm:true required.",
+         inputSchema: [type: "object", properties: [prefix: [type: "string", description: "Name prefix to purge; default BAT_E2E_."], confirm: [type: "boolean"]], required: ["confirm"]]],
         [name: "hub_set_app_disabled", description: "Toggle an installed app's disabled flag (the admin UI red-X) via POST /installedapp/disable; verified by read-back. confirm:true required.",
          inputSchema: [type: "object", properties: [appId: [type: "string"], disable: [type: "boolean"], confirm: [type: "boolean"]], required: ["appId", "disable", "confirm"]]],
         [name: "hub_get_metrics", description: "Current hub metrics (free memory, temp, DB size, uptime) + the hub's own health alerts. Read-only."],

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3727,7 +3727,12 @@ private Map _appTypeRegistry() {
         // Rule. But its inputs are submitOnChange with no updateRule button, so
         // commitButton is null. Verified live: appName="Basic Rule-1.0",
         // parentType="Basic Rules", generic createchild -> 302 configure/<id>.
-        basic_rule: [namespace: "hubitat", appName: "Basic Rule-1.0", parentTypeName: "Basic Rules", commitButton: null]
+        basic_rule: [namespace: "hubitat", appName: "Basic Rule-1.0", parentTypeName: "Basic Rules", commitButton: null],
+        // Button Rule-5.1's page graph shifts one level (root page named
+        // selectActions, not mainPage) and it is submitOnChange with no
+        // updateRule button, so commitButton is null -- _resolveCommitButton
+        // then returns null (real verdict) instead of defaulting to "updateRule".
+        button_rule: [namespace: "hubitat", appName: "Button Rule-5.1", parentTypeName: "Button Controllers", commitButton: null]
         // button_controller, groups_scenes, notifier child appName values were
         // verified on the live hub. Room Lighting parent exists but has no
         // probed children yet -- add when needed.

--- a/libraries/mcp-code-management-lib.groovy
+++ b/libraries/mcp-code-management-lib.groovy
@@ -332,6 +332,18 @@ def toolGetAppConfig(args) {
         try {
             summaryText = hubInternalGet(summaryPath, null, 30)
         } catch (Exception e) {
+            // Duck-type the HTTP status off the exception (HttpResponseException NCDFEs at parse
+            // time on the test classpath, so read e.response.status defensively). A 404/410 on the
+            // thin identity record means the app is gone (deleted/mid-delete) -- degrade to a clean
+            // not-found at warn, not an opaque ERROR.
+            def resp = null
+            try { resp = e.response } catch (Exception ig) { resp = null }
+            Integer st = null
+            try { st = resp?.status as Integer } catch (Exception ig) { st = null }
+            if (st == 404 || st == 410) {
+                mcpLog("warn", "hub-admin", "hub_get_app_config app ${appIdStr} not found (HTTP ${st} from ${summaryPath})")
+                return [success: false, error: "App ${appIdStr} not found (HTTP ${st} from ${summaryPath}). May be deleted, mid-delete, or a not-yet-committed install shell whose config page cannot render. Verify with hub_get_app_config(summary=true) or hub_list_apps.", appId: appIdStr as Integer, fingerprint: 'app not found (404)', status: st]
+            }
             mcpLogError("hub-admin", "hub_get_app_config summary fetch failed", e)
             return [success: false, error: "Failed to fetch app summary [${e.class.simpleName}]: ${e.message}", appId: appIdStr as Integer]
         }
@@ -364,6 +376,18 @@ def toolGetAppConfig(args) {
     try {
         responseText = hubInternalGet(path, null, 30)
     } catch (Exception e) {
+        // Duck-type the HTTP status off the exception (HttpResponseException NCDFEs at parse
+        // time on the test classpath, so read e.response.status defensively). A 404/410 here is
+        // benign: the configure page can't render for a deleted, mid-delete, or not-yet-committed
+        // install shell -- degrade to a clean not-found at warn, not an opaque ERROR.
+        def resp = null
+        try { resp = e.response } catch (Exception ig) { resp = null }
+        Integer st = null
+        try { st = resp?.status as Integer } catch (Exception ig) { st = null }
+        if (st == 404 || st == 410) {
+            mcpLog("warn", "hub-admin", "hub_get_app_config app ${appIdStr} not found (HTTP ${st} from ${path})")
+            return [success: false, error: "App ${appIdStr} not found (HTTP ${st} from ${path}). May be deleted, mid-delete, or a not-yet-committed install shell whose config page cannot render. Verify with hub_get_app_config(summary=true) or hub_list_apps.", appId: appIdStr as Integer, fingerprint: 'app not found (404)', status: st]
+        }
         mcpLogError("hub-admin", "hub_get_app_config fetch failed", e)
         return [success: false, error: "Failed to fetch app config [${e.class.simpleName}]: ${e.message}", appId: appIdStr as Integer]
     }
@@ -565,6 +589,18 @@ def toolListAppPages(args) {
     try {
         responseText = hubInternalGet(path, null, 30)
     } catch (Exception e) {
+        // Duck-type the HTTP status off the exception (HttpResponseException NCDFEs at parse
+        // time on the test classpath, so read e.response.status defensively). A 404/410 here is
+        // benign: the configure page can't render for a deleted, mid-delete, or not-yet-committed
+        // install shell -- degrade to a clean not-found at warn, not an opaque ERROR.
+        def resp = null
+        try { resp = e.response } catch (Exception ig) { resp = null }
+        Integer st = null
+        try { st = resp?.status as Integer } catch (Exception ig) { st = null }
+        if (st == 404 || st == 410) {
+            mcpLog("warn", "hub-admin", "hub_list_app_pages app ${appIdStr} not found (HTTP ${st} from ${path})")
+            return [success: false, error: "App ${appIdStr} not found (HTTP ${st} from ${path}). May be deleted, mid-delete, or a not-yet-committed install shell whose config page cannot render. Verify with hub_get_app_config(summary=true) or hub_list_apps.", appId: appIdStr as Integer, fingerprint: 'app not found (404)', status: st]
+        }
         mcpLogError("hub-admin", "hub_list_app_pages fetch failed", e)
         return [success: false, error: "Failed to fetch app config [${e.class.simpleName}]: ${e.message}", appId: appIdStr as Integer]
     }

--- a/libraries/mcp-diagnostics-lib.groovy
+++ b/libraries/mcp-diagnostics-lib.groovy
@@ -1489,7 +1489,17 @@ def toolSetZigbee(args) {
                     message: "Zigbee radio settings updated.", response: resp]
         } catch (Exception e) {
             mcpLogError("hub-admin", "Zigbee settings update failed", e)
-            return [success: false, error: "Zigbee settings update failed: ${e.message}", note: "Check Hub Security credentials."]
+            // Duck-type the HTTP status (e.response.status names HttpResponseException NCDFEs at
+            // parse time on the test classpath). A 404 on this path most often means the hub has
+            // no Zigbee radio at all, not a credential failure -- steer the note accordingly.
+            def resp = null
+            try { resp = e.response } catch (Exception ignore) { resp = null }
+            Integer st = null
+            try { st = resp?.status as Integer } catch (Exception ignore) { st = null }
+            def note = (st == 404)
+                ? "A 404 here usually means this hub has no active Zigbee radio (absent/disabled). Verify via hub_get_radio_details(radio='zigbee')."
+                : "Check Hub Security credentials."
+            return [success: false, error: "Zigbee settings update failed: ${e.message}", note: note]
         }
     }
 

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -3889,11 +3889,32 @@ private void _rmSubmitSubPageDone(Integer appId, String page, String parentPage,
 // commitButton:null app types (Basic Rule, Button Controller) the Done
 // is the session's ONLY lifecycle event, so a silent miss matters there.
 private Map _rmSubmitMainPageDone(Integer appId) {
+    // Most app types commit on mainPage -- fetch it directly so the common path stays a SINGLE config
+    // render (no per-edit regression). Button Rule-5.1's commit page is 'selectActions' instead, so a
+    // mainPage fetch fails there ("Cannot find page 'mainPage'"); ONLY on that miss do we probe the app
+    // type from the root config and retry on the resolved page (mirrors _rmInitSelectActionsPage).
+    def commitPage = "mainPage"
     def cfg
-    try { cfg = _rmFetchConfigJson(appId, "mainPage") }
-    catch (Exception fetchExc) {
-        mcpLog("warn", "rm-native", "_rmSubmitMainPageDone: mainPage fetch failed for app ${appId} (${fetchExc.message}) -- skipping Done click; lingering state markers (state.editAct/state.editCond) may corrupt subsequent edits")
-        return [done: false, reason: "mainPage fetch failed: ${fetchExc.message}".toString()]
+    try {
+        cfg = _rmFetchConfigJson(appId, commitPage)
+    } catch (Exception mainExc) {
+        String resolved = null
+        try {
+            def rootCfg = _rmFetchConfigJson(appId)
+            if (rootCfg?.app?.appType?.name == "Button Rule-5.1") resolved = "selectActions"
+        } catch (Exception probeExc) {
+            mcpLog("warn", "rm-native", "_rmSubmitMainPageDone: page-graph probe failed for app ${appId} after a mainPage miss (${probeExc.message})")
+        }
+        if (resolved == null) {
+            mcpLog("warn", "rm-native", "_rmSubmitMainPageDone: mainPage fetch failed for app ${appId} (${mainExc.message}) -- skipping Done click; lingering state markers (state.editAct/state.editCond) may corrupt subsequent edits")
+            return [done: false, reason: "mainPage fetch failed: ${mainExc.message}".toString()]
+        }
+        commitPage = resolved
+        try { cfg = _rmFetchConfigJson(appId, commitPage) }
+        catch (Exception reExc) {
+            mcpLog("warn", "rm-native", "_rmSubmitMainPageDone: ${commitPage} fetch failed for app ${appId} (${reExc.message}) -- skipping Done click")
+            return [done: false, reason: "${commitPage} fetch failed: ${reExc.message}".toString()]
+        }
     }
     def schema = _rmCollectInputSchema(cfg?.configPage)
     def status
@@ -3920,7 +3941,7 @@ private Map _rmSubmitMainPageDone(Integer appId) {
     }
     def body = _rmBuildSettingsBody(appId, settingsMap, schema)
     body.formAction = "update"
-    body.currentPage = "mainPage"
+    body.currentPage = commitPage
     body._action_update = "Done"
     body.pageBreadcrumbs = "[]"
     schema.each { name, meta ->

--- a/src/test/groovy/server/RadioGatewaySpec.groovy
+++ b/src/test/groovy/server/RadioGatewaySpec.groovy
@@ -26,6 +26,15 @@ class RadioGatewaySpec extends ToolSpecBase {
         stateMap.lastBackupTimestamp = 1234567890000L  // matches the harness's fixed now()
     }
 
+    /** Carries an HTTP status the way HttpResponseException does (duck-typed e.response.status). */
+    private static class FakeHttpException extends RuntimeException {
+        final def response
+        FakeHttpException(int status) {
+            super("HTTP ${status}")
+            this.response = [status: status]
+        }
+    }
+
     private Map gw() { script.getGatewayConfig() }
     private List allNames() { script.getAllToolDefinitions()*.name }
 
@@ -566,6 +575,44 @@ class RadioGatewaySpec extends ToolSpecBase {
         r.success == true
         r.rebuildNetworkOnReboot == true
         r.inactiveDevicePingEnabled == true   // preserved from current state
+    }
+
+    def "hub_set_zigbee settings 404 (no Zigbee radio) names an absent radio, not a credential problem"() {
+        given:
+        // Current state reads fine; the updateSettings write 404s -- on the e2e hub that means
+        // the Zigbee radio is absent/disabled, NOT a Hub Security credential failure.
+        hubGet.register('/hub/zigbeeDetails/json') { p -> JsonOutput.toJson([rebuildNetworkOnReboot: false, inactiveDevicePingEnabled: false]) }
+        hubGet.register('/hub/zigbee/updateSettings?rebuildNetworkOnReboot=true&inactiveDevicePingEnabled=false') { p ->
+            throw new FakeHttpException(404)
+        }
+
+        when:
+        def r = script.toolSetZigbee([rebuild_on_reboot: true])
+
+        then:
+        r.success == false
+        // (a) the requested path is EXACTLY the zigbee updateSettings path with both query flags
+        hubGet.calls*.path.contains('/hub/zigbee/updateSettings?rebuildNetworkOnReboot=true&inactiveDevicePingEnabled=false')
+        // (b) the note names an absent Zigbee radio and does NOT mislead toward credentials
+        r.note?.contains('Zigbee radio')
+        r.note?.toLowerCase()?.contains('absent')
+        !r.note?.toLowerCase()?.contains('credential')
+    }
+
+    def "hub_set_zigbee settings non-404 fault keeps the Hub Security credential hint"() {
+        given:
+        hubGet.register('/hub/zigbeeDetails/json') { p -> JsonOutput.toJson([rebuildNetworkOnReboot: false, inactiveDevicePingEnabled: false]) }
+        hubGet.register('/hub/zigbee/updateSettings?rebuildNetworkOnReboot=true&inactiveDevicePingEnabled=false') { p ->
+            throw new FakeHttpException(403)   // auth-class fault -> credential hint stays
+        }
+
+        when:
+        def r = script.toolSetZigbee([rebuild_on_reboot: true])
+
+        then:
+        r.success == false
+        r.note?.toLowerCase()?.contains('credential')
+        !r.note?.contains('Zigbee radio')
     }
 
     def "hub_set_zigbee ping_device toggles per-device keep-alive ping"() {

--- a/src/test/groovy/server/ToolGetAppConfigSpec.groovy
+++ b/src/test/groovy/server/ToolGetAppConfigSpec.groovy
@@ -18,7 +18,9 @@ import support.ToolSpecBase
  *  - includeSettings=true: settings key populated
  *  - summary=true: identity-only fast path via /installedapp/json (pass-through + error paths)
  *  - Empty hub response: returns success=false
- *  - Unknown appId (hub returns {app:null}): fingerprint check fires, success=false
+ *  - Unknown appId (hub returns {app:null}): 'missing app' fingerprint, success=false
+ *  - Not-found 404/410 throw (deleted / mid-delete / install shell whose config page
+ *    can't render): clean 'app not found (404)' degrade at warn, full + summary modes
  *  - HTML stripping: span tags removed from labels
  *
  * Each direct-call feature has a parallel "via dispatch" feature that fires
@@ -28,6 +30,18 @@ import support.ToolSpecBase
  * internals. Dispatch features are @Unroll'd across useGateways true/false.
  */
 class ToolGetAppConfigSpec extends ToolSpecBase {
+
+    // An exception that carries an HTTP status the way HttpResponseException does
+    // (duck-typed via .response.status). hubInternalGet's mock responder can throw
+    // this to drive the catch-block status-detection path. Mirrors the shape used in
+    // HubInternalRetrySpec.FakeHttpException.
+    private static class FakeHttpException extends RuntimeException {
+        final def response
+        FakeHttpException(int status) {
+            super("HTTP ${status}")
+            this.response = [status: status]
+        }
+    }
 
     // Canonical hub response for a simple single-page app.
     // Shape mirrors what /installedapp/configure/json/<id> actually returns
@@ -815,8 +829,10 @@ class ToolGetAppConfigSpec extends ToolSpecBase {
     def "returns success=false with fingerprint when app.app is null (unknown appId)"() {
         given:
         settingsMap.enableRead = true
-        // Hub returns top-level object but with app=null — matches what Hubitat
-        // returns for an unknown/deleted appId.
+        // Hub returns a 200 body whose top-level object has app=null -- the configure page
+        // rendered but found no app. This is the {app:null}-BODY not-found (fingerprint
+        // 'missing app'), distinct from the 404/410-THROW not-found below (fingerprint
+        // 'app not found (404)') where the page never renders at all.
         hubGet.register('/installedapp/configure/json/9999') { params ->
             JsonOutput.toJson([
                 app       : null,
@@ -865,6 +881,76 @@ class ToolGetAppConfigSpec extends ToolSpecBase {
 
         where:
         useGateways << [true, false]
+    }
+
+    def "returns a clean not-found (warn, not error) when the configure page fetch throws a 404"() {
+        given:
+        settingsMap.enableRead = true
+        // A deleted / mid-delete / not-yet-committed install shell: the configure page
+        // can't render, so hubInternalGet raises an HttpResponseException-shaped 404.
+        // The tool must degrade gracefully -- structured not-found, not an opaque error.
+        hubGet.register('/installedapp/configure/json/9999') { params ->
+            throw new FakeHttpException(404)
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 9999])
+
+        then:
+        result.success == false
+        result.fingerprint == 'app not found (404)'
+        result.status == 404
+        result.appId == 9999
+        result.error.toLowerCase().contains('not found')
+        // Steers the agent to the cheap identity probe instead of dead-end retries
+        result.error.contains('summary')
+    }
+
+    @spock.lang.Unroll
+    def "hub_get_app_config via dispatch returns a clean 404 not-found envelope (useGateways=#useGateways)"() {
+        given:
+        settingsMap.useGateways = useGateways
+        settingsMap.enableRead = true
+        hubGet.register('/installedapp/configure/json/9999') { params ->
+            throw new FakeHttpException(404)
+        }
+
+        when:
+        def response = mcpDriver.callTool('hub_get_app_config', [appId: 9999])
+
+        then: 'a graceful not-found is a normal tool result, not a transport error'
+        response.error == null
+        !response.result.isError
+        def inner = mcpDriver.parseInner(response)
+        inner.success == false
+        inner.fingerprint == 'app not found (404)'
+        inner.status == 404
+        inner.error.toLowerCase().contains('not found')
+        inner.error.contains('summary')
+
+        where:
+        useGateways << [true, false]
+    }
+
+    def "summary=true returns a clean not-found when the identity fetch throws a 404"() {
+        given:
+        settingsMap.enableRead = true
+        // The thin /installedapp/json record 404s when the app is gone -- same graceful
+        // degrade as the full-mode path, via the summary catch block.
+        hubGet.register('/installedapp/json/9999') { params ->
+            throw new FakeHttpException(404)
+        }
+
+        when:
+        def result = script.toolGetAppConfig([appId: 9999, summary: true])
+
+        then:
+        result.success == false
+        result.fingerprint == 'app not found (404)'
+        result.status == 404
+        result.appId == 9999
+        result.error.toLowerCase().contains('not found')
+        result.error.contains('summary')
     }
 
     def "returns success=false with fingerprint when response is not a JSON object"() {

--- a/src/test/groovy/server/ToolListAppPagesSpec.groovy
+++ b/src/test/groovy/server/ToolListAppPagesSpec.groovy
@@ -16,7 +16,9 @@ import support.ToolSpecBase
  *  - Golden path RM rule: single-page result with note
  *  - Unknown app type: single-page result with uncurated note
  *  - Empty hub response: returns success=false
- *  - Unknown appId (hub returns {app:null}): fingerprint check fires, success=false
+ *  - Unknown appId (hub returns {app:null}): 'missing app' fingerprint, success=false
+ *  - Not-found 404/410 throw (deleted / mid-delete / install shell whose config page
+ *    can't render): clean 'app not found (404)' degrade at warn, not an opaque error
  *
  * Each direct-call feature has a parallel "via dispatch" feature that fires
  * the same tool through {@code mcpDriver.callTool} so the production
@@ -25,6 +27,18 @@ import support.ToolSpecBase
  * internals. Dispatch features are @Unroll'd across useGateways true/false.
  */
 class ToolListAppPagesSpec extends ToolSpecBase {
+
+    // An exception that carries an HTTP status the way HttpResponseException does
+    // (duck-typed via .response.status). hubInternalGet's mock responder can throw
+    // this to drive the catch-block status-detection path. Mirrors the shape used in
+    // HubInternalRetrySpec.FakeHttpException.
+    private static class FakeHttpException extends RuntimeException {
+        final def response
+        FakeHttpException(int status) {
+            super("HTTP ${status}")
+            this.response = [status: status]
+        }
+    }
 
     // Helper: build a minimal hub response for /installedapp/configure/json/<id>
     private static String makeAppJson(String appTypeName, String primaryPageName = 'mainPage', String pageTitle = 'Settings') {
@@ -404,6 +418,9 @@ class ToolListAppPagesSpec extends ToolSpecBase {
     def "returns success=false with fingerprint when hub returns app=null (unknown appId)"() {
         given:
         settingsMap.enableRead = true
+        // Hub returns a 200 body whose top-level object has app=null -- the configure page
+        // rendered but found no app (fingerprint 'missing app'), distinct from the 404/410-THROW
+        // not-found below (fingerprint 'app not found (404)') where the page never renders at all.
         hubGet.register('/installedapp/configure/json/9999') { params ->
             JsonOutput.toJson([
                 app       : null,
@@ -420,6 +437,55 @@ class ToolListAppPagesSpec extends ToolSpecBase {
         result.success == false
         result.error != null
         result.fingerprint == 'missing app'
+    }
+
+    def "returns a clean not-found (warn, not error) when the configure page fetch throws a 404"() {
+        given:
+        settingsMap.enableRead = true
+        // A deleted / mid-delete / not-yet-committed install shell: the configure page
+        // can't render, so hubInternalGet raises an HttpResponseException-shaped 404.
+        // The tool must degrade gracefully -- structured not-found, not an opaque error.
+        hubGet.register('/installedapp/configure/json/9999') { params ->
+            throw new FakeHttpException(404)
+        }
+
+        when:
+        def result = script.toolListAppPages([appId: 9999])
+
+        then:
+        result.success == false
+        result.fingerprint == 'app not found (404)'
+        result.status == 404
+        result.appId == 9999
+        result.error.toLowerCase().contains('not found')
+        // Steers the agent to the cheap identity probe instead of dead-end retries
+        result.error.contains('summary')
+    }
+
+    @spock.lang.Unroll
+    def "hub_list_app_pages via dispatch returns a clean 404 not-found envelope (useGateways=#useGateways)"() {
+        given:
+        settingsMap.useGateways = useGateways
+        settingsMap.enableRead = true
+        hubGet.register('/installedapp/configure/json/9999') { params ->
+            throw new FakeHttpException(404)
+        }
+
+        when:
+        def response = mcpDriver.callTool('hub_list_app_pages', [appId: 9999])
+
+        then: 'a graceful not-found is a normal tool result, not a transport error'
+        response.error == null
+        !response.result.isError
+        def inner = mcpDriver.parseInner(response)
+        inner.success == false
+        inner.fingerprint == 'app not found (404)'
+        inner.status == 404
+        inner.error.toLowerCase().contains('not found')
+        inner.error.contains('summary')
+
+        where:
+        useGateways << [true, false]
     }
 
     @spock.lang.Unroll

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -689,6 +689,57 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         !posts.any { it.path == "/installedapp/update/json" }
     }
 
+    def "_rmSubmitMainPageDone commits on the selectActions page for Button Rule-5.1 (NOT mainPage)"() {
+        given:
+        // Button Rule-5.1's root/commit page is named selectActions (playing
+        // mainPage's role). The trailing Done must GET + POST selectActions; a
+        // hardcoded mainPage logs "Cannot find page 'mainPage'" and the fetch
+        // returns done:false. Only /selectActions is registered here, so a
+        // mainPage fetch would miss and the assertions below would fail.
+        def fetched = []
+        hubGet.register('/installedapp/configure/json/710') { params ->
+            fetched << "root"
+            JsonOutput.toJson([app: [id: 710, installed: true, version: 3, appType: [name: "Button Rule-5.1", namespace: "hubitat"]],
+                               configPage: [name: "selectActions", sections: []], settings: [:]])
+        }
+        hubGet.register('/installedapp/configure/json/710/selectActions') { params ->
+            fetched << "selectActions"
+            JsonOutput.toJson([app: [id: 710, name: "Button Rule-5.1", label: "r", installed: true, version: 3,
+                                     appType: [name: "Button Rule-5.1", namespace: "hubitat"]],
+                               configPage: [name: "selectActions", install: true, error: null, sections: [
+                                   [title: "", input: [[name: "origLabel", type: "text"]]]
+                               ]],
+                               settings: [:], childApps: []])
+        }
+        hubGet.register('/installedapp/statusJson/710') { statusJson(710) }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '{"status":"success"}']
+        }
+
+        when:
+        def r = script._rmSubmitMainPageDone(710)
+
+        then: "the commit page (selectActions), not mainPage, is fetched and posted -- and the Done succeeds"
+        fetched.contains("selectActions")
+        def done = posts.find { it.path == "/installedapp/update/json" }
+        done != null
+        done.body.currentPage == "selectActions"
+        r.done == true
+    }
+
+    def "_appTypeRegistry registers button_rule with appName Button Rule-5.1 + commitButton null"() {
+        when:
+        def reg = script._appTypeRegistry()
+
+        then:
+        reg.button_rule == [namespace: "hubitat", appName: "Button Rule-5.1", parentTypeName: "Button Controllers", commitButton: null]
+
+        and: "_resolveCommitButton returns a real null verdict for it (submitOnChange, no updateRule button)"
+        script._resolveCommitButton("Button Rule-5.1") == null
+    }
+
     def "_rmInitSelectActionsPage falls back to the RM 5.1 page graph when the root config fetch throws"() {
         given:
         // The app-type probe (root config fetch) is wrapped in a try/catch: if it

--- a/src/test/groovy/server/WatchdogV2Spec.groovy
+++ b/src/test/groovy/server/WatchdogV2Spec.groovy
@@ -667,6 +667,29 @@ class WatchdogV2Spec extends Specification {
         r.totalParsed == 3
     }
 
+    def "adminGetJobs reads /logs/json and maps checkDeadman (the watchdog schedule check)"() {
+        given:
+        // hub_get_jobs reads the verified /logs/json shape (jobs / runningJobs / hubCommands, keyed by
+        // methodName) -- NOT the old non-existent /hub/scheduledJobs/json that 404'd and blinded the
+        // pre-arm checkDeadman schedule check in mcp_arm_watchdog.sh.
+        String requestedPath = null
+        script.metaClass.hubGet = { String p, Map q ->
+            requestedPath = p
+            '{"uptime":"1d","jobs":[{"name":"checkDeadman","methodName":"checkDeadman","recurring":true}],"runningJobs":[],"hubCommands":[]}'
+        }
+
+        when:
+        def r = script.adminGetJobs([:])
+
+        then: 'the schedule check reads /logs/json, never /hub/scheduledJobs/json'
+        requestedPath == '/logs/json'
+
+        and: 'checkDeadman is surfaced via job.methodName so the arm-time jq can confirm it is scheduled'
+        r.scheduledJobs.count == 1
+        r.scheduledJobs.jobs[0].method == 'checkDeadman'
+        r.hubActions.count == 0
+    }
+
     def "adminListAppInstances flattens the /hub2/appsList tree with parentId"() {
         given:
         script.metaClass.hubGet = { String p, Map q ->

--- a/src/test/groovy/server/WatchdogV2Spec.groovy
+++ b/src/test/groovy/server/WatchdogV2Spec.groovy
@@ -325,6 +325,45 @@ class WatchdogV2Spec extends Specification {
         r.error?.contains("did not confirm")
     }
 
+    def "adminPurgeE2eArtifacts force-deletes only BAT_E2E_ apps + removes only BAT_E2E_ vars (one local sweep)"() {
+        given:
+        // /hub2/appsList returns a mix; the purge must touch ONLY the BAT_E2E_-prefixed entries
+        // (incl. a nested child) and leave real apps alone -- the prefix is the only safety scope.
+        def appsJson = groovy.json.JsonOutput.toJson([apps: [
+            [data: [id: 100, name: "BAT_E2E_Rule1", type: "rule"], children: []],
+            [data: [id: 200, name: "Real Rule", type: "rule"], children: [
+                [data: [id: 201, name: "BAT_E2E_Child", type: "x"], children: []]]],
+        ]])
+        def forced = []
+        script.metaClass.hubGet = { String path, Map q -> path == "/hub2/appsList" ? appsJson : "" }
+        script.metaClass.hubGetStatus = { String path, Map q ->
+            if (path.startsWith("/installedapp/forcedelete/")) { forced << path; [status: 302, location: "/installedapp/list", data: null] }
+            else { [status: 404, location: null, data: null] }   // gone-check: absent
+        }
+        def removedVars = []
+        script.metaClass.getAllGlobalVars = { -> [BAT_E2E_v1: [type: "string"], RealVar: [type: "string"], BAT_E2E_v2: [type: "integer"]] }
+        script.metaClass.removeGlobalVariable = { String n -> removedVars << n; true }
+
+        when:
+        def r = script.adminPurgeE2eArtifacts([confirm: true])
+
+        then:
+        r.success == true
+        r.deletedCount == 2
+        (r.deleted*.id).collect { it as Integer }.sort() == [100, 201]
+        forced.sort() == ["/installedapp/forcedelete/100/quiet", "/installedapp/forcedelete/201/quiet"]
+        r.variablesDeletedCount == 2
+        removedVars.sort() == ["BAT_E2E_v1", "BAT_E2E_v2"]
+    }
+
+    def "adminPurgeE2eArtifacts requires confirm (never deletes without it)"() {
+        when:
+        script.adminPurgeE2eArtifacts([:])
+
+        then:
+        thrown(Exception)
+    }
+
     @Unroll
     def "adminSetAppDisabled posts the Vue wire format and trusts only the read-back (#scenario)"() {
         given:

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -141,6 +141,14 @@ class HubitatMcpClient:
         if "hub_update_mcp_settings" in _pj:
             replay_safe = True
 
+        # Pace writes only. The heavy RM wizard edits (confirm:true) ride the cloud relay's
+        # gateway-timeout edge; a 0.2s pre-send gap caps the server app's short-window duty
+        # cycle so the write finishes before the relay 504s. Reads carry no such load and skip
+        # it -- that is the speedup. `not replay_safe` is the confirm-bearing-write marker;
+        # hub_update_mcp_settings is a light idempotent settings write and stays unpaced.
+        if not replay_safe:
+            time.sleep(0.2)
+
         # Chaos mode (E2E_CHAOS_504=<0..1>): after a WRITE completes, discard its response and
         # raise the exact relay-504 error with probability <rate>. This reproduces on demand the
         # cloud relay's worst behavior -- the op COMMITTED but the response was lost -- so every

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -341,6 +341,20 @@ class TestRunner:
         # a second hub_get_rule_health round-trip. Keyed by app; cleared on a relay-dropped/soft write.
         self._last_write_health: tuple[str, dict] | None = None
 
+        # Read-round-trip stashes -- each lets a downstream test reuse an UPSTREAM test's identical
+        # immutable read instead of re-fetching. EVERY one falls back to a live fetch when unset or
+        # the identity does not match (so a `--test <name>` isolation run still works) and is NEVER
+        # trusted across a write to the same entity. Initialized to None.
+        # (rule_id, fetched) from _create_rule_and_verify's read-back -- reused by _assert_rule_types
+        # and test_get_rule when the id matches; only valid before any write to that rule.
+        self._last_rule_obj: tuple[str, dict] | None = None
+        # hub_get_info called once with BOTH opt-in flags; the two opt-in tests read disjoint keys.
+        self._hub_info_optin: dict | None = None
+        # the hub_read_rooms gateway-catalog disclosure (deterministic static enumeration).
+        self._rooms_catalog: dict | None = None
+        # the resolved mcp-libraries bundle id (immutable) -- reused by test_export_bundle.
+        self._mcp_bundle_id: str | None = None
+
         # Cleanup tracking
         self.created_device_dnis: list[str] = []
         self.created_rule_ids: list[str] = []
@@ -693,6 +707,12 @@ class TestRunner:
         fetched = self.client.call_tool("hub_get_custom_rule", {"ruleId": rule_id})
         assert fetched.get("name") == name or fetched.get("name", "").startswith(PREFIX), \
             f"Rule name mismatch: expected '{name}', got '{fetched.get('name')}'"
+        # Stash this read-back so a downstream same-rule reader (_assert_rule_types, test_get_rule)
+        # can reuse it instead of re-fetching the SAME immutable rule. Keyed by rule_id; only trusted
+        # on an exact-id match and never across a write to the rule. (The 504-recovery branch above
+        # never reaches here with a `fetched`, so the stash stays whatever it was -> a mismatch ->
+        # the reader fetches live.)
+        self._last_rule_obj = (rule_id, fetched)
         return rule_id
 
     def _assert_rule_types(self, rule_id: str, key: str, expected_types: list[str],
@@ -702,7 +722,13 @@ class TestRunner:
         one (which a length-only check would miss). `normalize_away` lists input types the engine rewrites
         server-side (triggers: 'sunrise'/'sunset' -> 'time'), so they aren't required to appear under their
         original name; the count still must match."""
-        fetched = self.client.call_tool("hub_get_custom_rule", {"ruleId": rule_id})
+        # Reuse the create-verify read-back for the SAME rule (no write happens between create and this
+        # assert in any caller); fall back to a live fetch when the stash is unset or for a different rule
+        # (isolation-safe).
+        if self._last_rule_obj and self._last_rule_obj[0] == rule_id:
+            fetched = self._last_rule_obj[1]
+        else:
+            fetched = self.client.call_tool("hub_get_custom_rule", {"ruleId": rule_id})
         arr = fetched.get(key)
         assert isinstance(arr, list), f"custom rule '{key}' is not a list: {fetched.get(key)!r}"
         got = [e.get("type") for e in arr if isinstance(e, dict)]
@@ -902,6 +928,16 @@ class TestRunner:
         assert by_name["hub_read_diagnostics"]["idempotentHint"] is True, \
             "pure-read diagnostics gateway must roll up idempotent"
 
+    def _get_rooms_catalog(self) -> dict:
+        """The hub_read_rooms({}) gateway-catalog disclosure -- a deterministic static enumeration shared
+        by the two catalog-disclosure tests. Lazy + cached; falls back to a fresh fetch when unset
+        (isolation-safe). Immutable read, so no write invalidates it within a run."""
+        cached = self._rooms_catalog
+        if cached is None:
+            cached = self.client.call_tool("hub_read_rooms", {})
+            self._rooms_catalog = cached
+        return cached
+
     @test("infrastructure")
     def test_default_tools_list_omits_output_schema(self) -> None:
         # Issue #290: by default (publishOutputSchemas OFF) NO tools/list entry advertises
@@ -920,8 +956,9 @@ class TestRunner:
             f"(publishOutputSchemas defaults OFF), but these did: {with_schema}"
         )
         # Surface (b): the gateway no-arg catalog disclosure must also omit outputSchema by
-        # default (it is the other surface the toggle gates, in handleGateway).
-        catalog = self.client.call_tool("hub_read_rooms", {})
+        # default (it is the other surface the toggle gates, in handleGateway). Shared (identical
+        # deterministic disclosure) with test_gateway_catalog_titles.
+        catalog = self._get_rooms_catalog()
         cat_entries = catalog.get("tools", []) if isinstance(catalog, dict) else []
         assert cat_entries, "hub_read_rooms catalog returned no tools"
         cat_with_schema = [e.get("name") for e in cat_entries if "outputSchema" in e]
@@ -936,8 +973,9 @@ class TestRunner:
     @test("infrastructure")
     def test_gateway_catalog_titles(self) -> None:
         # Issue #245: the gateway no-arg catalog disclosure also surfaces each
-        # sub-tool's friendly title next to its bare name and schema.
-        catalog = self.client.call_tool("hub_read_rooms", {})
+        # sub-tool's friendly title next to its bare name and schema. Shared (identical deterministic
+        # disclosure) with test_default_tools_list_omits_output_schema.
+        catalog = self._get_rooms_catalog()
         assert catalog.get("mode") == "catalog", f"Expected catalog mode, got: {catalog.get('mode')}"
         entries = catalog.get("tools", [])
         assert entries, "hub_read_rooms catalog returned no tools"
@@ -1302,24 +1340,10 @@ class TestRunner:
 
     @test("devices")
     def test_get_attribute(self) -> None:
-        # Find a switch device
-        all_devs = self.client.call_tool("hub_list_devices")
-        devices = all_devs if isinstance(all_devs, list) else all_devs.get("devices", [])
-        switch_dev = None
-        for d in devices:
-            label = (d.get("label") or d.get("name") or "").lower()
-            caps = [c.lower() if isinstance(c, str) else c.get("name", "").lower()
-                    for c in d.get("capabilities", [])]
-            if "switch" in label or "switch" in caps:
-                switch_dev = d
-                break
-        if switch_dev is None:
-            # No real switch on the hub -- fall back to the persistent scaffolding switch
-            # (get_test_switch_id find-or-reuse) instead of provisioning + deleting a throwaway probe.
-            # This test ALWAYS runs (skips are failures).
-            switch_id = self.get_test_switch_id()
-        else:
-            switch_id = str(switch_dev["id"])
+        # Read the attribute off the persistent BAT_E2E_ scaffold switch (find-or-reuse, always exposes
+        # `switch`) -- the assertion below is existence-only and device-identity-irrelevant, so the
+        # throwaway hub_list_devices switch-hunt was a pure read round-trip with nothing to bind to it.
+        switch_id = self.get_test_switch_id()
         result = self.client.call_tool("hub_get_device_attribute", {
             "deviceId": switch_id,
             "attribute": "switch",
@@ -1602,7 +1626,13 @@ class TestRunner:
         rule_id = self._last_rule_id()
         if not rule_id:
             raise AssertionError("No rule created to get -- the upstream create-rule test must have failed")
-        result = self.client.call_tool("hub_get_custom_rule", {"ruleId": rule_id})
+        # test_create_rule's _create_rule_and_verify already fetched this SAME rule; reuse that read-back
+        # (runs right after create, before test_update_rule renames it -- no write between). Fall back to a
+        # live fetch when the stash is unset/for a different rule (isolation-safe).
+        if self._last_rule_obj and self._last_rule_obj[0] == rule_id:
+            result = self._last_rule_obj[1]
+        else:
+            result = self.client.call_tool("hub_get_custom_rule", {"ruleId": rule_id})
         assert result.get("name", "").startswith(PREFIX), \
             f"Rule name mismatch: {result.get('name')}"
         assert "triggers" in result or "trigger" in result, "Missing triggers in hub_get_custom_rule"
@@ -4787,10 +4817,22 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             lib.get("name") == "McpSmokeTestLib" and lib.get("namespace") == "mcp" for lib in libs
         ), f"McpSmokeTestLib not found in hub libraries (got {lib_names})"
 
+    def _get_hub_info_optin(self) -> dict:
+        """hub_get_info with BOTH additive opt-in blocks in ONE call, shared by the two opt-in tests
+        (they read DISJOINT keys: healthAlerts vs platformUpdate/appUpdate). Lazy + cached; the result is
+        an immutable read, so a fresh fetch falls back when the stash is unset (isolation-safe). Does NOT
+        affect test_get_hub_info, which makes its own no-flags call and asserts healthAlerts ABSENT."""
+        cached = self._hub_info_optin
+        if cached is None:
+            cached = self.client.call_tool(
+                "hub_get_info", {"includeHealthAlerts": True, "includeAppUpdate": True})
+            self._hub_info_optin = cached
+        return cached
+
     @test("system_tools")
     def test_hub_get_info_health_alerts_opt_in(self) -> None:
         # #13: the full alerts block appears only with includeHealthAlerts=true.
-        info = self.client.call_tool("hub_get_info", {"includeHealthAlerts": True})
+        info = self._get_hub_info_optin()
         ha = info.get("healthAlerts")
         assert ha is not None, f"includeHealthAlerts=true but healthAlerts absent/null: {sorted(info)}"
         for k in ("safeMode", "active", "details"):
@@ -4805,7 +4847,8 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
     def test_hub_get_info_update_reads(self) -> None:
         # Folded (was hub_get_update_status): hub_get_info carries platformUpdate (the pending HUB
         # firmware) always, and the MCP-app version check under appUpdate when includeAppUpdate=true.
-        res = self.client.call_tool("hub_get_info", {"includeAppUpdate": True})
+        # Shares the one both-flags call with test_hub_get_info_health_alerts_opt_in (disjoint keys).
+        res = self._get_hub_info_optin()
         assert "platformUpdate" in res, f"missing platformUpdate: {sorted(res)}"
         assert "available" in res["platformUpdate"], f"platformUpdate shape wrong: {res['platformUpdate']}"
         assert "appUpdate" in res, f"includeAppUpdate did not attach appUpdate: {sorted(res)}"
@@ -5222,21 +5265,29 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         )
         assert mcp_bundle and mcp_bundle.get("id"), \
             f"the mcp libraries bundle (containing McpRoomsLib) was not found: {[b.get('name') for b in bundles]}"
+        # Stash the resolved (immutable) bundle id so test_export_bundle can skip the identical
+        # list+filter round-trip; it falls back to a fresh hub_list_bundles when this is unset (isolation).
+        self._mcp_bundle_id = str(mcp_bundle["id"])
         print(f"    BUNDLES_LIST ok -- '{mcp_bundle.get('name')}' contains {(mcp_bundle.get('contains') or {}).get('libraries')}")
 
     @test("system_tools")
     def test_export_bundle(self) -> None:
         """hub_export_bundle saves a bundle's .zip to the File Manager (independently confirmed via
         hub_list_files). Self-cleaning."""
-        listed = self.client.call_tool("hub_read_apps_code", {"tool": "hub_list_bundles"})
-        bundles = listed.get("bundles", []) if isinstance(listed, dict) else []
-        target = next(
-            (b for b in bundles if b.get("namespace") == "mcp"
-             and "McpRoomsLib" in ((b.get("contains") or {}).get("libraries") or [])),
-            None,
-        )
-        assert target and target.get("id"), "no mcp libraries bundle available to export"
-        bid = str(target["id"])
+        # Reuse the immutable bundle id test_list_bundles already resolved; fall back to a fresh
+        # hub_list_bundles + identical filter when the stash is unset (isolation run).
+        if self._mcp_bundle_id:
+            bid = self._mcp_bundle_id
+        else:
+            listed = self.client.call_tool("hub_read_apps_code", {"tool": "hub_list_bundles"})
+            bundles = listed.get("bundles", []) if isinstance(listed, dict) else []
+            target = next(
+                (b for b in bundles if b.get("namespace") == "mcp"
+                 and "McpRoomsLib" in ((b.get("contains") or {}).get("libraries") or [])),
+                None,
+            )
+            assert target and target.get("id"), "no mcp libraries bundle available to export"
+            bid = str(target["id"])
         fname = f"{PREFIX}bundle_export_{bid}.zip"
         try:
             result = self.client.call_tool("hub_manage_code", {

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -89,6 +89,10 @@ class HubitatMcpClient:
         self.access_token = access_token
         self.verbose = verbose
         self._request_id = 0
+        # One reused connection for the whole run: HTTP keep-alive amortizes the TCP + TLS
+        # handshake (~300-500ms each over the cloud relay) across every MCP call instead of
+        # paying it per request.
+        self.session = requests.Session()
         # Per-op wall-clock timings (op_key, seconds) for the end-of-run "Per-op wall-clock" summary --
         # the only place real per-operation cost (RM create vs edit vs delete, etc.) is visible, since
         # the >> call traces are verbose-gated and never reach the CI log.
@@ -122,9 +126,6 @@ class HubitatMcpClient:
 
         self._log(f">> {method} {json.dumps(params or {})[:300]}")
 
-        # Rate-limit: don't overwhelm the hub
-        time.sleep(0.2)
-
         # NEVER transport-replay a WRITE. The retry loop below re-sends the identical request
         # on a 5xx or network error -- but a relay 504 means the response was LOST while the hub
         # kept processing, so replaying a non-idempotent wizard write commits it AGAIN (observed
@@ -154,7 +155,7 @@ class HubitatMcpClient:
         for attempt in range(3):
             resp = None
             try:
-                resp = requests.post(
+                resp = self.session.post(
                     self.endpoint,
                     params={"access_token": self.access_token},
                     json=payload,
@@ -230,11 +231,10 @@ class HubitatMcpClient:
         envelope (batch caps, 202-for-notifications, JSON-RPC framing) — paths
         the result-unwrapping call_tool/_send helpers deliberately hide.
         """
-        time.sleep(0.2)
         last_exc: Exception | None = None
         for attempt in range(3):
             try:
-                resp = requests.post(
+                resp = self.session.post(
                     self.endpoint,
                     params={"access_token": self.access_token},
                     json=payload,

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1815,6 +1815,22 @@ class TestRunner:
         if dw["relayDropped"]:
             assert dw["committed"], f"native app {app_id} still present after a relay-504 delete (did not commit)"
         self._untrack_native_app(app_id)
+        # The just-deleted app's configure page now 404s on the hub -- hub_get_app_config must DEGRADE
+        # GRACEFULLY to a structured result (the graceful-404 fix), never raise a raw HttpResponseException.
+        # (The 404 fingerprint/status shape is pinned in Spock; here we prove the real-hub no-raise degrade.)
+        if not dw["relayDropped"]:
+            try:
+                gone = self.client.call_tool("hub_read_apps_code", {
+                    "tool": "hub_get_app_config", "args": {"appId": app_id}})
+            except (McpError, McpToolError) as exc:
+                raise AssertionError(
+                    f"hub_get_app_config on a deleted app raised instead of degrading gracefully: {exc}") from exc
+            assert isinstance(gone, dict), f"hub_get_app_config should return a structured result, got: {gone}"
+            # Tolerate a brief post-delete render lag (still has app data); when it IS a not-found it must
+            # be the graceful 404 form, not a generic opaque error.
+            if gone.get("success") is False:
+                assert gone.get("status") in (404, 410) or "not found" in str(gone.get("error", "")).lower(), \
+                    f"deleted-app not-found should be the graceful 404 form, got: {gone}"
 
     @test("native_apps")
     def test_set_native_app_basic_rule_lifecycle(self) -> None:
@@ -1986,6 +2002,13 @@ class TestRunner:
                 "args": {"appId": rule_id, "addAction": {"capability": "log", "message": "E2E button rule"}, "confirm": True},
             })
             assert acted.get("success") is not False, f"authoring the button rule's action failed: {acted}"
+            # The trailing main-page Done commit must target the Button Rule's real commit page
+            # (selectActions), not a hardcoded 'mainPage' -- a 404 there sets mainPageDoneFailed/Error
+            # (the page-graph fix). With the hardcode bug this fails; after the fix these hold.
+            assert acted.get("mainPageDoneFailed") is not True, \
+                f"button rule Done commit hit a missing page (mainPage hardcode regression): {acted}"
+            assert not acted.get("mainPageDoneError"), \
+                f"button rule Done commit errored: {acted.get('mainPageDoneError')}"
         except (McpError, McpToolError, requests.HTTPError) as exc:
             if "504" not in str(exc):
                 raise
@@ -4928,6 +4951,9 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         assert "count" in sj, "scheduledJobs missing 'count'"
         assert "jobs" in sj, "scheduledJobs missing 'jobs'"
         assert isinstance(sj["jobs"], list), "scheduledJobs.jobs should be a list"
+        # count must match the array length -- a 404-degraded / empty read can't false-green here.
+        assert sj["count"] == len(sj["jobs"]), \
+            f"scheduledJobs.count {sj['count']} != len(jobs) {len(sj['jobs'])} (degraded/partial read?)"
         if sj["jobs"]:
             job = sj["jobs"][0]
             assert "name" in job, "Job missing 'name'"

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -2174,6 +2174,9 @@ class TestRunner:
             "tool": "hub_set_rule", "args": {"appId": app_id, "addAction": action, "confirm": True},
         })
         assert result.get("success") is not False, f"addAction({action}) reported failure: {result}"
+        # Block CLOSERS land here -- the cache MUST reflect the now-closed (healthy) rule, else a
+        # following _assert_rule_healthy reads the stale mid-build "missing END-IF" health from the opener.
+        self._cache_write_health(app_id, result)
         return result
 
     def _delete_native(self, app_id: Any, gateway: str = "hub_manage_rule_machine") -> None:

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -2394,9 +2394,11 @@ class TestRunner:
         # (never a hardcoded index -- RM action/trigger indices are persistent per-rule
         # counters that survive removals).
         sw = int(self.get_test_switch_id())
-        app_id = self._create_native_rule("TrigMut")
+        # Fold the first (non-index) addTrigger into the create -- one fewer round-trip; the
+        # index-returning addTrigger below still gets its own call so its triggerIndex is read.
+        app_id = self._create_native_rule(
+            "TrigMut", extra={"addTrigger": {"capability": "Switch", "deviceIds": [sw], "state": "on"}})
         try:
-            self._set_rule(app_id, {"addTrigger": {"capability": "Switch", "deviceIds": [sw], "state": "on"}}, strict=True)
             self._set_rule(app_id, {"addAction": {"capability": "switch", "action": "on", "deviceIds": [sw]}}, strict=True)
             self._assert_rule_healthy(app_id)
 
@@ -2726,46 +2728,43 @@ class TestRunner:
         # not appear in the bulk read for a beat -- and a fresh CREATE settles it. So each attempt
         # is create-then-poll, and on a race (create error OR poll-miss) the WHOLE create is
         # re-issued, up to a few times with short backoff. Only an exhausted retry budget fails.
-        def _create_and_wait(name: str, var_type: str) -> None:
-            self.created_variable_names.append(name)
+        def _create_vars_and_wait(items: list[dict]) -> None:
+            # Bulk-create ALL targets in ONE hub_create_variable call, then ONE shared poll until they
+            # are all visible in the bulk getAllGlobalVars() surface the setVariable validator consults.
+            # On the documented post-write visibility race (a commit that lags the bulk read, or a 504
+            # that still committed), re-issue the whole bulk create. Only an exhausted budget fails.
+            names = [it["name"] for it in items]
+            for n in names:
+                self.created_variable_names.append(n)
             max_attempts = 3
             poll_secs = 12.0
             for attempt in range(1, max_attempts + 1):
                 try:
-                    # A String var MUST get a NON-EMPTY value: an empty-string value does not
-                    # persist a String hub variable (the wizard reports complete but nothing lands
-                    # -> the var never becomes visible to getGlobalVar). Numeric vars take "0", a
-                    # Boolean takes "false", everything else a non-empty placeholder.
-                    init_value = {"Number": "0", "Boolean": "false"}.get(var_type, "init")
                     self.client.call_tool("hub_manage_variables", {
-                        "tool": "hub_create_variable",
-                        "args": {"name": name, "type": var_type, "value": init_value, "confirm": True}})
+                        "tool": "hub_create_variable", "args": {"variables": items, "confirm": True}})
                 except (McpError, McpToolError, requests.HTTPError) as exc:
-                    # A create error is itself a race symptom (or a relay 504 that still committed).
-                    # Don't fail here -- the visibility poll below is the authoritative gate; a
-                    # genuine non-creation surfaces as a poll-miss and triggers a re-create.
-                    print(f"    hub_create_variable({name}) attempt {attempt}/{max_attempts} raised "
+                    print(f"    bulk hub_create_variable attempt {attempt}/{max_attempts} raised "
                           f"({exc}); the visibility poll is authoritative")
-                # Poll the bulk getAllGlobalVars() surface (via hub_list_variables) until the new var
-                # is visible -- the SAME read the setVariable target validator consults.
                 deadline = time.time() + poll_secs
                 while time.time() < deadline:
-                    if self._hub_variable_visible_in_bulk(name):
+                    if all(self._hub_variable_visible_in_bulk(n) for n in names):
                         return
                     time.sleep(1.0)
                 if attempt < max_attempts:
-                    print(f"    hub variable {name!r} not visible in the bulk read after attempt "
-                          f"{attempt}/{max_attempts} (create_variable post-write visibility race); "
-                          f"re-issuing the create")
+                    print(f"    not all of {names} visible after attempt {attempt}/{max_attempts} "
+                          "(create_variable post-write visibility race); re-issuing the bulk create")
                     time.sleep(2.0)
             raise AssertionError(
-                f"hub variable {name!r} never appeared in the bulk getAllGlobalVars() read after "
-                f"{max_attempts} create attempts (the create_variable post-write visibility race "
-                f"did not settle) -- setVariable validation cannot proceed")
+                f"hub variables {names} never all appeared in the bulk getAllGlobalVars() read after "
+                f"{max_attempts} bulk-create attempts -- setVariable validation cannot proceed")
 
-        _create_and_wait(var_name, "Number")
-        _create_and_wait(str_var_name, "String")
-        _create_and_wait(bool_var_name, "Boolean")
+        # A String var MUST get a NON-EMPTY value (an empty string does not persist -- the wizard reports
+        # complete but nothing lands). Numeric -> "0", Boolean -> "false", String -> a non-empty placeholder.
+        _create_vars_and_wait([
+            {"name": var_name, "type": "Number", "value": "0"},
+            {"name": str_var_name, "type": "String", "value": "init"},
+            {"name": bool_var_name, "type": "Boolean", "value": "false"},
+        ])
         # The matrix is split across SMALL rules (<=3 setVariable actions each): the classic wizard
         # re-POSTs the FULL rule page per submitOnChange, so piling many actions into one rule trips
         # the hub's per-app load limiter (a 5th action lands numOp.<N> as not_in_schema). Each rule

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -337,6 +337,9 @@ class TestRunner:
         self.client = client
         self.verbose = verbose
         self.results: list[dict] = []  # {name, group, status, message, duration}
+        # (app_id, health) the last RM write returned, so _assert_rule_healthy can assert on it without
+        # a second hub_get_rule_health round-trip. Keyed by app; cleared on a relay-dropped/soft write.
+        self._last_write_health: tuple[str, dict] | None = None
 
         # Cleanup tracking
         self.created_device_dnis: list[str] = []
@@ -2101,8 +2104,10 @@ class TestRunner:
             print(f"    hub_set_rule({list(extra)}) response lost to relay 504 -- "
                   "soft contract: verifying the rule still renders instead of hard-failing")
             self._assert_rule_renders(app_id)
+            self._last_write_health = None
             return {"success": True, "asyncCommitLikely": True, "relayDropped": True}
         assert result.get("success") is not False, f"hub_set_rule({list(extra)}) reported failure: {result}"
+        self._cache_write_health(app_id, result)
         return result
 
     def _rm_call_soft(self, args: dict, strict: bool = False) -> Any:
@@ -2113,13 +2118,16 @@ class TestRunner:
         raises so _run_one's test-level retry re-runs the small test on a fresh rule (see
         _set_rule)."""
         try:
-            return self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": args})
+            result = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": args})
+            self._cache_write_health(args.get("appId"), result)
+            return result
         except (McpError, McpToolError, requests.HTTPError) as exc:
             if strict or "504" not in str(exc):
                 raise
             print(f"    hub_set_rule(appId={args.get('appId')}) response lost to relay 504 -- "
                   "soft contract: verifying rule health instead of hard-failing")
             self._assert_rule_renders(args.get("appId"))
+            self._last_write_health = None
             return {"success": True, "asyncCommitLikely": True, "relayDropped": True}
 
     def _assert_rule_renders(self, app_id: Any) -> None:
@@ -2133,7 +2141,23 @@ class TestRunner:
             print(f"    rule {app_id} renders with structural imbalance after the dropped response "
                   "(expected mid-build state; a reset/closer follows)")
 
+    def _cache_write_health(self, app_id: Any, result: Any) -> None:
+        """Stash the health object a hub_set_rule write already returned (the SAME _rmCheckRuleHealth a
+        standalone hub_get_rule_health re-derives), keyed by app, so a following _assert_rule_healthy
+        skips the extra round-trip. Cleared on a relay-dropped/soft envelope (no health) -> live fetch."""
+        if isinstance(result, dict) and isinstance(result.get("health"), dict):
+            self._last_write_health = (str(app_id), result["health"])
+        else:
+            self._last_write_health = None
+
     def _assert_rule_healthy(self, app_id: Any) -> None:
+        # Prefer the health the immediately-preceding write already returned -- no extra round-trip.
+        # Keyed by app so a stale/other-app cache is never trusted; a soft write cleared it -> live fetch.
+        cached = self._last_write_health
+        if cached is not None and cached[0] == str(app_id):
+            assert cached[1].get("ok") is not False, \
+                f"rule health (from the write response) reports broken: {cached[1]}"
+            return
         h = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_get_rule_health", "args": {"appId": app_id}})
         assert h.get("ok") is not False, f"hub_get_rule_health reports the rule broken: {h}"
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -6298,7 +6298,11 @@ def main() -> None:
         main_sha = os.environ.get("MAIN_SHA", "")
         if main_sha:
             print("Waiting for the watchdog's restore-to-main to complete (canonical-main marker)...")
-            for attempt in range(1, 49):
+            # Poll cadence: short early (the restore lands ~2-2.5 min in, so a tight early cadence trims
+            # the overshoot past completion), backing off to 10s for the long failed-restore tail -- same
+            # ~8-min worst-case ceiling, just more attempts at the shorter early intervals.
+            _restore_backoff = (3, 3, 3, 3, 5, 5, 5, 7, 7, 10)
+            for attempt in range(1, 60):
                 try:
                     marker = runner.client.call_tool("hub_manage_files", {
                         "tool": "hub_read_file",
@@ -6310,11 +6314,11 @@ def main() -> None:
                         break
                 except Exception:
                     pass
-                if attempt == 48:
+                if attempt == 59:
                     print("  [WARN] restore-complete marker never matched after ~8 min "
                           "(failed restore, or a slow recompile); sweeping anyway.")
                 else:
-                    time.sleep(10)
+                    time.sleep(_restore_backoff[min(attempt - 1, len(_restore_backoff) - 1)])
         runner.cleanup()
         # Gating verification: cleanup() and the disarm-time deferred sweep are otherwise all
         # best-effort (warn-only), so a silently-failed native-rule cleanup could leave BAT_E2E_ RM

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -2040,6 +2040,7 @@ class TestRunner:
         args = {"name": label, "confirm": True}
         if extra:
             args.update(extra)
+        created = None  # the fresh-create envelope (stays None on the 504 adopt-by-label path, which has none)
         try:
             created = self.client.call_tool("hub_manage_rule_machine", {
                 "tool": "hub_set_rule", "args": args,
@@ -2068,6 +2069,15 @@ class TestRunner:
                 })
                 app_id = created.get("appId")
         assert app_id, f"hub_set_rule create did not yield an appId for '{label}'"
+        # When a create BUNDLES an authoring shortcut (rank-2 fold), the create arm computes
+        # success = health.ok && !partial; a degraded-but-ok trigger/action reports partial:true. Without
+        # this check that envelope is discarded, so a partial-but-ok shortcut would pass silently --
+        # restore the strict success/not-partial contract the old separate _set_rule write provided. Only
+        # on the fresh-create path (created stays None on the 504 adopt-by-label path, which has no envelope).
+        if created is not None and extra and any(k in extra for k in (
+                "addTrigger", "addTriggers", "addAction", "addActions", "addRequiredExpression")):
+            assert created.get("success") is not False and not created.get("partial"), \
+                f"create-time authoring shortcut did not fully commit (partial or failed): {created}"
         self.created_native_app_ids.append(str(app_id))
         return app_id
 
@@ -2632,6 +2642,10 @@ class TestRunner:
             blob = str(cfg).lower()
             assert "is off" in blob, \
                 f"rendered Required Expression does not show the new 'is off' condition: {str(cfg)[:600]}"
+            # The DIRECT replace call (line ~2607) bypasses the caching write helpers, so seed the cache
+            # with ITS OWN post-replace health -- else _assert_rule_healthy reads the STALE pre-replace
+            # health and the destructive delete+rebuild's health check (this assert's whole point) false-passes.
+            self._cache_write_health(app_id, result)
             self._assert_rule_healthy(app_id)
         finally:
             self._delete_native(app_id)
@@ -3176,6 +3190,10 @@ class TestRunner:
                     raise
                 print("    moveAction response lost to relay 504 -- same unknown-commit contract as "
                       "asyncCommitLikely; rule health below is the binding assertion")
+            # The DIRECT moveAction (and its soft/504 paths) bypasses the caching helpers and its commit
+            # may be uncertain, so clear the stale pre-move cache to FORCE a live post-move health fetch --
+            # this assert is the sole verification the reorder didn't corrupt the rule.
+            self._last_write_health = None
             self._assert_rule_healthy(app_id)
         finally:
             self._delete_native(app_id)

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1001,7 +1001,10 @@ class TestRunner:
         # is set, so assert it strictly -- on a live hub (every Hubitat has a Z-Wave radio) the route
         # fetch must succeed, so a route-fetch regression (topology.error, or no route data) fails here
         # instead of slipping through a best-effort `if present` guard.
-        result = self.client.call_tool("hub_get_radio_details", {"radio": "zwave", "include_topology": True})
+        # Combined with include_status + include_firmware: one call returns every fold object, so the
+        # three former separate zwave-radio tests share a single round-trip, each keeping its assertion.
+        result = self.client.call_tool("hub_get_radio_details", {
+            "radio": "zwave", "include_topology": True, "include_status": True, "include_firmware": True})
         assert isinstance(result, dict), "hub_get_radio_details did not return an object"
         topo = result.get("topology")
         assert topo is not None, "include_topology=true did not return a topology object"
@@ -1010,6 +1013,9 @@ class TestRunner:
         assert "error" not in topo, f"include_topology route fetch errored (regression): {topo.get('error')}"
         assert "routes" in topo or "rawRoutes" in topo, \
             f"include_topology returned no route data: {topo}"
+        # include_status fold must not error the call (its former standalone assertion).
+        assert "error" not in result or isinstance(result.get("error"), str), \
+            f"include_status unexpected error shape: {result}"
 
     @test("diagnostics")
     def test_radio_details_matter(self) -> None:
@@ -1076,22 +1082,6 @@ class TestRunner:
     # per-node) only validate at the wire/validation level. Reads + gateway routing are
     # fully exercisable. Destructive writes ARE allowed on the e2e hub (no devices, the hub
     # is rebootable/rebuildable) but are kept conservative here.
-
-    @test("diagnostics")
-    def test_radio_details_include_status(self) -> None:
-        # Folded lifecycle-status pollers: include_status attaches repair/exclusion/Zigbee/Matter
-        # status reads onto hub_get_radio_details. Resilient to whatever radio the e2e hub has —
-        # assert the call succeeds and, when status fired, it's a structured object (not an error).
-        result = self.client.call_tool("hub_get_radio_details", {"radio": "zwave", "include_status": True})
-        assert isinstance(result, dict), f"radio details include_status did not return an object: {result}"
-        # A Z-Wave-capable hub returns a recognized shape; the fold must not error the call.
-        assert "error" not in result or isinstance(result.get("error"), str), f"unexpected error shape: {result}"
-
-    @test("diagnostics")
-    def test_radio_details_include_firmware(self) -> None:
-        # include_firmware attaches the firmware-eligible device/file lists (read-only).
-        result = self.client.call_tool("hub_get_radio_details", {"radio": "zwave", "include_firmware": True})
-        assert isinstance(result, dict), f"radio details include_firmware did not return an object: {result}"
 
     @test("diagnostics")
     def test_manage_radio_gateway_lists_subtools(self) -> None:
@@ -4712,6 +4702,17 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             "hub_get_info.smokeTestMarker missing/wrong -- the #include of McpSmokeTestLib did not "
             f"resolve on the hub (got {result.get('smokeTestMarker')!r})"
         )
+        # Folded from test_hub_get_info_platform_update_and_safemode (the SAME default hub_get_info call):
+        # #12/#13 -- platformUpdate + safeMode resolve from /hub2/hubData; the full alerts block stays out.
+        assert "platformUpdate" in result, f"hub_get_info missing platformUpdate: {sorted(result)}"
+        pu = result["platformUpdate"]
+        assert "currentVersion" in pu, f"platformUpdate missing currentVersion: {pu}"
+        assert isinstance(pu.get("available"), bool), \
+            f"platformUpdate.available not resolved -- /hub2/hubData unreadable? {pu}"
+        if pu["available"]:
+            assert pu.get("availableVersion"), f"available=true but no availableVersion: {pu}"
+        assert "safeMode" in result, f"hub_get_info missing safeMode: {sorted(result)}"
+        assert "healthAlerts" not in result, "healthAlerts must be absent without includeHealthAlerts=true"
 
     @test("system_tools")
     def test_list_libraries(self) -> None:
@@ -4744,29 +4745,6 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         assert any(
             lib.get("name") == "McpSmokeTestLib" and lib.get("namespace") == "mcp" for lib in libs
         ), f"McpSmokeTestLib not found in hub libraries (got {lib_names})"
-
-    @test("system_tools")
-    def test_manage_diagnostics(self) -> None:
-        result = self.client.call_tool("hub_manage_diagnostics", {
-            "tool": "hub_get_metrics",
-        })
-        assert result is not None, "hub_get_metrics returned None"
-
-    @test("system_tools")
-    def test_hub_get_info_platform_update_and_safemode(self) -> None:
-        # #12/#13: hub_get_info folds in the pending platform/firmware update + safeMode from
-        # /hub2/hubData. On a reachable hub the endpoint is readable, so these resolve (not the
-        # null degrade path); the full alerts block stays out unless opted in.
-        info = self.client.call_tool("hub_get_info", {})
-        assert "platformUpdate" in info, f"hub_get_info missing platformUpdate: {sorted(info)}"
-        pu = info["platformUpdate"]
-        assert "currentVersion" in pu, f"platformUpdate missing currentVersion: {pu}"
-        assert isinstance(pu.get("available"), bool), \
-            f"platformUpdate.available not resolved -- /hub2/hubData unreadable? {pu}"
-        if pu["available"]:
-            assert pu.get("availableVersion"), f"available=true but no availableVersion: {pu}"
-        assert "safeMode" in info, f"hub_get_info missing safeMode: {sorted(info)}"
-        assert "healthAlerts" not in info, "healthAlerts must be absent without includeHealthAlerts=true"
 
     @test("system_tools")
     def test_hub_get_info_health_alerts_opt_in(self) -> None:


### PR DESCRIPTION
## Summary

- **Refactor + speed up the e2e runner and suite:** HTTP keep-alive (one `requests.Session`), gate the
  per-call `time.sleep(0.2)` to writes only, and remove redundant read round-trips (assert RM health
  from the write response, bulk-create setVariable vars, merge duplicate zwave-radio / `hub_get_info`
  reads, reuse create-verify fetches). Teardown trims: failure-only post-run probe, restore-poll backoff.
- **Fold in the latent tool defects these runs surfaced** (the point of e2e), each with Spock + e2e
  coverage: graceful 404 in `hub_get_app_config` / `hub_list_app_pages`, the Button Rule commit-page fix,
  the **watchdog `hub_get_jobs` endpoint**, and the Zigbee 404 note.
- **Coverage-audit fixes** to the read-trip reductions (stale-cache health asserts; create-time
  authoring-shortcut contract).

## Type of change

- [ ] `feat` — new feature or capability
- [x] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [x] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [x] `test` — tests only
- [x] `ci` — CI/CD pipeline change

## Changes

**E2E runner / suite (refactor + perf)**
- HTTP keep-alive + gate-`sleep(0.2)`-to-writes (`_send`, `raw_request`).
- Read round-trips removed: RM health from the `hub_set_rule` response; bulk-create the 3 setVariable
  vars; merge 3 zwave `hub_get_radio_details(include_*)` into one; fold duplicate default `hub_get_info`
  reads; reuse the create-verify `hub_get_custom_rule` fetch (rule-types + get_rule); combined
  `hub_get_info` opt-in flags; shared `hub_read_rooms` catalog; reused bundle id; dropped a device probe.
- Teardown: post-run probe gated to failure-only; restore-completion poll backoff.

**Tool fixes (surfaced by e2e — each <500 LOC, folded in per scope)**
- `hub_get_app_config` (summary+full) + `hub_list_app_pages`: 404/410 → structured not-found at `warn`,
  not an opaque ERROR / raw exception.
- Button Rule `_rmSubmitMainPageDone`: resolve the commit page (`selectActions` for Button Rule-5.1)
  instead of hardcoding `mainPage`; register `button_rule` in `_appTypeRegistry`.
- **Watchdog `hub_get_jobs`** (`e2e-deadman-watchdog-v2.groovy` + `mcp_arm_watchdog.sh`): read the
  verified `/logs/json` (was a 404ing `/hub/scheduledJobs/json`), + a `hubActions` parity field. The
  watchdog is test-hub-only tooling deployed out-of-band, so this takes effect on its next redeploy.
- `hub_set_zigbee_settings`: a 404 note now names an absent radio, not credentials.

**Coverage-audit fixes**
- Rebind stale-cache RM health asserts to post-mutation state (replaceRequiredExpression / moveAction);
  restore the create-time authoring-shortcut success/partial contract.

## Release Notes

- Fixed `hub_get_app_config` / `hub_list_app_pages` returning an opaque error instead of a clean
  "not found" when an app is deleted or mid-install.
- Fixed Button Rule editing leaving the rule on a missing page ("Cannot find page 'mainPage'").
- Fixed the Zigbee settings error wrongly suggesting a credential problem when the hub has no Zigbee radio.
- _(Internal: e2e test-runner + suite refactor/speedups; no user-facing behaviour change.)_

## Testing

- `./gradlew test` → 4082 Spock tests green (new Spock for every tool fix).
- `python tests/sandbox_lint.py`, `ruff`, `py_compile` clean.
- Live e2e on this PR: 123/123 green; suite ~817–892s, down from the ~970–998s early-session band
  (relay-variance-wide).

## Checklist

- [x] Unit tests added (Spock) for every tool fix
- [x] Sandbox lint passes (CI)
- [x] `./gradlew test` passes
- [ ] Live-hub BAT — N/A (covered by e2e)
- [x] Documentation — N/A
- [x] Tool design rules — N/A (behaviour fixes; no new/renamed tools)
