### PR TITLE
perf: cut RM condition-build hub round-trips + two-lane e2e CI (closes #237)

### DIFF
--- a/.github/scripts/e2e_scope.py
+++ b/.github/scripts/e2e_scope.py
@@ -68,9 +68,11 @@ def _test_group_map() -> dict:
                 if dec:
                     cur = dec.group(1)
                     continue
-                d = re.match(r'\s*def (test_\w+)\(', line)
+                d = re.match(r'\s*def (\w+)\(', line)
                 if d:
-                    if cur:
+                    # Reset on ANY def so a @test decorator can't leak across a non-test helper
+                    # sitting between it and the next test function.
+                    if cur and d.group(1).startswith("test_"):
                         out[d.group(1)] = cur
                     cur = None
     except OSError:

--- a/.github/scripts/e2e_scope.py
+++ b/.github/scripts/e2e_scope.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Compute the FOCUSED e2e subset for a PR: the @test groups affected by the change.
+
+Two inputs (the gate step in hub-e2e.yml passes both):
+  - $CHANGED_FILES      -- the PR's changed-file list (newline-separated). Library/source files map to
+                           e2e @test groups via FILE_GROUP_MAP.
+  - $CHANGED_TEST_FUNCS -- test functions added in tests/e2e_test.py (space/newline-separated). Each is
+                           mapped to its OWN @test("group") (read from the checked-out test file), so a
+                           tests-only PR -- or a boy-scout test added in an otherwise-unrelated PR --
+                           runs the group that CONTAINS the new test, not just the smoke core.
+Plus a smoke core, always. Emits `groups` (csv) to $GITHUB_OUTPUT.
+
+The WORKFLOW decides the LANE (full when a release:*/e2e:full label is present, focused otherwise); the
+full lane ignores this script. An unmapped changed file adds no group -- smoke still runs and the FULL
+lane is the real safety net before merge.
+"""
+import os
+import re
+
+# Always run a tiny smoke core so no focused run has ZERO integration coverage.
+SMOKE_GROUPS = ["infrastructure", "protocol"]
+
+TEST_FILE = "tests/e2e_test.py"
+
+# Changed file -> e2e @test group(s) it exercises. Best-effort; refine as the suite evolves.
+FILE_GROUP_MAP = {
+    "libraries/mcp-native-rules-lib.groovy":    ["native_apps"],
+    "libraries/mcp-visual-rules-lib.groovy":    ["visual_rules"],
+    "libraries/mcp-custom-rules-lib.groovy":    ["rule_crud", "trigger_types", "condition_types", "action_types", "complex_patterns"],
+    "hubitat-mcp-rule.groovy":                  ["rule_crud", "trigger_types", "condition_types", "action_types", "complex_patterns"],
+    "libraries/mcp-diagnostics-lib.groovy":     ["diagnostics", "system_tools"],
+    "libraries/mcp-debug-logging-lib.groovy":   ["developer_mode", "diagnostics"],
+    "libraries/mcp-system-lib.groovy":          ["system_tools", "infrastructure"],
+    "libraries/mcp-self-admin-lib.groovy":      ["developer_mode"],
+    "libraries/mcp-devices-lib.groovy":         ["devices", "poll_until_attribute", "device_swap"],
+    "libraries/mcp-virtual-devices-lib.groovy": ["virtual_device_lifecycle", "devices"],
+    "libraries/mcp-variables-lib.groovy":       ["hub_variables"],
+    "libraries/mcp-code-management-lib.groovy": ["app_code_update", "driver_code_update", "installed_app_reads", "system_tools"],
+    "libraries/mcp-bundles-lib.groovy":         ["system_tools"],
+    "libraries/mcp-hpm-lib.groovy":             ["system_tools"],
+    "libraries/mcp-files-lib.groovy":           ["system_tools"],
+    "libraries/mcp-item-backups-lib.groovy":    ["system_tools"],
+    "libraries/mcp-rooms-lib.groovy":           ["infrastructure"],
+    "libraries/mcp-discovery-lib.groovy":       ["infrastructure", "protocol"],
+    "libraries/mcp-app-cloner-lib.groovy":      ["native_apps", "rule_crud"],
+    "libraries/mcp-smoke-test-lib.groovy":      ["infrastructure"],
+}
+
+
+def _changed_files() -> list[str]:
+    return [f.strip() for f in os.environ.get("CHANGED_FILES", "").splitlines() if f.strip()]
+
+
+def _changed_test_funcs() -> list[str]:
+    raw = os.environ.get("CHANGED_TEST_FUNCS", "")
+    return [t.strip() for t in raw.replace(",", " ").split() if t.strip()]
+
+
+def _test_group_map() -> dict:
+    """test_func_name -> @test group, read from the checked-out e2e test file (the @test("group")
+    decorator sits directly above each `def test_...`)."""
+    out: dict[str, str] = {}
+    cur = None
+    try:
+        with open(TEST_FILE, encoding="utf-8") as fh:
+            for line in fh:
+                dec = re.match(r'\s*@test\("([a-z_]+)"\)', line)
+                if dec:
+                    cur = dec.group(1)
+                    continue
+                d = re.match(r'\s*def (test_\w+)\(', line)
+                if d:
+                    if cur:
+                        out[d.group(1)] = cur
+                    cur = None
+    except OSError:
+        pass
+    return out
+
+
+def _emit(groups) -> None:
+    payload = f"groups={','.join(sorted(set(groups)))}"
+    print(payload)
+    gh_out = os.environ.get("GITHUB_OUTPUT")
+    if gh_out:
+        with open(gh_out, "a", encoding="utf-8") as fh:
+            fh.write(payload + "\n")
+
+
+def main() -> None:
+    groups = set(SMOKE_GROUPS)
+    for f in _changed_files():
+        if f in FILE_GROUP_MAP:
+            groups.update(FILE_GROUP_MAP[f])
+    changed_tests = _changed_test_funcs()
+    if changed_tests:
+        tg = _test_group_map()
+        for t in changed_tests:
+            g = tg.get(t)
+            if g:
+                groups.add(g)
+            else:
+                print(f"[scope] note: changed test {t} -> no @test group found (new group / helper?); full lane covers it")
+    print(f"[scope] focused subset -- groups={sorted(groups)}")
+    _emit(groups)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/mcp_setup_env.sh
+++ b/.github/scripts/mcp_setup_env.sh
@@ -67,10 +67,29 @@ jq -nc \
 echo "Captured pre-run state -> $PRE_STATE_FILE"
 cat "$PRE_STATE_FILE"
 
+# Stamp a hub backup FIRST. The hub_update_mcp_settings call below is destructive-confirm-gated
+# (confirm:true requires a hub backup within the last 24h). tests/e2e_test.py stamps a mock backup
+# too, but only LATER in the run (after this configure step), so a >24h gap since the previous e2e
+# run leaves the gate unsatisfied and configure fails ("BACKUP REQUIRED: No hub backup found within
+# the last 24 hours") before the test run ever gets to stamp it. Stamping here makes configure
+# self-sufficient regardless of the gap. Prefer the MOCK backup (stamps only the 24h gate record, no
+# real backupDB write); fall back to a real backup on an older server that lacks mock support.
+echo "Stamping a backup to satisfy the destructive-confirm 24h gate before enabling toggles..."
+BACKUP_RESP="$(mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hub_create_backup","arguments":{"confirm":true,"mock":true}}}' 2>/dev/null || true)"
+if printf '%s' "$BACKUP_RESP" | jq -e '.result.content[0].text | fromjson | .success == true' >/dev/null 2>&1; then
+  echo "  Backup gate stamped (MOCK -- no real backupDB write)."
+else
+  echo "::notice::Mock backup unsupported/failed on the baseline app -- falling back to a real backup."
+  mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hub_create_backup","arguments":{"confirm":true}}}' \
+    | jq -e '.result.content[0].text | fromjson | .success == true' >/dev/null || {
+    echo "::error::Could not create a hub backup (mock AND real failed). hub_update_mcp_settings below needs one (destructive-confirm 24h gate). Check the test hub."; exit 1; }
+  echo "  Backup gate stamped (REAL backup)."
+fi
+
 # Enable the one toggle the e2e suite needs that is not ON by default. Read/Write
 # are masters (default ON in the deployed PR app); enableCustomRuleEngine is the
 # only stable key this pre-deploy step sets, and it persists through the deploy.
-mcp_call '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"hub_manage_mcp","arguments":{"tool":"hub_update_mcp_settings","args":{"settings":{"enableCustomRuleEngine":true},"confirm":true}}}}' \
+mcp_call '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"hub_manage_mcp","arguments":{"tool":"hub_update_mcp_settings","args":{"settings":{"enableCustomRuleEngine":true},"confirm":true}}}}' \
   | jq -e '.result.content[0].text | fromjson | .success == true' >/dev/null
 
 echo "Test environment configured: enableCustomRuleEngine=true (Read/Write masters are ON by default in the deployed app)"

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -219,14 +219,16 @@ jobs:
     # though the lease itself would serialize hub access). Keying on `head_ref` (set for
     # pull_request_target = the PR's source branch) || `ref_name` (set for workflow_dispatch/push)
     # yields the SAME group for every event on a given branch, so a new push / a label add / a
-    # dispatch cancels the older run instead of racing it. (Same-repo branch<->PR is 1:1; two
-    # forks reusing one branch name is the only overlap, and the lease still serializes that.)
+    # dispatch cancels the older run instead of racing it. Keying on head-repo + branch keeps two
+    # FORKS that reuse a branch name (main/fix) in SEPARATE groups so they don't cancel each other
+    # (head.repo.full_name is empty for dispatch/push -> github.repository, so same-repo events on a
+    # branch still collapse to one group).
     # Cancellation is safe: the cleanup/restore/lease-release steps are `if: always()`, and a hard
     # kill is backstopped by the dead-man watchdog's deadline restore plus the lease TTL.
     # Scoped at the JOB level (not workflow level) so the `approve` gate -- which may sit waiting
     # on a human reviewer -- never holds the group.
     concurrency:
-      group: hub-e2e-${{ github.head_ref || github.ref_name }}
+      group: hub-e2e-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
 
     env:
@@ -299,6 +301,7 @@ jobs:
           files="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename')" || {
             echo "::warning::Could not list changed files — running the full E2E suite to be safe."
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "lane=full" >> "$GITHUB_OUTPUT"   # full suite runs here -> gate must post success/failure, not pending
             exit 0
           }
           # Hub-relevant allowlist — the source of truth for "what must exercise e2e".
@@ -622,7 +625,9 @@ jobs:
           if [ "$AVAIL" != "true" ]; then
             STATE=success; DESC="e2e skipped (no hub-relevant change / no test-hub secret); not required to run"
           elif [ "$LANE" = "full" ]; then
-            if [ "${{ steps.run_e2e.outcome }}" = "success" ] && [ "${{ steps.pkg_validate.outcome }}" = "success" ]; then
+            # pkg_validate is SKIPPED (not failed) under a skip_install one-off dispatch; only an actual
+            # failure should fail the gate, so a skipped validate counts as a pass.
+            if [ "${{ steps.run_e2e.outcome }}" = "success" ] && [ "${{ steps.pkg_validate.outcome }}" != "failure" ]; then
               STATE=success; DESC="full e2e passed"
             else
               STATE=failure; DESC="full e2e failed"

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -18,10 +18,35 @@ name: Hub E2E (test hub)
 # forked the whole project without a donated test hub) the e2e job skips cleanly
 # rather than failing -- see the secret gate inside it. A confirmed infra/flake
 # failure is triaged by the maintainer, not auto-ignored.
+#
+# ============================ TWO-LANE FLOW (issue #237) ============================
+# This job runs in one of two LANES, chosen by whether a full-run label is on the PR
+# (release:patch | release:minor | release:major | e2e:full):
+#
+#   FOCUSED lane (no label)  -> runs ONLY the e2e groups affected by the changed files
+#                               (the file->group map in .github/scripts/e2e_scope.py) + a
+#                               smoke core. Fast iteration signal. NOT the merge gate.
+#   FULL lane    (label on)  -> runs the WHOLE suite. This is what the required gate needs.
+#
+# The REQUIRED merge gate is a POSTED COMMIT STATUS named "Full e2e (runs with label)" -- NOT this job's
+# own check ("e2e (run)") -- on purpose, so the focused lane can HOLD the merge without green-washing it:
+#   - Iterating (focused lane): the gate is posted PENDING -> YELLOW, holds the merge. NOT skipped (a
+#     skipped required check counts as PASS and would let a focused-only PR merge) and NOT red (nothing
+#     failed) -- just pending until the full lane runs.
+#   - Add a release:*/e2e:full label -> the FULL lane runs -> the gate is posted success/failure.
+#     ONLY a green FULL run makes the PR mergeable.
+#   - Docs-only / no-secret PRs: the gate is posted success without running (the gate skip path).
+#
+# >>> A PENDING "Full e2e (runs with label)" on a PR is NORMAL and intended -- it's the gate waiting for
+# >>> the full-run label, NOT a stuck/missing run. Add release:*/e2e:full to run the full suite.
+# ===================================================================================
 
 on:
   pull_request_target:
     branches: [main]
+    # `labeled`/`unlabeled` are included so toggling the full-run label (release:patch|minor|major
+    # or e2e:full) re-evaluates the lane immediately. See the "TWO-LANE FLOW" block below.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     # Deliberately NO `paths:` filter. `e2e` is a REQUIRED status check, and a paths-filtered
     # required check never reports on a PR that doesn't touch those paths -- it sits at
     # "Expected -- waiting for status to be reported" forever, so a docs-only PR can never
@@ -155,6 +180,11 @@ jobs:
             echo "::error::hub_set_app_disabled did not verify the flip -- see result above."; exit 1; }
 
   e2e:
+    # This job's OWN check is "e2e (run)" -- it shows the lane that actually ran (focused green/red while
+    # iterating, full when labeled; the run summary prints which lane). The REQUIRED merge gate is the
+    # SEPARATE posted commit status named "Full e2e (runs with label)" (see TWO-LANE FLOW at top + the
+    # "Post e2e gate status" step). Branch protection requires "Full e2e (runs with label)", NOT "e2e (run)".
+    name: e2e (run)
     needs: [approve]
     if: inputs.probe_only != 'true'
     runs-on: ubuntu-latest
@@ -231,6 +261,7 @@ jobs:
           fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"   # manual dispatch always runs the real suite
+            echo "lane=full" >> "$GITHUB_OUTPUT"        # dispatch = the FULL lane
             exit 0
           fi
           # Fetch the PR's changed-file list. Fail SAFE: if it can't be read, run the full suite
@@ -252,6 +283,28 @@ jobs:
           done <<< "$files"
           if [ "$relevant" = "true" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            # LANE: full if a release:*/e2e:full label is on the PR, else focused (see TWO-LANE FLOW at top).
+            labels="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.labels[].name' 2>/dev/null | tr '\n' ' ')"
+            lane=focused
+            for L in release:patch release:minor release:major e2e:full; do
+              case " $labels " in *" $L "*) lane=full ;; esac
+            done
+            # Old PR that predates this flow: e2e_scope.py + the runner's --groups support live in the PR's
+            # checked-out HEAD, not here, so the focused lane can't run. Fall back to the FULL lane (the old
+            # runner handles `python tests/e2e_test.py`) until the PR merges main. (See AGENTS.md "Two-lane e2e".)
+            if [ "$lane" = "focused" ] && [ ! -f .github/scripts/e2e_scope.py ]; then
+              echo "::notice::e2e_scope.py not in the PR head — focused lane unavailable; running FULL. Merge main into the PR to enable the focused lane."
+              lane=full
+            fi
+            echo "lane=$lane" >> "$GITHUB_OUTPUT"
+            echo "E2E LANE: $lane" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$lane" = "focused" ]; then
+              # Map changed files to affected @test groups, AND pull in the group of any test ADDED to
+              # tests/e2e_test.py (so a tests-only change / a boy-scout test runs its group, not just
+              # smoke). Greps the file's patch for added `def test_...` lines.
+              test_funcs="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[] | select(.filename=="tests/e2e_test.py") | .patch // empty' 2>/dev/null | grep -oE '^\+[[:space:]]*def test_[A-Za-z0-9_]+' | sed -E 's/^\+[[:space:]]*def //' | sort -u | tr '\n' ' ')"
+              CHANGED_FILES="$files" CHANGED_TEST_FUNCS="$test_funcs" python .github/scripts/e2e_scope.py
+            fi
           else
             echo "::notice::No hub-relevant files changed — reporting E2E green WITHOUT running the suite (docs-only / non-hub PR)."
             echo "E2E NOT RUN — no hub-relevant files changed (docs-only / non-hub PR). Skipped on purpose; this green does NOT mean the e2e suite executed." >> "$GITHUB_STEP_SUMMARY"
@@ -475,7 +528,16 @@ jobs:
           # WATCHDOG_URL, overlapping the restore-poll wait) instead of the test critical path.
           # NOT set on the post-restore --cleanup-only step below, which stays the idempotent backstop.
           E2E_DEFER_NATIVE_DELETES: '1'
-        run: python tests/e2e_test.py
+          E2E_LANE: ${{ steps.gate.outputs.lane }}
+          E2E_GROUPS: ${{ steps.gate.outputs.groups }}
+        run: |
+          if [ "$E2E_LANE" = "focused" ]; then
+            echo "Running the FOCUSED lane -- groups: ${E2E_GROUPS:-<smoke only>}"
+            python tests/e2e_test.py --groups "$E2E_GROUPS"
+          else
+            echo "Running the FULL lane -- whole suite"
+            python tests/e2e_test.py
+          fi
 
       # The install above landed THIS PR's app on the hub, so hub_update_package now
       # exists there. Exercise its discovery path live (dryRun: fetch PR source ->
@@ -487,11 +549,42 @@ jobs:
       # watchdog PR-install step above plus the smokeTestMarker / hub_list_libraries
       # assertions in tests/e2e_test.py.
       - name: Validate hub_update_package dev tool (dryRun)
+        id: pkg_validate
         if: steps.gate.outputs.available == 'true'
         env:
           PR_RAW_BASE: ${{ env.PR_RAW_BASE }}
           PR_HEAD_SHA_RESOLVED: ${{ env.PR_HEAD_SHA_RESOLVED }}
         run: bash .github/scripts/mcp_validate_package_tool.sh
+
+      # Post the REQUIRED gate "Full e2e (runs with label)" as a COMMIT STATUS (NOT this job's own check)
+      # so the focused lane can hold the merge PENDING without green-washing it (a skipped/green required
+      # check would let a focused-only PR merge -- see TWO-LANE FLOW at top). The job's check is "e2e (run)".
+      #   focused lane          -> pending (yellow): holds the merge until the full lane runs.
+      #   full lane passed       -> success;   full lane failed -> failure.
+      #   docs-only / no secret  -> success (the gate skip path; e2e not required to run).
+      - name: Post e2e gate status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SHA="${{ github.event.pull_request.head.sha }}"
+          [ -z "$SHA" ] && SHA="${{ github.sha }}"
+          AVAIL="${{ steps.gate.outputs.available }}"
+          LANE="${{ steps.gate.outputs.lane }}"
+          if [ "$AVAIL" != "true" ]; then
+            STATE=success; DESC="e2e skipped (no hub-relevant change / no test-hub secret); not required to run"
+          elif [ "$LANE" = "full" ]; then
+            if [ "${{ steps.run_e2e.outcome }}" = "success" ] && [ "${{ steps.pkg_validate.outcome }}" = "success" ]; then
+              STATE=success; DESC="full e2e passed"
+            else
+              STATE=failure; DESC="full e2e failed"
+            fi
+          else
+            STATE=pending; DESC="e2e pending; no label -- add release:* or e2e:full to run the full suite"
+          fi
+          echo "Posting gate status 'Full e2e (runs with label)': $STATE -- $DESC"
+          gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
+            -f state="$STATE" -f context="Full e2e (runs with label)" -f description="$DESC" >/dev/null
 
       # Disarm the v2 dead-man watchdog -- this is also what RESTORES main: it pushes the pre-deploy
       # known-good snapshot back through the watchdog's own restore plumbing ($WATCHDOG_URL) (replacing

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -75,6 +75,10 @@ on:
 
 permissions:
   contents: read
+  # statuses: write lets the "Post e2e gate status" step POST the required commit status
+  # "Full e2e (runs with label)" (pending while focused, success/failure when full). Without it
+  # the POST 403s ("Resource not accessible by integration") and the gate can never report.
+  statuses: write
 
 jobs:
   # The hub-less self-deploy recovery guard (issue #237) is NOT here: running untrusted
@@ -199,17 +203,22 @@ jobs:
     # several PRs can sit queued for the single shared hub and run back-to-back.
     # It also covers a manual hub session GitHub's `concurrency` can't see.
     #
-    # The GitHub group is PER-PR (per-ref for dispatches) and exists only to cancel
-    # SUPERSEDED runs: a new commit pushed while the previous run is still lease-waiting
-    # (or mid-test on the now-outdated commit) cancels it -- its results are stale either
-    # way. Cancellation is safe: the cleanup/restore/lease-release steps are
-    # `if: always()` (GitHub still runs those on cancellation), and a hard kill is
-    # backstopped by the dead-man watchdog's deadline restore plus the lease TTL
-    # (an unreleased lease is reclaimable after at most 30 min).
-    # Scoped at the JOB level (not workflow level) so the `approve` gate -- which may
-    # sit waiting on a human reviewer -- never holds the group.
+    # The GitHub group is PER-BRANCH and exists to cancel SUPERSEDED runs AND to stop two runs
+    # for the SAME branch from starting at once. Both the focused (push) and full (label) lanes
+    # are pull_request_target on the same PR, and a maintainer workflow_dispatch validates the
+    # same branch -- ALL THREE must collapse into ONE group, else two runs start together and
+    # both hammer the cloud relay during lease acquisition (the 504 storm that fails a run even
+    # though the lease itself would serialize hub access). Keying on `head_ref` (set for
+    # pull_request_target = the PR's source branch) || `ref_name` (set for workflow_dispatch/push)
+    # yields the SAME group for every event on a given branch, so a new push / a label add / a
+    # dispatch cancels the older run instead of racing it. (Same-repo branch<->PR is 1:1; two
+    # forks reusing one branch name is the only overlap, and the lease still serializes that.)
+    # Cancellation is safe: the cleanup/restore/lease-release steps are `if: always()`, and a hard
+    # kill is backstopped by the dead-man watchdog's deadline restore plus the lease TTL.
+    # Scoped at the JOB level (not workflow level) so the `approve` gate -- which may sit waiting
+    # on a human reviewer -- never holds the group.
     concurrency:
-      group: hub-e2e-${{ github.event.pull_request.number || github.ref }}
+      group: hub-e2e-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
 
     env:

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -293,7 +293,10 @@ jobs:
           if [ "$relevant" = "true" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
             # LANE: full if a release:*/e2e:full label is on the PR, else focused (see TWO-LANE FLOW at top).
-            labels="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.labels[].name' 2>/dev/null | tr '\n' ' ')"
+            # `|| true`: the step runs under `-eo pipefail`, so a transient gh-api failure here would abort
+            # the whole gate; an empty label list just means "no full-run label" -> focused (the safe lane,
+            # which only HOLDS the merge pending -- it can't green-wash).
+            labels="$( { gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.labels[].name' 2>/dev/null || true; } | tr '\n' ' ')"
             lane=focused
             for L in release:patch release:minor release:major e2e:full; do
               case " $labels " in *" $L "*) lane=full ;; esac
@@ -311,7 +314,10 @@ jobs:
               # Map changed files to affected @test groups, AND pull in the group of any test ADDED to
               # tests/e2e_test.py (so a tests-only change / a boy-scout test runs its group, not just
               # smoke). Greps the file's patch for added `def test_...` lines.
-              test_funcs="$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[] | select(.filename=="tests/e2e_test.py") | .patch // empty' 2>/dev/null | grep -oE '^\+[[:space:]]*def test_[A-Za-z0-9_]+' | sed -E 's/^\+[[:space:]]*def //' | sort -u | tr '\n' ' ')"
+              # The `{ ... || true; }` around grep is REQUIRED: under `-eo pipefail`, a PR that adds NO new
+              # test function (the COMMON focused case) makes grep exit 1 and aborts the whole gate. The
+              # guard turns "no match" into an empty list (file-group + smoke still run).
+              test_funcs="$( { gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[] | select(.filename=="tests/e2e_test.py") | .patch // empty' 2>/dev/null || true; } | { grep -oE '^\+[[:space:]]*def test_[A-Za-z0-9_]+' || true; } | sed -E 's/^\+[[:space:]]*def //' | sort -u | tr '\n' ' ')"
               CHANGED_FILES="$files" CHANGED_TEST_FUNCS="$test_funcs" python .github/scripts/e2e_scope.py
             fi
           else
@@ -541,8 +547,12 @@ jobs:
           E2E_GROUPS: ${{ steps.gate.outputs.groups }}
         run: |
           if [ "$E2E_LANE" = "focused" ]; then
-            echo "Running the FOCUSED lane -- groups: ${E2E_GROUPS:-<smoke only>}"
-            python tests/e2e_test.py --groups "$E2E_GROUPS"
+            # The runner treats an EMPTY --groups as "no filter" = the FULL suite, so NEVER pass empty in
+            # focused mode (that would silently run everything). e2e_scope.py always emits >=smoke, so this
+            # only fires if the gate misbehaved -- fall back to the smoke core, not the whole suite.
+            groups="${E2E_GROUPS:-infrastructure,protocol}"
+            echo "Running the FOCUSED lane -- groups: $groups"
+            python tests/e2e_test.py --groups "$groups"
           else
             echo "Running the FULL lane -- whole suite"
             python tests/e2e_test.py

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -64,6 +64,10 @@ on:
         description: 'ONE-OFF: comma-separated test name(s) to run instead of the full suite (e.g. test_set_rule_required_expression_multi_condition). Blank = full suite. Installs the PR head first, same as a normal run.'
         required: false
         default: ''
+      skip_install:
+        description: 'ONE-OFF: skip installing the PR head — run against whatever is already deployed (usually main). For tests-only changes where the server code is unchanged. Keeps the lease; skips the watchdog arm/install/restore.'
+        required: false
+        default: 'false'
       probe_only:
         description: 'true = read-only hub inventory probe instead of the e2e suite (diagnose hub state)'
         required: false
@@ -453,7 +457,7 @@ jobs:
             >/dev/null || echo "::notice::stale-flag clear call failed/absent (watchdog/flag may not exist yet) -- continuing"
 
       - name: Compute PR source URL for importUrl deploy
-        if: steps.gate.outputs.available == 'true'
+        if: steps.gate.outputs.available == 'true' && inputs.skip_install != 'true'
         # The hub fetches the PR branch's raw source itself (importUrl mode), so the
         # ~1.5MB blob never crosses the cloud gateway. Resolve head repo + SHA for the
         # three trigger shapes (PR, dispatch-with-pr_number, plain dispatch).
@@ -529,7 +533,7 @@ jobs:
       # "Disarm dead-man watchdog (final)" step below clears it and restores main before the lease is
       # released. Placed BEFORE the PR install so the rollback target exists before the hub is mutated.
       - name: Backup + arm dead-man watchdog
-        if: steps.gate.outputs.available == 'true'
+        if: steps.gate.outputs.available == 'true' && inputs.skip_install != 'true'
         env:
           PR_RAW_BASE: ${{ env.PR_RAW_BASE }}
           PR_HEAD_SHA_RESOLVED: ${{ env.PR_HEAD_SHA_RESOLVED }}
@@ -546,7 +550,7 @@ jobs:
       # source last (HPM's bundle -> app order) in one step. Blocking:
       # a failed PR install means the tests would run against stale/broken hub code.
       - name: Watchdog - install PR
-        if: steps.gate.outputs.available == 'true'
+        if: steps.gate.outputs.available == 'true' && inputs.skip_install != 'true'
         env:
           PR_RAW_BASE: ${{ env.PR_RAW_BASE }}
           PR_HEAD_SHA_RESOLVED: ${{ env.PR_HEAD_SHA_RESOLVED }}
@@ -592,7 +596,9 @@ jobs:
       # assertions in tests/e2e_test.py.
       - name: Validate hub_update_package dev tool (dryRun)
         id: pkg_validate
-        if: steps.gate.outputs.available == 'true'
+        # Validates the PR's package tool against its installed source -- meaningless (and PR_RAW_BASE
+        # is unset) when skip_install ran the test against the already-deployed code.
+        if: steps.gate.outputs.available == 'true' && inputs.skip_install != 'true'
         env:
           PR_RAW_BASE: ${{ env.PR_RAW_BASE }}
           PR_HEAD_SHA_RESOLVED: ${{ env.PR_HEAD_SHA_RESOLVED }}
@@ -640,7 +646,7 @@ jobs:
       # restore or assert restoreResult/source-length here. A clean disarm also prevents handing the
       # next run an armed flag.
       - name: Disarm dead-man watchdog (restore main)
-        if: always() && steps.gate.outputs.available == 'true'
+        if: always() && steps.gate.outputs.available == 'true' && inputs.skip_install != 'true'
         run: bash .github/scripts/mcp_disarm_watchdog.sh
 
       - name: Cleanup BAT_E2E_ artifacts

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -60,6 +60,10 @@ on:
       pr_number:
         description: 'PR number to test (blank = current ref)'
         required: false
+      tests:
+        description: 'ONE-OFF: comma-separated test name(s) to run instead of the full suite (e.g. test_set_rule_required_expression_multi_condition). Blank = full suite. Installs the PR head first, same as a normal run.'
+        required: false
+        default: ''
       probe_only:
         description: 'true = read-only hub inventory probe instead of the e2e suite (diagnose hub state)'
         required: false
@@ -255,6 +259,7 @@ jobs:
         id: gate
         env:
           GH_TOKEN: ${{ github.token }}
+          TESTS_INPUT: ${{ inputs.tests }}
         run: |
           if [ -z "$MCP_URL" ]; then
             echo "::notice::LEVEL99_TEST_HUB_MCP_URL secret not available — skipping E2E (expected on repos without the test hub configured)"
@@ -270,7 +275,19 @@ jobs:
           fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"   # manual dispatch always runs the real suite
-            echo "lane=full" >> "$GITHUB_OUTPUT"        # dispatch = the FULL lane
+            if [ -n "$TESTS_INPUT" ]; then
+              # ONE-OFF lane: run only the named test(s) (still installs the PR head + holds the lease).
+              # Validate to test-name characters so the value can't inject into the runner command line.
+              if ! printf '%s' "$TESTS_INPUT" | grep -qE '^[A-Za-z0-9_,]+$'; then
+                echo "::error::tests input must be comma-separated test names ([A-Za-z0-9_,] only); got: $TESTS_INPUT"
+                exit 1
+              fi
+              echo "lane=oneoff" >> "$GITHUB_OUTPUT"
+              echo "tests=$TESTS_INPUT" >> "$GITHUB_OUTPUT"
+              echo "E2E LANE: one-off (--tests $TESTS_INPUT)" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "lane=full" >> "$GITHUB_OUTPUT"      # dispatch with no tests = the FULL lane
+            fi
             exit 0
           fi
           # Fetch the PR's changed-file list. Fail SAFE: if it can't be read, run the full suite
@@ -545,8 +562,14 @@ jobs:
           E2E_DEFER_NATIVE_DELETES: '1'
           E2E_LANE: ${{ steps.gate.outputs.lane }}
           E2E_GROUPS: ${{ steps.gate.outputs.groups }}
+          E2E_TESTS: ${{ steps.gate.outputs.tests }}
         run: |
-          if [ "$E2E_LANE" = "focused" ]; then
+          if [ "$E2E_LANE" = "oneoff" ]; then
+            # Maintainer one-off (workflow_dispatch tests=...): run only the named test(s). Gate already
+            # validated E2E_TESTS to [A-Za-z0-9_,]. The runner unions --tests into the selection.
+            echo "Running a ONE-OFF -- tests: $E2E_TESTS"
+            python tests/e2e_test.py --tests "$E2E_TESTS"
+          elif [ "$E2E_LANE" = "focused" ]; then
             # The runner treats an EMPTY --groups as "no filter" = the FULL suite, so NEVER pass empty in
             # focused mode (that would silently run everything). e2e_scope.py always emits >=smoke, so this
             # only fires if the gate misbehaved -- fall back to the smoke core, not the whole suite.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,17 @@ The watchdog itself is **not** deployed by e2e. **e2e never writes to the watchd
 - **Changing the CONTENT of an existing script / test / groovy file** (logic inside the e2e `.sh` scripts, `tests/e2e_test.py`, or the server/rule/watchdog source) → the auto `e2e` check exercises the PR's code in-PR. **Iterate normally** — this works for fork PRs too, which is the whole point. New MCP tools (incl. e.g. PR #247's bundle tools) and their `tests/e2e_test.py` scenarios fall here: no special handling.
 - **Restructuring the workflow FILE** — adding/removing/renaming a *step*, or deleting/renaming a script the base workflow *calls* — is NOT exercised by the auto check (it runs main's old structure, usually RED against the PR's deleted/renamed files). Validate such a PR with **`gh workflow run hub-e2e.yml --ref <branch>`** (`workflow_dispatch` runs the PR branch's OWN workflow file) and watch that run; the PR's `e2e` badge stays red until merge, and the dispatch run is the merge-readiness proof. This is the ONLY case that needs the dispatch dance (e.g. PR #248 restructured the steps and deleted the old deploy scripts).
 
+#### Two-lane e2e: focused (iterating) vs full (label) — why `e2e` sits PENDING (issue #237)
+
+A PR runs **one of two lanes**, chosen by whether a full-run label (`release:patch` / `release:minor` / `release:major` / `e2e:full`) is on the PR. The `gate` step in `hub-e2e.yml` decides it; the lane is printed in the run summary.
+
+- **Focused** (no label): runs only the e2e `@test` groups AFFECTED by the changed files — the `file → group` map in `.github/scripts/e2e_scope.py` — plus a smoke core (`infrastructure` + `protocol`). Fast iteration signal. The job's own check is named **`e2e (run)`**.
+- **Full** (label on): runs the WHOLE suite. The `e2e (run)` check shows its result.
+
+The **required merge gate is a posted commit status named `Full e2e (runs with label)`** (the "Post e2e gate status" step), NOT the job's own check (`e2e (run)`) — because a *skipped* required check counts as PASS and would let a focused-only PR merge. So while iterating, the gate is posted **PENDING (yellow)**, which HOLDS the merge without being red; adding a `release:*` / `e2e:full` label runs the full lane and posts the gate success/failure. **Only a green FULL run is mergeable.** Docs-only / no-secret PRs post the gate success without running.
+
+> **A pending `Full e2e (runs with label)` on a PR is NORMAL and intended** — it's the gate waiting for the full-run label, not a stuck or missing run. Add `release:*` / `e2e:full` to run the full suite. **Branch protection (ruleset `main-required-checks`) requires the `Full e2e (runs with label)` status, not the `e2e (run)` check.** This is a workflow-FILE change → validate with the `gh workflow run` dispatch dance above before merging.
+
 ### Sources
 
 All rules above cite verified sources, re-checked on 2026-05-26.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,17 @@ The watchdog itself is **not** deployed by e2e. **e2e never writes to the watchd
 - **Changing the CONTENT of an existing script / test / groovy file** (logic inside the e2e `.sh` scripts, `tests/e2e_test.py`, or the server/rule/watchdog source) → the auto `e2e` check exercises the PR's code in-PR. **Iterate normally** — this works for fork PRs too, which is the whole point. New MCP tools (incl. e.g. PR #247's bundle tools) and their `tests/e2e_test.py` scenarios fall here: no special handling.
 - **Restructuring the workflow FILE** — adding/removing/renaming a *step*, or deleting/renaming a script the base workflow *calls* — is NOT exercised by the auto check (it runs main's old structure, usually RED against the PR's deleted/renamed files). Validate such a PR with **`gh workflow run hub-e2e.yml --ref <branch>`** (`workflow_dispatch` runs the PR branch's OWN workflow file) and watch that run; the PR's `e2e` badge stays red until merge, and the dispatch run is the merge-readiness proof. This is the ONLY case that needs the dispatch dance (e.g. PR #248 restructured the steps and deleted the old deploy scripts).
 
+#### Two-lane e2e: focused (iterating) vs full (label) — why `e2e` sits PENDING (issue #237)
+
+A PR runs **one of two lanes**, chosen by whether a full-run label (`release:patch` / `release:minor` / `release:major` / `e2e:full`) is on the PR. The `gate` step in `hub-e2e.yml` decides it; the lane is printed in the run summary.
+
+- **Focused** (no label): runs only the e2e `@test` groups AFFECTED by the changed files — the `file → group` map in `.github/scripts/e2e_scope.py` — plus a smoke core (`infrastructure` + `protocol`). Fast iteration signal. The job's own check is named **`e2e (run)`**.
+- **Full** (label on): runs the WHOLE suite. The `e2e (run)` check shows its result.
+
+The **required merge gate is a posted commit status named `Full e2e (runs with label)`** (the "Post e2e gate status" step), NOT the job's own check (`e2e (run)`) — because a *skipped* required check counts as PASS and would let a focused-only PR merge. So while iterating, the gate is posted **PENDING (yellow)**, which HOLDS the merge without being red; adding a `release:*` / `e2e:full` label runs the full lane and posts the gate success/failure. **Only a green FULL run is mergeable.** Docs-only / no-secret PRs post the gate success without running.
+
+> **A pending `Full e2e (runs with label)` on a PR is NORMAL and intended** — it's the gate waiting for the full-run label, not a stuck or missing run. Add `release:*` / `e2e:full` to run the full suite. **Branch protection (ruleset `main-required-checks`) requires the `Full e2e (runs with label)` status, not the `e2e (run)` check.** This is a workflow-FILE change → validate with the `gh workflow run` dispatch dance above before merging.
+
 ### Sources
 
 All rules above cite verified sources, re-checked on 2026-05-26.

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3114,9 +3114,13 @@ private _hubRequest(String method, String path, Map opts = [:]) {
             result = bodyText
         }
     }
+    long _hubRtT0 = now()
     try {
         if (method == 'GET') httpGet(params, reader)
         else httpPost(params, reader)
+        // [hubrt] per-call diagnostic: every internal hub round-trip funnels through here, so one
+        // debug line profiles a heavy RM wizard build (count + latency of each GET/POST). Debug-gated.
+        logDebug("[hubrt] ${method} ${path} (${now() - _hubRtT0}ms)")
     } catch (Exception e) {
         // hubInternalGetRaw path: a 3xx with followRedirects=false is the success case (read the
         // Location header), not an error.

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -3992,7 +3992,7 @@ private Integer _rmCreateChildApp(Integer parentAppId, String namespace = "hubit
 // Non-private so test specs can override via script.metaClass — internal
 // Groovy-script dispatch to private methods bypasses the per-instance
 // metaClass override.
-def _rmClickAppButton(Integer appId, String buttonName, String stateAttribute = null, String pageName = null) {
+def _rmClickAppButton(Integer appId, String buttonName, String stateAttribute = null, String pageName = null, Map cache = null) {
     def body = [
         id: appId.toString(),
         name: buttonName,
@@ -4016,7 +4016,7 @@ def _rmClickAppButton(Integer appId, String buttonName, String stateAttribute = 
         // The hub uses `version` to detect concurrent edits. Fetch the
         // current value so we replay the exact one the UI would send.
         try {
-            def cfg = _rmFetchConfigJson(appId, pageName)
+            def cfg = _rmFetchConfigJson(appId, pageName, cache)
             def v = cfg?.app?.version
             if (v != null) body.version = v.toString()
         } catch (Exception verExc) {
@@ -4028,6 +4028,9 @@ def _rmClickAppButton(Integer appId, String buttonName, String stateAttribute = 
         }
     }
     def resp = hubInternalPostForm("/installedapp/btn", body)
+    // A button click (hasAll / updateRule / doneST / cancelCapab / editCond ...) re-renders the
+    // page and bumps app.version, so every cached page for this app is now stale.
+    _rmCacheInvalidate(cache, appId)
     if (resp?.status != null && resp.status >= 400) {
         throw new IllegalArgumentException("Button click '${buttonName}' on app ${appId} failed: status=${resp.status}")
     }
@@ -4082,8 +4085,8 @@ private String _rmSanitizeRenderForHash(Object sections) {
  */
 // Non-private so test specs can override via script.metaClass — see
 // _rmClickAppButton for the same rationale.
-def _rmWriteSettingOnPage(Integer appId, String pageName, String key, Object value, List applied, String typeHintOverride = null, List skipped = null) {
-    def config = _rmFetchConfigJson(appId, pageName)
+def _rmWriteSettingOnPage(Integer appId, String pageName, String key, Object value, List applied, String typeHintOverride = null, List skipped = null, Map cache = null) {
+    def config = _rmFetchConfigJson(appId, pageName, cache)
     def schema = _rmCollectInputSchema(config?.configPage)
     if (!schema?.containsKey(key)) {
         // Field not in current schema. This is normal for incremental
@@ -4117,23 +4120,32 @@ def _rmWriteSettingOnPage(Integer appId, String pageName, String key, Object val
     // schema unchanged; same write WITH page context committed).
     // Include the context whenever pageName is non-null and isn't the
     // default mainPage.
+    def writeResp = null
     if (pageName && pageName != "mainPage") {
         def body = _rmBuildSettingsBody(appId, settingsMap, schemaForBuild)
         body.formAction = "update"
         body.currentPage = pageName
         body.pageBreadcrumbs = '["mainPage"]'
         if (config?.app?.version != null) body.version = config.app.version.toString()
-        _rmPostSettings(appId, body)
+        writeResp = _rmPostSettings(appId, body, cache)
     } else {
-        _rmUpdateAppSettings(appId, settingsMap, schemaForBuild)
+        _rmUpdateAppSettings(appId, settingsMap, schemaForBuild, cache)
     }
-    // Verify the write took. Re-fetch and compare schemas.
-    def afterCfg = null
+    // Verify the write took. On the sub-page path the POST response IS the re-rendered page model
+    // (consume it -- no verify-GET; appUI.js consumes the same body), and it has the same {app,
+    // configPage, settings} shape a verify-GET would. The mainPage path goes through
+    // _rmUpdateAppSettings (which may re-POST for sticky multiple-flags), so its post-state is read
+    // fresh. The write above already invalidated the cache; consuming re-stores the post-write page.
+    def afterCfg = _rmPagePostResponse(writeResp)
     def verifyFetchErr = null
-    try { afterCfg = _rmFetchConfigJson(appId, pageName) }
-    catch (Exception fetchExc) {
-        verifyFetchErr = fetchExc.message
-        mcpLog("warn", "rm-native", "_rmWriteSettingOnPage: post-write fetch on ${pageName} failed for app ${appId} key=${key} (${fetchExc.message}) -- write status is unverified")
+    if (afterCfg != null) {
+        _rmCacheStore(cache, appId, pageName, afterCfg)
+    } else {
+        try { afterCfg = _rmFetchConfigJson(appId, pageName, cache) }
+        catch (Exception fetchExc) {
+            verifyFetchErr = fetchExc.message
+            mcpLog("warn", "rm-native", "_rmWriteSettingOnPage: post-write fetch on ${pageName} failed for app ${appId} key=${key} (${fetchExc.message}) -- write status is unverified")
+        }
     }
     if (afterCfg == null) {
         // Verification fetch failed — we cannot confirm persistence. Surface
@@ -4238,7 +4250,16 @@ def _rmWriteSettingOnPage(Integer appId, String pageName, String key, Object val
  * Callers (hub_get_app_config, hub_set_rule) use this to discover the input
  * schema (names + types + multiple flags) before issuing a write.
  */
-private Map _rmFetchConfigJson(Integer appId, String pageName = null) {
+private Map _rmFetchConfigJson(Integer appId, String pageName = null, Map cache = null) {
+    // Request-scoped page-schema cache (threaded by the RM condition builders; null for every
+    // other caller -> unchanged behaviour). Keyed strictly on (appId, pageName); only a real
+    // page is cached -- a root read (pageName == null) carries the volatile app.version token
+    // and MUST stay live. A HIT returns exactly what a live fetch would, because every
+    // wizard-page WRITE clears cache[appId] (see _rmCacheInvalidate / _rmCacheStore), so a
+    // cached page is provably current.
+    if (cache != null && pageName != null && cache[appId] instanceof Map && cache[appId].containsKey(pageName)) {
+        return cache[appId][pageName]
+    }
     def path = "/installedapp/configure/json/${appId}"
     if (pageName) path += "/${pageName}"
     def responseText = hubInternalGet(path)
@@ -4254,7 +4275,46 @@ private Map _rmFetchConfigJson(Integer appId, String pageName = null) {
     if (!(parsed instanceof Map) || !parsed.app) {
         throw new IllegalArgumentException("Unexpected response shape from ${path}: missing app object")
     }
+    if (cache != null && pageName != null) {
+        if (!(cache[appId] instanceof Map)) cache[appId] = [:]
+        cache[appId][pageName] = parsed
+    }
     return parsed
+}
+
+// Drop ALL cached pages for an app. Every wizard-page WRITE (any POST to
+// /installedapp/update/json or /installedapp/btn) calls this: cross-page render coupling
+// means one page's write can change how sibling pages render, AND the app.version token
+// shifts, so per-page invalidation would be unsafe. No-op when cache is null.
+private void _rmCacheInvalidate(Map cache, Integer appId) {
+    if (cache != null) cache[appId] = [:]
+}
+
+// Invalidate the app, then store a freshly-rendered page model -- used after a write whose
+// POST response IS the re-rendered page (the hub returns the configPage inline, exactly as
+// the browser consumes it; see _rmPagePostResponse), so the next read is a HIT with no
+// verify-GET. pageModel must be a parsed {app, configPage, ...} Map; if null/invalid the
+// app is just invalidated (next read re-fetches live).
+private void _rmCacheStore(Map cache, Integer appId, String pageName, Map pageModel) {
+    if (cache == null) return
+    cache[appId] = [:]
+    if (pageName != null && pageModel != null && pageModel.configPage != null) cache[appId][pageName] = pageModel
+}
+
+// Parse the page model the hub returns INLINE from an /installedapp/update/json POST. The
+// classic dynamicPage submit returns the re-rendered {app, configPage, settings, ...} in the
+// POST response body (appUI.js jsonSubmit consumes data.configPage directly, with NO
+// follow-up GET). hubInternalPostForm returns a struct {status, data:<body text>}. Returns
+// the parsed Map, or null when the body is empty / non-JSON / lacks app+configPage -- callers
+// fall back to a verify-fetch then (defensive: worst case == today's separate-GET behaviour).
+private Map _rmPagePostResponse(postResp) {
+    try {
+        def data = (postResp instanceof Map) ? postResp.data : postResp
+        if (!data) return null
+        def parsed = (data instanceof String) ? new groovy.json.JsonSlurper().parseText(data) : data
+        if (parsed instanceof Map && parsed.app && parsed.configPage) return parsed
+    } catch (Exception ignore) { }
+    return null
 }
 
 /**
@@ -4854,8 +4914,10 @@ private void _rmVerifyMultipleFlags(Integer appId, Map schema, List<String> touc
 // NOT throw on 4xx, so a rejected write -- typically a stale version token -- must be detected
 // here or it silently reports success. Mirrors the status guard in _rmSubmitFullPageForm
 // (same IllegalStateException runtime-error contract).
-private Map _rmPostSettings(Integer appId, Map body) {
+private Map _rmPostSettings(Integer appId, Map body, Map cache = null) {
     def resp = hubInternalPostForm("/installedapp/update/json", body)
+    // The settings POST re-renders the page and bumps app.version -> drop all cached pages.
+    _rmCacheInvalidate(cache, appId)
     if (resp?.status != null && resp.status >= 400) {
         def bodyPreview = resp.data?.toString()?.take(200)
         throw new IllegalStateException("Settings write for app ${appId} failed: status=${resp.status}${bodyPreview ? "; body=" + bodyPreview : ""}. The write was rejected so nothing was committed (a 4xx is usually a stale version token -- re-fetch via hub_get_app_config(appId=${appId}) and retry).")
@@ -4870,12 +4932,12 @@ private Map _rmPostSettings(Integer appId, Map body) {
  * if still divergent after retry — the caller should surface this and
  * suggest hub_restore_backup.
  */
-private Map _rmUpdateAppSettings(Integer appId, Map settingsMap, Map schema = null) {
+private Map _rmUpdateAppSettings(Integer appId, Map settingsMap, Map schema = null, Map cache = null) {
     if (schema == null) {
         schema = _rmCollectInputSchema(_rmFetchConfigJson(appId)?.configPage)
     }
     def body = _rmBuildSettingsBody(appId, settingsMap, schema)
-    def resp = _rmPostSettings(appId, body)
+    def resp = _rmPostSettings(appId, body, cache)
 
     def touched = settingsMap.keySet().collect { it.toString() }
     try {
@@ -4886,7 +4948,7 @@ private Map _rmUpdateAppSettings(Integer appId, Map settingsMap, Map schema = nu
         // already carries the .multiple=true sidecar intent from the
         // initial build, so the same body is correct to resend.
         mcpLog("warn", "rm-native", "Marshal divergence on app ${appId} -- retrying: ${divergence.message}")
-        _rmPostSettings(appId, body)
+        _rmPostSettings(appId, body, cache)
         _rmVerifyMultipleFlags(appId, schema, touched)
     }
     return resp

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -10026,7 +10026,12 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
                     // Step 1: re-fetch STPage to discover the RM-assigned condition
                     // slot index (cIdx). The cond=a write above causes RM to allocate
                     // a new rCapab_<N>/rDev_<N>/... slot; N is firmware-assigned and
-                    // must be read from the schema rather than assumed.
+                    // must be read from the schema rather than assumed. The cond=a POST
+                    // echo does NOT reliably show the new slot for a 2nd+ condition (it
+                    // renders the committed-view "cond,doneST"); a FRESH GET does. Invalidate
+                    // so this discovery read bypasses the cached write-echo and re-fetches the
+                    // settled schema live -- this is a genuine re-fetch, not a redundant read.
+                    _rmCacheInvalidate(rmCache, appId)
                     def navResp = _rmFetchConfigJson(appId, "STPage", rmCache)
                     def stInputs = (navResp?.configPage?.sections ?: []).collectMany { it?.input ?: [] }
                     def rCapabInput = stInputs.find { it?.name?.toString()?.startsWith("rCapab_") }

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -6835,6 +6835,18 @@ private Map _rmWalkStep(Integer appId, Map spec) {
     def operation = spec?.operation?.toString()?.trim() ?: "introspect"
     def validateEnum = spec?.validateEnum == true
 
+    // walkStep is a RAW action-authoring path that bypasses _rmAddAction. If a preceding
+    // addRequiredExpression deferred its predCapabs clear (Step 4b), run it now -- before any
+    // action lands on selectActions/doActPage -- so an action authored here after an RE isn't
+    // wrapped in IF(**Broken Condition**). Mutating ops only (a read lands no action); the helper
+    // fires the ghost clear at most once, then drops the flag.
+    if (operation in ["write", "click", "navigate"]) {
+        def navTarget = (operation == "navigate" && spec?.navigate instanceof Map) ? ((Map) spec.navigate).targetPage?.toString() : null
+        if (page == "selectActions" || page == "doActPage" || navTarget == "selectActions" || navTarget == "doActPage") {
+            _rmRunPendingPredCapabsClear(appId)
+        }
+    }
+
     // hrefContext lets the LLM keep state alive across multiple walkStep
     // calls on a sub-page that needs `state.<paramKey>` set every request.
     // Verified live: periodic schedule's `state.n` only exists
@@ -8587,9 +8599,16 @@ private void _rmRunPendingPredCapabsClear(Integer appId) {
     } catch (Exception e) {
         mcpLog("warn", "rm-native", "addAction: deferred predCapabs clear (ghost ifThen) failed for app ${appId} (${e.message ?: e.toString()}) -- this action may render under IF(**Broken Condition**); verify rule render or restore backup if needed")
     }
+    _rmDropPredClearPending(appId)
+}
+
+// Drop a rule's deferred predCapabs-clear flag WITHOUT firing the clear -- used when the rule's
+// predCapabs goes clean by other means (a rolled-back RE build restored from a clean backup, or the
+// rule deleted), so a stale flag can't trigger a wasted ghost clear on a later addAction or linger
+// in atomicState after the rule is gone.
+private void _rmDropPredClearPending(Integer appId) {
     def m = atomicState.predClearPending ?: [:]
-    m.remove(appId.toString())
-    atomicState.predClearPending = m
+    if (m.remove(appId.toString()) != null) atomicState.predClearPending = m
 }
 
 // Low-level reveal-step primitive for RM 5.1 progressive-disclosure wizard pages.
@@ -10616,6 +10635,10 @@ private Map _rmFinalizeRequiredExpressionWrite(Integer appId, Map innerResult, M
 // - replay + read-back both confirm -> restored:true.
 // - restore threw -> restored:false, "DELETED ... auto-restore ALSO failed".
 private Map _rmRestoreCommittedREFromBackup(Integer appId, Map backup, String errMsg, Map carry = [:]) {
+    // A rollback discards the failed new-RE build, so drop any predClearPending it flagged: the
+    // restored rule's predCapabs comes from a clean backup, and a leftover flag would fire a wasted
+    // ghost clear on the rule's next addAction.
+    _rmDropPredClearPending(appId)
     if (backup?.fileName == null) {
         // No usable backup handle -- cannot auto-restore. Say so loudly; the old RE
         // is gone and the caller must recover by hand.
@@ -12502,6 +12525,7 @@ def toolDeleteNativeApp(args) {
     try {
         if (force) {
             _rmForceDeleteApp(appId)
+            _rmDropPredClearPending(appId)   // rule gone -> drop any deferred predCapabs-clear flag
             return [
                 success: true,
                 appId: appId,
@@ -12524,6 +12548,7 @@ def toolDeleteNativeApp(args) {
                     note: "Soft delete refused by hub. Pass force=true to override (app's children will also be removed)."
                 ]
             }
+            _rmDropPredClearPending(appId)   // rule gone -> drop any deferred predCapabs-clear flag
             return [
                 success: true,
                 appId: appId,

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -4047,6 +4047,20 @@ private Map _rmWriteSubPageField(Integer appId, String page, String parentPage, 
     def beforeValueStr = schema?."${key}"?.value?.toString()
     def beforeRenderHash = _rmSanitizeRenderForHash(cfg?.configPage?.sections).hashCode()
     def body = _rmBuildSettingsBody(appId, [(key): value], schema)
+    // `cond` and `oper` are the condition-builder's enum pickers, and their type is known a priori.
+    // The request-scoped page cache consumes each write's inline echo, but a submitOnChange echo for
+    // these pickers lags one render behind -- a gap-operator (and the close-sub-expression operator)
+    // echoes a page that omits the very field the NEXT write needs. If the next write reads that
+    // cached schema, _rmBuildSettingsBody finds no `cond`/`oper` entry and DROPS the `<key>.type`
+    // sidecar, which RM silently no-ops -- the multi-condition / sub-expression RE failure
+    // ("rCapab_<N> not in STPage schema after cond=a"). Emit the picker's enum type explicitly so the
+    // write lands against the hub's real (settled) page regardless of the cached schema -- no
+    // invalidation, no extra re-fetch (keeps the round-trip win). Live-root-caused 2026-06-21 via the
+    // native RM wizard + claude-in-chrome.
+    if (key == "cond" || key == "oper") {
+        body["${key}.type".toString()] = "enum"
+        body["${key}.multiple".toString()] = "false"
+    }
     body.formAction = "update"
     body.currentPage = page
     // Live-UI capture (Chrome 2026-04-26, rule 1380 STPage cond=b probe):
@@ -4073,28 +4087,13 @@ private Map _rmWriteSubPageField(Integer appId, String page, String parentPage, 
     def verifyFetchErr = null
     def parsedPost = hasRealParams ? null : _rmPagePostResponse(postResp)
     if (parsedPost != null) {
-        // Consume the inline echo for routing (no extra GET). Whether to CACHE it for the NEXT
-        // write has two traps, both from the condition-builder's submitOnChange pickers lagging
-        // one render behind their settled state:
-        //  (1) `oper` (the gap-operator between conditions AND the close-sub-expression operator)
-        //      NEVER has a trustworthy echo -- it can add the expression-management buttons while
-        //      still omitting the `oper`/`cond` field the next write needs. Never cache an `oper`
-        //      write; always re-fetch the settled page.
-        //  (2) For every other write, a lagged echo can DIFFER by only DROPPING keys (a subset),
-        //      which is not a forward advance -- so require a NEW key, not merely "schema differs".
-        // Caching a stale schema feeds the next write a page missing its key, so
-        // _rmBuildSettingsBody omits the `<key>.type` sidecar and RM silently no-ops the write --
-        // the multi-condition / sub-expression RE "rCapab_<N> not in STPage schema after cond=a"
-        // failures. A non-cacheable echo invalidates so the next read re-fetches the settled page.
-        // The hot path (single condition: no `oper` writes; field reveals all add a key) is
-        // unaffected, so the round-trip win stands.
+        // Consume the inline echo as both the post-write state (routing below) AND the cached page
+        // for the next write -- no verify-GET, no invalidation. The condition-builder's `cond`/`oper`
+        // picker echoes can lag a render behind (omitting the next field), but the explicit
+        // `<key>.type` sidecar above makes the next picker write land against the hub's real page
+        // regardless, so caching the lagged echo is safe and keeps the round-trip count minimal.
+        _rmCacheStore(cache, appId, page, parsedPost)
         afterCfg = parsedPost
-        def parsedPostKeys = (_rmCollectInputSchema(parsedPost?.configPage)?.keySet() ?: []) as Set
-        if (key != "oper" && !(parsedPostKeys - beforeKeys).isEmpty()) {
-            _rmCacheStore(cache, appId, page, parsedPost)
-        } else {
-            _rmCacheInvalidate(cache, appId)
-        }
     } else {
         _rmCacheInvalidate(cache, appId)
         try {

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -4073,16 +4073,18 @@ private Map _rmWriteSubPageField(Integer appId, String page, String parentPage, 
     def verifyFetchErr = null
     def parsedPost = hasRealParams ? null : _rmPagePostResponse(postResp)
     if (parsedPost != null) {
-        // Consume the inline echo for routing (no extra GET), but only CACHE it when it
-        // DEMONSTRABLY advanced the schema. The dynamicPage echo lags one render behind for
-        // wizard-consumed enum pickers (STPage `oper`): it returns the pre-transition
-        // [oper,doneST] while the settled page is already [cond,doneST]. Caching that stale page
-        // makes the next write read a schema missing its key, drop the `<key>.type` sidecar, and
-        // silently no-op (the multi-condition RE cond=a failure). A non-advancing echo
-        // invalidates instead, so the next read re-fetches the settled page.
+        // Consume the inline echo for routing (no extra GET), but only CACHE it when it adds a
+        // NEW schema key -- a genuine forward advance. The echo for a wizard-consumed enum picker
+        // (STPage `oper`) lags one render behind: the gap `oper=AND` between conditions echoes
+        // [oper,doneST] (still the picker) while the settled page is the [cond,doneST] selector.
+        // Before the 3rd+ condition that lagged echo even DROPS keys (the expression-management
+        // buttons), so "schema differs" is too weak -- a key must be ADDED. Caching a
+        // non-advancing echo feeds the next write a schema missing its key, dropping the
+        // `<key>.type` sidecar so RM silently no-ops it (the multi-condition RE cond=a failure).
+        // A non-advancing echo invalidates so the next read re-fetches the settled page.
         afterCfg = parsedPost
         def parsedPostKeys = (_rmCollectInputSchema(parsedPost?.configPage)?.keySet() ?: []) as Set
-        if (parsedPostKeys != beforeKeys) {
+        if (!(parsedPostKeys - beforeKeys).isEmpty()) {
             _rmCacheStore(cache, appId, page, parsedPost)
         } else {
             _rmCacheInvalidate(cache, appId)

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -8501,11 +8501,21 @@ private Map _rmApplyLocalVarResult(Integer appId, Map varResult, Map backup, Str
 // the rule, so the clean predCapabs persists. Verified live via probe diag variants Y
 // and Z (2026-05-01/02). DO NOT remove or simplify without re-running full probe matrix.
 private void _rmClearPredCapabsViaGhostIfThen(Integer appId, String caller) {
+    // Thread a request-scoped page cache so the repeated doActPage reads inside this fixed
+    // sequence reuse the page a prior step already fetched/echoed instead of re-GETting it.
+    // This does NOT change the wire POST sequence (same steps, same order, same bodies -- the
+    // probe-matrix-verified shape above is untouched); it only drops redundant verify-GETs.
+    // Clicks/navs invalidate the cache (they genuinely re-render + bump app.version), so the
+    // only HITs are provably-current reads: the actType write reusing the slot page step 2
+    // just fetched, the actionCancel version read reusing the actSubType echo, and the
+    // mainPage nav's version read reusing the selectActions render the prior nav returned.
+    Map cache = [:]
+
     // Open a new action slot on selectActions.
-    _rmClickAppButton(appId, "N", "doActN", "selectActions")
+    _rmClickAppButton(appId, "N", "doActN", "selectActions", cache)
 
     // Discover the index RM allocated (same pattern as _rmAddAction).
-    def ghostCfg = _rmFetchConfigJson(appId, "doActPage")
+    def ghostCfg = _rmFetchConfigJson(appId, "doActPage", cache)
     def ghostSchema = _rmCollectInputSchema(ghostCfg?.configPage)
     def ghostActTypeField = ghostSchema?.keySet()?.find { it.toString() ==~ /^actType\.\d+$/ }
     def ghostIdx = 1
@@ -8520,14 +8530,24 @@ private void _rmClearPredCapabsViaGhostIfThen(Integer appId, String caller) {
     // alone does not trigger the clear (Variant Z: condActs alone still broken).
     def ghostApplied = []
     def ghostSkipped = []
-    _rmWriteSettingOnPage(appId, "doActPage", "actType.${ghostIdx}", "condActs", ghostApplied, null, ghostSkipped)
-    _rmWriteSettingOnPage(appId, "doActPage", "actSubType.${ghostIdx}", "getIfThen", ghostApplied, null, ghostSkipped)
+    _rmWriteSettingOnPage(appId, "doActPage", "actType.${ghostIdx}", "condActs", ghostApplied, null, ghostSkipped, cache)
+    // actType=condActs reveals actSubType via submitOnChange, and that picker's POST echo can
+    // lag one render (no actSubType in the returned schema yet -- same class as the STPage
+    // cond/oper picker bug). A cache HIT is trusted as "provably current", so caching that
+    // lagged echo would make the next write skip as not_in_schema (_rmWriteSettingOnPage:4091)
+    // and silently leave predCapabs uncleared. Drop the cache so the actSubType write reads the
+    // settled page fresh.
+    _rmCacheInvalidate(cache, appId)
+    _rmWriteSettingOnPage(appId, "doActPage", "actSubType.${ghostIdx}", "getIfThen", ghostApplied, null, ghostSkipped, cache)
+    if (ghostSkipped.any { it?.key?.toString()?.startsWith("actSubType") && it?.reason == "not_in_schema" }) {
+        mcpLog("warn", "rm-native", "${caller}: ghost ifThen actSubType=getIfThen write was SKIPPED not_in_schema (${ghostSkipped}) for app ${appId} -- the actType->actSubType reveal echo lagged past the fresh re-read; predCapabs may NOT be cleared, so a later non-expression action could render under IF(Broken Condition).")
+    }
 
     // Cancel WITHOUT clicking actionDone. This discards the slot before
     // commit so no action is added to the rule, but the re-initialized
     // predCapabs state (from the getIfThen init) persists.
     // DO NOT replace with actionDone -- that bakes an empty IF() block.
-    _rmClickAppButton(appId, "actionCancel", null, "doActPage")
+    _rmClickAppButton(appId, "actionCancel", null, "doActPage", cache)
 
     // Return to selectActions to finalize the cancel, then navigate
     // back to mainPage. Without the mainPage nav, the app's server-side
@@ -8537,8 +8557,12 @@ private void _rmClearPredCapabsViaGhostIfThen(Integer appId, String caller) {
     // missing or not passing validation" on STPage. Without this nav,
     // STPage shows a validation error after addRequiredExpression completes;
     // with it, STPage opens cleanly.
-    _rmNavigateToPage(appId, "doActPage", "selectActions")
-    _rmNavigateToPage(appId, "selectActions", "mainPage")
+    def navBack = _rmNavigateToPage(appId, "doActPage", "selectActions", 0, "name", null, cache)
+    // A plain name-nav render carries no param-state, so it equals a live selectActions GET;
+    // _rmNavigateToPage deliberately doesn't self-store its render, so cache it here for the
+    // mainPage nav's version read (drops one more re-GET).
+    if (navBack?.configPage != null) _rmCacheStore(cache, appId, "selectActions", navBack)
+    _rmNavigateToPage(appId, "selectActions", "mainPage", 0, "name", null, cache)
 
     mcpLog("info", "rm-native", "${caller}: ghost ifThen clear fired for app ${appId} (clears atomicState.predCapabs without adding an action)")
 }

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -4073,18 +4073,24 @@ private Map _rmWriteSubPageField(Integer appId, String page, String parentPage, 
     def verifyFetchErr = null
     def parsedPost = hasRealParams ? null : _rmPagePostResponse(postResp)
     if (parsedPost != null) {
-        // Consume the inline echo for routing (no extra GET), but only CACHE it when it adds a
-        // NEW schema key -- a genuine forward advance. The echo for a wizard-consumed enum picker
-        // (STPage `oper`) lags one render behind: the gap `oper=AND` between conditions echoes
-        // [oper,doneST] (still the picker) while the settled page is the [cond,doneST] selector.
-        // Before the 3rd+ condition that lagged echo even DROPS keys (the expression-management
-        // buttons), so "schema differs" is too weak -- a key must be ADDED. Caching a
-        // non-advancing echo feeds the next write a schema missing its key, dropping the
-        // `<key>.type` sidecar so RM silently no-ops it (the multi-condition RE cond=a failure).
-        // A non-advancing echo invalidates so the next read re-fetches the settled page.
+        // Consume the inline echo for routing (no extra GET). Whether to CACHE it for the NEXT
+        // write has two traps, both from the condition-builder's submitOnChange pickers lagging
+        // one render behind their settled state:
+        //  (1) `oper` (the gap-operator between conditions AND the close-sub-expression operator)
+        //      NEVER has a trustworthy echo -- it can add the expression-management buttons while
+        //      still omitting the `oper`/`cond` field the next write needs. Never cache an `oper`
+        //      write; always re-fetch the settled page.
+        //  (2) For every other write, a lagged echo can DIFFER by only DROPPING keys (a subset),
+        //      which is not a forward advance -- so require a NEW key, not merely "schema differs".
+        // Caching a stale schema feeds the next write a page missing its key, so
+        // _rmBuildSettingsBody omits the `<key>.type` sidecar and RM silently no-ops the write --
+        // the multi-condition / sub-expression RE "rCapab_<N> not in STPage schema after cond=a"
+        // failures. A non-cacheable echo invalidates so the next read re-fetches the settled page.
+        // The hot path (single condition: no `oper` writes; field reveals all add a key) is
+        // unaffected, so the round-trip win stands.
         afterCfg = parsedPost
         def parsedPostKeys = (_rmCollectInputSchema(parsedPost?.configPage)?.keySet() ?: []) as Set
-        if (!(parsedPostKeys - beforeKeys).isEmpty()) {
+        if (key != "oper" && !(parsedPostKeys - beforeKeys).isEmpty()) {
             _rmCacheStore(cache, appId, page, parsedPost)
         } else {
             _rmCacheInvalidate(cache, appId)

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -4073,8 +4073,20 @@ private Map _rmWriteSubPageField(Integer appId, String page, String parentPage, 
     def verifyFetchErr = null
     def parsedPost = hasRealParams ? null : _rmPagePostResponse(postResp)
     if (parsedPost != null) {
-        _rmCacheStore(cache, appId, page, parsedPost)
+        // Consume the inline echo for routing (no extra GET), but only CACHE it when it
+        // DEMONSTRABLY advanced the schema. The dynamicPage echo lags one render behind for
+        // wizard-consumed enum pickers (STPage `oper`): it returns the pre-transition
+        // [oper,doneST] while the settled page is already [cond,doneST]. Caching that stale page
+        // makes the next write read a schema missing its key, drop the `<key>.type` sidecar, and
+        // silently no-op (the multi-condition RE cond=a failure). A non-advancing echo
+        // invalidates instead, so the next read re-fetches the settled page.
         afterCfg = parsedPost
+        def parsedPostKeys = (_rmCollectInputSchema(parsedPost?.configPage)?.keySet() ?: []) as Set
+        if (parsedPostKeys != beforeKeys) {
+            _rmCacheStore(cache, appId, page, parsedPost)
+        } else {
+            _rmCacheInvalidate(cache, appId)
+        }
     } else {
         _rmCacheInvalidate(cache, appId)
         try {
@@ -10023,15 +10035,11 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
                 writeST(hrefParams, "cond", "a", "cond")
                 cancelledByWalker = false
                 try {
-                    // Step 1: re-fetch STPage to discover the RM-assigned condition
-                    // slot index (cIdx). The cond=a write above causes RM to allocate
-                    // a new rCapab_<N>/rDev_<N>/... slot; N is firmware-assigned and
-                    // must be read from the schema rather than assumed. The cond=a POST
-                    // echo does NOT reliably show the new slot for a 2nd+ condition (it
-                    // renders the committed-view "cond,doneST"); a FRESH GET does. Invalidate
-                    // so this discovery read bypasses the cached write-echo and re-fetches the
-                    // settled schema live -- this is a genuine re-fetch, not a redundant read.
-                    _rmCacheInvalidate(rmCache, appId)
+                    // Step 1: discover the RM-assigned condition slot index (cIdx). The cond=a
+                    // write allocates a new rCapab_<N>/rDev_<N>/... slot (N firmware-assigned,
+                    // read from the schema). Its echo settles to the new-condition form and is
+                    // cached, so this read hits it -- no extra round-trip. The rCapab guard below
+                    // throws the actionable "got cond, doneST" dump if cond=a silently no-ops.
                     def navResp = _rmFetchConfigJson(appId, "STPage", rmCache)
                     def stInputs = (navResp?.configPage?.sections ?: []).collectMany { it?.input ?: [] }
                     def rCapabInput = stInputs.find { it?.name?.toString()?.startsWith("rCapab_") }

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -4288,6 +4288,11 @@ private Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = fal
     if (actionSpec.discover == true) {
         return _rmActionSchemaForDiscover()
     }
+    // If a preceding addRequiredExpression deferred its predCapabs clear (Step 4b), run it now -- before
+    // this action lands -- so the action isn't wrapped in IF(**Broken Condition**). Flag-gated + best-
+    // effort; a no-op when nothing is pending. Bulk addActions are safe: the first add clears the flag,
+    // so the rest short-circuit.
+    _rmRunPendingPredCapabsClear(appId)
     def cap = actionSpec.capability?.toString()?.trim()
     def action = actionSpec.action?.toString()?.trim()
     if (!cap) throw new IllegalArgumentException("addAction.capability is required (e.g. 'switch'). Common values: switch, dimmer, color, log, notification, mode, setVariable, runCommand, delay, repeat, ifThen. Pass {discover: true} to get the full structured schema.")
@@ -8567,6 +8572,26 @@ private void _rmClearPredCapabsViaGhostIfThen(Integer appId, String caller) {
     mcpLog("info", "rm-native", "${caller}: ghost ifThen clear fired for app ${appId} (clears atomicState.predCapabs without adding an action)")
 }
 
+// Just-in-time predCapabs clear. addRequiredExpression Step 4b no longer pays the ~9-round-trip ghost
+// ifThen up front (it would make the relay-504-prone RE build heavier for nothing when no action
+// follows); instead it flags the rule in atomicState.predClearPending. _rmAddAction calls this at its
+// entry: if the rule is flagged, fire the SAME ghost ifThen now -- before the action lands -- so the
+// action isn't wrapped in IF(**Broken Condition**), then drop the flag so it runs at most once.
+// Best-effort + idempotent: a clean predCapabs re-clears harmlessly, and a failed clear degrades to
+// the pre-deferral worst case (a possible IF(Broken Condition) wrap, surfaced as a warn).
+private void _rmRunPendingPredCapabsClear(Integer appId) {
+    def pending = atomicState.predClearPending ?: [:]
+    if (!pending[appId.toString()]) return
+    try {
+        _rmClearPredCapabsViaGhostIfThen(appId, "addAction (deferred from addRequiredExpression)")
+    } catch (Exception e) {
+        mcpLog("warn", "rm-native", "addAction: deferred predCapabs clear (ghost ifThen) failed for app ${appId} (${e.message ?: e.toString()}) -- this action may render under IF(**Broken Condition**); verify rule render or restore backup if needed")
+    }
+    def m = atomicState.predClearPending ?: [:]
+    m.remove(appId.toString())
+    atomicState.predClearPending = m
+}
+
 // Low-level reveal-step primitive for RM 5.1 progressive-disclosure wizard pages.
 //
 // Snapshot field names on a page, execute a trigger closure (button click or
@@ -9569,9 +9594,12 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
     // ---- Default path: enum / numeric device capabilities ----
     // Covers Switch, Motion, Contact, Lock, Temperature, Humidity, etc.
     // Write order: rCapab -> rDev_<N> -> rCustomAttr_<N> (if attribute set) ->
-    //              RelrDev_<N> (if comparator set; NO re-fetch needed here for non-CustomAttr
-    //              because state_<N> is already in the schema for numeric caps) ->
-    //              state_<N> -> hasAll.
+    //              RelrDev_<N> (if comparator set; for non-CustomAttr numeric caps RelrDev_<N> is
+    //              already exposed after rDev_<N>, so no re-fetch is needed before writing it -- but
+    //              state_<N> is NOT present yet: it is progressive-disclosure-gated behind RelrDev_<N>
+    //              and appears only after the comparator commits, so RelrDev+state cannot share a POST.
+    //              Live-probed 2026-06-21: at the RelrDev_<N> write the schema holds [rDev_<N>,
+    //              RelrDev_<N>], state_<N> absent) -> state_<N> -> hasAll.
     writeST(hrefParams, "rCapab_${cIdx}".toString(), capCanonical)
     if (cond.deviceIds != null) {
         writeST(hrefParams, "rDev_${cIdx}".toString(), cond.deviceIds)
@@ -9943,7 +9971,10 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
     // size-sensitive STPage read per replace. Standalone add callers leave it false.
     if (!skipExistingRECheck) {
         try {
-            def preNames = _rmCollectPageInputNames(appId, "STPage")
+            // Thread rmCache so this precheck's STPage GET warms the cache: nothing writes STPage
+            // between here and the walk's first writeST(cond,"a"), so that write's pre-fetch is a HIT
+            // instead of a second back-to-back GET of the same page (F2).
+            def preNames = _rmCollectPageInputNames(appId, "STPage", rmCache)
             // Add path uses the stricter three-field tell (cancelST+editST+stopOnST,
             // no inline new-condition selector) via _rmIsCommittedRETell(requireStopOnST=true).
             if (_rmIsCommittedRETell(preNames, true)) {
@@ -10233,28 +10264,26 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
     // evalOnBoot fields, which is correct for the Done-mode back-nav.
     _rmSubmitSubPageDone(appId, "STPage", "mainPage", "name", hrefParams, rmCache)
 
-    // Step 4b. Clear RM's residual condition-builder atomicState after
-    // the expression-builder hasRule click.
+    // Step 4b. DEFER the predCapabs clear to the next addAction (just-in-time).
     //
     // BACKGROUND:
-    //   The walkConds writes + hasRule seal leave atomicState.predCapabs in a
-    //   stale state that wraps subsequent addAction calls in
-    //   IF(**Broken Condition**).  _rmClearPredCapabsViaGhostIfThen fires the
-    //   ghost ifThen workaround (open condActs/getIfThen slot + actionCancel)
-    //   that resets predCapabs without leaving a visible action in the rule.
+    //   The walkConds writes + hasRule seal leave atomicState.predCapabs in a stale state that would
+    //   wrap a SUBSEQUENT addAction in IF(**Broken Condition**). The fix is the ghost ifThen workaround
+    //   (open condActs/getIfThen slot + actionCancel) -- but running it HERE costs ~9 hub round-trips on
+    //   every RE build even when no action follows, and the multi-condition RE build is already heavy
+    //   enough to time out the cloud relay. So we DEFER it: flag the rule, and _rmAddAction runs the
+    //   EXACT same _rmClearPredCapabsViaGhostIfThen just-in-time, before the next action lands.
+    //   predCapabs is STILL cleared (the probe-matrix contract -- groups A / A-seal / A-extended --
+    //   holds; only the timing moves), so this is NOT a removal of the clear.
     //
-    //   See _rmClearPredCapabsViaGhostIfThen Groovydoc for the full mechanistic
-    //   rationale.  DO NOT remove this call without re-running the full probe
-    //   matrix (probes in groups A, A-seal, and A-extended are the regression
-    //   gates).
-    try {
-        _rmClearPredCapabsViaGhostIfThen(appId, "addRequiredExpression")
-    } catch (Exception ghostExc) {
-        // Best-effort: if the ghost ifThen sequence fails, subsequent addAction
-        // calls MAY produce IF(**Broken Condition**) wrapping. The RE itself
-        // is fully committed -- this only affects the next addAction.
-        mcpLog("warn", "rm-native", "addRequiredExpression: ghost ifThen clear failed for app ${appId} (${ghostExc.message ?: ghostExc.toString()}) -- subsequent addAction may produce IF(**Broken Condition**) wrapper (ghost IF/THEN wrap detected after Required Expression commit); verify rule render or restore backup if needed")
-    }
+    //   Routing is safe to leave here: Step 3b's doneST already put STPage in Done mode (cond no longer
+    //   required=true), and the "Required Fields missing / not passing validation" popup is a
+    //   required-FIELDS check (appUI.js:559-563 empty required device buttons / 700-701 errorCount),
+    //   NOT a routing/editAct check -- so STPage opens cleanly without the ghost ifThen. (The helper's
+    //   old "routing reset" comment only undid the ghost ifThen's OWN nav to doActPage.)
+    def _predPending = atomicState.predClearPending ?: [:]
+    _predPending[appId.toString()] = true
+    atomicState.predClearPending = _predPending
 
     // Step 5. Post-commit validation. RM 5.1's STPage silently accepts
     // many invalid inputs at the field-write level (e.g. unknown device
@@ -10387,8 +10416,8 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
 // existing-RE edit-mode detection and the replace-RE delete-verification so
 // both read the page through the identical lens (a committed RE renders the
 // cancelST/editST controls, a deleted one no longer shows them).
-private Set _rmCollectPageInputNames(Integer appId, String pageName) {
-    def cfg = _rmFetchConfigJson(appId, pageName)
+private Set _rmCollectPageInputNames(Integer appId, String pageName, Map cache = null) {
+    def cfg = _rmFetchConfigJson(appId, pageName, cache)
     return (cfg?.configPage?.sections ?: []).collectMany { sec ->
         (sec?.input ?: []).collect { it?.name?.toString() }
     }.findAll { it } as Set

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -3751,7 +3751,7 @@ private Map _rmMoveAction(Integer appId, Integer actionIdx, String direction) {
 // The body is intentionally minimal — the server only needs the
 // navigation marker to perform the transition. We don't need to mirror
 // every hidden button input on the source page.
-private Map _rmNavigateToPage(Integer appId, String fromPage, String targetPage, Integer hrefIndex = 0, String hrefName = "name", Map hrefParams = null) {
+private Map _rmNavigateToPage(Integer appId, String fromPage, String targetPage, Integer hrefIndex = 0, String hrefName = "name", Map hrefParams = null, Map cache = null) {
     // For plain page navigation use hrefName="name" + hrefIndex=0. The
     // server treats the marker `_action_href_name|<page>|0` as a generic
     // navigation request.
@@ -3787,7 +3787,7 @@ private Map _rmNavigateToPage(Integer appId, String fromPage, String targetPage,
         body[paramsMarker] = groovy.json.JsonOutput.toJson(hrefParams)
     }
     try {
-        def cfg = _rmFetchConfigJson(appId, fromPage)
+        def cfg = _rmFetchConfigJson(appId, fromPage, cache)
         def v = cfg?.app?.version
         if (v != null) body.version = v.toString()
     } catch (Exception versionExc) {
@@ -3795,6 +3795,10 @@ private Map _rmNavigateToPage(Integer appId, String fromPage, String targetPage,
     }
     try {
         def resp = hubInternalPostForm("/installedapp/update/json", body)
+        // This nav POST re-renders the target page + bumps app.version -> drop cached pages for
+        // this app. We do NOT store the returned render: the caller consumes navResp.configPage
+        // directly, and it carries state.<paramKey> context a later plain GET would not.
+        _rmCacheInvalidate(cache, appId)
         if (resp?.data) {
             try {
                 return new groovy.json.JsonSlurper().parseText(resp.data) as Map
@@ -3848,15 +3852,15 @@ private Map _rmLiveSettingsFromStatus(Map status) {
 // for sub-page-driven capabilities (Periodic Schedule, Cron String,
 // etc.). Caller passes the current page name + parent page + the href
 // params (so paramsForPage routes correctly).
-private void _rmSubmitSubPageDone(Integer appId, String page, String parentPage, String hrefName, Map hrefParams) {
+private void _rmSubmitSubPageDone(Integer appId, String page, String parentPage, String hrefName, Map hrefParams, Map cache = null) {
     // Sub-pages with route params (periodic.n, etc.) lose state.<paramKey>
     // on a plain GET — `_rmFetchConfigJson(appId, page)` returns the page
     // rendered with state=null, which means the schema is empty/wrong and
     // the version field is unreadable. Round-trip via _rmNavigateToPage to
     // get a fresh response that has the param state in scope.
     def hrefIndex = hrefParams?.n != null ? (hrefParams.n as Integer) : 0
-    def navResp = _rmNavigateToPage(appId, parentPage ?: page, page, hrefIndex, hrefName ?: "name", hrefParams)
-    def cfg = navResp ? [configPage: navResp.configPage, app: navResp.app] : _rmFetchConfigJson(appId, page)
+    def navResp = _rmNavigateToPage(appId, parentPage ?: page, page, hrefIndex, hrefName ?: "name", hrefParams, cache)
+    def cfg = navResp ? [configPage: navResp.configPage, app: navResp.app] : _rmFetchConfigJson(appId, page, cache)
     def schema = _rmCollectInputSchema(cfg?.configPage)
     def status = _rmFetchStatusJson(appId)
     def liveSettings = _rmLiveSettingsFromStatus(status)
@@ -3908,6 +3912,8 @@ private void _rmSubmitSubPageDone(Integer appId, String page, String parentPage,
     //     (log-only) -- best-effort cleanup, the following updateRule handles the commit.
     // Catching inside the helper would erase all three distinctions, so it does not.
     hubInternalPostForm("/installedapp/update/json", body)
+    // The Done POST commits the sub-page + bumps app.version -> drop cached pages for this app.
+    _rmCacheInvalidate(cache, appId)
 }
 
 // Submit mainPage with `_action_update: Done` — mirrors clicking the
@@ -4020,7 +4026,7 @@ private Map _rmSubmitMainPageDone(Integer appId) {
     return [done: true]
 }
 
-private Map _rmWriteSubPageField(Integer appId, String page, String parentPage, String hrefName, Integer hrefIndex, Map hrefParams, String key, Object value) {
+private Map _rmWriteSubPageField(Integer appId, String page, String parentPage, String hrefName, Integer hrefIndex, Map hrefParams, String key, Object value, Map cache = null) {
     // For pages with meaningful state.<paramKey> (e.g. periodic schedule's
     // state.n), schema requires the navigate response to set state in scope.
     // For pages with placeholder hrefParams (STPage uses [unUsed: null]),
@@ -4031,10 +4037,10 @@ private Map _rmWriteSubPageField(Integer appId, String page, String parentPage, 
     def hasRealParams = (hrefParams != null) && hrefParams.values().any { it != null }
     def cfg
     if (hasRealParams) {
-        def navResp = _rmNavigateToPage(appId, parentPage ?: page, page, hrefIndex, hrefName, hrefParams)
-        cfg = navResp ? [configPage: navResp.configPage, app: navResp.app] : _rmFetchConfigJson(appId, page)
+        def navResp = _rmNavigateToPage(appId, parentPage ?: page, page, hrefIndex, hrefName, hrefParams, cache)
+        cfg = navResp ? [configPage: navResp.configPage, app: navResp.app] : _rmFetchConfigJson(appId, page, cache)
     } else {
-        cfg = _rmFetchConfigJson(appId, page)
+        cfg = _rmFetchConfigJson(appId, page, cache)
     }
     def schema = _rmCollectInputSchema(cfg?.configPage)
     def beforeKeys = (schema?.keySet() ?: []) as Set
@@ -4054,21 +4060,29 @@ private Map _rmWriteSubPageField(Integer appId, String page, String parentPage, 
     // not via re-firing the action_href on every write.
     body.pageBreadcrumbs = '[]'
     if (cfg?.app?.version != null) body.version = cfg.app.version.toString()
-    hubInternalPostForm("/installedapp/update/json", body)
-    // Post-write verification — re-fetch the page and detect whether the
-    // write either (a) shifted the schema (wizard advanced; key disappeared
-    // or new keys appeared), or (b) landed the new value verbatim. Returns
-    // a Map so callers can route into applied vs skipped lists rather than
-    // optimistically appending to applied regardless of outcome (RM 5.1
-    // returns 200 for many writes that never land; the previous optimistic
-    // bookkeeping hid these silent rejections).
+    def postResp = hubInternalPostForm("/installedapp/update/json", body)
+    // Post-write verification. The classic dynamicPage submit RETURNS the re-rendered page model
+    // inline (appUI.js jsonSubmit consumes data.configPage with NO follow-up GET), so on the
+    // plain-params path (STPage/doActPage condition writes — the hot path) we consume that
+    // response as afterCfg, eliminating the separate verify-GET. The hasRealParams path keeps its
+    // re-navigate so the state.<paramKey> render context (periodic schedule's state.n) is
+    // preserved exactly. Either way afterCfg drives the same schema/value/render diff below
+    // (applied vs silently-rejected). RM 5.1 returns 200 for many writes that never land, so the
+    // diff — not the POST status — is what routes applied vs skipped.
     def afterCfg = null
     def verifyFetchErr = null
-    try {
-        afterCfg = hasRealParams ? _rmNavigateToPage(appId, parentPage ?: page, page, hrefIndex, hrefName, hrefParams) : _rmFetchConfigJson(appId, page)
-    } catch (Exception fetchExc) {
-        verifyFetchErr = fetchExc.message
-        mcpLog("warn", "rm-native", "_rmWriteSubPageField: post-write fetch on ${page} failed for app ${appId} key=${key} (${fetchExc.message}) -- write status is unverified")
+    def parsedPost = hasRealParams ? null : _rmPagePostResponse(postResp)
+    if (parsedPost != null) {
+        _rmCacheStore(cache, appId, page, parsedPost)
+        afterCfg = parsedPost
+    } else {
+        _rmCacheInvalidate(cache, appId)
+        try {
+            afterCfg = hasRealParams ? _rmNavigateToPage(appId, parentPage ?: page, page, hrefIndex, hrefName, hrefParams, cache) : _rmFetchConfigJson(appId, page, cache)
+        } catch (Exception fetchExc) {
+            verifyFetchErr = fetchExc.message
+            mcpLog("warn", "rm-native", "_rmWriteSubPageField: post-write fetch on ${page} failed for app ${appId} key=${key} (${fetchExc.message}) -- write status is unverified")
+        }
     }
     if (afterCfg == null) {
         // Verification fetch failed OR returned null. We CANNOT confirm
@@ -8601,13 +8615,13 @@ private void _rmWriteMathOperand(Integer appId, int idx, Object operandValue, St
     }
 }
 
-private Map _rmRevealStep(Integer appId, String page, String pattern, Closure trigger) {
-    def preCfg = _rmFetchConfigJson(appId, page)
+private Map _rmRevealStep(Integer appId, String page, String pattern, Closure trigger, Map cache = null) {
+    def preCfg = _rmFetchConfigJson(appId, page, cache)
     def preNames = (preCfg?.configPage?.sections ?: []).collectMany { sec ->
         (sec?.input ?: []).collect { it?.name?.toString() }
     }.findAll { it } as Set
     trigger.call()
-    def postCfg = _rmFetchConfigJson(appId, page)
+    def postCfg = _rmFetchConfigJson(appId, page, cache)
     def postInputs = (postCfg?.configPage?.sections ?: []).collectMany { sec ->
         (sec?.input ?: [])
     }
@@ -8715,6 +8729,10 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
         throw new IllegalArgumentException("_rmWalkConditionReveal requires ctx.skipped (the caller's settingsSkipped List) -- the walker records degradation skips into it. Pass skipped: <list>.")
     }
     def page                  = ctx.page?.toString() ?: "STPage"
+    // Request-scoped page-schema cache threaded from the builder (null when absent). Passed into
+    // every reveal/fetch/click below: reveal pre-fetches HIT the prior write's cached POST
+    // response, and every click invalidates the app's cached pages.
+    def cache                 = ctx.cache as Map
     // _rmRevealStep returns fallbackToExisting=true when only revealedAny matched (a
     // matching field was already visible BEFORE the trigger closure ran). On static-schema
     // firmware this is normal; on progressive-disclosure firmware it can mask a silent
@@ -8731,7 +8749,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
     // Empty-trigger callers use the discoverField() helper below which routes through
     // _rmRevealStep directly without the sentinel push.
     def revealStep = { Integer aId, String pg, String pattern, Closure trigger ->
-        def step = _rmRevealStep(aId, pg, pattern, trigger)
+        def step = _rmRevealStep(aId, pg, pattern, trigger, cache)
         // skippedAccum is non-null (guarded at entry).
         if (step?.fallbackToExisting == true) {
             skippedAccum << [key: pattern, reason: "reveal_fallback_to_existing_field", condIdx: condIdx]
@@ -8742,7 +8760,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
     // Same return shape as revealStep but does NOT push the reveal-fallback sentinel
     // (these calls are by design discovery-only and would emit false positives).
     def discoverField = { Integer aId, String pg, String pattern ->
-        return _rmRevealStep(aId, pg, pattern, {})
+        return _rmRevealStep(aId, pg, pattern, {}, cache)
     }
 
     // ---- Pre-walker guard: discrete-event sensor capabilities ----
@@ -8844,7 +8862,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
         if (cond.rawSettings instanceof Map) {
             (cond.rawSettings as Map).each { rk, rv -> writeST(hrefParams, rk.toString(), rv) }
         }
-        _rmClickAppButton(appId, "hasAll", null, page)
+        _rmClickAppButton(appId, "hasAll", null, page, cache)
         return
     }
 
@@ -8989,7 +9007,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
         if (cond.rawSettings instanceof Map) {
             (cond.rawSettings as Map).each { rk, rv -> writeST(hrefParams, rk.toString(), rv) }
         }
-        _rmClickAppButton(appId, "hasAll", null, page)
+        _rmClickAppButton(appId, "hasAll", null, page, cache)
         return
     }
 
@@ -9113,7 +9131,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
             if (cond.rawSettings instanceof Map) {
                 (cond.rawSettings as Map).each { rk, rv -> writeST(hrefParams, rk.toString(), rv) }
             }
-            _rmClickAppButton(appId, "hasAll", null, page)
+            _rmClickAppButton(appId, "hasAll", null, page, cache)
             return
         }
 
@@ -9151,7 +9169,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
         if (cond.rawSettings instanceof Map) {
             (cond.rawSettings as Map).each { rk, rv -> writeST(hrefParams, rk.toString(), rv) }
         }
-        _rmClickAppButton(appId, "hasAll", null, page)
+        _rmClickAppButton(appId, "hasAll", null, page, cache)
         return
     }
 
@@ -9235,7 +9253,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
                 if (cond.rawSettings instanceof Map) {
                     (cond.rawSettings as Map).each { rk, rv -> writeST(hrefParams, rk.toString(), rv) }
                 }
-                _rmClickAppButton(appId, "hasAll", null, page)
+                _rmClickAppButton(appId, "hasAll", null, page, cache)
                 return
             }
             if (relrReveal.input) {
@@ -9318,7 +9336,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
         if (cond.rawSettings instanceof Map) {
             (cond.rawSettings as Map).each { rk, rv -> writeST(hrefParams, rk.toString(), rv) }
         }
-        _rmClickAppButton(appId, "hasAll", null, page)
+        _rmClickAppButton(appId, "hasAll", null, page, cache)
         return
     }
 
@@ -9406,7 +9424,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
         // lingering sibling slot would let a loose-find write land in another condition's
         // RelrDev_<other> (writeST verifies the wrong-but-valid field as applied, so the
         // mistake is silent). The exact-key write mirrors the offset state_<cIdx> anchor.
-        def afterBaseFields = _rmFetchConfigJson(appId, page)
+        def afterBaseFields = _rmFetchConfigJson(appId, page, cache)
         def afterBaseInputs = (afterBaseFields?.configPage?.sections ?: []).collectMany { it?.input ?: [] }
         def relrKey = "RelrDev_${cIdx}".toString()
         def relrInput = afterBaseInputs.find { it?.name?.toString() ==~ /RelrDev_\d+/ }
@@ -9501,7 +9519,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
         if (cond.rawSettings instanceof Map) {
             (cond.rawSettings as Map).each { rk, rv -> writeST(hrefParams, rk.toString(), rv) }
         }
-        _rmClickAppButton(appId, "hasAll", null, page)
+        _rmClickAppButton(appId, "hasAll", null, page, cache)
         return
     }
 
@@ -9555,7 +9573,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
             // second probe re-fetch (which would be both redundant and a fresh abort risk).
             def afterAttrInputs = null
             try {
-                def afterCfg = _rmFetchConfigJson(appId, page)
+                def afterCfg = _rmFetchConfigJson(appId, page, cache)
                 afterAttrInputs = (afterCfg?.configPage?.sections ?: []).collectMany { it?.input ?: [] }
             } catch (Exception revealEx) {
                 mcpLog("warn", "rm-native", "conditions[${condIdx}]: Custom Attribute (default block): exposure-probe re-fetch after rCustomAttr_${cIdx} failed for app ${appId} on page ${page} (${revealEx.message ?: revealEx}); force-writing comparator RelrDev_${cIdx} as fallback (partial)")
@@ -9635,7 +9653,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
     // threshold) is the alias for Custom Attribute and numeric comparator paths.
     def condStateOrValue = cond.state != null ? cond.state : cond.value
     if (condStateOrValue != null) {
-        def stateNavResp = _rmFetchConfigJson(appId, page)
+        def stateNavResp = _rmFetchConfigJson(appId, page, cache)
         def stateInputs = (stateNavResp?.configPage?.sections ?: []).collectMany { it?.input ?: [] }
         def stateInput = stateInputs.find { it?.name?.toString() == "state_${cIdx}".toString() }
         if (stateInput?.options) {
@@ -9657,7 +9675,7 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
             writeST(hrefParams, rk.toString(), rv)
         }
     }
-    _rmClickAppButton(appId, "hasAll", null, page)
+    _rmClickAppButton(appId, "hasAll", null, page, cache)
 }
 
 // Validate a Required Expression spec's pure INPUT SHAPE -- the checks that
@@ -9829,8 +9847,13 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
     // based on the helper's persistence verification (Map return). Use this
     // for every STPage wizard field write so silent rejections are caught
     // and surfaced rather than optimistically claimed as applied.
+    // Request-scoped page-schema cache: each field write's POST response populates it (see
+    // _rmWriteSubPageField / _rmCacheStore), so reveal pre-fetches HIT it instead of re-GETting an
+    // unchanged STPage, and every write helper invalidates it on its POST. Threaded through writeST,
+    // the walker (ctx.cache), and every fetch/click/navigate below. Lives only for this build.
+    def rmCache = [:]
     def writeST = { Map params, String fieldKey, Object fieldValue, String label = null ->
-        def wr = _rmWriteSubPageField(appId, "STPage", "mainPage", "name", 0, params, fieldKey, fieldValue)
+        def wr = _rmWriteSubPageField(appId, "STPage", "mainPage", "name", 0, params, fieldKey, fieldValue, rmCache)
         if (wr?.persisted) {
             applied << (label ?: fieldKey)
         } else if (wr?.verifyFetchFailed) {
@@ -9852,7 +9875,7 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
     // so it does not flip partial on an otherwise-clean expression (e.g. a clean
     // enum Custom Attribute condition). Other useST failures keep their reason.
     int skippedBeforeUseST = skipped.size()
-    _rmWriteSettingOnPage(appId, "mainPage", "useST", true, applied, "bool", skipped)
+    _rmWriteSettingOnPage(appId, "mainPage", "useST", true, applied, "bool", skipped, rmCache)
     if (skipped.size() > skippedBeforeUseST) {
         def useStSkip = skipped[skippedBeforeUseST]
         if (useStSkip instanceof Map && useStSkip.key == "useST" && useStSkip.reason == "silent_rejection") {
@@ -9921,7 +9944,7 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
     def currentCondIdx = -1
     def cancelInFlightCondition = {
         cancelledByWalker = true
-        try { _rmClickAppButton(appId, "cancelCapab", null, "STPage") }
+        try { _rmClickAppButton(appId, "cancelCapab", null, "STPage", rmCache) }
         catch (Exception cancelExc) {
             wizardCleanupFailed = true
             wizardCleanupErr = cancelExc.message
@@ -10004,7 +10027,7 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
                     // slot index (cIdx). The cond=a write above causes RM to allocate
                     // a new rCapab_<N>/rDev_<N>/... slot; N is firmware-assigned and
                     // must be read from the schema rather than assumed.
-                    def navResp = _rmFetchConfigJson(appId, "STPage")
+                    def navResp = _rmFetchConfigJson(appId, "STPage", rmCache)
                     def stInputs = (navResp?.configPage?.sections ?: []).collectMany { it?.input ?: [] }
                     def rCapabInput = stInputs.find { it?.name?.toString()?.startsWith("rCapab_") }
                     if (!rCapabInput) {
@@ -10040,7 +10063,8 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
                         capCanonical: capCanonical,
                         hrefParams: hrefParams,
                         applied: applied,
-                        skipped: skipped
+                        skipped: skipped,
+                        cache: rmCache
                     ], cond, cIdx)
                     for (int sIdx = skippedBefore; sIdx < skipped.size(); sIdx++) {
                         def sEntry = skipped[sIdx]
@@ -10148,7 +10172,7 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
     //   Wire format: POST /installedapp/btn with settings[doneST]=clicked,
     //   stateAttribute=doneST, doneST.type=button, pageBreadcrumbs=["mainPage"].
     try {
-        _rmClickAppButton(appId, "doneST", "doneST", "STPage")
+        _rmClickAppButton(appId, "doneST", "doneST", "STPage", rmCache)
     } catch (Exception doneStExc) {
         // doneST click failure is non-fatal for the formula itself -- the RE
         // is fully committed. It only means the browser may show the
@@ -10163,7 +10187,7 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
     // After Step 3b, STPage is in Done mode (cond not required); the schema
     // sent by _rmSubmitSubPageDone now reflects editST/cancelST/stopOnST/
     // evalOnBoot fields, which is correct for the Done-mode back-nav.
-    _rmSubmitSubPageDone(appId, "STPage", "mainPage", "name", hrefParams)
+    _rmSubmitSubPageDone(appId, "STPage", "mainPage", "name", hrefParams, rmCache)
 
     // Step 4b. Clear RM's residual condition-builder atomicState after
     // the expression-builder hasRule click.
@@ -10202,7 +10226,7 @@ private Map _rmAddRequiredExpression(Integer appId, Map exprSpec, boolean preVal
     // Set verificationFetchFailed=true and return success=false instead.
     def mainCfg = null
     def verificationFetchFailed = false
-    try { mainCfg = _rmFetchConfigJson(appId, "mainPage") }
+    try { mainCfg = _rmFetchConfigJson(appId, "mainPage", rmCache) }
     catch (Exception verifyExc) {
         verificationFetchFailed = true
         mcpLog("warn", "rm-native", "addRequiredExpression: post-commit mainPage fetch failed for app ${appId} (${verifyExc.message}) -- cannot verify expression baked; returning verificationFetchFailed=true")

--- a/src/test/groovy/server/ReplaceRequiredExpressionSpec.groovy
+++ b/src/test/groovy/server/ReplaceRequiredExpressionSpec.groovy
@@ -643,7 +643,10 @@ class ReplaceRequiredExpressionSpec extends ToolSpecBase {
         def restored = [false]
         registerHelperPages(phase, null, restored)
         def restoreFileRead = installRestoreDownload(restored)
-        script.metaClass._rmClickAppButton = { Integer aId, String name, String stateAttr = null, String pageName = null ->
+        // _rmClickAppButton now takes a trailing cache param (the page-schema cache threaded by
+        // the RM condition builders); the stub must accept it or the 5-arg production call won't
+        // match this override and the REAL click runs (no cancelCapab throw -> no wizardStuck).
+        script.metaClass._rmClickAppButton = { Integer aId, String name, String stateAttr = null, String pageName = null, Map cache = null ->
             if (name == "cancelST") { phase[0] = 1; return [status: 200, location: null, data: ''] }
             if (name == "cancelCapab") throw new RuntimeException("cancelCapab POST refused (status=400)")
             [status: 200, location: null, data: '']

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -1848,6 +1848,349 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         !atomicStateMap.predClearPending?.get("100")
     }
 
+    // doActPage schema that serves BOTH the deferred ghost-ifThen clear AND a real log
+    // action's own writes off the same stub: the ghost needs actType.N=condActs +
+    // actSubType.N=getIfThen + actionCancel; the log action needs actType.N=messageActs +
+    // actSubType.N=getLogMsg + logmsg.N + actionDone. Incrementing paragraphs make every
+    // _rmWriteSettingOnPage observe a render shift so writes route applied (not skipped),
+    // but the seam test only asserts POST ORDER, so applied-vs-skipped is immaterial here.
+    private String doActPageGhostAndLogSchemaJson(int ruleId, int seqNum) {
+        JsonOutput.toJson([
+            app: [id: ruleId, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                  appType: [name: "Rule-5.1", namespace: "hubitat"]],
+            configPage: [name: "doActPage", title: "T", install: false, error: null,
+                         sections: [[title: "", input: [
+                             [name: "actType.1", type: "enum",
+                              options: ["condActs": "Conditional Actions", "messageActs": "Messaging and Logging"]],
+                             [name: "actSubType.1", type: "enum",
+                              options: ["getIfThen": "IF Expression THEN", "getLogMsg": "Log a message"]],
+                             [name: "logmsg.1", type: "textarea"],
+                             [name: "actionCancel", type: "button"],
+                             [name: "actionDone", type: "button"]
+                         ], paragraphs: ["seq ${seqNum}".toString()]]]],
+            settings: [:],
+            childApps: []
+        ])
+    }
+
+    def "seam: _rmAddAction fires the deferred predCapabs clear at its entry (ghost POSTs precede the action's own writes; flag dropped)"() {
+        // TEST A. Pins the _rmAddAction entry seam (lib ~4295): a real (non-discover) addAction
+        // calls _rmRunPendingPredCapabsClear FIRST, so the deferred ghost ifThen sequence
+        // (condActs/getIfThen + actionCancel) lands on the wire BEFORE the action bakes its own
+        // doActPage writes (messageActs/getLogMsg), and the predClearPending flag is consumed.
+        given:
+        enableWrite()
+        def fetchSeq = 0
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params ->
+            ruleConfigJson(100, "r", [[name: "N", type: "button"]])
+        }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params ->
+            fetchSeq++
+            doActPageGhostAndLogSchemaJson(100, fetchSeq)
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        // A preceding addRequiredExpression flagged the rule (Step 4b deferral).
+        atomicStateMap.predClearPending = ["100": true]
+
+        when: "a real (non-discover) addAction runs while the rule is flagged"
+        script._rmAddAction(100, [capability: "log", message: "seam"])
+
+        then: "(a) the ghost clear's condActs/getIfThen + actionCancel land BEFORE the action's own messageActs write"
+        // Index of the ghost's distinctive getIfThen write (unique to _rmClearPredCapabsViaGhostIfThen).
+        def ghostGetIfThenIdx = posts.findIndexOf { it.path == "/installedapp/update/json" &&
+            it.body?.any { k, v -> k?.toString()?.startsWith("settings[actSubType.") && v == "getIfThen" } }
+        // Index of the ghost's actionCancel (NOT actionDone) -- the slot is discarded, never baked.
+        def ghostCancelIdx = posts.findIndexOf { it.path == "/installedapp/btn" && it.body?.name == "actionCancel" }
+        // Index of the ACTION's own actType write (messageActs is unique to the log action, not the ghost).
+        def actionTypeIdx = posts.findIndexOf { it.path == "/installedapp/update/json" &&
+            it.body?.any { k, v -> k?.toString()?.startsWith("settings[actType.") && v == "messageActs" } }
+
+        ghostGetIfThenIdx >= 0
+        ghostCancelIdx >= 0
+        actionTypeIdx >= 0
+        ghostGetIfThenIdx < actionTypeIdx
+        ghostCancelIdx < actionTypeIdx
+
+        and: "the ghost never bakes a slot of its own (no actionDone before the action's own writes)"
+        // The first actionDone in the stream, if any, belongs to the ACTION (its bake), never the ghost clear.
+        def firstActionDoneIdx = posts.findIndexOf { it.path == "/installedapp/btn" && it.body?.name == "actionDone" }
+        firstActionDoneIdx < 0 || firstActionDoneIdx > ghostCancelIdx
+
+        and: "(b) the predClearPending flag was consumed -- the deferred clear fires at most once"
+        !atomicStateMap.predClearPending?.get("100")
+    }
+
+    def "seam: _rmAddAction discover mode never touches the hub and leaves the deferred flag intact"() {
+        // TEST A, second case. The discover early-return (lib ~4288) sits ABOVE the
+        // _rmRunPendingPredCapabsClear call (~4295): a {discover:true} probe returns the static
+        // schema with ZERO hub POSTs and MUST NOT consume the pending flag -- a schema probe is
+        // not an action, so it can't be allowed to fire (or eat) the just-in-time clear.
+        given:
+        enableWrite()
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        atomicStateMap.predClearPending = ["100": true]
+
+        when: "a discover-mode probe runs while the rule is flagged"
+        def schema = script._rmAddAction(100, [discover: true])
+
+        then: "discover returned a schema without issuing any hub POST"
+        schema != null
+        posts.isEmpty()
+
+        and: "the pending flag is untouched -- discover neither fires nor consumes the deferred clear"
+        atomicStateMap.predClearPending?.get("100") == true
+    }
+
+    def "seam: bulk addActions fires the deferred ghost clear exactly once (first add drops the flag, the rest short-circuit)"() {
+        // TEST A, third case. Two sequential _rmAddAction calls under one pending flag: the first
+        // add runs the ghost clear and consumes the flag; the second add's entry-call to
+        // _rmRunPendingPredCapabsClear sees no flag and short-circuits, so the ~9-round-trip ghost
+        // ifThen sequence fires EXACTLY ONCE across the whole bulk add (the lib ~4293 invariant).
+        given:
+        enableWrite()
+        def fetchSeq = 0
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params ->
+            ruleConfigJson(100, "r", [[name: "N", type: "button"]])
+        }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params ->
+            fetchSeq++
+            doActPageGhostAndLogSchemaJson(100, fetchSeq)
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+        atomicStateMap.predClearPending = ["100": true]
+
+        when: "two actions are added back-to-back (the bulk addActions shape: sequential _rmAddAction)"
+        script._rmAddAction(100, [capability: "log", message: "first"], true)
+        script._rmAddAction(100, [capability: "log", message: "second"], true)
+
+        then: "the ghost ifThen getIfThen write fired EXACTLY ONCE across both adds"
+        def ghostGetIfThenWrites = posts.count { it.path == "/installedapp/update/json" &&
+            it.body?.any { k, v -> k?.toString()?.startsWith("settings[actSubType.") && v == "getIfThen" } }
+        ghostGetIfThenWrites == 1
+
+        and: "the ghost actionCancel likewise fired exactly once (the clear is not re-run per action)"
+        posts.count { it.path == "/installedapp/btn" && it.body?.name == "actionCancel" } == 1
+
+        and: "the flag is consumed after the first add"
+        !atomicStateMap.predClearPending?.get("100")
+    }
+
+    // ---------- cached cond=a echo: discovery read hits the request cache (no extra STPage GET) ----------
+
+    def "cached cond=a echo: the rCapab discovery read HITs the request cache, no extra STPage GET"() {
+        // TEST E (fuller walker variant). Guards lib ~10105: after the walker writes cond=a via
+        // _rmWriteSubPageField (plain-params path), the POST's inline page echo -- which carries the
+        // freshly-allocated rCapab_<N> slot -- is stored in the request cache via _rmCacheStore. The
+        // very next _rmFetchConfigJson(appId, "STPage", rmCache) that discovers the condition slot
+        // index (cIdx) MUST resolve off that cached echo, issuing NO additional live STPage GET. This
+        // is the round-trip win the PR depends on; a regression that invalidated the cond=a echo would
+        // re-fetch here and re-introduce a round-trip per condition.
+        //
+        // This is the FULLER walker variant requested: it drives the real cond=a write primitive
+        // (_rmWriteSubPageField, exactly as the STPage walker's writeST closure does) plus the real
+        // discovery read (_rmFetchConfigJson), so the cache contract is exercised end-to-end through
+        // production code rather than asserted directly on _rmCacheStore.
+        given:
+        enableWrite()
+        int getCount = 0
+        // The live STPage GET (cache MISS path). If the discovery read ever issues a live GET, this
+        // increments -- the negative assertion below catches it. rCapab_7 to prove cIdx parses off the echo.
+        hubGet.register('/installedapp/configure/json/100/STPage') { params ->
+            getCount++
+            ruleConfigJson(100, "r", [
+                [name: "cond", type: "enum", options: ["a": "New condition", "b": "( sub-expression"]],
+                [name: "rCapab_7", type: "enum", options: ["Switch", "Contact", "Motion"]],
+                [name: "doneST", type: "button"]
+            ])
+        }
+        // The cond=a write's inline POST echo: the SETTLED new-condition page carrying the allocated
+        // rCapab_7 slot. _rmWriteSubPageField stores this in the cache via _rmCacheStore, so the
+        // discovery read that follows is a HIT. (Same echo-construction idiom as the ~1573 sidecar test.)
+        def condAEchoPage = [
+            [name: "cond", type: "enum", options: ["a": "New condition", "b": "( sub-expression"]],
+            [name: "rCapab_7", type: "enum", options: ["Switch", "Contact", "Motion"]],
+            [name: "rDev_7", type: "capability.sensor", multiple: true],
+            [name: "doneST", type: "button"]
+        ]
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            // Inline page echo = the post-write re-rendered STPage carrying rCapab_7.
+            [status: 200, location: null, data: ruleConfigJson(100, "r", condAEchoPage)]
+        }
+
+        when: "the walker writes cond=a (plain-params STPage write, exactly as writeST does), then discovers cIdx"
+        def rmCache = [:]
+        // _rmWriteSubPageField with all-null hrefParams takes the plain-GET path and consumes the
+        // inline echo into the cache -- this is the production cond=a write primitive.
+        script._rmWriteSubPageField(100, "STPage", "mainPage", "name", 0, [unUsed: null], "cond", "a", rmCache)
+        int getsAfterCondWrite = getCount
+        // The discovery read (lib ~10105): resolves the rCapab_<N> slot off the cached cond=a echo.
+        def navResp = script._rmFetchConfigJson(100, "STPage", rmCache)
+        def stInputs = (navResp?.configPage?.sections ?: []).collectMany { it?.input ?: [] }
+        def rCapabInput = stInputs.find { it?.name?.toString()?.startsWith("rCapab_") }
+        def m = rCapabInput?.name?.toString() =~ /rCapab_(\d+)/
+        def cIdx = m ? ((m[0] as List)[1] as Integer) : null
+
+        then: "the discovery read did NOT issue an additional STPage GET (it HIT the cached cond=a echo)"
+        getCount == getsAfterCondWrite
+
+        and: "the cond=a write itself emitted its enum-type sidecar (forced, regardless of cached schema)"
+        def condWrite = posts.find { it.body["settings[cond]"] == "a" }
+        condWrite != null
+        condWrite.body["cond.type"] == "enum"
+
+        and: "the slot index resolved correctly off the cached echo (rCapab_7 -> cIdx 7)"
+        cIdx == 7
+    }
+
+    // ---------- deferred predCapabs clear: other firing seams (walkStep) + flag drops (restore, delete) ----------
+
+    def "walkStep mutating op on an action page fires the deferred predCapabs clear; reads + non-action pages do not"() {
+        // P2c. _rmWalkStep is a RAW action-authoring path that bypasses _rmAddAction (lib ~6843), so it
+        // carries its own copy of the just-in-time clear: a mutating op (write/click/navigate) on
+        // selectActions or doActPage (or a navigate whose targetPage is one of those) must fire the
+        // deferred ghost ifThen before the raw step lands, else an action authored here after an RE is
+        // wrapped in IF(**Broken Condition**). A read (introspect) lands no action -> no clear; a
+        // mutating op on a non-action page (e.g. selectTriggers) lands no ACTION -> no clear.
+        given:
+        enableWrite()
+        def fetchSeq = 0
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params ->
+            ruleConfigJson(100, "r", [[name: "N", type: "button"]])
+        }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params ->
+            fetchSeq++
+            doActPageGhostAndLogSchemaJson(100, fetchSeq)
+        }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            ruleConfigJson(100, "r", [[name: "tCapab1", type: "enum", options: ["Switch"]]])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            [status: 200, location: null, data: '']
+        }
+
+        when: "POSITIVE: a write on doActPage (an action page) runs while the rule is flagged"
+        atomicStateMap.predClearPending = ["100": true]
+        // The walkStep tail (raw doActPage write against a minimal schema) may no-op or throw after the
+        // entry-clear has already fired; we only assert the clear ran + flag dropped, so swallow the tail.
+        try {
+            script._rmWalkStep(100, [page: "doActPage", operation: "write", write: ["actType.1": "x"]])
+        } catch (Exception ignored) { /* tail write is immaterial; the entry-clear is what's under test */ }
+
+        then: "the deferred ghost ifThen clear fired (its getIfThen write + actionCancel are observable)"
+        posts.any { it.path == "/installedapp/update/json" &&
+                    it.body?.any { k, v -> k?.toString()?.startsWith("settings[actSubType.") && v == "getIfThen" } }
+        posts.any { it.path == "/installedapp/btn" && it.body?.name == "actionCancel" }
+
+        and: "the predClearPending flag is dropped -- the clear fires at most once"
+        !atomicStateMap.predClearPending?.get("100")
+
+        when: "NEGATIVE (read): an introspect on doActPage runs while the rule is flagged"
+        posts.clear()
+        atomicStateMap.predClearPending = ["100": true]
+        try {
+            script._rmWalkStep(100, [page: "doActPage", operation: "introspect"])
+        } catch (Exception ignored) { }
+
+        then: "no ghost clear fired (a read lands no action) -- no getIfThen write, no actionCancel"
+        !posts.any { it.path == "/installedapp/update/json" &&
+                     it.body?.any { k, v -> k?.toString()?.startsWith("settings[actSubType.") && v == "getIfThen" } }
+        !posts.any { it.path == "/installedapp/btn" && it.body?.name == "actionCancel" }
+
+        and: "the flag is left intact -- a read must not consume the deferred clear"
+        atomicStateMap.predClearPending?.get("100") == true
+
+        when: "NEGATIVE (non-action page): a write on selectTriggers runs while the rule is flagged"
+        posts.clear()
+        atomicStateMap.predClearPending = ["100": true]
+        try {
+            script._rmWalkStep(100, [page: "selectTriggers", operation: "write", write: ["tCapab1": "Switch"]])
+        } catch (Exception ignored) { }
+
+        then: "no ghost clear fired (no action lands on a trigger page) -- no getIfThen write, no actionCancel"
+        !posts.any { it.path == "/installedapp/update/json" &&
+                     it.body?.any { k, v -> k?.toString()?.startsWith("settings[actSubType.") && v == "getIfThen" } }
+        !posts.any { it.path == "/installedapp/btn" && it.body?.name == "actionCancel" }
+
+        and: "the flag is left intact -- a non-action-page edit must not consume the deferred clear"
+        atomicStateMap.predClearPending?.get("100") == true
+    }
+
+    def "replaceRequiredExpression restore drops the deferred predCapabs-clear flag (null-backup early return)"() {
+        // D. _rmRestoreCommittedREFromBackup rolls back a failed new-RE build, so it drops any
+        // predClearPending the failed build flagged (lib ~10641, at the top before the fileName check):
+        // the restored rule's predCapabs comes from a clean backup, and a leftover flag would fire a
+        // wasted ghost clear on the rule's next addAction. The null-backup early-return path
+        // (fileName == null) reaches the drop and needs no hub stubs.
+        given:
+        enableWrite()
+        atomicStateMap.predClearPending = ["100": true]
+
+        when: "the restore runs with no usable backup handle (null fileName -> early return)"
+        def result = script._rmRestoreCommittedREFromBackup(100, [fileName: null], "boom")
+
+        then: "the restore reports the RE was NOT restored (no backup to restore from)"
+        result.requiredExpressionRestored == false
+
+        and: "the deferred predCapabs-clear flag is dropped -- the rolled-back build's flag is cleared"
+        !atomicStateMap.predClearPending?.get("100")
+    }
+
+    def "toolDeleteNativeApp force-delete drops the deferred predCapabs-clear flag"() {
+        // F. A deleted rule can't carry a deferred clear, so toolDeleteNativeApp drops the flag on a
+        // successful delete (both force and soft paths; lib ~12528/~12551) -- otherwise a later rule
+        // reusing the same appId would inherit a stale flag and fire a wasted ghost clear. Force path
+        // here (copies the existing force-delete spec's hubInternalGetRaw 302 stubbing).
+        given:
+        enableWrite()
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "to-delete") }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalGetRaw = { String path, Map q = null, Integer t = 30 ->
+            [status: 302, location: "/installedapps", data: ""]
+        }
+        atomicStateMap.predClearPending = ["100": true]
+
+        when: "the rule is force-deleted while flagged"
+        def result = script.toolDeleteNativeApp([appId: 100, confirm: true, force: true])
+
+        then: "the delete succeeded"
+        result.success == true
+
+        and: "the deferred predCapabs-clear flag is dropped -- the rule is gone, no stale flag survives"
+        !atomicStateMap.predClearPending?.get("100")
+    }
+
     def "addTrigger writes isCondTrig.<N>=false finalize for non-conditional triggers"() {
         given:
         enableWrite()

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -1570,52 +1570,53 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         !posts.any { it.body["settings[cond]"]?.toString()?.contains("sub-expression") }
     }
 
-    def "STPage oper write is never cached (its echo lags), so the next cond=a still carries cond.type (multi-condition + sub-expression RE regression)"() {
+    def "STPage cond/oper picker writes always emit their enum type sidecar, so a lagged cached echo can't no-op them (multi-condition + sub-expression RE regression)"() {
         // Regression gate for the multi-condition / sub-expression Required Expression failures
-        // (live-root-caused 2026-06-21 via the native RM wizard + claude-in-chrome). Every `oper`
-        // write -- the gap-operator between conditions AND the close-sub-expression operator --
-        // returns a POST echo that LAGS one render behind the hub's settled state, and the lag is
-        // not uniform: it can DROP keys (the 3rd-condition gap-op echoes a subset) OR ADD keys
-        // (the close-paren echo adds the expression-management buttons editToken/eraseRule/hasRule)
-        // while STILL omitting the field the next write needs. So no key-delta heuristic is safe
-        // for an `oper` echo -- it must NEVER be cached. This stub models the harder ADD-keys case:
-        // the oper echo gains the expression buttons (a NEW key that would fool a "cache on new
-        // key" test) yet the settled page is the [cond, doneST] selector. Caching the lagged echo
-        // makes the next `cond=a` read a schema MISSING `cond`, _rmBuildSettingsBody drops the
-        // `cond.type=enum` sidecar, RM silently no-op's the write, and the walker throws
-        // "rCapab_<N> not in STPage schema after cond=a". (Static-schema stubs can't catch this.)
+        // (live-root-caused 2026-06-21 via the native RM wizard + claude-in-chrome). The request-
+        // scoped page cache consumes each write's inline POST echo with NO verify-GET -- that is the
+        // round-trip win that keeps a multi-condition build under the relay budget. But a
+        // submitOnChange echo for the `cond`/`oper` pickers LAGS one render behind: a gap-operator
+        // (and the close-sub-expression operator) echoes a page that OMITS the very field the NEXT
+        // picker write needs. Reading that cached schema, _rmBuildSettingsBody would find no
+        // `cond`/`oper` entry and DROP the `<key>.type=enum` sidecar, which RM silently no-ops -- the
+        // walker then throws "rCapab_<N> not in STPage schema after cond=a". The fix emits the
+        // picker's KNOWN enum type explicitly, so the write lands against the hub's real page
+        // regardless of the cached schema -- no invalidation, no extra re-fetch (the alternative,
+        // re-fetching the settled page after every operator, is exactly the round-trip cost this PR
+        // exists to remove). This stub primes the cache with a lagged oper echo that omits `cond`.
         given:
-        def operPicker = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]], [name: "doneST", type: "button"]]
-        // Lagged oper echo that ADDS the expression-management buttons (a new key) but is still NOT
-        // the settled [cond, doneST] selector -- the close-sub-expression shape.
-        def operEchoWithButtons = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]],
-                                   [name: "doneST", type: "button"], [name: "editToken", type: "button"],
-                                   [name: "eraseRule", type: "button"], [name: "hasRule", type: "button"]]
-        def condSelector = [[name: "cond", type: "enum", options: ["": "Click to set", "a": "--> New Condition"]], [name: "doneST", type: "button"]]
-        // GET is stateful: oper picker before the oper write commits, settled cond selector after.
-        def settled = false
+        // The page the oper write caches LACKS `cond` (its echo lags -- still the oper page).
+        def operPage = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]], [name: "doneST", type: "button"]]
+        int getCount = 0
         hubGet.register('/installedapp/configure/json/100/STPage') { params ->
-            ruleConfigJson(100, "r", settled ? condSelector : operPicker)
+            getCount++
+            ruleConfigJson(100, "r", operPage)
         }
         def posts = []
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
             posts << [path: path, body: body]
-            // Lagged echo: ADDS the expression buttons (new key) but is still the oper page, not the
-            // settled cond selector -- while the hub's settled state has advanced for the next GET.
-            def echo = ruleConfigJson(100, "r", operEchoWithButtons)
-            settled = true
-            [status: 200, location: null, data: echo]
+            // Lagged echo: still the oper page (omits `cond`) -- this is what the cache stores.
+            [status: 200, location: null, data: ruleConfigJson(100, "r", operPage)]
         }
 
-        when: "the oper write commits, then the next condition's cond=a write builds its body"
+        when: "an oper write caches its lagged echo, then a cond=a write builds its body from that cache"
         def cache = [:]
         script._rmWriteSubPageField(100, "STPage", "mainPage", "name", 0, [unUsed: null], "oper", "AND", cache)
+        int getsAfterOper = getCount
         script._rmWriteSubPageField(100, "STPage", "mainPage", "name", 0, [unUsed: null], "cond", "a", cache)
 
-        then: "the cond=a body carries cond.type=enum (schema read from the settled page, not the lagged oper echo)"
+        then: "the cond=a body carries cond.type=enum despite the cached schema lacking `cond` (forced, not schema-derived)"
         def condWrite = posts.reverse().find { it.body["settings[cond]"] == "a" }
         condWrite != null
         condWrite.body["cond.type"] == "enum"
+        condWrite.body["cond.multiple"] == "false"
+
+        and: "the oper write likewise forces its enum type"
+        def operWrite = posts.find { it.body["settings[oper]"] == "AND" }
+        operWrite.body["oper.type"] == "enum"
+
+        and: "no extra re-fetch: the cond=a write read the cached page (no STPage GET beyond the oper write's own)"
+        getCount == getsAfterOper
     }
 
     // ---------- ghost ifThen predCapabs clear (Step 4b) ----------

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -1570,42 +1570,48 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         !posts.any { it.body["settings[cond]"]?.toString()?.contains("sub-expression") }
     }
 
-    def "STPage gap-oper write does not cache a stale POST echo, so the next cond=a still carries cond.type (multi-condition RE regression)"() {
+    def "STPage gap-oper write does not cache a non-advancing POST echo, so the next cond=a still carries cond.type (multi-condition RE regression)"() {
         // Regression gate for the multi-condition Required Expression failure (live-root-caused
         // 2026-06-21 via the native RM wizard + claude-in-chrome). The gap `oper=AND` written
-        // between two RE conditions returns a POST echo that LAGS one render behind: it still
-        // shows the [oper, doneST] picker while the hub's SETTLED state has advanced to the
-        // [cond, doneST] new-element selector. The consume-POST cache cached that stale echo, so
-        // the next `cond=a` write read its schema from a page MISSING `cond`, _rmBuildSettingsBody
-        // omitted the `cond.type=enum` sidecar, and RM silently no-op'd the write -> the walker's
-        // discovery read threw "rCapab_<N> not in STPage schema after cond=a; got cond, doneST".
-        // Fix: _rmWriteSubPageField caches a POST echo ONLY when it advanced the page schema;
-        // a non-advancing echo invalidates the cache so the next read re-fetches the settled page.
-        // (Static-schema stubs like the cond=b test above can't catch this -- they return the same
-        // schema for every GET, so a stale-vs-settled divergence never arises.)
+        // between RE conditions returns a POST echo that LAGS one render behind: it still shows
+        // the [oper, doneST] picker while the hub's SETTLED state has advanced to the
+        // [cond, doneST] new-element selector. This stub models the 3rd-condition gap-operator,
+        // where the pre-write page also carries the expression-management buttons
+        // (editToken/eraseRule/hasRule) -- so the lagged echo DIFFERS from the pre-write schema
+        // by only DROPPING keys. "schema differs" is therefore too weak a cache test (it caches
+        // the subset echo); the fix caches a POST echo ONLY when it introduced a NEW key (a real
+        // forward advance). Without it, the next `cond=a` reads a schema MISSING `cond`,
+        // _rmBuildSettingsBody omits the `cond.type=enum` sidecar, RM silently no-op's the write,
+        // and the walker throws "rCapab_<N> not in STPage schema after cond=a; got cond, doneST".
+        // (Static-schema stubs like the cond=b test above can't catch this.)
         given:
-        def operPicker = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]], [name: "doneST", type: "button"]]
+        // Pre-write page at the 3rd-condition gap-operator: oper picker PLUS the expression buttons.
+        def operPickerWithButtons = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]],
+                                     [name: "doneST", type: "button"], [name: "editToken", type: "button"],
+                                     [name: "eraseRule", type: "button"], [name: "hasRule", type: "button"]]
+        def lagEcho = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]], [name: "doneST", type: "button"]]
         def condSelector = [[name: "cond", type: "enum", options: ["": "Click to set", "a": "--> New Condition"]], [name: "doneST", type: "button"]]
-        // GET is stateful: oper picker before the gap-oper write commits, settled cond selector after.
+        // GET is stateful: the buttoned oper page before the gap-oper write commits, settled cond selector after.
         def settled = false
         hubGet.register('/installedapp/configure/json/100/STPage') { params ->
-            ruleConfigJson(100, "r", settled ? condSelector : operPicker)
+            ruleConfigJson(100, "r", settled ? condSelector : operPickerWithButtons)
         }
         def posts = []
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
             posts << [path: path, body: body]
-            // STALE echo: the oper write's response still shows the pre-transition [oper, doneST]...
-            def echo = ruleConfigJson(100, "r", operPicker)
-            settled = true  // ...while the hub's settled state has advanced for the next GET
+            // NON-ADVANCING echo: drops the expression buttons but still shows the [oper, doneST]
+            // picker (no new key) -- while the hub's settled state has advanced for the next GET.
+            def echo = ruleConfigJson(100, "r", lagEcho)
+            settled = true
             [status: 200, location: null, data: echo]
         }
 
-        when: "the gap oper=AND write commits, then the 2nd condition's cond=a write builds its body"
+        when: "the gap oper=AND write commits, then the next condition's cond=a write builds its body"
         def cache = [:]
         script._rmWriteSubPageField(100, "STPage", "mainPage", "name", 0, [unUsed: null], "oper", "AND", cache)
         script._rmWriteSubPageField(100, "STPage", "mainPage", "name", 0, [unUsed: null], "cond", "a", cache)
 
-        then: "the cond=a body carries cond.type=enum (schema read from the settled page, not the stale echo)"
+        then: "the cond=a body carries cond.type=enum (schema read from the settled page, not the non-advancing echo)"
         def condWrite = posts.reverse().find { it.body["settings[cond]"] == "a" }
         condWrite != null
         condWrite.body["cond.type"] == "enum"

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -12613,13 +12613,20 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             ])
         }
         hubGet.register('/installedapp/configure/json/100/STPage') { params ->
-            // The attr write's own _rmWriteSubPageField does a leading fetch (pre-write) and a
-            // trailing verify (1st post-write fetch). The revealStep re-fetch that exposes the
-            // picker is the 2nd post-write fetch -- fail exactly that one so the throw lands on
-            // the reveal (force-write path), not the verify.
+            // Page-schema cache: the attr write's own _rmWriteSubPageField CONSUMES its POST
+            // response; the test stubs POSTs to return data:'' so the consume falls back to a
+            // verify-GET that, on success, STORES the STPage so the following revealStep probe
+            // HITS the cache and issues no GET of its own -- the verify-GET IS the exposure probe
+            // now. To still drive the walker's force-write-on-probe-failure path we fail the FIRST
+            // TWO post-attr STPage fetches: fetch 1 is the rCustomAttr verify-GET (swallowed by
+            // _rmWriteSubPageField, which invalidates the cache), so fetch 2 -- the revealStep
+            // postCfg -- becomes a real GET that also throws and propagates into the walker's
+            // force-write catch. Fetch 3+ (the hasAll click's version fetch) must succeed, hence
+            // the <=2 bound. '*changed*' carries no explicit value, so the catch skips the state_1
+            // write and the picker's *changed* option is never routed (the force-write distinction).
             if (rCustomAttrWritten) {
                 postAttrStFetches++
-                if (postAttrStFetches == 2) return ''
+                if (postAttrStFetches <= 2) return ''
             }
             def inputs = [
                 [name: "cond",          type: "enum",              options: ["a": "New condition"]],
@@ -13442,12 +13449,20 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             ])
         }
         hubGet.register('/installedapp/configure/json/100/STPage') { params ->
-            // The attr write's own _rmWriteSubPageField does a leading fetch (pre-write) and
-            // a trailing verify (1st post-write fetch). The revealStep exposure probe is the
-            // 2nd post-write fetch -- fail exactly that one so the throw lands on the probe.
+            // Page-schema cache: the attr write's own _rmWriteSubPageField now CONSUMES its POST
+            // response; the test stubs POSTs to return data:'' so the consume falls back to a
+            // verify-GET that, on success, STORES the STPage so the following revealStep probe
+            // (preCfg/postCfg) HITS the cache and issues no GET of its own. The verify-GET IS the
+            // exposure probe now. To still drive the walker's force-write-on-probe-failure
+            // contract we fail the FIRST TWO post-attr STPage fetches: fetch 1 is the rCustomAttr
+            // write's verify-GET (swallowed by _rmWriteSubPageField, which invalidates the cache),
+            // so fetch 2 -- the revealStep postCfg -- becomes a real GET that also throws and
+            // propagates out of _rmRevealStep into the walker's force-write catch. Fetch 3+ (the
+            // post-force-write state_1 write + hasAll click) must succeed so the degraded path
+            // completes, hence the <=2 bound rather than an open-ended throw.
             if (rCustomAttrWritten) {
                 postAttrStFetches++
-                if (postAttrStFetches == 2) return ''
+                if (postAttrStFetches <= 2) return ''
             }
             def inputs = [
                 [name: "cond",          type: "enum",              options: ["a": "New condition"]],
@@ -13557,13 +13572,19 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             ])
         }
         hubGet.register('/installedapp/configure/json/100/STPage') { params ->
-            // Site B default path: rCapab_1=Temperature (a standard capability), NOT
-            // Custom Attribute. The attr write's own _rmWriteSubPageField does a leading
-            // fetch + a trailing verify; discoverField's first fetch is the 2nd post-write
-            // fetch -- fail exactly that one so the throw lands on the exposure probe.
+            // Site B default path: rCapab_1=Temperature (a standard capability), NOT Custom
+            // Attribute. Page-schema cache: the attr write's own _rmWriteSubPageField CONSUMES
+            // its POST response; the test stubs POSTs to return data:'' so the consume falls back
+            // to a verify-GET that, on success, STORES the STPage so the following exposure-probe
+            // re-fetch HITS the cache -- the verify-GET IS the exposure probe now. To still drive
+            // Site B's force-write-on-probe-failure path we fail the FIRST TWO post-attr STPage
+            // fetches: fetch 1 is the rCustomAttr verify-GET (swallowed, invalidates the cache),
+            // so fetch 2 -- the exposure-probe re-fetch at the default-block try/catch -- becomes a
+            // real GET that throws and lands in Site B's force-write catch. Fetch 3+ (the
+            // post-force-write state_1 write) must succeed, hence the <=2 bound.
             if (rCustomAttrWritten) {
                 postAttrStFetches++
-                if (postAttrStFetches == 2) return ''
+                if (postAttrStFetches <= 2) return ''
             }
             def inputs = [
                 [name: "cond",          type: "enum",                   options: ["a": "New condition"]],
@@ -13972,11 +13993,21 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             ])
         }
         hubGet.register('/installedapp/configure/json/100/STPage') { params ->
-            // The attr write's own fetch + verify succeed; the revealStep exposure probe is
-            // the 2nd post-write fetch -- fail exactly that one to trigger the force-write.
+            // Page-schema cache: the attr write's own _rmWriteSubPageField CONSUMES its POST
+            // response; with POSTs stubbed to data:'' the consume falls back to a verify-GET that,
+            // on success, STORES the STPage so the revealStep exposure probe HITS the cache -- the
+            // verify-GET IS the probe now, so the clean-rCustomAttr + thrown-separate-probe shape
+            // the old `==2` relied on no longer exists. We fail the FIRST TWO post-attr fetches:
+            // fetch 1 (the rCustomAttr verify-GET) throws -> rCustomAttr records a
+            // verification_fetch_failed skip (a genuinely-lost entry) and the cache is invalidated;
+            // fetch 2 (the revealStep postCfg) becomes a real GET that throws into the force-write
+            // catch -> RelrDev_1 force-written. Fetch 3+ (the state_1 write) succeeds. So this run
+            // now carries TWO degraded reasons and exercises BOTH arms of the repairHints split:
+            // the verify-don't-rewrite hint for the force-written comparator AND the generic
+            // degraded-path hint for the lost rCustomAttr field. Asserted below.
             if (rCustomAttrWritten) {
                 postAttrStFetches++
-                if (postAttrStFetches == 2) return ''
+                if (postAttrStFetches <= 2) return ''
             }
             def inputs = [
                 [name: "cond",          type: "enum",              options: ["a": "New condition"]],
@@ -14045,11 +14076,19 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         verifyHint.toString().contains("value IS in settingsApplied")
         verifyHint.toString().contains("Do NOT re-write")
 
-        and: "it does NOT fold the force-written comparator into the generic fill-missing-fields hint"
-        // The generic lost-field hint exists only when there are genuinely-lost degraded
-        // entries; this run has none (only the force-written skip), so the generic hint must
-        // be absent entirely -- the force-written key is NOT treated as a lost field.
-        !hints.any { it?.toString()?.contains("re-run with rawSettings to fill missing fields") }
+        and: "the force-written comparator is NOT folded into the generic degraded-path hint"
+        // Under the page-schema cache this run carries TWO degraded reasons: RelrDev_1's
+        // comparator_force_written_unverified AND rCustomAttr_1's verification_fetch_failed (the
+        // failed verify-GET that doubles as the exposure probe -- see the STPage stub comment).
+        // The split guard is unchanged and is exactly what matters: the FORCE-WRITTEN comparator
+        // must stay in its verify-don't-rewrite hint and must NEVER be named by the generic
+        // degraded-path hint (which would wrongly tell the caller to re-write a value that DID
+        // land). The generic hint counts lost conditions without naming keys, so RelrDev_1 must
+        // not appear in it; rCustomAttr_1 is the only genuinely-lost field driving it.
+        def genericHint = hints.find { it?.toString()?.contains("used a degraded write path") }
+        genericHint != null
+        !genericHint.toString().contains("RelrDev_1")
+        ((result.settingsSkipped as List) ?: []).any { it instanceof Map && it.key == "rCustomAttr_1" && it.reason == "verification_fetch_failed" }
     }
 
     def "addAction ifThen walker Site B free-path: a non-enum attribute reveals RelrDev_1 and the comparator IS written on doActPage (negative pin)"() {
@@ -31770,14 +31809,20 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             ruleConfigJson(100, "r", [[name: "useST", type: "bool"]])
         }
         hubGet.register('/installedapp/configure/json/100/STPage') { params ->
-            // Throw on the SECOND post-rCapab fetch -- the revealStep post-trigger fetch
-            // (the first post-rCapab fetch is _rmWriteSettingOnPage's verify-fetch,
-            // which is wrapped in its own try/catch and would swallow the exception).
-            // Mirrors F4's doActPage throw pattern.
+            // Page-schema cache: the rCapab write's own _rmWriteSubPageField CONSUMES its POST
+            // response; the test stubs POSTs to return data:'' so the consume falls back to a
+            // verify-GET that, on success, STORES the STPage so the revealStep post-trigger fetch
+            // HITS the cache. The verify-GET IS the post-trigger probe now. To still propagate a
+            // mid-walk fetch error out of _rmRevealStep we throw on the FIRST TWO post-rCapab
+            // fetches: fetch 1 is the rCapab verify-GET (swallowed by _rmWriteSubPageField, which
+            // invalidates the cache), so fetch 2 -- the revealStep postCfg -- becomes a real GET
+            // that throws and propagates into the walkConds per-condition catch. Fetch 3 (the
+            // outer-catch cancelCapab's version fetch) must succeed so the single cancel click
+            // lands, hence the <=2 bound. stThrowArmed is set on the propagating throw (fetch 2).
             if (rCapabWritten) {
                 stFetchesAfterRCapab++
-                if (stFetchesAfterRCapab == 2 && !stThrowArmed) {
-                    stThrowArmed = true
+                if (stFetchesAfterRCapab <= 2) {
+                    if (stFetchesAfterRCapab == 2) stThrowArmed = true
                     throw new RuntimeException("simulated mid-walk fetch error on STPage (revealStep post-trigger fetch)")
                 }
             }

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -1646,11 +1646,13 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     // Step 4b. Both an STPage Done POST (currentPage=STPage, _action_previous=Done)
     // and the ghost ifThen N click (currentPage=selectActions) must appear.
 
-    def "addRequiredExpression Step 4b fires ghost ifThen: N on selectActions, condActs+getIfThen, actionCancel, nav"() {
-        // Regression gate: ghost IF/THEN wrap after Required Expression commit.
-        // Verifies the exact wire sequence of the ghost ifThen clear:
-        // N click (selectActions) -> actType=condActs -> actSubType=getIfThen
-        // -> actionCancel (doActPage) -> nav doActPage->selectActions.
+    def "addRequiredExpression Step 4b DEFERS the ghost ifThen: flags predClearPending, no ghost POSTs"() {
+        // Regression gate for the ghost-ifThen DEFERRAL. addRequiredExpression no longer runs the
+        // ~9-round-trip ghost ifThen up front (it made the relay-504-prone RE build heavier for nothing
+        // when no action follows). Instead it flags the rule (atomicState.predClearPending); the next
+        // addAction runs the SAME _rmClearPredCapabsViaGhostIfThen just-in-time (see the deferred-clear
+        // specs below). So the RE build emits NO ghost-ifThen POSTs (no N-on-selectActions, no
+        // condActs/getIfThen on doActPage, no actionCancel/Done), and the flag IS set.
         given:
         enableWrite()
         def fetchSeq = 0
@@ -1702,46 +1704,28 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         then: "RE committed successfully (bake-check passed with baked paragraph)"
         result.success == true
 
-        and: "(a) N button clicked on selectActions with stateAttribute=doActN"
-        def nClick = posts.find { it.path == "/installedapp/btn" &&
-                                   it.body?.name == "N" &&
-                                   it.body?.currentPage == "selectActions" }
-        nClick != null
-        nClick.body?.stateAttribute == "doActN"
+        and: "(deferral) NO ghost-ifThen N click on selectActions during the RE build"
+        !posts.any { it.path == "/installedapp/btn" && it.body?.name == "N" &&
+                     it.body?.currentPage == "selectActions" }
 
-        and: "(b) actType.{idx}=condActs written on doActPage"
-        posts.any { it.path == "/installedapp/update/json" &&
-                    it.body?.currentPage == "doActPage" &&
-                    it.body?.any { k, v -> k?.toString()?.startsWith("settings[actType.") && v == "condActs" } }
+        and: "(deferral) NO condActs / getIfThen writes on doActPage during the RE build"
+        !posts.any { it.path == "/installedapp/update/json" && it.body?.currentPage == "doActPage" &&
+                     it.body?.any { k, v -> k?.toString()?.startsWith("settings[actType.") && v == "condActs" } }
+        !posts.any { it.path == "/installedapp/update/json" && it.body?.currentPage == "doActPage" &&
+                     it.body?.any { k, v -> k?.toString()?.startsWith("settings[actSubType.") && v == "getIfThen" } }
 
-        and: "(b) actSubType.{idx}=getIfThen written on doActPage"
-        posts.any { it.path == "/installedapp/update/json" &&
-                    it.body?.currentPage == "doActPage" &&
-                    it.body?.any { k, v -> k?.toString()?.startsWith("settings[actSubType.") && v == "getIfThen" } }
+        and: "(deferral) the rule is flagged predClearPending so the next addAction runs the clear just-in-time"
+        atomicStateMap.predClearPending?.get("100") == true
 
-        and: "(c) actionCancel clicked on doActPage -- NOT actionDone"
-        def cancelClick = posts.find { it.path == "/installedapp/btn" &&
-                                        it.body?.name == "actionCancel" &&
-                                        it.body?.currentPage == "doActPage" }
-        cancelClick != null
-        !posts.any { it.path == "/installedapp/btn" &&
-                     it.body?.name == "actionDone" &&
-                     it.body?.currentPage == "doActPage" }
-
-        and: "(d) doActPage->selectActions nav fires after the cancel"
-        posts.any { it.path == "/installedapp/update/json" &&
-                    it.body?.currentPage == "doActPage" &&
-                    it.body?.any { k, v -> k?.toString()?.contains("_action_href_name|selectActions|") } }
-
-        and: "(e) no actionDone fired on doActPage anywhere in the sequence"
-        !posts.any { it.path == "/installedapp/btn" && it.body?.name == "actionDone" }
+        and: "no actionCancel / actionDone here -- the ghost slot is never opened during the RE build"
+        !posts.any { it.path == "/installedapp/btn" && it.body?.name in ["actionCancel", "actionDone"] }
     }
 
-    def "addRequiredExpression Step 4b ghost clear fires AFTER STPage Done (not before)"() {
-        // The ghost ifThen clear must occur AFTER _rmSubmitSubPageDone exits STPage.
-        // Ordering invariant: the STPage Done back-nav (currentPage=STPage,
-        // _action_previous=Done) appears in the POST log BEFORE the selectActions
-        // N click.
+    def "deferred predCapabs clear: _rmRunPendingPredCapabsClear fires the ghost ifThen when flagged, then drops the flag"() {
+        // The deferral's other half. addAction calls _rmRunPendingPredCapabsClear at its entry; when a
+        // preceding addRequiredExpression flagged the rule (atomicState.predClearPending), the SAME
+        // ghost ifThen wire sequence fires (N on selectActions -> condActs+getIfThen on doActPage ->
+        // actionCancel -> nav back) and the flag is dropped. Proves the clear is MOVED, not lost.
         given:
         enableWrite()
         def fetchSeq = 0
@@ -1781,32 +1765,33 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             seenPosts << [path: path, body: body]
             [status: 200, location: null, data: '']
         }
+        // A preceding addRequiredExpression flagged the rule (Step 4b defers the clear to here).
+        atomicStateMap.predClearPending = ["100": true]
 
-        when:
-        script.toolSetRule([
-            appId: 100,
-            addRequiredExpression: [conditions: [[capability: "Switch", deviceIds: [8], state: "on"]]],
-            confirm: true
-        ])
+        when: "the just-in-time clear runs for the flagged rule (as _rmAddAction does at its entry)"
+        script._rmRunPendingPredCapabsClear(100)
 
-        then: "STPage Done back-nav POST fires before the selectActions N click"
-        // STPage Done: _action_previous=Done is in the POST body (set by _rmSubmitSubPageDone)
-        def stPageDoneIdx = seenPosts.findIndexOf { it.path == "/installedapp/update/json" &&
-                                                     it.body?.currentPage == "STPage" &&
-                                                     it.body?._action_previous == "Done" }
-        // Ghost clear N click
-        def nClickIdx = seenPosts.findIndexOf { it.path == "/installedapp/btn" &&
-                                                 it.body?.name == "N" &&
-                                                 it.body?.currentPage == "selectActions" }
-        stPageDoneIdx != -1
-        nClickIdx != -1
-        stPageDoneIdx < nClickIdx
+        then: "the ghost ifThen N click fires on selectActions with stateAttribute=doActN"
+        def nClick = seenPosts.find { it.path == "/installedapp/btn" && it.body?.name == "N" &&
+                                      it.body?.currentPage == "selectActions" }
+        nClick != null
+        nClick.body?.stateAttribute == "doActN"
+
+        and: "actSubType.{idx}=getIfThen written on doActPage, actionCancel clicked (NOT actionDone)"
+        seenPosts.any { it.path == "/installedapp/update/json" && it.body?.currentPage == "doActPage" &&
+                        it.body?.any { k, v -> k?.toString()?.startsWith("settings[actSubType.") && v == "getIfThen" } }
+        seenPosts.any { it.path == "/installedapp/btn" && it.body?.name == "actionCancel" }
+        !seenPosts.any { it.path == "/installedapp/btn" && it.body?.name == "actionDone" }
+
+        and: "the predClearPending flag is dropped -- the clear fires at most once"
+        !atomicStateMap.predClearPending?.get("100")
     }
 
-    def "addRequiredExpression Step 4b ghost clear failure warns and still returns success"() {
-        // If the ghost ifThen sequence throws (e.g. N click fails), addRequiredExpression
-        // must still return success=true (the RE itself committed successfully).
-        // A warn mcpLog must fire so the operator can diagnose ghost IF/THEN wrap risk.
+    def "deferred predCapabs clear failure warns and still drops the flag (best-effort)"() {
+        // If the deferred ghost ifThen throws (e.g. N click fails) inside _rmRunPendingPredCapabsClear,
+        // it must NOT propagate out of addAction -- the clear is best-effort. A warn mcpLog fires so the
+        // operator can diagnose the IF(Broken Condition) wrap risk, and the flag is dropped so a failed
+        // clear doesn't retry on every subsequent addAction.
         given:
         enableWrite()
         def fetchSeq = 0
@@ -1844,26 +1829,23 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         }
 
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
-            // N button click on selectActions throws -- simulates ghost clear failure
+            // N button click throws -- simulates the deferred ghost clear failing
             if (path == "/installedapp/btn" && body?.name == "N") {
                 throw new RuntimeException("hub returned 500 on N click (simulated ghost clear failure)")
             }
             [status: 200, location: null, data: '']
         }
+        // A preceding addRequiredExpression flagged the rule; the deferred clear runs here.
+        atomicStateMap.predClearPending = ["100": true]
 
-        when:
-        def result = script.toolSetRule([
-            appId: 100,
-            addRequiredExpression: [conditions: [[capability: "Switch", deviceIds: [8], state: "on"]]],
-            confirm: true
-        ])
+        when: "the deferred just-in-time clear runs but the ghost ifThen N click throws"
+        script._rmRunPendingPredCapabsClear(100)
 
-        then: "addRequiredExpression still returns a result -- ghost clear is best-effort, not fatal"
-        result != null
-        result.success == true
+        then: "a warn log fires naming the deferred-clear failure and the IF(Broken Condition) risk"
+        warnLogs.any { it.msg?.contains("deferred predCapabs clear") && it.msg?.contains("Broken Condition") }
 
-        and: "a warn log fires naming the failure and noting the IF Broken Condition risk"
-        warnLogs.any { it.msg?.contains("ghost ifThen clear failed") && it.msg?.contains("Broken Condition") }
+        and: "the flag is still dropped -- best-effort, never retries forever"
+        !atomicStateMap.predClearPending?.get("100")
     }
 
     def "addTrigger writes isCondTrig.<N>=false finalize for non-conditional triggers"() {
@@ -16373,10 +16355,11 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     // This mirrors addTrigger's pattern (selectTriggers->mainPage nav at end)
     // and leaves the app in mainPage context for the browser's next visit.
 
-    def "addRequiredExpression Step 4b ends with selectActions->mainPage nav"() {
-        // Verifies the RE nav fix: after the doActPage->selectActions nav, a
-        // second selectActions->mainPage nav fires, leaving the app in mainPage
-        // context so browser STPage visits don't see a conflicting editAct context.
+    def "deferred predCapabs clear ends with selectActions->mainPage nav"() {
+        // The ghost ifThen's nav sequence, now run by _rmRunPendingPredCapabsClear in the DEFERRED
+        // path (not addRequiredExpression): after the doActPage->selectActions nav, a second
+        // selectActions->mainPage nav fires, leaving the app in mainPage context so browser STPage
+        // visits don't see a conflicting editAct context.
         given:
         enableWrite()
         def fetchSeq = 0
@@ -16416,15 +16399,13 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
             posts << [path: path, body: body]
             [status: 200, location: null, data: '']
         }
+        // A preceding addRequiredExpression flagged the rule (Step 4b defers the clear to here).
+        atomicStateMap.predClearPending = ["100": true]
 
-        when:
-        script.toolSetRule([
-            appId: 100,
-            addRequiredExpression: [conditions: [[capability: "Switch", deviceIds: [8], state: "on"]]],
-            confirm: true
-        ])
+        when: "the deferred just-in-time clear runs (as _rmAddAction does at its entry)"
+        script._rmRunPendingPredCapabsClear(100)
 
-        then: "doActPage->selectActions nav fires (existing invariant d)"
+        then: "doActPage->selectActions nav fires (the ghost ifThen nav, now in the deferred clear)"
         def doActToSelectActionsIdx = posts.findIndexOf { it.path == "/installedapp/update/json" &&
                                                            it.body?.currentPage == "doActPage" &&
                                                            it.body?.any { k, v ->
@@ -35747,12 +35728,13 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         hubGet.register('/device/fullJson/8') { params -> '{"id":"8","name":"S1"}' }
         script.metaClass.uploadHubFile = { String fn, byte[] b -> }
 
-        // The RE walk's ghost-ifThen clear ends with a doActPage->selectActions
-        // nav; once that lands, the next updateRule btn click is the RE-block
-        // trailing one -- fail exactly it.
+        // The RE walk ends with the STPage Done back-nav (Step 4, _action_previous=Done); once that
+        // lands, the next updateRule btn click is the RE-block trailing one -- fail exactly it. (The
+        // ghost-ifThen clear is now DEFERRED to addAction, so its doActPage->selectActions nav no longer
+        // runs here to mark the boundary; the Done back-nav is the new last-nav-before-trailing-updateRule.)
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
-            if (path == "/installedapp/update/json" && body?.currentPage == "doActPage" &&
-                body?.any { k, v -> k?.toString()?.contains("_action_href_name|selectActions|") }) {
+            if (path == "/installedapp/update/json" && body?.currentPage == "STPage" &&
+                body?._action_previous == "Done") {
                 reWalkDone = true
             }
             if (reWalkDone && path == "/installedapp/btn" && body?.name == "updateRule") {

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -1570,48 +1570,49 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         !posts.any { it.body["settings[cond]"]?.toString()?.contains("sub-expression") }
     }
 
-    def "STPage gap-oper write does not cache a non-advancing POST echo, so the next cond=a still carries cond.type (multi-condition RE regression)"() {
-        // Regression gate for the multi-condition Required Expression failure (live-root-caused
-        // 2026-06-21 via the native RM wizard + claude-in-chrome). The gap `oper=AND` written
-        // between RE conditions returns a POST echo that LAGS one render behind: it still shows
-        // the [oper, doneST] picker while the hub's SETTLED state has advanced to the
-        // [cond, doneST] new-element selector. This stub models the 3rd-condition gap-operator,
-        // where the pre-write page also carries the expression-management buttons
-        // (editToken/eraseRule/hasRule) -- so the lagged echo DIFFERS from the pre-write schema
-        // by only DROPPING keys. "schema differs" is therefore too weak a cache test (it caches
-        // the subset echo); the fix caches a POST echo ONLY when it introduced a NEW key (a real
-        // forward advance). Without it, the next `cond=a` reads a schema MISSING `cond`,
-        // _rmBuildSettingsBody omits the `cond.type=enum` sidecar, RM silently no-op's the write,
-        // and the walker throws "rCapab_<N> not in STPage schema after cond=a; got cond, doneST".
-        // (Static-schema stubs like the cond=b test above can't catch this.)
+    def "STPage oper write is never cached (its echo lags), so the next cond=a still carries cond.type (multi-condition + sub-expression RE regression)"() {
+        // Regression gate for the multi-condition / sub-expression Required Expression failures
+        // (live-root-caused 2026-06-21 via the native RM wizard + claude-in-chrome). Every `oper`
+        // write -- the gap-operator between conditions AND the close-sub-expression operator --
+        // returns a POST echo that LAGS one render behind the hub's settled state, and the lag is
+        // not uniform: it can DROP keys (the 3rd-condition gap-op echoes a subset) OR ADD keys
+        // (the close-paren echo adds the expression-management buttons editToken/eraseRule/hasRule)
+        // while STILL omitting the field the next write needs. So no key-delta heuristic is safe
+        // for an `oper` echo -- it must NEVER be cached. This stub models the harder ADD-keys case:
+        // the oper echo gains the expression buttons (a NEW key that would fool a "cache on new
+        // key" test) yet the settled page is the [cond, doneST] selector. Caching the lagged echo
+        // makes the next `cond=a` read a schema MISSING `cond`, _rmBuildSettingsBody drops the
+        // `cond.type=enum` sidecar, RM silently no-op's the write, and the walker throws
+        // "rCapab_<N> not in STPage schema after cond=a". (Static-schema stubs can't catch this.)
         given:
-        // Pre-write page at the 3rd-condition gap-operator: oper picker PLUS the expression buttons.
-        def operPickerWithButtons = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]],
-                                     [name: "doneST", type: "button"], [name: "editToken", type: "button"],
-                                     [name: "eraseRule", type: "button"], [name: "hasRule", type: "button"]]
-        def lagEcho = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]], [name: "doneST", type: "button"]]
+        def operPicker = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]], [name: "doneST", type: "button"]]
+        // Lagged oper echo that ADDS the expression-management buttons (a new key) but is still NOT
+        // the settled [cond, doneST] selector -- the close-sub-expression shape.
+        def operEchoWithButtons = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]],
+                                   [name: "doneST", type: "button"], [name: "editToken", type: "button"],
+                                   [name: "eraseRule", type: "button"], [name: "hasRule", type: "button"]]
         def condSelector = [[name: "cond", type: "enum", options: ["": "Click to set", "a": "--> New Condition"]], [name: "doneST", type: "button"]]
-        // GET is stateful: the buttoned oper page before the gap-oper write commits, settled cond selector after.
+        // GET is stateful: oper picker before the oper write commits, settled cond selector after.
         def settled = false
         hubGet.register('/installedapp/configure/json/100/STPage') { params ->
-            ruleConfigJson(100, "r", settled ? condSelector : operPickerWithButtons)
+            ruleConfigJson(100, "r", settled ? condSelector : operPicker)
         }
         def posts = []
         script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
             posts << [path: path, body: body]
-            // NON-ADVANCING echo: drops the expression buttons but still shows the [oper, doneST]
-            // picker (no new key) -- while the hub's settled state has advanced for the next GET.
-            def echo = ruleConfigJson(100, "r", lagEcho)
+            // Lagged echo: ADDS the expression buttons (new key) but is still the oper page, not the
+            // settled cond selector -- while the hub's settled state has advanced for the next GET.
+            def echo = ruleConfigJson(100, "r", operEchoWithButtons)
             settled = true
             [status: 200, location: null, data: echo]
         }
 
-        when: "the gap oper=AND write commits, then the next condition's cond=a write builds its body"
+        when: "the oper write commits, then the next condition's cond=a write builds its body"
         def cache = [:]
         script._rmWriteSubPageField(100, "STPage", "mainPage", "name", 0, [unUsed: null], "oper", "AND", cache)
         script._rmWriteSubPageField(100, "STPage", "mainPage", "name", 0, [unUsed: null], "cond", "a", cache)
 
-        then: "the cond=a body carries cond.type=enum (schema read from the settled page, not the non-advancing echo)"
+        then: "the cond=a body carries cond.type=enum (schema read from the settled page, not the lagged oper echo)"
         def condWrite = posts.reverse().find { it.body["settings[cond]"] == "a" }
         condWrite != null
         condWrite.body["cond.type"] == "enum"

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -1570,6 +1570,47 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         !posts.any { it.body["settings[cond]"]?.toString()?.contains("sub-expression") }
     }
 
+    def "STPage gap-oper write does not cache a stale POST echo, so the next cond=a still carries cond.type (multi-condition RE regression)"() {
+        // Regression gate for the multi-condition Required Expression failure (live-root-caused
+        // 2026-06-21 via the native RM wizard + claude-in-chrome). The gap `oper=AND` written
+        // between two RE conditions returns a POST echo that LAGS one render behind: it still
+        // shows the [oper, doneST] picker while the hub's SETTLED state has advanced to the
+        // [cond, doneST] new-element selector. The consume-POST cache cached that stale echo, so
+        // the next `cond=a` write read its schema from a page MISSING `cond`, _rmBuildSettingsBody
+        // omitted the `cond.type=enum` sidecar, and RM silently no-op'd the write -> the walker's
+        // discovery read threw "rCapab_<N> not in STPage schema after cond=a; got cond, doneST".
+        // Fix: _rmWriteSubPageField caches a POST echo ONLY when it advanced the page schema;
+        // a non-advancing echo invalidates the cache so the next read re-fetches the settled page.
+        // (Static-schema stubs like the cond=b test above can't catch this -- they return the same
+        // schema for every GET, so a stale-vs-settled divergence never arises.)
+        given:
+        def operPicker = [[name: "oper", type: "enum", options: ["": "Click to set", "AND": "AND"]], [name: "doneST", type: "button"]]
+        def condSelector = [[name: "cond", type: "enum", options: ["": "Click to set", "a": "--> New Condition"]], [name: "doneST", type: "button"]]
+        // GET is stateful: oper picker before the gap-oper write commits, settled cond selector after.
+        def settled = false
+        hubGet.register('/installedapp/configure/json/100/STPage') { params ->
+            ruleConfigJson(100, "r", settled ? condSelector : operPicker)
+        }
+        def posts = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            posts << [path: path, body: body]
+            // STALE echo: the oper write's response still shows the pre-transition [oper, doneST]...
+            def echo = ruleConfigJson(100, "r", operPicker)
+            settled = true  // ...while the hub's settled state has advanced for the next GET
+            [status: 200, location: null, data: echo]
+        }
+
+        when: "the gap oper=AND write commits, then the 2nd condition's cond=a write builds its body"
+        def cache = [:]
+        script._rmWriteSubPageField(100, "STPage", "mainPage", "name", 0, [unUsed: null], "oper", "AND", cache)
+        script._rmWriteSubPageField(100, "STPage", "mainPage", "name", 0, [unUsed: null], "cond", "a", cache)
+
+        then: "the cond=a body carries cond.type=enum (schema read from the settled page, not the stale echo)"
+        def condWrite = posts.reverse().find { it.body["settings[cond]"] == "a" }
+        condWrite != null
+        condWrite.body["cond.type"] == "enum"
+    }
+
     // ---------- ghost ifThen predCapabs clear (Step 4b) ----------
     //
     // After addRequiredExpression completes, RM's atomicState.predCapabs retains

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -2370,6 +2370,118 @@ class TestRunner:
             self._delete_native(app_id)
 
     @test("native_apps")
+    def test_set_rule_walkstep_action_after_required_expression(self) -> None:
+        # P2c regression: an action authored ENTIRELY via SINGLE-STEP walkStep (not
+        # _rmAddAction, not operation='drive') AFTER a Required Expression must land
+        # TOP-LEVEL, never wrapped under IF(Broken Condition). RM leaves
+        # atomicState.predCapabs dirty after an RE commit; the deferred predClear runs on
+        # the FIRST action-page op (the navigate into doActPage), so the slot is created
+        # with predCapabs already cleared. test_set_rule_action_after_required_expression
+        # proves the same guard for _rmAddAction; this one proves the single-step walker
+        # path -- _rmWalkStep's own deferred-clear hook -- which _rmAddAction's flow never
+        # exercises. strict=True so a relay 504 re-runs this small rule once.
+        sw = int(self.get_test_switch_id())
+        app_id = self._create_native_rule("WalkActRE")
+        try:
+            # RE first: sets predClearPending and dirties predCapabs.
+            re_res = self._rm_call_soft({
+                "appId": app_id,
+                "addRequiredExpression": {"conditions": [
+                    {"capability": "Switch", "deviceIds": [sw], "state": "on"}]},
+                "confirm": True,
+            }, strict=True)
+            assert re_res.get("success") is not False, \
+                f"addRequiredExpression reported failure: {re_res}"
+            # Single-step navigate into the action editor -- this is the op that fires the
+            # deferred predCapabs clear, BEFORE the new action slot is created.
+            nav = self._set_rule(app_id, {"walkStep": {"page": "selectActions", "operation": "navigate",
+                                                       "navigate": {"targetPage": "doActPage"}}}, strict=True)
+            assert nav.get("page") == "doActPage", f"navigate should land on doActPage: {nav}"
+            # The new action's index is the n in the revealed actType.<n> picker -- DERIVE it.
+            act_field = next((i.get("name") for i in ((nav.get("after") or {}).get("inputs") or [])
+                              if str(i.get("name")).startswith("actType.")), None)
+            assert act_field, f"doActPage should reveal an actType.<n> picker: {nav}"
+            n = act_field.split(".", 1)[1]
+            # Author a log action via single-step writes (each reveals the next field) + a Done.
+            self._set_rule(app_id, {"walkStep": {"page": "doActPage", "operation": "write",
+                                                 "write": {f"actType.{n}": "messageActs"}}}, strict=True)
+            self._set_rule(app_id, {"walkStep": {"page": "doActPage", "operation": "write",
+                                                 "write": {f"actSubType.{n}": "getLogMsg"}}}, strict=True)
+            wr = self._set_rule(app_id, {"walkStep": {"page": "doActPage", "operation": "write",
+                                                      "write": {f"logmsg.{n}": "walkstep-after-RE"}}}, strict=True)
+            assert (wr.get("valueEcho") or {}).get("match") is True, \
+                f"single-step logmsg write should round-trip live (valueEcho.match): {wr}"
+            self._set_rule(app_id, {"walkStep": {"page": "doActPage", "operation": "click",
+                                                 "click": {"name": "actionDone"}}}, strict=True)
+            cfg = self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_app_config", "args": {"appId": app_id}})
+            assert "Broken Condition" not in str(cfg), \
+                f"predCapabs leaked -- the walkStep-authored post-RE action is wrapped under IF(Broken Condition): {str(cfg)[:800]}"
+            assert "walkstep-after-RE" in str(cfg), \
+                f"the walkStep-authored log action did not commit top-level: {str(cfg)[:800]}"
+        finally:
+            self._delete_native(app_id)
+
+    @test("native_apps")
+    def test_set_native_app_walkstep_button_controller(self) -> None:
+        # The single-step walkStep walker (introspect + write) is a GENERIC
+        # classic-dynamicPage walker, not RM-specific. The other walkStep tests only drive
+        # an RM rule's appId; this one proves it works on a real NON-RM classic app -- a
+        # Button Controller -- routed through hub_set_native_app. Assign a virtual button
+        # device via a single-step write, and prove both the live round-trip (valueEcho)
+        # and the submitOnChange reveal (origLabel appears once a device is bound).
+        controller_id = None
+        button_dni = None
+        try:
+            # Virtual button device for the controller to bind to (tracked for cleanup).
+            dev = self.client.call_tool("hub_manage_virtual_device", {
+                "action": "create", "deviceType": "Virtual Button",
+                "deviceLabel": f"{PREFIX}WalkBtnDev", "confirm": True,
+            })
+            device_id = str((dev.get("device") or {}).get("id") or "")
+            assert device_id, f"virtual button create did not return a device id: {dev}"
+            button_dni = str((dev.get("device") or {}).get("deviceNetworkId") or "")
+            if button_dni:
+                self.created_device_dnis.append(button_dni)
+
+            # Button Controller instance (tracked for cleanup).
+            ctrl = self.client.call_tool("hub_manage_native_rules_and_apps", {
+                "tool": "hub_set_native_app",
+                "args": {"appType": "button_controller", "name": f"{PREFIX}WalkBtnCtrl", "confirm": True},
+            })
+            controller_id = ctrl.get("appId")
+            assert controller_id, f"button controller create did not return an appId: {ctrl}"
+            self.created_native_app_ids.append(str(controller_id))
+
+            # Single-step walkStep INTROSPECT on the non-RM app.
+            intro = self.client.call_tool("hub_manage_native_rules_and_apps", {
+                "tool": "hub_set_native_app",
+                "args": {"appId": controller_id, "walkStep": {"page": "mainPage", "operation": "introspect"}, "confirm": True},
+            })
+            assert intro.get("page") == "mainPage", \
+                f"walkStep introspect should land on mainPage of the button controller: {intro}"
+            intro_names = [i.get("name") for i in ((intro.get("before") or {}).get("inputs") or [])]
+            assert "buttonDev" in intro_names, \
+                f"mainPage should expose the buttonDev (capability.pushableButton) picker: {intro_names}"
+
+            # Single-step walkStep WRITE on the non-RM app -- assign the device.
+            wr = self.client.call_tool("hub_manage_native_rules_and_apps", {
+                "tool": "hub_set_native_app",
+                "args": {"appId": controller_id, "walkStep": {"page": "mainPage", "operation": "write",
+                                                              "write": {"buttonDev": [device_id]}}, "confirm": True},
+            })
+            assert (wr.get("valueEcho") or {}).get("match") is True, \
+                f"single-step buttonDev write should round-trip live (valueEcho.match): {wr}"
+            after_names = [i.get("name") for i in ((wr.get("after") or {}).get("inputs") or [])]
+            assert "origLabel" in after_names, \
+                f"submitOnChange reveal: origLabel should appear once a button device is assigned: {after_names}"
+        finally:
+            # The controller delete is the only inline teardown; the device is swept by
+            # created_device_dnis. _delete_native handles the deferred-delete mode.
+            if controller_id:
+                self._delete_native(controller_id, gateway="hub_manage_native_rules_and_apps")
+
+    @test("native_apps")
     def test_rule_health_prefers_rulebuilderjson(self) -> None:
         # issue #254: hub_get_rule_health now reads the rule's compiled atomicState
         # (GET /app/ruleBuilderJson) for an authoritative `broken` boolean, with the

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3225,17 +3225,19 @@ class TestRunner:
 
     @test("native_apps")
     def test_set_rule_required_expression_multi_condition(self) -> None:
-        # hub_set_rule edit -> addRequiredExpression with TWO conditions joined by AND.
+        # hub_set_rule edit -> addRequiredExpression with THREE conditions joined by AND.
         # Regression guard for the multi-condition gap-operator bug (root-caused 2026-06-21
-        # via the native RM wizard + claude-in-chrome): the `oper=AND` written BETWEEN the two
+        # via the native RM wizard + claude-in-chrome): each `oper=AND` written BETWEEN
         # conditions returns a POST echo that lags one render behind ([oper, doneST] instead of
         # the settled [cond, doneST]); the request-scoped page cache stored that stale echo, so
-        # the 2nd condition's `cond=a` built its body from a schema missing `cond`, dropped the
+        # the next condition's `cond=a` built its body from a schema missing `cond`, dropped the
         # `cond.type=enum` sidecar, RM silently no-op'd the write, and the walker failed with
-        # "rCapab_<N> not in STPage schema after cond=a; got cond, doneST". Single-condition REs
-        # never hit this (no gap-oper), which is why the existing RE tests stayed green. This
-        # proves a 2-condition RE builds end-to-end on a live hub: BOTH condition slots allocate
-        # and the rule renders both conditions joined by AND.
+        # "rCapab_<N> not in STPage schema after cond=a; got cond, doneST". THREE conditions
+        # exercise BOTH gap-operators -- the 2nd one's echo merely DROPS the expression-
+        # management buttons (a subset, no new key), which a naive "schema differs" cache test
+        # mis-classifies as an advance (the 2-condition case alone would not catch it). Single-
+        # condition REs never hit this (no gap-oper). This proves a 3-condition RE builds end-to-
+        # end on a live hub: ALL THREE slots allocate and the rule renders them joined by AND.
         dev_a, dev_b = self.get_test_temperature_ids()
         app_id = self._create_native_rule("MultiCondRE")
         try:
@@ -3246,27 +3248,28 @@ class TestRunner:
                     "conditions": [
                         {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">", "state": 70},
                         {"capability": "Temperature", "deviceIds": [int(dev_b)], "comparator": "<", "state": 80},
+                        {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">=", "state": 65},
                     ],
                 },
                 "confirm": True,
             }, strict=True)
             assert result.get("success") is not False, \
                 f"multi-condition addRequiredExpression reported failure (the gap-oper cache regression): {result}"
-            # BOTH condition slots must have allocated -- before the fix the 2nd `cond=a` no-op'd,
-            # so the walker threw and only the first (or no) slot landed.
+            # ALL THREE condition slots must have allocated -- before the fix a `cond=a` after a
+            # gap-operator no-op'd, so the walker threw and not every slot landed.
             cidx = result.get("conditionIndices") or []
-            assert len(cidx) == 2, \
-                f"multi-condition RE did not allocate both condition slots (expected 2 conditionIndices): {result}"
+            assert len(cidx) == 3, \
+                f"multi-condition RE did not allocate all three condition slots (expected 3 conditionIndices): {result}"
             self._assert_rule_healthy(app_id)
-            # The rule renders BOTH Temperature conditions joined by AND.
+            # The rule renders all THREE Temperature conditions joined by AND.
             cfg = self.client.call_tool("hub_read_apps_code", {
                 "tool": "hub_get_app_config", "args": {"appId": app_id},
             })
             blob = str(cfg)
-            assert blob.lower().count("temperature of") >= 2, \
-                f"rule does not render both Temperature conditions: {blob[:600]}"
+            assert blob.lower().count("temperature of") >= 3, \
+                f"rule does not render all three Temperature conditions: {blob[:800]}"
             assert "AND" in blob, \
-                f"rule does not render the AND joining operator: {blob[:600]}"
+                f"rule does not render the AND joining operator: {blob[:800]}"
         finally:
             self._delete_native(app_id)
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3225,84 +3225,75 @@ class TestRunner:
 
     @test("native_apps")
     def test_set_rule_required_expression_multi_condition(self) -> None:
-        # hub_set_rule edit -> addRequiredExpression with THREE conditions joined by AND.
+        # hub_set_rule edit -> addRequiredExpression with TWO conditions joined by AND.
         # Regression guard for the multi-condition gap-operator bug (root-caused 2026-06-21
-        # via the native RM wizard + claude-in-chrome): each `oper=AND` written BETWEEN
+        # via the native RM wizard + claude-in-chrome): the `oper=AND` written BETWEEN the two
         # conditions returns a POST echo that lags one render behind ([oper, doneST] instead of
         # the settled [cond, doneST]); the request-scoped page cache stored that stale echo, so
-        # the next condition's `cond=a` built its body from a schema missing `cond`, dropped the
+        # the 2nd condition's `cond=a` built its body from a schema missing `cond`, dropped the
         # `cond.type=enum` sidecar, RM silently no-op'd the write, and the walker failed with
-        # "rCapab_<N> not in STPage schema after cond=a; got cond, doneST". THREE conditions
-        # exercise BOTH gap-operators -- the 2nd one's echo merely DROPS the expression-
-        # management buttons (a subset, no new key), which a naive "schema differs" cache test
-        # mis-classifies as an advance (the 2-condition case alone would not catch it). Single-
-        # condition REs never hit this (no gap-oper). This proves a 3-condition RE builds end-to-
-        # end on a live hub: ALL THREE slots allocate and the rule renders them joined by AND.
+        # "rCapab_<N> not in STPage schema after cond=a; got cond, doneST". Single-condition REs
+        # never hit this (no gap-oper).
+        #
+        # KEPT SMALL ON PURPOSE: each wizard write re-renders the full rule page, so a tools/call
+        # building 3+ conditions (or a sub-expression) does enough server-side round-trips to blow
+        # past the cloud-relay ~10s ceiling and 504. A 2-condition AND is the lightest shape that
+        # still exercises a gap-operator live. The heavier cases -- the 3rd-condition subset echo
+        # and the sub-expression close-paren `oper` -- are covered by the Spock gate
+        # (ToolRmNativeCrudSpec "STPage oper write is never cached...") plus the live BAT on the
+        # personal hub (no relay), per AGENTS.md "keep every rule SMALL".
         dev_a, dev_b = self.get_test_temperature_ids()
         app_id = self._create_native_rule("MultiCondRE")
-        try:
-            result = self._rm_call_soft({
-                "appId": app_id,
-                "addRequiredExpression": {
-                    "operator": "AND",
-                    "conditions": [
-                        {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">", "state": 70},
-                        {"capability": "Temperature", "deviceIds": [int(dev_b)], "comparator": "<", "state": 80},
-                        {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">=", "state": 65},
-                    ],
-                },
-                "confirm": True,
-            }, strict=True)
-            assert result.get("success") is not False, \
-                f"multi-condition addRequiredExpression reported failure (the gap-oper cache regression): {result}"
-            # ALL THREE condition slots must have allocated -- before the fix a `cond=a` after a
-            # gap-operator no-op'd, so the walker threw and not every slot landed.
-            cidx = result.get("conditionIndices") or []
-            assert len(cidx) == 3, \
-                f"multi-condition RE did not allocate all three condition slots (expected 3 conditionIndices): {result}"
-            self._assert_rule_healthy(app_id)
-            # The rule renders all THREE Temperature conditions joined by AND.
+
+        def _assert_renders_both() -> None:
+            # The genuine wire-format assertion: the rule renders BOTH Temperature conditions
+            # joined by AND. If the gap-op regression were present, the 2nd cond=a no-op'd and only
+            # one "Temperature of ..." paragraph would render.
             cfg = self.client.call_tool("hub_read_apps_code", {
                 "tool": "hub_get_app_config", "args": {"appId": app_id},
             })
             blob = str(cfg)
-            assert blob.lower().count("temperature of") >= 3, \
-                f"rule does not render all three Temperature conditions: {blob[:800]}"
+            assert blob.lower().count("temperature of") >= 2, \
+                f"rule does not render both Temperature conditions: {blob[:800]}"
             assert "AND" in blob, \
                 f"rule does not render the AND joining operator: {blob[:800]}"
-        finally:
-            self._delete_native(app_id)
 
-        # Sub-expression shape: (A > 70 OR B < 80) AND A >= 65. This exercises the close-sub-
-        # expression operator (oper="end-sub-expression )") followed by the outer gap-operator --
-        # an `oper` echo that ADDS the expression-management buttons while still lagging, which a
-        # "cache on new key" heuristic mis-caches. The outer condition's cond=a then no-op'd before
-        # the fix (oper writes are never cached). Proves the paren/sub-expression path builds live.
-        sub_app_id = self._create_native_rule("SubExprRE")
         try:
-            sub = self._rm_call_soft({
-                "appId": sub_app_id,
-                "addRequiredExpression": {
-                    "operator": "AND",
-                    "conditions": [
-                        {"subExpression": {"operator": "OR", "conditions": [
+            # A multi-condition build is a bigger tools/call than the single-condition device tests,
+            # so it can graze the cloud-relay ~10s ceiling. On a dropped response the build still
+            # COMPLETES hub-side, so on a 504 verify by readback rather than hard-failing -- the
+            # readback IS the regression check (only one paragraph renders if the 2nd cond=a no-op'd).
+            # A non-504 error still propagates (a real failure must not be masked).
+            try:
+                result = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": {
+                    "appId": app_id,
+                    "addRequiredExpression": {
+                        "operator": "AND",
+                        "conditions": [
                             {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">", "state": 70},
                             {"capability": "Temperature", "deviceIds": [int(dev_b)], "comparator": "<", "state": 80},
-                        ]}},
-                        {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">=", "state": 65},
-                    ],
-                },
-                "confirm": True,
-            }, strict=True)
-            assert sub.get("success") is not False, \
-                f"sub-expression addRequiredExpression reported failure (close-paren/outer-oper cache regression): {sub}"
-            # Two inner + one outer condition slot must all allocate.
-            scidx = sub.get("conditionIndices") or []
-            assert len(scidx) == 3, \
-                f"sub-expression RE did not allocate all three condition slots (2 inner + 1 outer): {sub}"
-            self._assert_rule_healthy(sub_app_id)
+                        ],
+                    },
+                    "confirm": True,
+                }})
+            except (McpError, McpToolError, requests.HTTPError) as exc:
+                if "504" not in str(exc):
+                    raise
+                print("    addRequiredExpression response lost to relay 504 (heavy multi-cond build) -- "
+                      "verifying both conditions committed by readback")
+                time.sleep(3.0)
+                _assert_renders_both()
+            else:
+                assert result.get("success") is not False, \
+                    f"multi-condition addRequiredExpression reported failure (the gap-oper cache regression): {result}"
+                # BOTH condition slots must have allocated -- before the fix the 2nd `cond=a` no-op'd
+                # (the gap `oper` poisoned the cache), so the walker threw and only the first landed.
+                cidx = result.get("conditionIndices") or []
+                assert len(cidx) == 2, \
+                    f"multi-condition RE did not allocate both condition slots (expected 2 conditionIndices): {result}"
+                _assert_renders_both()
         finally:
-            self._delete_native(sub_app_id)
+            self._delete_native(app_id)
 
     @test("native_apps")
     def test_set_rule_action_mutations(self) -> None:

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3306,6 +3306,38 @@ class TestRunner:
             self._delete_native(sub_app_id)
 
     @test("native_apps")
+    def test_set_rule_action_after_required_expression(self) -> None:
+        # predCapabs-clearing guard for the ghost-ifThen (Step 4b of addRequiredExpression).
+        # RM leaves atomicState.predCapabs dirty after an RE commit; without the ghost-ifThen
+        # clear the NEXT non-expression action opens doActPage with that stale predCapabs and RM
+        # wraps the action under "IF (Broken Condition)". NO other e2e adds an action AFTER an RE,
+        # so the ghost-ifThen -- and the page-cache threading that optimizes it -- had no live
+        # guard: a silent predCapabs leak passes every other RE test (none add a trailing action).
+        # Build an RE, add a plain log action, and assert it lands as a top-level action, NOT a
+        # Broken-Condition wrap. strict=True so a relay 504 re-runs this small rule once.
+        sw = int(self.get_test_switch_id())
+        app_id = self._create_native_rule("ActAfterRE")
+        try:
+            re_res = self._rm_call_soft({
+                "appId": app_id,
+                "addRequiredExpression": {"conditions": [
+                    {"capability": "Switch", "deviceIds": [sw], "state": "on"}]},
+                "confirm": True,
+            }, strict=True)
+            assert re_res.get("success") is not False, \
+                f"addRequiredExpression reported failure: {re_res}"
+            # The action added AFTER the RE must NOT be wrapped under a Broken Condition IF --
+            # that wrap is exactly the stale-predCapabs symptom the ghost-ifThen clears.
+            self._add_action_or_raise_504(app_id, {"capability": "log", "message": "after-RE"})
+            self._assert_rule_healthy(app_id)
+            cfg = self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_app_config", "args": {"appId": app_id}})
+            assert "Broken Condition" not in str(cfg), \
+                f"ghost-ifThen failed to clear predCapabs -- the post-RE action is wrapped under IF(Broken Condition): {str(cfg)[:800]}"
+        finally:
+            self._delete_native(app_id)
+
+    @test("native_apps")
     def test_set_rule_action_mutations(self) -> None:
         # hub_set_rule edit -> addActions (bulk) + removeAction + clearActions +
         # replaceActions -- the index-bearing action-list mutations on one small rule.

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3225,75 +3225,85 @@ class TestRunner:
 
     @test("native_apps")
     def test_set_rule_required_expression_multi_condition(self) -> None:
-        # hub_set_rule edit -> addRequiredExpression with TWO conditions joined by AND.
-        # Regression guard for the multi-condition gap-operator bug (root-caused 2026-06-21
-        # via the native RM wizard + claude-in-chrome): the `oper=AND` written BETWEEN the two
-        # conditions returns a POST echo that lags one render behind ([oper, doneST] instead of
-        # the settled [cond, doneST]); the request-scoped page cache stored that stale echo, so
-        # the 2nd condition's `cond=a` built its body from a schema missing `cond`, dropped the
+        # hub_set_rule edit -> addRequiredExpression with THREE conditions joined by AND, then a
+        # sub-expression. Regression guard for the multi-condition gap-operator bug (root-caused
+        # 2026-06-21 via the native RM wizard + claude-in-chrome): each `oper=AND` written BETWEEN
+        # conditions returns a POST echo that lags one render behind ([oper, doneST] instead of the
+        # settled [cond, doneST]); the request-scoped page cache consumed that lagged echo, so the
+        # next condition's `cond=a` built its body from a schema missing `cond`, dropped the
         # `cond.type=enum` sidecar, RM silently no-op'd the write, and the walker failed with
-        # "rCapab_<N> not in STPage schema after cond=a; got cond, doneST". Single-condition REs
-        # never hit this (no gap-oper).
-        #
-        # KEPT SMALL ON PURPOSE: each wizard write re-renders the full rule page, so a tools/call
-        # building 3+ conditions (or a sub-expression) does enough server-side round-trips to blow
-        # past the cloud-relay ~10s ceiling and 504. A 2-condition AND is the lightest shape that
-        # still exercises a gap-operator live. The heavier cases -- the 3rd-condition subset echo
-        # and the sub-expression close-paren `oper` -- are covered by the Spock gate
-        # (ToolRmNativeCrudSpec "STPage oper write is never cached...") plus the live BAT on the
-        # personal hub (no relay), per AGENTS.md "keep every rule SMALL".
+        # "rCapab_<N> not in STPage schema after cond=a; got cond, doneST". THREE conditions exercise
+        # BOTH gap-operators (the 2nd one's lag differs from the 1st), and the sub-expression
+        # exercises the close-sub-expression `oper`. The fix emits `cond`/`oper`'s known enum type
+        # explicitly so the write lands regardless of the lagged cache -- no invalidation, no extra
+        # re-fetch (the round-trip budget that keeps this build under the relay is preserved).
+        # Single-condition REs never hit this (no gap-oper). strict=True: a relay 504 re-runs the
+        # small test once, then is an honest red (a persistent 504 means the build is still too
+        # heavy -- a tool problem to fix, not a test to weaken).
         dev_a, dev_b = self.get_test_temperature_ids()
         app_id = self._create_native_rule("MultiCondRE")
-
-        def _assert_renders_both() -> None:
-            # The genuine wire-format assertion: the rule renders BOTH Temperature conditions
-            # joined by AND. If the gap-op regression were present, the 2nd cond=a no-op'd and only
-            # one "Temperature of ..." paragraph would render.
+        try:
+            result = self._rm_call_soft({
+                "appId": app_id,
+                "addRequiredExpression": {
+                    "operator": "AND",
+                    "conditions": [
+                        {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">", "state": 70},
+                        {"capability": "Temperature", "deviceIds": [int(dev_b)], "comparator": "<", "state": 80},
+                        {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">=", "state": 65},
+                    ],
+                },
+                "confirm": True,
+            }, strict=True)
+            assert result.get("success") is not False, \
+                f"multi-condition addRequiredExpression reported failure (the gap-oper cache regression): {result}"
+            # ALL THREE condition slots must have allocated -- before the fix a `cond=a` after a
+            # gap-operator no-op'd, so the walker threw and not every slot landed.
+            cidx = result.get("conditionIndices") or []
+            assert len(cidx) == 3, \
+                f"multi-condition RE did not allocate all three condition slots (expected 3 conditionIndices): {result}"
+            self._assert_rule_healthy(app_id)
+            # The rule renders all THREE Temperature conditions joined by AND.
             cfg = self.client.call_tool("hub_read_apps_code", {
                 "tool": "hub_get_app_config", "args": {"appId": app_id},
             })
             blob = str(cfg)
-            assert blob.lower().count("temperature of") >= 2, \
-                f"rule does not render both Temperature conditions: {blob[:800]}"
+            assert blob.lower().count("temperature of") >= 3, \
+                f"rule does not render all three Temperature conditions: {blob[:800]}"
             assert "AND" in blob, \
                 f"rule does not render the AND joining operator: {blob[:800]}"
-
-        try:
-            # A multi-condition build is a bigger tools/call than the single-condition device tests,
-            # so it can graze the cloud-relay ~10s ceiling. On a dropped response the build still
-            # COMPLETES hub-side, so on a 504 verify by readback rather than hard-failing -- the
-            # readback IS the regression check (only one paragraph renders if the 2nd cond=a no-op'd).
-            # A non-504 error still propagates (a real failure must not be masked).
-            try:
-                result = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": {
-                    "appId": app_id,
-                    "addRequiredExpression": {
-                        "operator": "AND",
-                        "conditions": [
-                            {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">", "state": 70},
-                            {"capability": "Temperature", "deviceIds": [int(dev_b)], "comparator": "<", "state": 80},
-                        ],
-                    },
-                    "confirm": True,
-                }})
-            except (McpError, McpToolError, requests.HTTPError) as exc:
-                if "504" not in str(exc):
-                    raise
-                print("    addRequiredExpression response lost to relay 504 (heavy multi-cond build) -- "
-                      "verifying both conditions committed by readback")
-                time.sleep(3.0)
-                _assert_renders_both()
-            else:
-                assert result.get("success") is not False, \
-                    f"multi-condition addRequiredExpression reported failure (the gap-oper cache regression): {result}"
-                # BOTH condition slots must have allocated -- before the fix the 2nd `cond=a` no-op'd
-                # (the gap `oper` poisoned the cache), so the walker threw and only the first landed.
-                cidx = result.get("conditionIndices") or []
-                assert len(cidx) == 2, \
-                    f"multi-condition RE did not allocate both condition slots (expected 2 conditionIndices): {result}"
-                _assert_renders_both()
         finally:
             self._delete_native(app_id)
+
+        # Sub-expression shape: (A > 70 OR B < 80) AND A >= 65. Exercises the close-sub-expression
+        # operator (oper="end-sub-expression )") followed by the outer gap-operator -- an `oper`
+        # echo that ADDS the expression-management buttons while still lagging. The outer cond=a
+        # no-op'd before the fix. Proves the paren/sub-expression path builds live.
+        sub_app_id = self._create_native_rule("SubExprRE")
+        try:
+            sub = self._rm_call_soft({
+                "appId": sub_app_id,
+                "addRequiredExpression": {
+                    "operator": "AND",
+                    "conditions": [
+                        {"subExpression": {"operator": "OR", "conditions": [
+                            {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">", "state": 70},
+                            {"capability": "Temperature", "deviceIds": [int(dev_b)], "comparator": "<", "state": 80},
+                        ]}},
+                        {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">=", "state": 65},
+                    ],
+                },
+                "confirm": True,
+            }, strict=True)
+            assert sub.get("success") is not False, \
+                f"sub-expression addRequiredExpression reported failure (close-paren/outer-oper cache regression): {sub}"
+            # Two inner + one outer condition slot must all allocate.
+            scidx = sub.get("conditionIndices") or []
+            assert len(scidx) == 3, \
+                f"sub-expression RE did not allocate all three condition slots (2 inner + 1 outer): {sub}"
+            self._assert_rule_healthy(sub_app_id)
+        finally:
+            self._delete_native(sub_app_id)
 
     @test("native_apps")
     def test_set_rule_action_mutations(self) -> None:

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3224,6 +3224,53 @@ class TestRunner:
             self._delete_native(reject_app_id)
 
     @test("native_apps")
+    def test_set_rule_required_expression_multi_condition(self) -> None:
+        # hub_set_rule edit -> addRequiredExpression with TWO conditions joined by AND.
+        # Regression guard for the multi-condition gap-operator bug (root-caused 2026-06-21
+        # via the native RM wizard + claude-in-chrome): the `oper=AND` written BETWEEN the two
+        # conditions returns a POST echo that lags one render behind ([oper, doneST] instead of
+        # the settled [cond, doneST]); the request-scoped page cache stored that stale echo, so
+        # the 2nd condition's `cond=a` built its body from a schema missing `cond`, dropped the
+        # `cond.type=enum` sidecar, RM silently no-op'd the write, and the walker failed with
+        # "rCapab_<N> not in STPage schema after cond=a; got cond, doneST". Single-condition REs
+        # never hit this (no gap-oper), which is why the existing RE tests stayed green. This
+        # proves a 2-condition RE builds end-to-end on a live hub: BOTH condition slots allocate
+        # and the rule renders both conditions joined by AND.
+        dev_a, dev_b = self.get_test_temperature_ids()
+        app_id = self._create_native_rule("MultiCondRE")
+        try:
+            result = self._rm_call_soft({
+                "appId": app_id,
+                "addRequiredExpression": {
+                    "operator": "AND",
+                    "conditions": [
+                        {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">", "state": 70},
+                        {"capability": "Temperature", "deviceIds": [int(dev_b)], "comparator": "<", "state": 80},
+                    ],
+                },
+                "confirm": True,
+            }, strict=True)
+            assert result.get("success") is not False, \
+                f"multi-condition addRequiredExpression reported failure (the gap-oper cache regression): {result}"
+            # BOTH condition slots must have allocated -- before the fix the 2nd `cond=a` no-op'd,
+            # so the walker threw and only the first (or no) slot landed.
+            cidx = result.get("conditionIndices") or []
+            assert len(cidx) == 2, \
+                f"multi-condition RE did not allocate both condition slots (expected 2 conditionIndices): {result}"
+            self._assert_rule_healthy(app_id)
+            # The rule renders BOTH Temperature conditions joined by AND.
+            cfg = self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_app_config", "args": {"appId": app_id},
+            })
+            blob = str(cfg)
+            assert blob.lower().count("temperature of") >= 2, \
+                f"rule does not render both Temperature conditions: {blob[:600]}"
+            assert "AND" in blob, \
+                f"rule does not render the AND joining operator: {blob[:600]}"
+        finally:
+            self._delete_native(app_id)
+
+    @test("native_apps")
     def test_set_rule_action_mutations(self) -> None:
         # hub_set_rule edit -> addActions (bulk) + removeAction + clearActions +
         # replaceActions -- the index-bearing action-list mutations on one small rule.

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3273,6 +3273,37 @@ class TestRunner:
         finally:
             self._delete_native(app_id)
 
+        # Sub-expression shape: (A > 70 OR B < 80) AND A >= 65. This exercises the close-sub-
+        # expression operator (oper="end-sub-expression )") followed by the outer gap-operator --
+        # an `oper` echo that ADDS the expression-management buttons while still lagging, which a
+        # "cache on new key" heuristic mis-caches. The outer condition's cond=a then no-op'd before
+        # the fix (oper writes are never cached). Proves the paren/sub-expression path builds live.
+        sub_app_id = self._create_native_rule("SubExprRE")
+        try:
+            sub = self._rm_call_soft({
+                "appId": sub_app_id,
+                "addRequiredExpression": {
+                    "operator": "AND",
+                    "conditions": [
+                        {"subExpression": {"operator": "OR", "conditions": [
+                            {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">", "state": 70},
+                            {"capability": "Temperature", "deviceIds": [int(dev_b)], "comparator": "<", "state": 80},
+                        ]}},
+                        {"capability": "Temperature", "deviceIds": [int(dev_a)], "comparator": ">=", "state": 65},
+                    ],
+                },
+                "confirm": True,
+            }, strict=True)
+            assert sub.get("success") is not False, \
+                f"sub-expression addRequiredExpression reported failure (close-paren/outer-oper cache regression): {sub}"
+            # Two inner + one outer condition slot must all allocate.
+            scidx = sub.get("conditionIndices") or []
+            assert len(scidx) == 3, \
+                f"sub-expression RE did not allocate all three condition slots (2 inner + 1 outer): {sub}"
+            self._assert_rule_healthy(sub_app_id)
+        finally:
+            self._delete_native(sub_app_id)
+
     @test("native_apps")
     def test_set_rule_action_mutations(self) -> None:
         # hub_set_rule edit -> addActions (bulk) + removeAction + clearActions +

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -35,6 +35,12 @@ import requests
 # ---------------------------------------------------------------------------
 
 PREFIX = "BAT_E2E_"
+# Persistent scaffold devices (the shared switch + temp sensors that rule fixtures reference and the
+# poll tests read) carry this marker so the cleanup sweeps SKIP them by name -- created once and
+# reused across runs, never deleted. Under-test fixtures use the bare PREFIX and are still reaped.
+# (The watchdog purges apps/vars only, never devices, so this is purely the test-side device sweep;
+# no watchdog change is needed -- the devices are simply named to dodge the sweep.)
+SCAFFOLD_PREFIX = f"{PREFIX}KEEP_"  # "BAT_E2E_KEEP_"
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -508,7 +514,7 @@ class TestRunner:
             dev_list = vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])
             for d in dev_list:
                 lbl = d.get("label") or d.get("name") or ""
-                if f"{PREFIX}Action_Switch" in lbl:
+                if f"{SCAFFOLD_PREFIX}Action_Switch" in lbl:
                     self._test_switch_id = str(d["id"])
                     return self._test_switch_id
         except Exception:
@@ -518,7 +524,7 @@ class TestRunner:
         # deliberately NOT tracked in created_device_dnis, so teardown leaves it on
         # the hub for the next run to find-and-reuse -- skipping a create+delete
         # every run. Devices that ARE under test still track + delete themselves.
-        self._test_switch_id = self._create_virtual_switch_device(f"{PREFIX}Action_Switch")
+        self._test_switch_id = self._create_virtual_switch_device(f"{SCAFFOLD_PREFIX}Action_Switch")
         assert self._test_switch_id, "Failed to create test switch"
         return self._test_switch_id
 
@@ -566,7 +572,7 @@ class TestRunner:
         if getattr(self, "_test_temp_ids", None):
             return self._test_temp_ids
 
-        labels = [f"{PREFIX}Temp_A", f"{PREFIX}Temp_B"]
+        labels = [f"{SCAFFOLD_PREFIX}Temp_A", f"{SCAFFOLD_PREFIX}Temp_B"]
         found: dict[str, str] = {}
         try:
             vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": PREFIX})
@@ -5958,10 +5964,12 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             dev_list = vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])
             for d in dev_list:
                 lbl = d.get("label") or d.get("name") or ""
-                # Keep the persistent scaffolding switch (get_test_switch_id find-and-reuse): sweeping it
-                # would defeat the reuse and pay a create every run. Narrow suffix match, NOT a blanket
-                # prefix skip, so genuine under-test device leftovers are still reclaimed.
-                if lbl.endswith("Action_Switch"):
+                # Keep the persistent scaffold devices (shared switch + temp sensors that
+                # get_test_switch_id / get_test_temperature_ids find-and-reuse): sweeping them would
+                # defeat the reuse and pay a create every run. They carry the SCAFFOLD_PREFIX marker,
+                # so this skips ONLY them -- genuine under-test device leftovers (bare PREFIX) are
+                # still reclaimed.
+                if SCAFFOLD_PREFIX in lbl:
                     continue
                 if PREFIX in lbl:
                     dni = str(d.get("deviceNetworkId", d.get("dni", "")))

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -6245,15 +6245,28 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
     # -----------------------------------------------------------------------
 
     def run(self, filter_group: str | None = None,
-            filter_test: str | None = None) -> bool:
-        """Run tests. Returns True if all passed."""
+            filter_test: str | None = None,
+            filter_groups: list[str] | None = None,
+            filter_tests: list[str] | None = None) -> bool:
+        """Run tests. Returns True if all passed.
+
+        Selection is a UNION: a test runs if its group is in the requested groups
+        (--group / --groups) OR its display name contains any requested substring
+        (--test / --tests). With no selector, every test runs (the full suite)."""
         self._test_start_time = datetime.now(UTC).isoformat()
+
+        groups_set = set(filter_groups or [])
+        if filter_group:
+            groups_set.add(filter_group)
+        name_subs = list(filter_tests or [])
+        if filter_test:
+            name_subs.append(filter_test)
+        selective = bool(groups_set or name_subs)
 
         tests_to_run = []
         for group, display_name, method_name in TEST_REGISTRY:
-            if filter_group and group != filter_group:
-                continue
-            if filter_test and filter_test not in display_name:
+            if selective and not (group in groups_set
+                                  or any(sub in display_name for sub in name_subs)):
                 continue
             tests_to_run.append((group, display_name, method_name))
 
@@ -6428,6 +6441,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Hubitat MCP Server E2E Tests")
     parser.add_argument("--test", help="Run tests matching this substring")
     parser.add_argument("--group", help="Run only this test group")
+    parser.add_argument("--groups", help="Run only these test groups (comma-separated); unions with --tests")
+    parser.add_argument("--tests", help="Run tests whose name contains any of these substrings (comma-separated); unions with --groups")
     parser.add_argument("--cleanup-only", action="store_true",
                         help="Just clean up BAT_E2E_ test artifacts")
     parser.add_argument("--verbose", "-v", action="store_true",
@@ -6565,7 +6580,10 @@ def main() -> None:
                 print(f"  [WARN] Backup failed: {exc}")
                 print("  Tests requiring backup may fail.\n")
 
-    all_passed = runner.run(filter_group=args.group, filter_test=args.test)
+    _grps = [s.strip() for s in args.groups.split(",") if s.strip()] if args.groups else None
+    _tsts = [s.strip() for s in args.tests.split(",") if s.strip()] if args.tests else None
+    all_passed = runner.run(filter_group=args.group, filter_test=args.test,
+                            filter_groups=_grps, filter_tests=_tsts)
     sys.exit(0 if all_passed else 1)
 
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -6393,6 +6393,13 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             tests_to_run.append((group, display_name, method_name))
 
         if not tests_to_run:
+            if selective:
+                # An explicit --groups/--tests selector that resolves to ZERO tests is an error, not a
+                # pass: a typo'd or renamed name would otherwise exit 0 (green) having run nothing -- a
+                # false green on exactly the one-off lane a maintainer reaches for to confirm a fix.
+                print(f"ERROR: no registered test matched the selector (groups={sorted(groups_set)}, "
+                      f"tests={name_subs}). Nothing ran -- likely a typo or a renamed test.")
+                return False
             print("No tests matched the filter criteria.")
             return True
 


### PR DESCRIPTION
## Summary

Makes Rule Machine condition / Required-Expression building reliable over the cloud relay, plus a two-lane e2e CI that lets a PR run only its affected tests.

- **RM round-trip cuts (fix the relay-504 flakiness).** The classic RM wizard re-renders the whole rule page on every submitOnChange field write, so a multi-condition Required Expression build was heavy enough to time out the cloud relay. Three cuts, no behaviour change:
  - **consume-POST + page cache** — each write POST's returned page model is reused instead of a separate verify-GET, behind a request-scoped page-schema cache.
  - **ghost-ifThen deferral** — `addRequiredExpression` no longer runs the ~9-round-trip predCapabs clear up front; it flags the rule and the next `addAction` (or a raw `walkStep` action) runs the same clear just-in-time, only when an action actually follows. This is what fixes the multi-condition 504.
- **Multi-condition Required Expression correctness.** A gap-operator (`oper=AND`) write returns a POST echo lagging one render; the cache consumed it and dropped the next condition's `.type=enum` sidecar, so RM silently no-op'd the condition. The picker writes now emit their known enum type explicitly so the write lands regardless of the cached schema.
- **Two-lane e2e CI (closes #237)** — a PR runs only the affected `@test` groups (focused) unless a `release:*`/`e2e:full` label runs the whole suite. Plus one-off dispatch inputs (`tests`, `skip_install`) for running a single test against the PR head or the already-deployed code.

## Type of change

- [x] `perf` — RM condition-build hub round-trips (the 504 fix)
- [x] `fix` — multi-condition Required Expression correctness
- [x] `ci` — two-lane e2e CI + dispatch inputs

## Changes

- `libraries/mcp-native-rules-lib.groovy`:
  - **Ghost-ifThen deferral**: `addRequiredExpression` Step 4b sets `atomicState.predClearPending`; `_rmAddAction` AND `_rmWalkStep` (the raw action path) run the same `_rmClearPredCapabsViaGhostIfThen` just-in-time before an action lands. predCapabs is still cleared (only the timing moves); STPage opens cleanly without it (doneST -> Done mode). The flag is dropped on a rolled-back RE build (restore) and on rule delete.
  - **Force-type sidecar**: the `cond`/`oper` STPage pickers emit `.type=enum` explicitly so a lagged cached echo can't drop the write.
  - Page-cache threading through the condition walk, the ghost-ifThen, and the existing-RE precheck.
- `hubitat-mcp-server.groovy`: the consume-POST inline-echo + request-scoped page cache (`_rmWriteSubPageField` / `_rmClickAppButton` / `_rmCacheStore` / `_rmCacheInvalidate`) and a debug-gated `[hubrt]` per-round-trip log.
- `.github/workflows/hub-e2e.yml` + `.github/scripts/e2e_scope.py`: the two-lane gate; the `tests` one-off input (single test, still installs the PR head); the `skip_install` input (run against deployed code, no install/restore, keeps the lease); a skipped pkg_validate counts as a gate pass; the changed-file fail-safe sets lane=full; concurrency keys on head-repo + branch.
- `tests/e2e_test.py`: `test_set_rule_required_expression_multi_condition` (3-condition AND + sub-expression), `test_set_rule_action_after_required_expression` (the predCapabs-clear guard), two single-step walkStep guards — `test_set_rule_walkstep_action_after_required_expression` (a walkStep-authored action after an RE lands top-level, the raw-path P2c guard) and `test_set_native_app_walkstep_button_controller` (single-step walkStep introspect+write on a non-RM button controller) — `--groups`/`--tests` multi-select, and a hard failure when an explicit selector matches zero tests.
- `src/test/groovy/server/ToolRmNativeCrudSpec.groovy`: the ghost-ifThen specs rewritten for the deferral, plus regression guards for the `_rmAddAction`/`walkStep` clear seams, the cached cond=a read, and the flag lifecycle.
- `AGENTS.md`/`CLAUDE.md`: the two-lane flow.

## Release Notes

- **Rule Machine condition building no longer times out over the cloud relay.** Building a multi-condition Required Expression (or a condition that compares against another device) is now reliable — the wizard reuses each write's returned page, caches reads, and defers a one-time internal cleanup to when it's actually needed, cutting the per-build hub round-trips. A multi-condition AND / sub-expression build that previously failed intermittently now succeeds clean.

## Testing

- `python tests/sandbox_lint.py` + the full Spock suite green (incl. the rewritten ghost-ifThen specs and the new seam / walkStep / cache / flag guards); workflow YAML parses.
- **Verified live on the e2e hub**: `multi_condition` 5/5 clean (was a 504 + retry nearly every run before the deferral); the predCapabs guard passes (an action added after an RE is not `IF(Broken Condition)`).
- **BAT on CrameHub**: RE->addAction renders the action top-level; an RE-only rule's STPage opens with no "Required Fields" popup (claude-in-chrome); a raw `walkStep` action after an RE fires the deferred clear and lands clean.
- **Reviewed via the PR-review toolkit (workflow) + an independent Codex review**; all confirmed findings addressed in-PR.

## Notes (post-merge, tracked)

- At merge, the ruleset `main-required-checks` required context swaps `e2e` -> `Full e2e (runs with label)` (this PR posts the new name).
