### PR TITLE
chore: clarify the hub-var refresh-failure log message

### DIFF
--- a/libraries/mcp-variables-lib.groovy
+++ b/libraries/mcp-variables-lib.groovy
@@ -12,7 +12,7 @@ private void _refreshHubVarInUseRegistrations() {
         mcpLog("error", "hub-vars",
             "_refreshHubVarInUseRegistrations: getAllGlobalVars failed (${e.class.simpleName}: ${e.message}) -- " +
             "in-use safety registrations are STALE. hub_delete_variable's hub-side warning may not fire until " +
-            "this resolves and updated() runs again.")
+            "this transient failure resolves and updated() re-runs the refresh.")
         return
     }
     if (!hubVarNames) {


### PR DESCRIPTION
## Summary

Clarify the `_refreshHubVarInUseRegistrations` `getAllGlobalVars`-failure log line — make the recovery condition explicit ("until this transient failure resolves and updated() re-runs the refresh") instead of the vaguer "until this resolves and updated() runs again".

Also the first PR exercising the post-#301 two-lane e2e flow: a single-library change (`libraries/mcp-variables-lib.groovy`) should run **only the FOCUSED lane** — smoke (`infrastructure`+`protocol`) + `hub_variables` — with the `Full e2e (runs with label)` gate held **pending** (holding merge without going red) until a `release:*`/`e2e:full` label runs the full suite.

## Type of change

- [x] `chore` — internal log-message clarity


## Testing

- Comment/log-string only; no logic change. The two-lane e2e it triggers is itself the validation.
