### PR TITLE
ci: fix lease double-booking + FIFO-order the e2e queue

### DIFF
--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -92,6 +92,25 @@ set_lease_value() {
   mcp_call "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"hub_manage_variables\",\"arguments\":{\"tool\":\"hub_set_variable\",\"args\":{\"name\":\"_TEST_HUB_LEASED_BY\",\"value\":${value_json}}}}}" >/dev/null
 }
 
+fifo_my_turn() {
+  # FIFO across PRs, decided GitHub-side (the hub never schedules e2e -- GitHub does): a FREE
+  # lease is claimed only by the EARLIEST run still in line -- the lowest run_number among
+  # in-progress hub-e2e runs (GitHub run order == arrival order). So when one PR's run finishes,
+  # the next-oldest PR's run goes, then the next, and so on. `status=in_progress` excludes fork
+  # PRs still parked on the approve gate (those are status=waiting), so a pending approval never
+  # blocks the line; a run that pushes a new commit while waiting is cancelled by the per-branch
+  # concurrency and its replacement takes a fresh (higher) number at the back. On any GitHub-API
+  # hiccup this returns "my turn" -- the lease claim+verify still guarantees one-at-a-time, so a
+  # blip only degrades FIFO to first-come, never a double-book.
+  [ -n "${GITHUB_RUN_NUMBER:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] || return 0
+  command -v gh >/dev/null 2>&1 || return 0
+  local min_rn
+  min_rn="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/hub-e2e.yml/runs?status=in_progress&per_page=100" \
+            --jq '[.workflow_runs[].run_number] | min // empty' 2>/dev/null)" || return 0
+  [ -z "$min_rn" ] && return 0
+  [ "$min_rn" -ge "$GITHUB_RUN_NUMBER" ]   # nobody earlier is still in-progress -> my turn
+}
+
 # Wait (polling) until the lease is free, expired, or already ours — or until the
 # wait budget runs out. The job's own timeout-minutes bounds the total, and because
 # we claim only AFTER this wait, the lease TTL below starts at acquisition.
@@ -133,7 +152,16 @@ while :; do
       continue
     fi
     if [ -z "$CONFIRM" ]; then
-      break  # released (confirmed empty by two consecutive reads)
+      # Released (confirmed empty) -- but only the FIFO-earliest run in line claims it; an
+      # earlier-queued run goes first. (The expired-lease reclaim further down is NOT gated:
+      # that path is crash recovery for a holder that never released, where the dead holder
+      # must not keep its place in line.)
+      if fifo_my_turn; then
+        break  # released + my turn
+      fi
+      echo "::notice::Lease is free but an earlier hub-e2e run is ahead in the queue; waiting my turn."
+      sleep "$LEASE_POLL_INTERVAL_S"
+      continue
     fi
     CURRENT="$CONFIRM"  # a lease appeared between the two reads -- fall through to the BUSY parse below
   fi

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -66,9 +66,18 @@ mcp_call() {
 }
 
 get_lease_value() {
-  mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_manage_variables","arguments":{"tool":"hub_get_variable","args":{"name":"_TEST_HUB_LEASED_BY"}}}}' \
-    | jq -r '.result.content[0].text' \
-    | jq -r '.value // ""'
+  # Returns 0 + the lease value (which may legitimately be "" when released) ONLY for a
+  # well-formed tools/call result. A JSON-RPC ERROR envelope -- -32602 (the variable failed
+  # to resolve) or -32603 (internal error, which the main app emits while its class is being
+  # recompiled by ANOTHER run's deploy) -- carries `.error` and NO `.result.content`. The
+  # `jq -e` makes that case exit non-zero so the caller routes it to the read-fail/poll path
+  # and never claims. Without `-e`, a missing `.result.content[0].text` printed literal
+  # `null`, which `.value // ""` then collapsed to empty -> read as "released" -> a run
+  # claimed over a still-valid lease and double-booked the single hub. That is the bug.
+  local resp text
+  resp="$(mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_manage_variables","arguments":{"tool":"hub_get_variable","args":{"name":"_TEST_HUB_LEASED_BY"}}}}')" || return 1
+  text="$(printf '%s' "$resp" | jq -e -r '.result.content[0].text')" || return 1
+  printf '%s' "$text" | jq -e -r '.value // ""' || return 1
 }
 
 set_lease_value() {
@@ -107,7 +116,20 @@ while :; do
   read_fail_since=""  # a successful read clears the unreachable streak
 
   if [ -z "$CURRENT" ]; then
-    break  # released
+    # One empty read must NEVER claim on its own. Even with the strict parse in
+    # get_lease_value, confirm "released" with a SECOND read before treating the hub as
+    # free -- mirroring the defensiveness the BUSY path already has for a malformed
+    # non-empty value (a single degraded read must not be enough to claim).
+    sleep "$VERIFY_SLEEP_S"
+    if ! CONFIRM="$(get_lease_value)"; then
+      echo "::notice::Lease read empty once but the confirm read failed; polling instead of claiming."
+      sleep "$LEASE_POLL_INTERVAL_S"
+      continue
+    fi
+    if [ -z "$CONFIRM" ]; then
+      break  # released (confirmed empty by two consecutive reads)
+    fi
+    CURRENT="$CONFIRM"  # a lease appeared between the two reads -- fall through to the BUSY parse below
   fi
 
   NOW_MS="$(now_ms)"

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -4,9 +4,11 @@
 # Usage:  lease_acquire.sh <by-identifier>
 # Env:    MCP_URL — full cloud OAuth URL with access_token
 #         LEASE_WAIT_TIMEOUT_S        — max seconds to WAIT for a successfully-read but HELD
-#                                       lease to free before aborting (default 14400 = 4h: runs
-#                                       QUEUE on the lease, so several PRs can wait their turn
-#                                       on the single shared hub). Set 0 to fail fast.
+#                                       lease to free before aborting (default 14400 = 4h).
+#                                       Native concurrency (the hub-e2e-serialized group) already
+#                                       serializes CI runs, so at most one ever reaches the lease;
+#                                       this budget exists to wait out a HUMAN holding the hub by
+#                                       hand, which concurrency can't see. Set 0 to fail fast.
 #         LEASE_UNREACHABLE_TIMEOUT_S — max seconds to tolerate the endpoint being UNREADABLE
 #                                       (5xx on every read = hub/app down, not lease held)
 #                                       before fast-failing (default 120). Much shorter than the
@@ -14,14 +16,15 @@
 #                                       waiting it out just burns ~10min per run.
 #         LEASE_POLL_INTERVAL_S       — seconds between polls while waiting (default 30).
 #
-# Exits 0 on successful claim. While the lease is read as held by someone else and not
-# expired, this WAITS (polling) and claims it automatically the moment it frees or
-# the holder's TTL lapses — so a run queued behind another holder, or behind a manual
-# hub session that GitHub's `concurrency` group can't see, starts on its own instead
-# of needing a manual re-run. A brief read failure or a malformed/corrupt lease value
-# mid-wait is polled through, never treated as free. Exits 1 if the lease is STILL held
-# after LEASE_WAIT_TIMEOUT_S, if the endpoint stays UNREADABLE past LEASE_UNREACHABLE_TIMEOUT_S
-# (the fast-fail for a down hub/app), or if the post-write race-check shows another claim last.
+# Exits 0 on successful claim. While the lease is read as held and not expired, this WAITS
+# (polling) and claims it automatically the moment it frees or the holder's TTL lapses — so a
+# run blocked by a manual hub session that GitHub's `concurrency` group can't see (a human
+# holding the lease by hand) starts on its own instead of needing a re-run. Cross-PR CI queueing
+# is GitHub native concurrency's job now (the hub-e2e-serialized group), not the lease's. A brief
+# read failure or a malformed/corrupt lease value mid-wait is polled through, never treated as
+# free. Exits 1 if the lease is STILL held after LEASE_WAIT_TIMEOUT_S, if the endpoint stays
+# UNREADABLE past LEASE_UNREACHABLE_TIMEOUT_S (the fast-fail for a down hub/app), or if the
+# post-write race-check shows another claim last.
 #
 # Lease shape (JSON, written into Hubitat Hub Variable `_TEST_HUB_LEASED_BY`):
 #   {"by":"<who>","since":<epoch_ms>,"until":<epoch_ms>}

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -93,22 +93,34 @@ set_lease_value() {
 }
 
 fifo_my_turn() {
-  # FIFO across PRs, decided GitHub-side (the hub never schedules e2e -- GitHub does): a FREE
-  # lease is claimed only by the EARLIEST run still in line -- the lowest run_number among
-  # in-progress hub-e2e runs (GitHub run order == arrival order). So when one PR's run finishes,
-  # the next-oldest PR's run goes, then the next, and so on. `status=in_progress` excludes fork
-  # PRs still parked on the approve gate (those are status=waiting), so a pending approval never
-  # blocks the line; a run that pushes a new commit while waiting is cancelled by the per-branch
-  # concurrency and its replacement takes a fresh (higher) number at the back. On any GitHub-API
-  # hiccup this returns "my turn" -- the lease claim+verify still guarantees one-at-a-time, so a
-  # blip only degrades FIFO to first-come, never a double-book.
-  [ -n "${GITHUB_RUN_NUMBER:-}" ] && [ -n "${GITHUB_REPOSITORY:-}" ] || return 0
+  # FIFO across PRs, decided GitHub-side (the hub never schedules e2e -- GitHub does). Ordered by
+  # when each run actually ENTERED THE LINE: the start time of its "e2e (run)" job -- NOT
+  # run_number (which is creation order). That distinction matters for two maintainer-flagged
+  # cases:
+  #   * an outside-contributor PR parks on the approve gate (status=waiting, already excluded
+  #     below) until a human approves it; its e2e job then STARTS at approval time, so it joins
+  #     the BACK of the line then -- it does NOT cut ahead on its old creation-time number.
+  #   * applying a release:*/e2e:full label spawns a NEW run whose e2e job starts at label time,
+  #     so it joins at the back too (the per-branch concurrency cancels the old focused run).
+  # A FREE lease is claimed only by the run whose e2e job started earliest (ties broken by run id).
+  # On any GitHub-API hiccup this returns "my turn" -- the lease claim+verify still guarantees
+  # one-at-a-time, so a blip only degrades FIFO to first-come, never a double-book.
+  [ -n "${GITHUB_REPOSITORY:-}" ] && [ -n "${GITHUB_RUN_ID:-}" ] || return 0
   command -v gh >/dev/null 2>&1 || return 0
-  local min_rn
-  min_rn="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/hub-e2e.yml/runs?status=in_progress&per_page=100" \
-            --jq '[.workflow_runs[].run_number] | min // empty' 2>/dev/null)" || return 0
-  [ -z "$min_rn" ] && return 0
-  [ "$min_rn" -ge "$GITHUB_RUN_NUMBER" ]   # nobody earlier is still in-progress -> my turn
+  local ids id ts earliest_id="" earliest_ts=""
+  ids="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/hub-e2e.yml/runs?status=in_progress&per_page=100" \
+         --jq '.workflow_runs[].id' 2>/dev/null)" || return 0
+  [ -z "$ids" ] && return 0
+  for id in $ids; do
+    ts="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${id}/jobs" \
+          --jq '[.jobs[] | select(.name=="e2e (run)" and .started_at != null) | .started_at] | min // empty' 2>/dev/null)" || continue
+    [ -z "$ts" ] && continue   # this run's e2e job hasn't started yet -> not contending for the lease yet
+    if [ -z "$earliest_ts" ] || [[ "$ts" < "$earliest_ts" ]] || { [ "$ts" = "$earliest_ts" ] && [ "$id" -lt "$earliest_id" ]; }; then
+      earliest_ts="$ts"; earliest_id="$id"
+    fi
+  done
+  [ -z "$earliest_id" ] && return 0          # nobody's e2e job has started -> proceed (defensive)
+  [ "$earliest_id" = "$GITHUB_RUN_ID" ]      # the earliest-started e2e job is mine -> my turn
 }
 
 # Wait (polling) until the lease is free, expired, or already ours — or until the

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -66,16 +66,22 @@ mcp_call() {
 }
 
 get_lease_value() {
-  # Returns 0 + the lease value (which may legitimately be "" when released) ONLY for a
-  # well-formed tools/call result. A JSON-RPC ERROR envelope -- -32602 (the variable failed
-  # to resolve) or -32603 (internal error, which the main app emits while its class is being
-  # recompiled by ANOTHER run's deploy) -- carries `.error` and NO `.result.content`. The
-  # `jq -e` makes that case exit non-zero so the caller routes it to the read-fail/poll path
-  # and never claims. Without `-e`, a missing `.result.content[0].text` printed literal
-  # `null`, which `.value // ""` then collapsed to empty -> read as "released" -> a run
-  # claimed over a still-valid lease and double-booked the single hub. That is the bug.
-  local resp text
+  # Prints the lease value (may be "" when released) + exit 0 for a well-formed tools/call
+  # result OR a "variable not found" error -- a FRESH hub where _TEST_HUB_LEASED_BY was never
+  # created reads as released, so the first claim can bootstrap it (the claim write
+  # auto-creates the var). Any OTHER non-result response exits non-zero so the caller polls
+  # (read-fail path) and never falsely claims: a -32603 the main app emits mid-recompile during
+  # another run's deploy, a transport failure, a non-JSON body. `jq -e` distinguishes a real
+  # result from an error envelope; without it a missing .result.content collapsed to "" and
+  # read as "released", double-booking the single hub.
+  local resp
   resp="$(mcp_call '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hub_manage_variables","arguments":{"tool":"hub_get_variable","args":{"name":"_TEST_HUB_LEASED_BY"}}}}')" || return 1
+  # "Variable not found" -> the lease var was never created -> released/free. (A transient
+  # not-found can't false-claim: the empty-break still requires a confirming second read.)
+  if printf '%s' "$resp" | jq -e '(.error.message // "") | test("not found"; "i")' >/dev/null 2>&1; then
+    return 0
+  fi
+  local text
   text="$(printf '%s' "$resp" | jq -e -r '.result.content[0].text')" || return 1
   printf '%s' "$text" | jq -e -r '.value // ""' || return 1
 }
@@ -116,10 +122,10 @@ while :; do
   read_fail_since=""  # a successful read clears the unreachable streak
 
   if [ -z "$CURRENT" ]; then
-    # One empty read must NEVER claim on its own. Even with the strict parse in
-    # get_lease_value, confirm "released" with a SECOND read before treating the hub as
-    # free -- mirroring the defensiveness the BUSY path already has for a malformed
-    # non-empty value (a single degraded read must not be enough to claim).
+    # A single empty read is already trustworthy now that get_lease_value strict-parses (a
+    # degraded response returns non-zero and polls, never a false-empty). This confirming read
+    # closes the remaining race: a lease WRITTEN between read1 and our claim. If one appears,
+    # fall through to the BUSY parse below instead of claiming over it.
     sleep "$VERIFY_SLEEP_S"
     if ! CONFIRM="$(get_lease_value)"; then
       echo "::notice::Lease read empty once but the confirm read failed; polling instead of claiming."
@@ -184,11 +190,17 @@ CLAIM_AS_STRING="$(printf '%s' "$CLAIM_JSON" | jq -Rs .)"
 
 set_lease_value "$CLAIM_AS_STRING"
 
-# Post-write race-check: re-read after a short delay. If "by" isn't us,
-# someone else's claim landed last and stole the lease — abort.
+# Post-write race-check: re-read after a short delay. If "by" isn't us, someone else's claim
+# landed last and stole the lease — abort. Ride out a lone transient read failure here the way
+# the wait loop does (one retry) so a blip in this 2s window doesn't fail a claim that actually
+# landed; a sustained failure still aborts safely (the 30-min TTL bounds the lease we wrote).
 sleep "$VERIFY_SLEEP_S"
-AFTER="$(get_lease_value)"
-AFTER_BY="$(echo "$AFTER" | jq -r '.by // ""' 2>/dev/null || echo "")"
+if ! AFTER="$(get_lease_value)"; then
+  echo "::warning::Post-write verify read failed transiently; re-reading once."
+  sleep "$VERIFY_SLEEP_S"
+  AFTER="$(get_lease_value)" || { echo "::error::Could not re-read the lease to verify our claim after writing; aborting (the 30-min TTL bounds the lease we wrote)."; exit 1; }
+fi
+AFTER_BY="$(printf '%s' "$AFTER" | jq -r '.by // ""' 2>/dev/null || echo "")"
 
 if [ "$AFTER_BY" != "$BY" ]; then
   echo "::error::Lease stolen by '$AFTER_BY' before our verify check. Aborting."

--- a/.github/scripts/lease_acquire.sh
+++ b/.github/scripts/lease_acquire.sh
@@ -92,37 +92,6 @@ set_lease_value() {
   mcp_call "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"hub_manage_variables\",\"arguments\":{\"tool\":\"hub_set_variable\",\"args\":{\"name\":\"_TEST_HUB_LEASED_BY\",\"value\":${value_json}}}}}" >/dev/null
 }
 
-fifo_my_turn() {
-  # FIFO across PRs, decided GitHub-side (the hub never schedules e2e -- GitHub does). Ordered by
-  # when each run actually ENTERED THE LINE: the start time of its "e2e (run)" job -- NOT
-  # run_number (which is creation order). That distinction matters for two maintainer-flagged
-  # cases:
-  #   * an outside-contributor PR parks on the approve gate (status=waiting, already excluded
-  #     below) until a human approves it; its e2e job then STARTS at approval time, so it joins
-  #     the BACK of the line then -- it does NOT cut ahead on its old creation-time number.
-  #   * applying a release:*/e2e:full label spawns a NEW run whose e2e job starts at label time,
-  #     so it joins at the back too (the per-branch concurrency cancels the old focused run).
-  # A FREE lease is claimed only by the run whose e2e job started earliest (ties broken by run id).
-  # On any GitHub-API hiccup this returns "my turn" -- the lease claim+verify still guarantees
-  # one-at-a-time, so a blip only degrades FIFO to first-come, never a double-book.
-  [ -n "${GITHUB_REPOSITORY:-}" ] && [ -n "${GITHUB_RUN_ID:-}" ] || return 0
-  command -v gh >/dev/null 2>&1 || return 0
-  local ids id ts earliest_id="" earliest_ts=""
-  ids="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/workflows/hub-e2e.yml/runs?status=in_progress&per_page=100" \
-         --jq '.workflow_runs[].id' 2>/dev/null)" || return 0
-  [ -z "$ids" ] && return 0
-  for id in $ids; do
-    ts="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${id}/jobs" \
-          --jq '[.jobs[] | select(.name=="e2e (run)" and .started_at != null) | .started_at] | min // empty' 2>/dev/null)" || continue
-    [ -z "$ts" ] && continue   # this run's e2e job hasn't started yet -> not contending for the lease yet
-    if [ -z "$earliest_ts" ] || [[ "$ts" < "$earliest_ts" ]] || { [ "$ts" = "$earliest_ts" ] && [ "$id" -lt "$earliest_id" ]; }; then
-      earliest_ts="$ts"; earliest_id="$id"
-    fi
-  done
-  [ -z "$earliest_id" ] && return 0          # nobody's e2e job has started -> proceed (defensive)
-  [ "$earliest_id" = "$GITHUB_RUN_ID" ]      # the earliest-started e2e job is mine -> my turn
-}
-
 # Wait (polling) until the lease is free, expired, or already ours — or until the
 # wait budget runs out. The job's own timeout-minutes bounds the total, and because
 # we claim only AFTER this wait, the lease TTL below starts at acquisition.
@@ -164,16 +133,7 @@ while :; do
       continue
     fi
     if [ -z "$CONFIRM" ]; then
-      # Released (confirmed empty) -- but only the FIFO-earliest run in line claims it; an
-      # earlier-queued run goes first. (The expired-lease reclaim further down is NOT gated:
-      # that path is crash recovery for a holder that never released, where the dead holder
-      # must not keep its place in line.)
-      if fifo_my_turn; then
-        break  # released + my turn
-      fi
-      echo "::notice::Lease is free but an earlier hub-e2e run is ahead in the queue; waiting my turn."
-      sleep "$LEASE_POLL_INTERVAL_S"
-      continue
+      break  # released (confirmed empty by two consecutive reads)
     fi
     CURRENT="$CONFIRM"  # a lease appeared between the two reads -- fall through to the BUSY parse below
   fi

--- a/.github/scripts/lease_release.sh
+++ b/.github/scripts/lease_release.sh
@@ -1,21 +1,60 @@
 #!/usr/bin/env bash
-# Release test hub lease (write empty string to `_TEST_HUB_LEASED_BY`).
+# Release test hub lease.
 #
-# Env: MCP_URL — full cloud OAuth URL with access_token.
+# Usage:  lease_release.sh [<by-identifier>]
+# Env:    MCP_URL — full cloud OAuth URL with access_token.
 #
-# Always exits 0 even if the release call fails — the lease has a 30-min
-# TTL safety net, and this script runs in `if: always()` workflow steps
-# where a non-zero exit would mask the real test failure.
+# With a <by-identifier> (the same "ci-run-<run_id>" the acquire used) this does a
+# COMPARE-AND-CLEAR: it reads the current holder and only blanks the variable if WE still
+# hold it (or it is already empty). A run must NEVER clear a DIFFERENT run's live lease --
+# e.g. a slow or cancelled run releasing after another run has legitimately claimed (exactly
+# what happened downstream of the #306/#307 double-book: #307 released and blanked #306's
+# value). A degraded/error read (`jq -e`) falls to "unreadable" -> leave it alone; the 30-min
+# TTL bounds it. With NO argument (a base-workflow call that predates this arg) it falls back
+# to the old UNCONDITIONAL clear, so a pull_request_target run executing main's workflow file
+# still releases its own lease.
+#
+# Always exits 0 even if the call fails — the lease has a 30-min TTL safety net, and this
+# script runs in `if: always()` steps where a non-zero exit would mask the real test failure.
 
 set -uo pipefail
 
 : "${MCP_URL:?MCP_URL env var required}"
+BY="${1:-}"
 
-if curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
+clear_lease() {
+  if curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
+      -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"hub_manage_variables","arguments":{"tool":"hub_set_variable","args":{"name":"_TEST_HUB_LEASED_BY","value":""}}}}' \
+      >/dev/null; then
+    echo "Lease released."
+  else
+    echo "::warning::Lease release failed — relying on 30-min TTL to clear it."
+  fi
+}
+
+# Legacy / no-identity call (base-workflow before the arg is wired in): unconditional clear.
+if [ -z "$BY" ]; then
+  clear_lease
+  exit 0
+fi
+
+# Compare-and-clear. Read the current lease value defensively; `jq -e` makes an error
+# envelope or any 200 lacking .result.content fall to "__unreadable__" (never a false-empty).
+LEASE="$(curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
     -H "Content-Type: application/json" \
-    -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"hub_manage_variables","arguments":{"tool":"hub_set_variable","args":{"name":"_TEST_HUB_LEASED_BY","value":""}}}}' \
-    >/dev/null; then
-  echo "Lease released."
+    -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"hub_manage_variables","arguments":{"tool":"hub_get_variable","args":{"name":"_TEST_HUB_LEASED_BY"}}}}' 2>/dev/null \
+  | jq -e -r '.result.content[0].text' 2>/dev/null | jq -r '.value // ""' 2>/dev/null)" || LEASE="__unreadable__"
+
+if [ "$LEASE" = "__unreadable__" ]; then
+  echo "::warning::Could not read the lease before release; NOT clearing it (the 30-min TTL will bound it)."
+elif [ -z "$LEASE" ]; then
+  echo "Lease already empty; nothing to release."
 else
-  echo "::warning::Lease release failed — relying on 30-min TTL to clear it."
+  HOLDER="$(printf '%s' "$LEASE" | jq -r '.by // ""' 2>/dev/null || echo "")"
+  if [ "$HOLDER" = "$BY" ]; then
+    clear_lease
+  else
+    echo "::warning::Lease now held by '$HOLDER', not us ('$BY') — NOT clearing it (another run owns it; its TTL bounds it)."
+  fi
 fi

--- a/.github/scripts/lease_release.sh
+++ b/.github/scripts/lease_release.sh
@@ -7,9 +7,9 @@
 # With a <by-identifier> (the same "ci-run-<run_id>" the acquire used) this does a
 # COMPARE-AND-CLEAR: it reads the current holder and only blanks the variable if WE still
 # hold it (or it is already empty). A run must NEVER clear a DIFFERENT run's live lease --
-# e.g. a slow or cancelled run releasing after another run has legitimately claimed (exactly
-# what happened downstream of the #306/#307 double-book: #307 released and blanked #306's
-# value). A degraded/error read (`jq -e`) falls to "unreadable" -> leave it alone; the 30-min
+# e.g. a slow or cancelled run releasing after another run has legitimately claimed would
+# otherwise blank the new holder's live value. A degraded/error read (`jq -e`) falls to
+# "unreadable" -> leave it alone; the 30-min
 # TTL bounds it. With NO argument (a base-workflow call that predates this arg) it falls back
 # to the old UNCONDITIONAL clear, so a pull_request_target run executing main's workflow file
 # still releases its own lease.
@@ -44,13 +44,17 @@ fi
 LEASE="$(curl -sS --fail --max-time 30 -X POST "$MCP_URL" \
     -H "Content-Type: application/json" \
     -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"hub_manage_variables","arguments":{"tool":"hub_get_variable","args":{"name":"_TEST_HUB_LEASED_BY"}}}}' 2>/dev/null \
-  | jq -e -r '.result.content[0].text' 2>/dev/null | jq -r '.value // ""' 2>/dev/null)" || LEASE="__unreadable__"
+  | jq -e -r '.result.content[0].text' 2>/dev/null | jq -e -r '.value // empty' 2>/dev/null)" || LEASE="__unreadable__"
 
 if [ "$LEASE" = "__unreadable__" ]; then
   echo "::warning::Could not read the lease before release; NOT clearing it (the 30-min TTL will bound it)."
 elif [ -z "$LEASE" ]; then
   echo "Lease already empty; nothing to release."
 else
+  # read-then-clear is not atomic (the MCP set_variable surface has no compare-and-swap). If our
+  # TTL lapsed between this read and the clear, another run could reclaim and our clear would
+  # blank ITS fresh lease -- a milder replay of the bug this fixes. The window is ~2 back-to-back
+  # POSTs and the 30-min TTL bounds the worst case; fully closing it needs hub-side CAS.
   HOLDER="$(printf '%s' "$LEASE" | jq -r '.by // ""' 2>/dev/null || echo "")"
   if [ "$HOLDER" = "$BY" ]; then
     clear_lease

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -94,6 +94,9 @@ permissions:
 # each other, and an unapproved fork PR only ever holds ITS OWN branch's group -- never the shared
 # hub or another PR. Cross-PR FIFO serialization is the e2e job's SEPARATE `queue: max` group; the
 # two can't be one block (queue:max + cancel-in-progress:true is an invalid combination).
+# Cancelling mid-run is safe: the e2e job's disarm/restore + lease-release steps are `if: always()`
+# (so a cancel still frees the hub), and a hard kill is backstopped by the dead-man watchdog's
+# deadline restore plus the 30-min lease TTL.
 concurrency:
   group: hub-e2e-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
@@ -140,6 +143,11 @@ jobs:
     timeout-minutes: 15
     concurrency:
       group: hub-e2e-serialized
+      # queue:max (matching the e2e job) so a probe dispatch QUEUES behind a pending e2e run rather
+      # than evicting it -- the group's default queue:single would let a probe cancel a pending PR's
+      # e2e out of the FIFO line. queue:max + cancel-in-progress:false is valid (only queue:max +
+      # cancel-in-progress:true is rejected).
+      queue: max
       cancel-in-progress: false
     env:
       MCP_URL: ${{ secrets.LEVEL99_TEST_HUB_MCP_URL }}
@@ -211,25 +219,33 @@ jobs:
     needs: [approve]
     if: inputs.probe_only != 'true'
     runs-on: ubuntu-latest
-    # Bounds the whole job: up to a 4h lease-queue wait (LEASE_WAIT_TIMEOUT_S in
-    # lease_acquire.sh) + the ~30-min post-acquisition run window. The lease is claimed
-    # only AFTER the wait, so the run itself always stays within the 30-min lease TTL.
+    # Bounds the EXECUTING job. Cross-PR queueing happens BEFORE this clock starts (a run waits its
+    # turn in the hub-e2e-serialized concurrency group, and behind the approve gate, both in
+    # queued/waiting state -- neither counts against timeout-minutes). So this covers: up to a 4h
+    # wait for a HUMAN-held lease to free (LEASE_WAIT_TIMEOUT_S in lease_acquire.sh) + the ~30-min
+    # post-acquisition run window. The lease is claimed only AFTER that wait, so the run itself
+    # always stays within the 30-min lease TTL.
     timeout-minutes: 270
 
     # Serialization model: GitHub's NATIVE concurrency does the cross-PR FIFO QUEUE; the lease is
     # the hub-side lock (and the only thing that can see a HUMAN holding the hub by hand).
     #   * `queue: max` lets up to 100 e2e runs WAIT in this one global group and processes them ONE
     #     AT A TIME in first-in-first-out order (by when each STARTED WAITING on the group). This
-    #     job is `needs: [approve]`, so it enters the group only AFTER the approve gate clears --
-    #     an approved outside-contributor PR therefore takes its place at APPROVAL time (not its old
-    #     creation order), and a release:*/e2e:full label spawns a new run that enters at the BACK.
-    #     Both lanes (focused/full) are this same job in this same group, so they queue together.
+    #     job is `needs: [approve]`, so it enters the group only AFTER the approve gate clears
+    #     (GitHub's observed behavior: a needs-gated job doesn't start waiting on its own group
+    #     until it's eligible to run) -- an approved outside-contributor PR therefore takes its
+    #     place at APPROVAL time (not its old creation order), and a release:*/e2e:full label spawns
+    #     a new run that enters at the BACK. Both lanes (focused/full) are this same job in this
+    #     same group, so they queue together.
     #   * Cancelling a SUPERSEDED run (new commit on the same branch) is the WORKFLOW-level
     #     per-branch group near the top of this file. It can't live here: `queue: max` and
     #     `cancel-in-progress: true` cannot be combined in one concurrency block.
     #   * lease_acquire.sh still claims/releases _TEST_HUB_LEASED_BY, but it NO LONGER orders the
     #     queue (concurrency does). Its remaining job is to block when a HUMAN holds the lease by
-    #     hand to take the hub for manual use -- which GitHub concurrency can't see.
+    #     hand to take the hub for manual use -- which GitHub concurrency can't see. Because only the
+    #     head-of-line run is in_progress, a head run waiting out a human-held lease blocks the whole
+    #     queue for that wait (bounded by timeout-minutes above; the human hold is the only thing it
+    #     ever waits on now).
     concurrency:
       group: hub-e2e-serialized
       queue: max

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -706,4 +706,4 @@ jobs:
 
       - name: Release test hub lease
         if: always() && steps.gate.outputs.available == 'true'
-        run: bash .github/scripts/lease_release.sh
+        run: bash .github/scripts/lease_release.sh "ci-run-${{ github.run_id }}"

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -83,11 +83,20 @@ on:
 
 permissions:
   contents: read
-  actions: read   # lease_acquire.sh lists in-progress hub-e2e runs (run_number order) for FIFO lease ordering
   # statuses: write lets the "Post e2e gate status" step POST the required commit status
   # "Full e2e (runs with label)" (pending while focused, success/failure when full). Without it
   # the POST 403s ("Resource not accessible by integration") and the gate can never report.
   statuses: write
+
+# New-commit-cancel, per branch: a fresh push / label add / dispatch on a branch cancels the older
+# in-flight run for that SAME branch, and its replacement re-queues at the BACK of the e2e job's
+# FIFO group. Per-branch (head-repo + head_ref) so two forks reusing a branch name don't cancel
+# each other, and an unapproved fork PR only ever holds ITS OWN branch's group -- never the shared
+# hub or another PR. Cross-PR FIFO serialization is the e2e job's SEPARATE `queue: max` group; the
+# two can't be one block (queue:max + cancel-in-progress:true is an invalid combination).
+concurrency:
+  group: hub-e2e-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   # The hub-less self-deploy recovery guard (issue #237) is NOT here: running untrusted
@@ -108,9 +117,10 @@ jobs:
   # file is taken from the base branch under pull_request_target, so a PR can't edit
   # this gate to promote itself.
   #
-  # SEPARATE job from `e2e` on purpose: it holds no hub lease and no concurrency group,
-  # so an outside PR sitting unapproved can't stall the shared test hub for trusted
-  # runs. e2e starts only once this job succeeds (`needs`).
+  # SEPARATE job from `e2e` on purpose: it holds no hub lease and is NOT in the e2e job's cross-PR
+  # FIFO group (hub-e2e-serialized), so an outside PR sitting unapproved can't stall the shared test
+  # hub for trusted runs -- it's only in the workflow-level per-branch group, which is isolated per
+  # branch. e2e starts only once this job succeeds (`needs`).
   approve:
     runs-on: ubuntu-latest
     environment:
@@ -122,14 +132,14 @@ jobs:
   # Read-only hub inventory dump (dispatch with probe_only=true). Diagnoses test-hub
   # state -- devices, apps, rules, jobs, memory, watchdog flags -- without deploying or
   # mutating anything beyond one labeled command round-trip on the BAT scaffold switch.
-  # Shares the hub-e2e concurrency group so it never overlaps a live e2e run.
+  # Shares the e2e job's hub-e2e-serialized concurrency group so it never overlaps a live e2e run.
   probe:
     needs: [approve]
     if: inputs.probe_only == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     concurrency:
-      group: hub-e2e
+      group: hub-e2e-serialized
       cancel-in-progress: false
     env:
       MCP_URL: ${{ secrets.LEVEL99_TEST_HUB_MCP_URL }}
@@ -206,31 +216,23 @@ jobs:
     # only AFTER the wait, so the run itself always stays within the 30-min lease TTL.
     timeout-minutes: 270
 
-    # Serialization model: runs QUEUE ON THE LEASE, not on a global GitHub group.
-    # lease_acquire.sh is the PRIMARY serializer -- every run enters its wait loop
-    # (poll every 30s, up to 4h) and claims the hub the moment its turn comes, so
-    # several PRs can sit queued for the single shared hub and run back-to-back.
-    # It also covers a manual hub session GitHub's `concurrency` can't see.
-    #
-    # The GitHub group is PER-BRANCH and exists to cancel SUPERSEDED runs AND to stop two runs
-    # for the SAME branch from starting at once. Both the focused (push) and full (label) lanes
-    # are pull_request_target on the same PR, and a maintainer workflow_dispatch validates the
-    # same branch -- ALL THREE must collapse into ONE group, else two runs start together and
-    # both hammer the cloud relay during lease acquisition (the 504 storm that fails a run even
-    # though the lease itself would serialize hub access). Keying on `head_ref` (set for
-    # pull_request_target = the PR's source branch) || `ref_name` (set for workflow_dispatch/push)
-    # yields the SAME group for every event on a given branch, so a new push / a label add / a
-    # dispatch cancels the older run instead of racing it. Keying on head-repo + branch keeps two
-    # FORKS that reuse a branch name (main/fix) in SEPARATE groups so they don't cancel each other
-    # (head.repo.full_name is empty for dispatch/push -> github.repository, so same-repo events on a
-    # branch still collapse to one group).
-    # Cancellation is safe: the cleanup/restore/lease-release steps are `if: always()`, and a hard
-    # kill is backstopped by the dead-man watchdog's deadline restore plus the lease TTL.
-    # Scoped at the JOB level (not workflow level) so the `approve` gate -- which may sit waiting
-    # on a human reviewer -- never holds the group.
+    # Serialization model: GitHub's NATIVE concurrency does the cross-PR FIFO QUEUE; the lease is
+    # the hub-side lock (and the only thing that can see a HUMAN holding the hub by hand).
+    #   * `queue: max` lets up to 100 e2e runs WAIT in this one global group and processes them ONE
+    #     AT A TIME in first-in-first-out order (by when each STARTED WAITING on the group). This
+    #     job is `needs: [approve]`, so it enters the group only AFTER the approve gate clears --
+    #     an approved outside-contributor PR therefore takes its place at APPROVAL time (not its old
+    #     creation order), and a release:*/e2e:full label spawns a new run that enters at the BACK.
+    #     Both lanes (focused/full) are this same job in this same group, so they queue together.
+    #   * Cancelling a SUPERSEDED run (new commit on the same branch) is the WORKFLOW-level
+    #     per-branch group near the top of this file. It can't live here: `queue: max` and
+    #     `cancel-in-progress: true` cannot be combined in one concurrency block.
+    #   * lease_acquire.sh still claims/releases _TEST_HUB_LEASED_BY, but it NO LONGER orders the
+    #     queue (concurrency does). Its remaining job is to block when a HUMAN holds the lease by
+    #     hand to take the hub for manual use -- which GitHub concurrency can't see.
     concurrency:
-      group: hub-e2e-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: true
+      group: hub-e2e-serialized
+      queue: max
 
     env:
       MCP_URL: ${{ secrets.LEVEL99_TEST_HUB_MCP_URL }}
@@ -450,8 +452,6 @@ jobs:
 
       - name: Acquire test hub lease
         if: steps.gate.outputs.available == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}   # FIFO check lists in-progress hub-e2e runs via gh api
         run: bash .github/scripts/lease_acquire.sh "ci-run-${{ github.run_id }}"
 
       - name: Pre-run hub status probe

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -83,6 +83,7 @@ on:
 
 permissions:
   contents: read
+  actions: read   # lease_acquire.sh lists in-progress hub-e2e runs (run_number order) for FIFO lease ordering
   # statuses: write lets the "Post e2e gate status" step POST the required commit status
   # "Full e2e (runs with label)" (pending while focused, success/failure when full). Without it
   # the POST 403s ("Resource not accessible by integration") and the gate can never report.
@@ -449,6 +450,8 @@ jobs:
 
       - name: Acquire test hub lease
         if: steps.gate.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}   # FIFO check lists in-progress hub-e2e runs via gh api
         run: bash .github/scripts/lease_acquire.sh "ci-run-${{ github.run_id }}"
 
       - name: Pre-run hub status probe

--- a/.github/workflows/lease-scripts-test.yml
+++ b/.github/workflows/lease-scripts-test.yml
@@ -1,0 +1,25 @@
+name: lease-scripts-test
+
+# Regression guard for the e2e hub-lease scripts. Runs the pure-shell parser test
+# (tests/lease_scripts_test.sh) whenever the lease scripts or the test change, so the
+# false-empty read that double-booked the test hub cannot quietly come back. No hub, no
+# secrets -- just bash + jq on the runner.
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/lease_acquire.sh'
+      - '.github/scripts/lease_release.sh'
+      - 'tests/lease_scripts_test.sh'
+      - '.github/workflows/lease-scripts-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  lease-parse-guard:
+    name: lease parse guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run lease parse guard
+        run: bash tests/lease_scripts_test.sh

--- a/docs/firmware-update-research.md
+++ b/docs/firmware-update-research.md
@@ -123,8 +123,9 @@ Builds on the existing 30-min lease (`lease_acquire.sh`) + importUrl deploy mode
 
 ### Integration points (existing)
 
-- Lease: `.github/scripts/lease_acquire.sh:21-22,68-75`; serialized via `hub-e2e.yml:37-39`
-  concurrency group.
+- Lease: `.github/scripts/lease_acquire.sh` (`get_lease_value` strict-parse); cross-PR runs are
+  serialized by the `hub-e2e-serialized` concurrency group (`hub-e2e.yml` e2e job, `queue: max`)
+  plus the workflow-level per-branch cancel group. The lease is the hub-side lock for a human-held hub.
 - 5xx-tolerant deploy/verify pattern to mirror for reboot polling:
   `mcp_deploy_source.sh:187-213`, `mcp_verify_deploy.sh:102-118`.
 - Destructive-ops gateway: `hubitat-mcp-server.groovy`.

--- a/tests/lease_scripts_test.sh
+++ b/tests/lease_scripts_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression guard for the e2e lease scripts' response parsing.
+#
+# The bug this locks down: a JSON-RPC ERROR envelope (e.g. -32603 the main app emits while its
+# class is recompiled by another run's deploy) must NEVER read as "released". That false-empty
+# let a run claim over a still-valid lease and double-booked the single shared test hub.
+#
+# It extracts the REAL get_lease_value out of lease_acquire.sh and runs it (re-extracted every
+# run, so the test can't drift from the shipped parser), feeding each response shape through a
+# stubbed network call. Pure shell + jq; no hub, no secrets.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$HERE/../.github/scripts/lease_acquire.sh"
+[ -f "$SRC" ] || { echo "missing $SRC"; exit 1; }
+
+# Load the shipped get_lease_value (its closing brace is the only `}` at column 0 in the function).
+eval "$(sed -n '/^get_lease_value()/,/^}/p' "$SRC")"
+type get_lease_value >/dev/null 2>&1 || { echo "could not load get_lease_value from $SRC"; exit 1; }
+
+fail=0
+check() {  # check <name> <canned-response> <HELD|RELEASED|POLL>
+  local name="$1" want="$3" out got
+  CANNED_RESP="$2"                              # global: read by the stub (avoids colliding with
+  mcp_call() { printf '%s' "$CANNED_RESP"; }    # get_lease_value's own `local resp`)
+  if out="$(get_lease_value 2>/dev/null)"; then
+    [ -z "$out" ] && got=RELEASED || got=HELD
+  else
+    got=POLL
+  fi
+  if [ "$got" = "$want" ]; then
+    printf '  ok    %-24s -> %s\n' "$name" "$got"
+  else
+    printf '  FAIL  %-24s -> got %s, want %s\n' "$name" "$got" "$want"
+    fail=1
+  fi
+}
+
+held_text="$(jq -nc '{name:"_TEST_HUB_LEASED_BY",type:"string",value:(({by:"ci-run-X",until:1}|tojson))}')"
+check "held lease"          "$(jq -nc --arg t "$held_text" '{result:{content:[{text:$t}]}}')"   HELD
+check "released (value '')" "$(jq -nc '{result:{content:[{text:({value:""}|tojson)}]}}')"        RELEASED
+check "-32603 recompile"    '{"error":{"code":-32603,"message":"Internal error"}}'               POLL
+check "-32602 not found"    '{"error":{"code":-32602,"message":"Variable not found: X"}}'         RELEASED
+check "-32602 other"        '{"error":{"code":-32602,"message":"Invalid params"}}'                POLL
+check "non-JSON 504 body"   '<html>504 Gateway Timeout</html>'                                    POLL
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "lease parse guard: PASS"
+else
+  echo "lease parse guard: FAIL -- a response shape parsed unsafely (see above). The double-book bug is back."
+  exit 1
+fi

--- a/tests/lease_scripts_test.sh
+++ b/tests/lease_scripts_test.sh
@@ -1,24 +1,31 @@
 #!/usr/bin/env bash
-# Regression guard for the e2e lease scripts' response parsing.
+# Regression guard for the e2e lease scripts: acquire-side response parsing + release-side
+# compare-and-clear. Two bug classes it locks down:
+#   1. ACQUIRE false-empty -- a JSON-RPC ERROR envelope (e.g. -32603 the main app emits while its
+#      class is recompiled by another run's deploy) must NEVER read as "released". That false-empty
+#      let a run claim over a still-valid lease and double-booked the single shared test hub.
+#   2. RELEASE over-clear -- lease_release.sh must blank _TEST_HUB_LEASED_BY ONLY when WE still hold
+#      it. A degraded read or a lease now held by ANOTHER run must be left alone (else a slow/cancelled
+#      run could wipe the new holder's live lease -- a milder replay of the same double-book).
 #
-# The bug this locks down: a JSON-RPC ERROR envelope (e.g. -32603 the main app emits while its
-# class is recompiled by another run's deploy) must NEVER read as "released". That false-empty
-# let a run claim over a still-valid lease and double-booked the single shared test hub.
-#
-# It extracts the REAL get_lease_value out of lease_acquire.sh and runs it (re-extracted every
-# run, so the test can't drift from the shipped parser), feeding each response shape through a
-# stubbed network call. Pure shell + jq; no hub, no secrets.
+# get_lease_value is extracted from lease_acquire.sh and run directly (re-extracted every run, so the
+# test can't drift from the shipped parser); lease_release.sh is driven end-to-end with a curl stub
+# on PATH. Pure shell + jq; no hub, no secrets.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC="$HERE/../.github/scripts/lease_acquire.sh"
+SRC_REL="$HERE/../.github/scripts/lease_release.sh"
 [ -f "$SRC" ] || { echo "missing $SRC"; exit 1; }
+[ -f "$SRC_REL" ] || { echo "missing $SRC_REL"; exit 1; }
 
 # Load the shipped get_lease_value (its closing brace is the only `}` at column 0 in the function).
 eval "$(sed -n '/^get_lease_value()/,/^}/p' "$SRC")"
 type get_lease_value >/dev/null 2>&1 || { echo "could not load get_lease_value from $SRC"; exit 1; }
 
 fail=0
+
+# ---------- acquire-side parse guard ----------
 check() {  # check <name> <canned-response> <HELD|RELEASED|POLL>
   local name="$1" want="$3" out got
   CANNED_RESP="$2"                              # global: read by the stub (avoids colliding with
@@ -29,13 +36,14 @@ check() {  # check <name> <canned-response> <HELD|RELEASED|POLL>
     got=POLL
   fi
   if [ "$got" = "$want" ]; then
-    printf '  ok    %-24s -> %s\n' "$name" "$got"
+    printf '  ok    %-26s -> %s\n' "$name" "$got"
   else
-    printf '  FAIL  %-24s -> got %s, want %s\n' "$name" "$got" "$want"
+    printf '  FAIL  %-26s -> got %s, want %s\n' "$name" "$got" "$want"
     fail=1
   fi
 }
 
+echo "acquire parse (get_lease_value):"
 held_text="$(jq -nc '{name:"_TEST_HUB_LEASED_BY",type:"string",value:(({by:"ci-run-X",until:1}|tojson))}')"
 check "held lease"          "$(jq -nc --arg t "$held_text" '{result:{content:[{text:$t}]}}')"   HELD
 check "released (value '')" "$(jq -nc '{result:{content:[{text:({value:""}|tojson)}]}}')"        RELEASED
@@ -44,10 +52,58 @@ check "-32602 not found"    '{"error":{"code":-32602,"message":"Variable not fou
 check "-32602 other"        '{"error":{"code":-32602,"message":"Invalid params"}}'                POLL
 check "non-JSON 504 body"   '<html>504 Gateway Timeout</html>'                                    POLL
 
+# ---------- release-side compare-and-clear guard ----------
+# Drive the REAL lease_release.sh end-to-end with a curl stub on PATH: the GET (hub_get_variable)
+# returns a canned lease (or fails for __FAIL__), and a clear POST (hub_set_variable, value:"") is
+# recorded. We assert WHO gets cleared. The held fixtures use the real wire shape -- {by,until} is a
+# JSON STRING inside .value -- so the test exercises the same parse the script ships.
+STUBDIR="$(mktemp -d)"
+cat > "$STUBDIR/curl" <<'STUB'
+#!/usr/bin/env bash
+payload=""
+while [ $# -gt 0 ]; do [ "$1" = "-d" ] && { payload="$2"; shift; }; shift; done
+if printf '%s' "$payload" | grep -q hub_get_variable; then
+  [ "$REL_CANNED_GET" = "__FAIL__" ] && exit 22   # simulate curl --fail (e.g. 504)
+  printf '%s' "$REL_CANNED_GET"
+elif printf '%s' "$payload" | grep -q hub_set_variable; then
+  echo CLEAR >> "$REL_CLEAR_LOG"                  # record that a clear was attempted
+  printf '{"result":{}}'
+fi
+exit 0
+STUB
+chmod +x "$STUBDIR/curl"
+
+rel_check() {  # rel_check <name> <canned-get> <by-arg> <CLEAR|KEEP>
+  local name="$1" want="$4" got
+  REL_CLEAR_LOG="$(mktemp)"; export REL_CLEAR_LOG
+  REL_CANNED_GET="$2"; export REL_CANNED_GET
+  PATH="$STUBDIR:$PATH" MCP_URL="stub://x" bash "$SRC_REL" "$3" >/dev/null 2>&1
+  [ -s "$REL_CLEAR_LOG" ] && got=CLEAR || got=KEEP
+  rm -f "$REL_CLEAR_LOG"
+  if [ "$got" = "$want" ]; then
+    printf '  ok    %-26s -> %s\n' "$name" "$got"
+  else
+    printf '  FAIL  %-26s -> got %s, want %s\n' "$name" "$got" "$want"
+    fail=1
+  fi
+}
+
+mk_held() { jq -nc --arg by "$1" '{result:{content:[{text:({value:(({by:$by,until:99}|tojson))}|tojson)}]}}'; }
+rel_empty="$(jq -nc '{result:{content:[{text:({value:""}|tojson)}]}}')"
+
+echo
+echo "release compare-and-clear (lease_release.sh):"
+rel_check "held by us -> clear"     "$(mk_held ci-run-7)"     ci-run-7  CLEAR
+rel_check "held by other -> keep"   "$(mk_held ci-run-OTHER)" ci-run-7  KEEP
+rel_check "already empty -> keep"   "$rel_empty"              ci-run-7  KEEP
+rel_check "-32603 read -> keep"     '{"error":{"code":-32603,"message":"Internal error"}}' ci-run-7 KEEP
+rel_check "504 read-fail -> keep"   '__FAIL__'                ci-run-7  KEEP
+rm -rf "$STUBDIR"
+
 echo
 if [ "$fail" -eq 0 ]; then
-  echo "lease parse guard: PASS"
+  echo "lease scripts guard: PASS"
 else
-  echo "lease parse guard: FAIL -- a response shape parsed unsafely (see above). The double-book bug is back."
+  echo "lease scripts guard: FAIL -- a response shape parsed unsafely (see above). The double-book bug is back."
   exit 1
 fi

--- a/tests/lease_scripts_test.sh
+++ b/tests/lease_scripts_test.sh
@@ -44,41 +44,6 @@ check "-32602 not found"    '{"error":{"code":-32602,"message":"Variable not fou
 check "-32602 other"        '{"error":{"code":-32602,"message":"Invalid params"}}'                POLL
 check "non-JSON 504 body"   '<html>504 Gateway Timeout</html>'                                    POLL
 
-# --- fifo_my_turn: FIFO ordering by e2e-job START time (earliest in line claims a free lease) ---
-eval "$(sed -n '/^fifo_my_turn()/,/^}/p' "$SRC")"
-type fifo_my_turn >/dev/null 2>&1 || { echo "could not load fifo_my_turn from $SRC"; exit 1; }
-export GITHUB_REPOSITORY="owner/repo"
-declare -A STUB_TS
-fifo_check() {  # fifo_check <name> <my_run_id> <TURN|WAIT>  (globals: STUB_IDS, STUB_TS[id]=e2e_started_at)
-  local name="$1" want="$3" got rid
-  export GITHUB_RUN_ID="$2"
-  gh() {  # stub: emulate `gh api --jq` for the two endpoints fifo_my_turn calls
-    case "$*" in
-      *"workflows/hub-e2e.yml/runs"*) printf '%s\n' $STUB_IDS ;;
-      *"/actions/runs/"*"/jobs"*) rid="$(printf '%s' "$*" | sed -E 's#.*/actions/runs/([0-9]+)/jobs.*#\1#')"; printf '%s' "${STUB_TS[$rid]:-}" ;;
-      *) printf '' ;;
-    esac
-  }
-  if fifo_my_turn; then got=TURN; else got=WAIT; fi
-  if [ "$got" = "$want" ]; then
-    printf '  ok    %-30s -> %s\n' "$name" "$got"
-  else
-    printf '  FAIL  %-30s -> got %s, want %s\n' "$name" "$got" "$want"
-    fail=1
-  fi
-}
-echo
-echo "fifo_my_turn (FIFO by e2e-job start time):"
-STUB_IDS="100 101"; STUB_TS[100]="2026-06-22T10:00:00Z"; STUB_TS[101]="2026-06-22T10:05:00Z"
-fifo_check "earliest e2e-start (100)" 100 TURN
-fifo_check "later e2e-start (101)"    101 WAIT
-# approved fork: low run id 50 but its e2e job started LAST (approved late) -> earlier-started 99 goes first
-STUB_IDS="50 99"; STUB_TS[50]="2026-06-22T12:00:00Z"; STUB_TS[99]="2026-06-22T11:00:00Z"
-fifo_check "fork approved late (50)"  50 WAIT
-fifo_check "earlier e2e-start (99)"   99 TURN
-STUB_IDS=""
-fifo_check "api empty -> proceed"     100 TURN
-
 echo
 if [ "$fail" -eq 0 ]; then
   echo "lease parse guard: PASS"

--- a/tests/lease_scripts_test.sh
+++ b/tests/lease_scripts_test.sh
@@ -44,6 +44,29 @@ check "-32602 not found"    '{"error":{"code":-32602,"message":"Variable not fou
 check "-32602 other"        '{"error":{"code":-32602,"message":"Invalid params"}}'                POLL
 check "non-JSON 504 body"   '<html>504 Gateway Timeout</html>'                                    POLL
 
+# --- fifo_my_turn: GitHub-side FIFO ordering (the lowest in-progress run_number claims a free lease) ---
+eval "$(sed -n '/^fifo_my_turn()/,/^}/p' "$SRC")"
+type fifo_my_turn >/dev/null 2>&1 || { echo "could not load fifo_my_turn from $SRC"; exit 1; }
+export GITHUB_REPOSITORY="owner/repo"
+fifo_check() {  # fifo_check <name> <my_run_number> <stub-min-run_number> <TURN|WAIT>
+  local name="$1" want="$4" got
+  export GITHUB_RUN_NUMBER="$2"
+  FIFO_MIN="$3"
+  gh() { printf '%s' "$FIFO_MIN"; }     # stub `gh api ... --jq` -> the min in-progress run_number
+  if fifo_my_turn; then got=TURN; else got=WAIT; fi
+  if [ "$got" = "$want" ]; then
+    printf '  ok    %-24s -> %s\n' "$name" "$got"
+  else
+    printf '  FAIL  %-24s -> got %s, want %s\n' "$name" "$got" "$want"
+    fail=1
+  fi
+}
+echo
+echo "fifo_my_turn (FIFO ordering):"
+fifo_check "earliest in line"      100 100 TURN
+fifo_check "earlier still running" 101 100 WAIT
+fifo_check "api empty -> proceed"  100 ""  TURN
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "lease parse guard: PASS"

--- a/tests/lease_scripts_test.sh
+++ b/tests/lease_scripts_test.sh
@@ -44,28 +44,40 @@ check "-32602 not found"    '{"error":{"code":-32602,"message":"Variable not fou
 check "-32602 other"        '{"error":{"code":-32602,"message":"Invalid params"}}'                POLL
 check "non-JSON 504 body"   '<html>504 Gateway Timeout</html>'                                    POLL
 
-# --- fifo_my_turn: GitHub-side FIFO ordering (the lowest in-progress run_number claims a free lease) ---
+# --- fifo_my_turn: FIFO ordering by e2e-job START time (earliest in line claims a free lease) ---
 eval "$(sed -n '/^fifo_my_turn()/,/^}/p' "$SRC")"
 type fifo_my_turn >/dev/null 2>&1 || { echo "could not load fifo_my_turn from $SRC"; exit 1; }
 export GITHUB_REPOSITORY="owner/repo"
-fifo_check() {  # fifo_check <name> <my_run_number> <stub-min-run_number> <TURN|WAIT>
-  local name="$1" want="$4" got
-  export GITHUB_RUN_NUMBER="$2"
-  FIFO_MIN="$3"
-  gh() { printf '%s' "$FIFO_MIN"; }     # stub `gh api ... --jq` -> the min in-progress run_number
+declare -A STUB_TS
+fifo_check() {  # fifo_check <name> <my_run_id> <TURN|WAIT>  (globals: STUB_IDS, STUB_TS[id]=e2e_started_at)
+  local name="$1" want="$3" got rid
+  export GITHUB_RUN_ID="$2"
+  gh() {  # stub: emulate `gh api --jq` for the two endpoints fifo_my_turn calls
+    case "$*" in
+      *"workflows/hub-e2e.yml/runs"*) printf '%s\n' $STUB_IDS ;;
+      *"/actions/runs/"*"/jobs"*) rid="$(printf '%s' "$*" | sed -E 's#.*/actions/runs/([0-9]+)/jobs.*#\1#')"; printf '%s' "${STUB_TS[$rid]:-}" ;;
+      *) printf '' ;;
+    esac
+  }
   if fifo_my_turn; then got=TURN; else got=WAIT; fi
   if [ "$got" = "$want" ]; then
-    printf '  ok    %-24s -> %s\n' "$name" "$got"
+    printf '  ok    %-30s -> %s\n' "$name" "$got"
   else
-    printf '  FAIL  %-24s -> got %s, want %s\n' "$name" "$got" "$want"
+    printf '  FAIL  %-30s -> got %s, want %s\n' "$name" "$got" "$want"
     fail=1
   fi
 }
 echo
-echo "fifo_my_turn (FIFO ordering):"
-fifo_check "earliest in line"      100 100 TURN
-fifo_check "earlier still running" 101 100 WAIT
-fifo_check "api empty -> proceed"  100 ""  TURN
+echo "fifo_my_turn (FIFO by e2e-job start time):"
+STUB_IDS="100 101"; STUB_TS[100]="2026-06-22T10:00:00Z"; STUB_TS[101]="2026-06-22T10:05:00Z"
+fifo_check "earliest e2e-start (100)" 100 TURN
+fifo_check "later e2e-start (101)"    101 WAIT
+# approved fork: low run id 50 but its e2e job started LAST (approved late) -> earlier-started 99 goes first
+STUB_IDS="50 99"; STUB_TS[50]="2026-06-22T12:00:00Z"; STUB_TS[99]="2026-06-22T11:00:00Z"
+fifo_check "fork approved late (50)"  50 WAIT
+fifo_check "earlier e2e-start (99)"   99 TURN
+STUB_IDS=""
+fifo_check "api empty -> proceed"     100 TURN
 
 echo
 if [ "$fail" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Hardens the single-hub e2e lease and adds the FIFO queue it was missing.

- **Double-book fix (root cause).** A lease read landing in another run's Install-PR recompile window got a JSON-RPC error envelope (`-32602`/`-32603`); `get_lease_value` collapsed any 200 lacking `.result.content` to `""` and the loop claimed it as "released", so a run claimed over a still-valid lease (observed: #306 over #307). Now it strict-parses with `jq -e` (error envelope → poll, never a false-empty), confirms an empty read twice before claiming, and treats a genuine "variable not found" as released so a fresh hub still bootstraps.
- **FIFO ordering via native GitHub concurrency.** The e2e job runs in one global `concurrency: { group: hub-e2e-serialized, queue: max }` group — GitHub queues up to 100 runs and processes them one at a time, first-in-first-out, so PRs run in arrival order on the single shared hub. The job is `needs: [approve]`, so it enters the group only after the approve gate: an approved outside-contributor PR joins at approval time (not its old creation order), a `release:*`/`e2e:full` label spawns a run that joins at the back, and a new commit while waiting is cancelled by the workflow-level per-branch group and re-queues at the back.
- **Release compare-and-clear.** `lease_release.sh` only clears the lease when this run still holds it, so a slow/cancelled run can't blank another run's live lease.

The lease no longer orders the queue — concurrency does. It stays as the hub-side lock and the only thing that blocks CI when a human takes the hub by hand (which GitHub concurrency can't see).

## Type of change

- [x] `ci` — CI/CD pipeline change

## Changes

- `lease_acquire.sh`: strict-parse `get_lease_value` (+ not-found bootstrap, confirming re-read, hardened post-write verify). The wait loop now only rides out a human-held lease; cross-PR ordering is concurrency's job.
- `lease_release.sh`: compare-and-clear, optional `BY` arg (base-workflow argless call still works under `pull_request_target`), parser symmetric with acquire.
- `hub-e2e.yml`: e2e job `concurrency: { group: hub-e2e-serialized, queue: max }` for cross-PR FIFO; workflow-level per-branch `cancel-in-progress: true` for new-commit cancel; probe job re-pointed to the same group (`queue: max`) so it never overlaps or evicts an e2e run; release step passes `ci-run-<run_id>`.
- `tests/lease_scripts_test.sh` + `.github/workflows/lease-scripts-test.yml`: pure-shell guard that extracts the real `get_lease_value` and drives `lease_release.sh` end-to-end via a curl stub — asserts every parse case (error envelope → poll, not-found → released) and every release case (held-by-us → clear; held-by-other / empty / error-read → keep).

## Testing

- `bash tests/lease_scripts_test.sh` green (6 acquire-parse + 5 release cases); `bash -n` clean; YAML valid; `lease parse guard` + `e2e (run)` green in CI.
- The concurrency/queue + release-arg bits live in the workflow file, so they activate post-merge under `pull_request_target`; the acquire-side parse fix is exercised in-PR by the e2e acquire step.
