### PR TITLE
ci: fail-fast bind-check in e2e deploy

### DIFF
--- a/.github/scripts/mcp_watchdog_deploy.sh
+++ b/.github/scripts/mcp_watchdog_deploy.sh
@@ -531,5 +531,47 @@ else
   fi
 fi
 
+# Post-deploy BIND-CHECK (fail-fast). verify_includes_current above proves each #include'd library FILE
+# is on the hub (correct length); it does NOT prove the app INLINED it. A library can land yet fail to
+# bind, leaving its part-methods (_readOnlyToolNames_part<X>, _getAllToolDefinitions_part<X>, ...)
+# undefined on the compiled app class -- then getToolDefinitions() throws MissingMethodException from one
+# of the catalog aggregators (getReadOnlyToolNames/getAllToolDefinitions/...) and EVERY tool is dead.
+# initialize does NOT exercise that path (the readiness check above can't catch it); tools/list does.
+# Probe tools/list and DISTINGUISH the two failure classes so we never mislabel one as the other:
+#   - a real inline failure is a JSON-RPC error naming a missing _part<X> aggregator method -> fail FAST,
+#     named, before the suite runs;
+#   - an empty / non-JSON / transient response (relay drop, post-bounce warmup, load throttle) is NOT a
+#     proven bind failure -> retry, then fail with a cause-neutral message (not "library didn't inline").
+if [ -n "${HUBITAT_HUB_URL:-}" ] && [ -n "${HUBITAT_ACCESS_TOKEN:-}" ] && [ -n "${SERVER_APP_ID:-}" ]; then
+  BIND_MCP_URL="${HUBITAT_HUB_URL}/apps/${SERVER_APP_ID}/mcp?access_token=${HUBITAT_ACCESS_TOKEN}"
+  BIND_STATE="pending"; TL_RESP=""; BAD_LIB=""
+  for ATTEMPT in 1 2 3 4 5 6; do
+    TL_RESP=$(curl -sS --max-time 45 -X POST "$BIND_MCP_URL" -H "Content-Type: application/json" \
+      --data-binary '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' 2>/dev/null || true)
+    TL_TOOLS=$(printf '%s' "$TL_RESP" | jq -r '.result.tools | length' 2>/dev/null || echo "")
+    case "$TL_TOOLS" in ''|*[!0-9]*) TL_TOOLS="" ;; esac
+    if [ -n "$TL_TOOLS" ] && [ "$TL_TOOLS" -gt 0 ]; then
+      echo "Post-deploy bind-check OK on attempt ${ATTEMPT}: tools/list served ${TL_TOOLS} tools -- all ${#INCLUDES[@]} #include'd library(ies) inlined."
+      BIND_STATE="ok"; break
+    fi
+    # A genuine inline failure names a missing aggregator part-method -- stop and fail fast.
+    BAD_LIB=$(printf '%s' "$TL_RESP" | grep -oiE '_(getAllToolDefinitions|readOnlyToolNames|idempotentWriteToolNames|openWorldToolNames|toolDisplayMeta)_part[A-Za-z0-9_]+' | head -1)
+    if [ -n "$BAD_LIB" ]; then BIND_STATE="unbound"; break; fi
+    # Otherwise empty/non-JSON/transient (relay, warmup, throttle) -- not a proven bind failure; retry.
+    echo "  bind-check attempt ${ATTEMPT}/6: no usable catalog yet and no inline-failure signature (relay/warmup/throttle?); retrying in 10s..."
+    sleep 10
+  done
+  if [ "$BIND_STATE" = "unbound" ]; then
+    BIND_ERR=$(printf '%s' "$TL_RESP" | jq -r '.error.message? // (.error|strings) // (.error|tojson) // empty' 2>/dev/null || true)
+    echo "::error::Post-deploy BIND-CHECK FAILED -- a bundled library LANDED but did NOT inline into the app (${BAD_LIB}() is undefined), so its part-methods are uncallable and EVERY tool is dead. Failing the deploy now instead of running the whole suite against a broken app. tools/list error: ${BIND_ERR:-<none>}"
+    exit 1
+  elif [ "$BIND_STATE" != "ok" ]; then
+    echo "::error::Post-deploy BIND-CHECK could not get a usable tools/list after 6 attempts, with NO library-inline-failure signature -- likely a relay/transport or post-bounce warmup/throttle problem rather than a bind failure. Re-run. Last response: $(printf '%s' "$TL_RESP" | head -c 300)"
+    exit 1
+  fi
+else
+  echo "::warning::HUBITAT_HUB_URL / HUBITAT_ACCESS_TOKEN / SERVER_APP_ID not all set -- skipping the post-deploy bind-check (the test runner's own setup still gates)."
+fi
+
 echo "Full-repair deploy succeeded via watchdog: ${DEPLOYED_APPS} app(s) + their library bundle(s) live on the hub."
 echo "WATCHDOG_DEPLOY_OK apps=${DEPLOYED_APPS} libraries=${#INCLUDES[@]}"


### PR DESCRIPTION
## Summary

- Add a post-deploy bind-check to the e2e watchdog deploy: after the app is installed and bounced, probe the live server's own `tools/list`. If a bundled library landed on the hub but failed to **inline** into the app (its `_part<X>` methods undefined, so building the catalog throws `MissingMethodException`), fail the deploy immediately and name the unbound library, instead of running the whole ~15-25 min suite against an app where every tool is dead.

## Type of change

- [ ] `feat` -- new feature or capability
- [ ] `fix` -- bug fix
- [ ] `chore` -- maintenance, dependency bump, or housekeeping
- [ ] `refactor` -- code restructure with no behaviour change
- [ ] `docs` -- documentation only
- [ ] `test` -- tests only
- [x] `ci` -- CI/CD pipeline change

## Changes

- `.github/scripts/mcp_watchdog_deploy.sh`: after the post-bounce readiness check, probe `tools/list` on the main server endpoint. The existing `verify_includes_current` confirms each library **file** is on the hub (correct length) but not that the app **inlined** it; `initialize` does not exercise the catalog path, but `tools/list` (which builds the catalog via `getReadOnlyToolNames()` / `getAllToolDefinitions()` / ...) does. A probe whose error names a missing `_part<X>` aggregator method is a real inline failure -> emit a clear `::error::` naming the unbound method and `exit 1` before the test suite runs. Empty / non-JSON / transient responses (relay drop, post-bounce warmup, load throttle) are retried and, if unresolved, fail with a cause-neutral message rather than being mislabeled as a bind failure. Guards `SERVER_APP_ID` so a missing app id cannot probe a malformed URL.

## Release Notes

## Testing

- `bash -n` on the script passes.
- Validated against a real landed-but-not-inlined library: the check failed the deploy in ~6.5 min, named the unbound `_part<X>` method, and skipped the test suite -- vs ~25 min running the whole suite against a dead catalog.

## Checklist

- [ ] **Unit tests added for any new MCP tools, regressions, or bug fixes** (required -- see [docs/testing.md](docs/testing.md) for the harness + recipes)
- [ ] **e2e tests added for new tools and/or regression tests added for any bug fix** (see `tests/e2e_test.py`)
- [ ] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
- [ ] Documentation updated if user-facing behaviour or tool surface changed
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema)
