### PR TITLE
fix: report distinct tool count from hub_search_tools, not gateway-membership rows

### DIFF
--- a/libraries/mcp-discovery-lib.groovy
+++ b/libraries/mcp-discovery-lib.groovy
@@ -108,7 +108,11 @@ def toolSearchTools(args) {
     return [
         query: query,
         resultsCount: results.size(),
-        totalToolsSearched: visibleCorpus.size(),
+        // Count DISTINCT tools, not corpus rows: a tool in N gateways (the
+        // read/write split lists every read in both a hub_read_* and a
+        // hub_manage_* gateway) yields N corpus entries, so visibleCorpus.size()
+        // over-reports the tool count. results is deduped by name the same way.
+        totalToolsSearched: visibleCorpus.collect { it.name }.unique().size(),
         results: results
     ]
 }
@@ -276,7 +280,7 @@ def _getAllToolDefinitions_partDiscovery() {
                 properties: [
                     query: [type: "string", description: "Echoed search query"],
                     resultsCount: [type: "integer", description: "Number of ranked results returned"],
-                    totalToolsSearched: [type: "integer", description: "Size of the searched tool corpus"],
+                    totalToolsSearched: [type: "integer", description: "Number of distinct visible tools searched (a tool in multiple gateways is counted once)"],
                     results: [type: "array", description: "Ranked matching tools", items: [type: "object", properties: [
                         tool: [type: "string", description: "Tool name"],
                         title: [type: "string", description: "Friendly tool name (absent when served from a pre-title cached corpus)"],

--- a/libraries/mcp-discovery-lib.groovy
+++ b/libraries/mcp-discovery-lib.groovy
@@ -112,7 +112,7 @@ def toolSearchTools(args) {
         // read/write split lists every read in both a hub_read_* and a
         // hub_manage_* gateway) yields N corpus entries, so visibleCorpus.size()
         // over-reports the tool count. results is deduped by name the same way.
-        totalToolsSearched: visibleCorpus.collect { it.name }.unique().size(),
+        totalToolsSearched: visibleCorpus*.name.toSet().size(),
         results: results
     ]
 }

--- a/src/test/groovy/server/ToolSearchToolsSpec.groovy
+++ b/src/test/groovy/server/ToolSearchToolsSpec.groovy
@@ -113,6 +113,28 @@ class ToolSearchToolsSpec extends ToolSpecBase {
         roomHit.relevance > 0
     }
 
+    def "totalToolsSearched counts DISTINCT tools, not multi-gateway corpus rows"() {
+        given: 'a clean cache so the corpus is freshly built'
+        searchEnabled()
+        atomicStateMap.remove('toolSearchCorpus')
+        atomicStateMap.remove('toolSearchTokens')
+
+        when:
+        def result = script.toolSearchTools([query: 'list device room variable rule file', maxResults: 5])
+        // Mirror the production visibility filter (getHiddenToolNames is the single
+        // source of truth toolSearchTools uses) so the expected counts match exactly.
+        def hidden = (script.getHiddenToolNames() ?: []) as Set
+        def visibleRows = atomicStateMap.toolSearchCorpus*.name.findAll { !hidden.contains(it) }
+        def visibleDistinct = visibleRows.unique(false)
+
+        then: 'the corpus genuinely carries multi-gateway duplicate rows (read/write split lists reads in both gateways)'
+        visibleRows.size() > visibleDistinct.size()
+
+        and: 'the reported count is the distinct tool count, never the inflated row count'
+        result.totalToolsSearched == visibleDistinct.size()
+        result.totalToolsSearched < visibleRows.size()
+    }
+
     def "updated() invalidates both BM25 atomicState entries and the gateway requiredParams memo in lockstep"() {
         given: 'populated caches and a no-op initialize so updated() does not hit platform APIs'
         atomicStateMap.toolSearchCorpus = [[name: 'x', description: 'd']]

--- a/src/test/groovy/server/ToolSearchToolsSpec.groovy
+++ b/src/test/groovy/server/ToolSearchToolsSpec.groovy
@@ -98,6 +98,9 @@ class ToolSearchToolsSpec extends ToolSpecBase {
 
         and: 'results remain well-formed (deduped)'
         offResult.results*.tool == offResult.results*.tool.unique()
+
+        and: 'the reported count tracks the VISIBLE corpus -- it shrinks when custom_* tools are hidden, proving it is not counted over the full corpus'
+        offResult.totalToolsSearched < onResult.totalToolsSearched
     }
 
     def "a query semantically anchors to the right corpus entry (proves token<->corpus alignment)"() {
@@ -125,6 +128,8 @@ class ToolSearchToolsSpec extends ToolSpecBase {
         // source of truth toolSearchTools uses) so the expected counts match exactly.
         def hidden = (script.getHiddenToolNames() ?: []) as Set
         def visibleRows = atomicStateMap.toolSearchCorpus*.name.findAll { !hidden.contains(it) }
+        // unique(false) is the NON-mutating overload -- bare unique() dedups visibleRows
+        // in place, which would collapse the visibleRows-vs-visibleDistinct check below.
         def visibleDistinct = visibleRows.unique(false)
 
         then: 'the corpus genuinely carries multi-gateway duplicate rows (read/write split lists reads in both gateways)'
@@ -133,6 +138,23 @@ class ToolSearchToolsSpec extends ToolSpecBase {
         and: 'the reported count is the distinct tool count, never the inflated row count'
         result.totalToolsSearched == visibleDistinct.size()
         result.totalToolsSearched < visibleRows.size()
+    }
+
+    def "disabling a multi-gateway tool drops totalToolsSearched by exactly one (count is post-dedup, not per-row)"() {
+        given: 'hub_get_device lives in BOTH hub_read_devices and hub_manage_devices -- two corpus rows'
+        searchEnabled()
+        atomicStateMap.remove('toolSearchCorpus')
+        atomicStateMap.remove('toolSearchTokens')
+        def before = script.toolSearchTools([query: 'device get attribute', maxResults: 25])
+        assert before.results*.tool.contains('hub_get_device')   // precondition: the multi-gateway tool is present
+
+        when: 'it is disabled by name, removing BOTH of its gateway rows from the visible corpus'
+        settingsMap.disabled_tools = ['hub_get_device']
+        def after = script.toolSearchTools([query: 'device get attribute', maxResults: 25])
+
+        then: 'the distinct count falls by exactly one -- counting rows would have dropped two'
+        before.totalToolsSearched - after.totalToolsSearched == 1
+        !after.results*.tool.contains('hub_get_device')
     }
 
     def "updated() invalidates both BM25 atomicState entries and the gateway requiredParams memo in lockstep"() {

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1106,6 +1106,32 @@ class TestRunner:
         assert rooms["title"] == "List Rooms", f"hub_list_rooms catalog title unexpected: {rooms['title']!r}"
 
     @test("infrastructure")
+    def test_search_tools_counts_distinct_not_gateway_rows(self) -> None:
+        # hub_search_tools builds its BM25 corpus with one row per (gateway, tool)
+        # membership, and the read/write split lists every read tool in BOTH a
+        # hub_read_* and a hub_manage_* gateway -- so multi-gateway tools occupy
+        # several corpus rows. totalToolsSearched must report DISTINCT tools, not
+        # corpus rows (regression: visibleCorpus.size() reported ~139 rows instead
+        # of the ~108 distinct tools). results is already deduped by tool name.
+        result = self.client.call_tool("hub_search_tools", {
+            "query": "list get device room variable rule file log backup",
+            "maxResults": 500,
+        })
+        assert isinstance(result, dict), f"hub_search_tools returned non-dict: {type(result)}"
+        total = result.get("totalToolsSearched")
+        names = [r.get("tool") for r in result.get("results", [])]
+        assert isinstance(total, int) and total > 0, f"totalToolsSearched not a positive int: {total!r}"
+        assert len(names) == len(set(names)), \
+            f"hub_search_tools returned duplicate tool names: {sorted(n for n in set(names) if names.count(n) > 1)}"
+        assert result.get("resultsCount") == len(names) <= total, \
+            f"resultsCount/results/total inconsistent: {result.get('resultsCount')}, {len(names)}, {total}"
+        # The double-count regression inflated total to the corpus row count (~139,
+        # = ~108 distinct + ~31 duplicate gateway memberships). Cap well below that so
+        # the duplicate rows cannot creep back into the count.
+        assert total <= 125, \
+            f"totalToolsSearched={total} looks inflated by multi-gateway duplicate rows (expected distinct ~108)"
+
+    @test("infrastructure")
     def test_health_endpoint(self) -> None:
         data = self.client.get_health()
         assert data.get("status") == "ok", f"Health status != ok: {data.get('status')}"

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -1111,8 +1111,8 @@ class TestRunner:
         # membership, and the read/write split lists every read tool in BOTH a
         # hub_read_* and a hub_manage_* gateway -- so multi-gateway tools occupy
         # several corpus rows. totalToolsSearched must report DISTINCT tools, not
-        # corpus rows (regression: visibleCorpus.size() reported ~139 rows instead
-        # of the ~108 distinct tools). results is already deduped by tool name.
+        # corpus rows (regression: it reported the per-(gateway,tool) row count
+        # instead of the distinct tool count). results is already deduped by name.
         result = self.client.call_tool("hub_search_tools", {
             "query": "list get device room variable rule file log backup",
             "maxResults": 500,
@@ -1123,13 +1123,17 @@ class TestRunner:
         assert isinstance(total, int) and total > 0, f"totalToolsSearched not a positive int: {total!r}"
         assert len(names) == len(set(names)), \
             f"hub_search_tools returned duplicate tool names: {sorted(n for n in set(names) if names.count(n) > 1)}"
-        assert result.get("resultsCount") == len(names) <= total, \
-            f"resultsCount/results/total inconsistent: {result.get('resultsCount')}, {len(names)}, {total}"
-        # The double-count regression inflated total to the corpus row count (~139,
-        # = ~108 distinct + ~31 duplicate gateway memberships). Cap well below that so
-        # the duplicate rows cannot creep back into the count.
-        assert total <= 125, \
-            f"totalToolsSearched={total} looks inflated by multi-gateway duplicate rows (expected distinct ~108)"
+        assert result.get("resultsCount") == len(names), \
+            f"resultsCount != distinct results: {result.get('resultsCount')} vs {len(names)}"
+        assert len(names) <= total, \
+            f"more distinct results ({len(names)}) than tools searched ({total})"
+        # Heuristic regression ceiling: the distinct catalog sits comfortably below this,
+        # whereas the double-count regression inflated the value by every duplicate gateway
+        # membership (roughly a third again as large). The exact distinct-vs-rows pin lives
+        # in the Spock unit test; this only guards the live surface against re-inflation.
+        # Raise the ceiling if the real catalog ever grows past it.
+        assert total <= 120, \
+            f"totalToolsSearched={total} looks inflated by multi-gateway duplicate rows"
 
     @test("infrastructure")
     def test_health_endpoint(self) -> None:


### PR DESCRIPTION
## Summary

- `hub_search_tools` reported `totalToolsSearched` from the BM25 corpus row count, which lists every multi-gateway tool once per gateway — over-reporting the catalog (139 instead of ~108 distinct tools).
- Count distinct tool names instead; `results` is already deduped the same way.

## Type of change

- [ ] `feat` — new feature or capability
- [x] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- `libraries/mcp-discovery-lib.groovy`: `totalToolsSearched` now counts distinct visible tool names instead of `visibleCorpus.size()`. The read/write gateway split intentionally lists each read tool in both a `hub_read_*` and a `hub_manage_*` gateway, so the corpus holds N rows per N-gateway tool (29 such tools → +31 duplicate rows). The duplicate rows stay in the BM25 corpus (good for matching); only the reported count is deduped. Stale `outputSchema` field description updated to match.
- Added a `ToolSearchToolsSpec` regression test and an `infrastructure`-group `tests/e2e_test.py` scenario.

## Release Notes

- Fixed `hub_search_tools` reporting an inflated `totalToolsSearched` — it now counts each tool once instead of once per gateway it appears in.

## Testing

- `python tests/sandbox_lint.py` — clean
- `./gradlew test --tests server.ToolSearchToolsSpec` — pass (new test reports 108 vs prior 139)
- `ToolRmNativeCrudSpec` upper-bound assertions still pass
- e2e scenario added (runs in the infrastructure/protocol lanes)

## Checklist

- [x] **Unit tests added for any new MCP tools, regressions, or bug fixes** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes)
- [x] **e2e tests added for new tools and/or regression tests added for any bug fix** (see `tests/e2e_test.py`)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
- [ ] Documentation updated if user-facing behaviour or tool surface changed
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema)
