### PR TITLE
test: reframe BAT test_prompts goal-first — state goals, not tool names

### DIFF
--- a/tests/BAT-rm-native-crud.md
+++ b/tests/BAT-rm-native-crud.md
@@ -16,7 +16,7 @@ Supplement to `tests/BAT-v2.md`. Scenarios in this file exercise the native Rule
 - `hub_manage_native_rules_and_apps.hub_set_rule_private_boolean`
 - `hub_read_apps_code.hub_get_app_config` (used as fallback verification)
 
-**Note on tool names:** prompts use the shipped tool names — `hub_set_rule` for RM create/edit (omit appId to create, pass appId to edit), `hub_delete_native_app` for delete, and `hub_get_app_config` (in `hub_read_apps_code`) for readback.
+**Note on tool names:** the expected tool paths are `hub_set_rule` for RM create/edit (omit appId to create, pass appId to edit), `hub_delete_native_app` for delete, and `hub_get_app_config` (in `hub_read_apps_code`) for readback. These names live in each test's title and **Expected** grading text — the `test_prompt`s themselves stay goal-first (see Prompt style below).
 
 **Status:** Use this file as the acceptance bar for the native CRUD tools: every T### must pass before declaring the feature stable.
 
@@ -31,6 +31,10 @@ Each test is a JSON scenario with optional `setup_prompt`, required `test_prompt
   "teardown_prompt": "Cleanup after the test"
 }
 ```
+
+### Prompt style — goal-first
+
+Same rule as [BAT-v2.md](./BAT-v2.md): the `test_prompt` fed to the sub-agent under test states the scenario + goal in plain language and does **not** name any MCP tool, gateway, or call arg — tool names belong in the test title, **Expected**, and failure-mode grading text. `setup_prompt` / `teardown_prompt` are orchestrator scaffolding and MAY name tools directly. Per-test edge case: a test whose *subject is* the MCP surface itself (wire-shape regressions, deliberately malformed calls, gateway-override visibility) may still name that surface in its `test_prompt`.
 
 ### Pass / Fail / Partial
 
@@ -80,7 +84,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 ```json
 {
-  "test_prompt": "Create a new Rule Machine rule named 'BAT-RM-Empty Create' with no triggers or actions yet. After creation, verify the rule exists by calling hub_get_app_config and confirm the name round-trips. Report the new rule's id.",
+  "test_prompt": "Create a new Rule Machine rule named 'BAT-RM-Empty Create' with no triggers or actions yet. After creation, verify the rule exists by reading it back and confirm the name round-trips. Report the new rule's id.",
   "teardown_prompt": "Delete the rule you just created via hub_manage_rule_machine.hub_delete_native_app with force=true."
 }
 ```
@@ -92,7 +96,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Rename Before' and remember its id.",
-  "test_prompt": "Rename that rule to 'BAT-RM-Rename After' using hub_set_rule(appId=ruleId, settings={origLabel: 'BAT-RM-Rename After'}). Then read it back with hub_get_app_config to confirm the new name.",
+  "test_prompt": "Rename that rule to 'BAT-RM-Rename After', then read it back to confirm the new name.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -104,7 +108,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Comments Test' and remember its id.",
-  "test_prompt": "Use hub_set_rule(appId=ruleId, ...) to set the rule's comments/notes to the string 'BAT test scenario — verifies textarea round-trip. Multi-line input: line 2 here.'. Read the rule back with hub_get_app_config and confirm the comments field round-trips exactly, including the newline.",
+  "test_prompt": "Set the rule's comments/notes to the string 'BAT test scenario — verifies textarea round-trip. Multi-line input: line 2 here.'. Read the rule back and confirm the comments field round-trips exactly, including the newline.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -116,7 +120,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-ReqExpr Flag' and remember its id.",
-  "test_prompt": "Use hub_set_rule(appId=ruleId, ...) to enable the Required Expression feature on the rule (the useST flag). Read the rule back with hub_get_app_config and confirm useST is true AND that the required-expression editor sub-page/section is now present in the config.",
+  "test_prompt": "Enable the Required Expression feature on the rule (the useST flag). Read the rule back and confirm useST is true AND that the required-expression editor sub-page/section is now present in the config.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -128,7 +132,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Function Mode' and remember its id.",
-  "test_prompt": "Use hub_set_rule(appId=ruleId, ...) to mark the rule as a function (isFunction=true). Verify by reading back with hub_get_app_config that isFunction round-trips as true.",
+  "test_prompt": "Mark the rule as a function (isFunction=true). Verify by reading it back that isFunction round-trips as true.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -140,7 +144,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Logging Combo' and remember its id.",
-  "test_prompt": "Use hub_set_rule(appId=ruleId, ...) to set the rule's logging options to include all three values ['Events', 'Triggers', 'Actions'] and also enable Display Current Values (dValues=true). Read back with hub_get_app_config and confirm: (a) logging contains all three entries, (b) dValues is true.",
+  "test_prompt": "Set the rule's logging options to include all three values ['Events', 'Triggers', 'Actions'] and also enable Display Current Values (dValues=true). Read back and confirm: (a) logging contains all three entries, (b) dValues is true.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -152,7 +156,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch native RM rule via hub_set_rule(name='BAT-RM-Full Create', confirm=true) (omit appId to create). Capture the returned appId.",
-  "test_prompt": "STEP 1 (populate in one update): Call hub_set_rule(appId=<id>, settings={comments: 'Created with every rule-level field populated', useST: true, isFunction: false, logging: ['Triggers','Actions'], dValues: true}, confirm=true). Verify the response reports configPageError=null and settingsApplied lists all five keys.\n\nSTEP 2 (read-back #1): Call hub_get_app_config(appId=<id>, includeSettings=true). Assert every one of these round-trips: app.label === 'BAT-RM-Full Create'; settings.comments === the exact string; settings.useST === 'true'; settings.isFunction === 'false'; settings.logging is a JSON array === ['Triggers','Actions'] (length 2, NOT collapsed to CSV); settings.dValues === 'true'. The page paragraphs MUST include 'Define Required Expression' — this proves useST=true actually exposed the required-expression editor section.\n\nSTEP 3 (force a re-init): Call hub_set_rule(appId=<id>, button='updateRule', confirm=true). Verify configPageError is null.\n\nSTEP 4 (read-back #2, post re-init): Call hub_get_app_config(appId=<id>, includeSettings=true). Assert ALL fields from STEP 2 are still present with the same values and logging is STILL a 2-element array. This is the wire-format regression guard — enum-multi persisted from the in-memory write must survive the updateRule re-marshal.\n\nReport any field whose read value does not match what was sent, either after STEP 2 or after STEP 4.",
+  "test_prompt": "STEP 1 (populate in one edit): In a single edit, populate the rule with every rule-level field at once — comments 'Created with every rule-level field populated', enable Required Expression (useST), isFunction false, logging ['Triggers','Actions'], and Display Current Values (dValues). Verify the edit reports no config-page error and that all five fields were applied.\n\nSTEP 2 (read-back #1): Read the rule back including its settings. Assert every one of these round-trips: app.label === 'BAT-RM-Full Create'; settings.comments === the exact string; settings.useST === 'true'; settings.isFunction === 'false'; settings.logging is a JSON array === ['Triggers','Actions'] (length 2, NOT collapsed to CSV); settings.dValues === 'true'. The page paragraphs MUST include 'Define Required Expression' — this proves useST=true actually exposed the required-expression editor section.\n\nSTEP 3 (force a re-init): Press the rule's 'Update Rule' button to force it to re-initialize. Verify there is no config-page error.\n\nSTEP 4 (read-back #2, post re-init): Read the rule back again including its settings. Assert ALL fields from STEP 2 are still present with the same values and logging is STILL a 2-element array. This is the wire-format regression guard — enum-multi persisted from the in-memory write must survive the updateRule re-marshal.\n\nReport any field whose read value does not match what was sent, either after STEP 2 or after STEP 4.",
   "teardown_prompt": "Force-delete the rule via hub_delete_native_app(appId=<id>, force=true, confirm=true)."
 }
 ```
@@ -173,7 +177,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Soft Delete' and remember its id. Do NOT add any child apps or nested rules.",
-  "test_prompt": "Delete the rule using the soft-delete path — hub_delete_native_app(appId=ruleId) with force=false (or force omitted). Confirm the tool returns success, then verify the rule is gone by calling hub_list_rules and checking that the id is absent.",
+  "test_prompt": "Delete the rule (a normal, non-forced delete). Confirm the delete succeeded, then verify the rule no longer appears in the rules list (its id is absent).",
   "teardown_prompt": "If the rule still exists, clean up with hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -185,7 +189,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Force Delete' and remember its id.",
-  "test_prompt": "Delete the rule using force=true — hub_delete_native_app(appId=ruleId, force=true). Confirm success and verify the id is absent from hub_list_rules afterwards.",
+  "test_prompt": "Delete the rule using a force delete. Confirm success and verify the id is absent from the rules list afterwards.",
   "teardown_prompt": "No teardown — the test itself is the teardown. If the rule somehow still exists, call hub_delete_native_app(appId=ruleId, force=true) again."
 }
 ```
@@ -197,7 +201,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Pause Update Path' and remember its id.",
-  "test_prompt": "First, pause the rule by calling hub_manage_rule_machine.hub_set_rule_paused(ruleId=ruleId, value=true). Confirm via hub_get_app_config that the rule shows as paused/disabled. Then resume it by calling hub_manage_rule_machine.hub_set_rule_paused(ruleId=ruleId, value=false). Confirm it is running again. Report the state at each step.",
+  "test_prompt": "First, pause the rule. Confirm by reading it back that the rule shows as paused/disabled. Then resume it. Confirm it is running again. Report the state at each step.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -209,7 +213,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-RunAct Verb', with a single harmless action like 'Log a Message: BAT T310 fired'. Remember the rule id.",
-  "test_prompt": "Invoke the rule's actions directly by calling hub_manage_rule_machine.hub_call_rule(ruleId=ruleId, action='actions'). Confirm the tool returns {success: true, rmAction: 'runRuleAct'}. Report what the AI saw.",
+  "test_prompt": "Run the rule's actions directly, without waiting for its trigger to fire. Confirm the run was acknowledged. Report what the AI saw.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -221,7 +225,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Stop Start' and at least one trivial trigger (e.g., a virtual switch trigger on 'BAT-RM Switch 1'). Remember the rule id.",
-  "test_prompt": "Stop the rule via hub_manage_rule_machine.hub_call_rule(ruleId=ruleId, action='stop') (stopRuleAct). Verify: via hub_get_app_config + statusJson, confirm eventSubscriptions drops to zero / the rule's delays and repeats are cancelled. Then Start the rule again via hub_call_rule(ruleId=ruleId, action='start'). Verify eventSubscriptions.length > 0 afterwards (Start also resets Private Boolean to true).",
+  "test_prompt": "Stop the rule (stopRuleAct). Verify by reading it back that statusJson.eventSubscriptions drops to zero / the rule's delays and repeats are cancelled. Then Start the rule again. Verify eventSubscriptions.length > 0 afterwards (Start also resets Private Boolean to true).",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -233,7 +237,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Update Btn' with one trigger on 'BAT-RM Switch 1'. Remember the rule id.",
-  "test_prompt": "Use hub_set_rule(appId=ruleId, ...) to modify the rule (e.g., toggle dValues=true) AND also trigger the 'Update Rule' button action so subscriptions are re-initialized in place. Verify via hub_get_app_config that dValues round-trips AND that statusJson.eventSubscriptions.length > 0 (subscription not dropped by the re-init).",
+  "test_prompt": "Modify the rule (e.g., toggle dValues=true) AND also trigger the 'Update Rule' button action so subscriptions are re-initialized in place. Verify by reading it back that dValues round-trips AND that statusJson.eventSubscriptions.length > 0 (subscription not dropped by the re-init).",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -245,7 +249,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Done Btn' with one trigger on 'BAT-RM Switch 1'. Remember the rule id.",
-  "test_prompt": "Simulate the 'Done' button press on the rule — this is usually done by hub_set_rule(appId=ruleId, ...) with a flag like commit=true or done=true, or by a dedicated lifecycle call. After Done, confirm via hub_get_app_config that the rule still has its trigger (statusJson.eventSubscriptions.length > 0) and that configPage.error is null. The Done button should re-run initialize() and resubscribe.",
+  "test_prompt": "Simulate the 'Done' button press on the rule (whatever lifecycle path accomplishes a Done/commit). After Done, confirm by reading the rule back that it still has its trigger (statusJson.eventSubscriptions.length > 0) and that configPage.error is null. The Done button should re-run initialize() and resubscribe.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -257,7 +261,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create two virtual switches named 'BAT-RM Switch 1' and 'BAT-RM Switch 2' via hub_manage_virtual_device if they do not exist.",
-  "test_prompt": "Create a Rule Machine rule named 'BAT-RM-MultiDev Flag' with a single Switch trigger bound to BOTH 'BAT-RM Switch 1' and 'BAT-RM Switch 2' (multi-device capability input). After creation, call hub_get_app_config — you MUST verify that statusJson.appSettings for the switch capability input has multiple=true (NOT false, NOT missing). Also verify configPage.error is null and eventSubscriptions.length >= 2. This is the flag-poisoning regression check.",
+  "test_prompt": "Create a Rule Machine rule named 'BAT-RM-MultiDev Flag' with a single Switch trigger bound to BOTH 'BAT-RM Switch 1' and 'BAT-RM Switch 2' (multi-device capability input). After creation, read the rule back — you MUST verify that statusJson.appSettings for the switch capability input has multiple=true (NOT false, NOT missing). Also verify configPage.error is null and eventSubscriptions.length >= 2. This is the flag-poisoning regression check.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true). Leave the virtual switches in place for later tests."
 }
 ```
@@ -269,7 +273,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Ensure virtual device 'BAT-RM Switch 1' exists (create via hub_manage_virtual_device if needed).",
-  "test_prompt": "Run this end-to-end round-trip on a single rule: (1) hub_set_rule(name='BAT-RM-Roundtrip', comments='step 1 comment', logging=['Events']) — capture the ruleId; (2) hub_get_app_config(appId=ruleId) and record the full config; (3) hub_set_rule(appId=ruleId, settings={comments: 'step 3 comment updated', logging: ['Triggers','Actions'], dValues: true, useST: true}); (4) hub_get_app_config(appId=ruleId) again and confirm EVERY field from step 3's patch round-trips; (5) hub_delete_native_app(appId=ruleId, force=true). Report side-by-side the before/after config values for comments, logging, dValues, useST.",
+  "test_prompt": "Run this end-to-end round-trip on a single rule: (1) create a rule named 'BAT-RM-Roundtrip' with comments 'step 1 comment' and logging ['Events'] — capture the ruleId; (2) read the rule back and record the full config; (3) edit the rule to set comments 'step 3 comment updated', logging ['Triggers','Actions'], dValues true, and useST true; (4) read it back again and confirm EVERY field from step 3's patch round-trips; (5) force-delete the rule. Report side-by-side the before/after config values for comments, logging, dValues, useST.",
   "teardown_prompt": "If the rule still exists because step 5 failed, delete it now via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -281,12 +285,12 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Remove Btn' and remember its id.",
-  "test_prompt": "Remove the rule using the 'Remove' button path — this may be exposed as hub_delete_native_app(appId=ruleId) without force, or as a separate remove action. Confirm the rule is gone from hub_list_rules afterwards and that no orphan child apps remain (check via hub_list_apps for any entry referencing the removed ruleId).",
+  "test_prompt": "Remove the rule using the 'Remove' button path. Confirm the rule is gone from the rules list afterwards and that no orphan child apps remain (check the installed-apps list for any entry referencing the removed ruleId).",
   "teardown_prompt": "If the rule still exists, clean up with hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
 
-**Expected**: AI invokes the remove path. Rule is absent from `hub_list_rules`. No orphan child apps reference the removed id. Covers the `Remove` button lifecycle verb from matrix §7.
+**Expected**: AI invokes the remove path (`hub_delete_native_app`). Rule is absent from `hub_list_rules`. No orphan child apps reference the removed id (verified via `hub_list_apps`). Covers the `Remove` button lifecycle verb from matrix §7.
 
 ## Section 2: Triggers + conditions (T320–T349)
 
@@ -487,7 +491,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "No devices needed. Confirm the hub has a configured location (latitude/longitude) so sunrise/sunset is calculable.",
-  "test_prompt": "Create 'BAT-RM-T336a-SunriseOffset' with a single Certain Time trigger: 30 minutes after sunrise (no day-of-week restriction). Verify the sunrise-offset of +30 minutes round-trips via hub_get_app_config.",
+  "test_prompt": "Create 'BAT-RM-T336a-SunriseOffset' with a single Certain Time trigger: 30 minutes after sunrise (no day-of-week restriction). Verify the +30-minute sunrise offset round-trips by reading the rule back.",
   "teardown_prompt": "Force-delete 'BAT-RM-T336a-SunriseOffset'."
 }
 ```
@@ -499,7 +503,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a BAT-RM-T336b-Motion virtual motion sensor.",
-  "test_prompt": "Create 'BAT-RM-T336b-Weekdays' triggered by BAT-RM-T336b-Motion becoming active, with a Days of Week restriction limiting firing to Monday through Friday (weekdays, excluding Sat/Sun). Verify the 5 weekday flags round-trip correctly via hub_get_app_config.",
+  "test_prompt": "Create 'BAT-RM-T336b-Weekdays' triggered by BAT-RM-T336b-Motion becoming active, with a Days of Week restriction limiting firing to Monday through Friday (weekdays, excluding Sat/Sun). Verify the 5 weekday flags round-trip correctly by reading the rule back.",
   "teardown_prompt": "Force-delete 'BAT-RM-T336b-Weekdays' and the BAT-RM-T336b-Motion virtual device."
 }
 ```
@@ -631,7 +635,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create BAT virtual devices: 'BAT-Motion-U1' and 'BAT-Motion-U2' (Virtual Motion Sensors). Record IDs.",
-  "test_prompt": "Step 1: Create 'BAT-RM-Update Triggers' with a single trigger: BAT-Motion-U1 becomes active. Step 2: Use hub_set_rule (addTrigger) to ADD a second trigger (BAT-Motion-U2 becomes active). Step 3: Use hub_set_rule (addTrigger) to MODIFY the first trigger (change motion=active to motion=inactive). Step 4: Use hub_set_rule to REMOVE the second trigger. After each step, read the rule back and verify the exact trigger set. Assert configPage.error stays null throughout and eventSubscriptions updates accordingly.",
+  "test_prompt": "Step 1: Create 'BAT-RM-Update Triggers' with a single trigger: BAT-Motion-U1 becomes active. Step 2: ADD a second trigger (BAT-Motion-U2 becomes active). Step 3: MODIFY the first trigger (change motion=active to motion=inactive). Step 4: REMOVE the second trigger. After each step, read the rule back and verify the exact trigger set. Assert configPage.error stays null throughout and eventSubscriptions updates accordingly.",
   "teardown_prompt": "Delete the rule and remove both motion sensors."
 }
 ```
@@ -643,7 +647,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create BAT virtual device 'BAT-Switch-Del' (Virtual Switch). Record ID.",
-  "test_prompt": "Create 'BAT-RM-Delete Me' triggered by BAT-Switch-Del turning on. Then attempt a SOFT delete (hub_delete_native_app without force=true). Verify it succeeds for a rule without children. Re-create the same-named rule, then do a FORCE delete (force=true). Verify force delete also succeeds and returns success regardless. After both deletes, hub_list_rules must not contain the rule name.",
+  "test_prompt": "Create 'BAT-RM-Delete Me' triggered by BAT-Switch-Del turning on. Then attempt a SOFT delete (a normal, non-forced delete). Verify it succeeds for a rule without children. Re-create the same-named rule, then do a FORCE delete. Verify force delete also succeeds and returns success regardless. After both deletes, the rules list must not contain the rule name.",
   "teardown_prompt": "Ensure rule is gone (force-delete by name if still present). Remove BAT-Switch-Del."
 }
 ```
@@ -655,7 +659,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create BAT virtual devices: 'BAT-RT-Motion' (motion), 'BAT-RT-Sw1' and 'BAT-RT-Sw2' (switches, for multi-device), 'BAT-RT-Temp' (temperature), 'BAT-RT-Lock' (lock). Create hub variable 'BAT_RT_var' (number, init 0). Record all IDs.",
-  "test_prompt": "Create 'BAT-RM-Round Trip Sampler' as a comprehensive coverage test with SIX triggers in one rule: (1) BAT-RT-Motion active as a CONDITIONAL TRIGGER with attached condition (BAT-RT-Lock is unlocked), (2) BAT-RT-Sw1 + BAT-RT-Sw2 as a SINGLE multi-device Switch trigger (any turns on), (3) BAT-RT-Temp > 75 with AND-STAYS for 5 minutes, (4) Mode changes to Day, (5) hub variable BAT_RT_var > 10, (6) Certain Time: 08:00 on weekdays only. Then: (A) Read the rule back via hub_get_app_config and verify ALL six triggers are present with their flags/values. (B) Read statusJson and assert `configPage.error == null`, `eventSubscriptions.length >= 5` (one per non-HTTP trigger including each multi-device member), and CRITICALLY `appSettings[<multi-device tDev>].multiple == true`. (C) Report any trigger whose round-trip value doesn't match what was sent.",
+  "test_prompt": "Create 'BAT-RM-Round Trip Sampler' as a comprehensive coverage test with SIX triggers in one rule: (1) BAT-RT-Motion active as a CONDITIONAL TRIGGER with attached condition (BAT-RT-Lock is unlocked), (2) BAT-RT-Sw1 + BAT-RT-Sw2 as a SINGLE multi-device Switch trigger (any turns on), (3) BAT-RT-Temp > 75 with AND-STAYS for 5 minutes, (4) Mode changes to Day, (5) hub variable BAT_RT_var > 10, (6) Certain Time: 08:00 on weekdays only. Then: (A) Read the rule back and verify ALL six triggers are present with their flags/values. (B) Read statusJson and assert `configPage.error == null`, `eventSubscriptions.length >= 5` (one per non-HTTP trigger including each multi-device member), and CRITICALLY `appSettings[<multi-device tDev>].multiple == true`. (C) Report any trigger whose round-trip value doesn't match what was sent.",
   "teardown_prompt": "Delete the rule, all five BAT-RT-* virtual devices, and hub variable BAT_RT_var."
 }
 ```
@@ -693,7 +697,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a virtual button device BAT-RM-Btn1 (driver: Virtual Button) and a second BAT-RM-Btn2. Note two existing hub modes.",
-  "test_prompt": "Create rule 'BAT-RM-ButtonBundle' with a Mode trigger. Actions: (1) Push button 1 on BAT-RM-Btn1, (2) Push button per mode — button 2 in mode[0], button 3 in mode[1] on BAT-RM-Btn1, (3) Choose button per mode — BAT-RM-Btn1 in mode[0], BAT-RM-Btn2 in mode[1], push button 1. Verify round-trip via hub_get_app_config.",
+  "test_prompt": "Create rule 'BAT-RM-ButtonBundle' with a Mode trigger. Actions: (1) Push button 1 on BAT-RM-Btn1, (2) Push button per mode — button 2 in mode[0], button 3 in mode[1] on BAT-RM-Btn1, (3) Choose button per mode — BAT-RM-Btn1 in mode[0], BAT-RM-Btn2 in mode[1], push button 1. Verify round-trip by reading the rule back.",
   "teardown_prompt": "Delete rule and both virtual buttons."
 }
 ```
@@ -789,19 +793,19 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Verify HSM is installed via hub_list_apps. Record current HSM status via hub_get_hsm_status for restoration.",
-  "test_prompt": "Create rule 'BAT-RM-HSMBundle-DoNotRun' (paused at creation). Trigger: a harmless Certain Time far in the future (e.g. 2099-01-01). Actions: (1) Arm Away, (2) Disarm, (3) Disarm All, (4) Cancel All Alerts. Confirm the rule is created via hub_set_rule and then paused via hub_set_rule_paused, and all 4 actions round-trip via hub_get_app_config. Do NOT run the rule.",
+  "test_prompt": "Create rule 'BAT-RM-HSMBundle-DoNotRun' (paused at creation). Trigger: a harmless Certain Time far in the future (e.g. 2099-01-01). Actions: (1) Arm Away, (2) Disarm, (3) Disarm All, (4) Cancel All Alerts. Confirm the rule is created and then paused, and all 4 actions round-trip when you read it back. Do NOT run the rule.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app. Confirm HSM status matches the original recorded state."
 }
 ```
 
-**Expected**: Rule is created DISABLED/paused; `statusJson` shows rule disabled. `hub_get_app_config.actions` has all 4 HSM actions. HSM real state untouched. [INV-1] `configPage.error == null`.
+**Expected**: AI creates the rule via `hub_set_rule` and pauses it via `hub_set_rule_paused`; `statusJson` shows rule disabled. `hub_get_app_config.actions` has all 4 HSM actions. HSM real state untouched. [INV-1] `configPage.error == null`.
 
 ### T361 — HSM per-rule arm/disarm + cancel rule alert + arm all rules
 
 ```json
 {
   "setup_prompt": "Via hub_list_apps find any existing HSM custom monitoring rule (or skip and mark SKIPPED if none). Confirm rule is paused-at-creation is supported.",
-  "test_prompt": "Create rule 'BAT-RM-HSMPerRule-DoNotRun' paused. Trigger: year-2099 Certain Time. Actions: (1) Arm specific HSM rule [discovered id], (2) Disarm specific HSM rule, (3) Cancel HSM Rule Alert for that rule, (4) Arm All HSM Rules. Verify round-trip via hub_get_app_config.",
+  "test_prompt": "Create rule 'BAT-RM-HSMPerRule-DoNotRun' paused. Trigger: year-2099 Certain Time. Actions: (1) Arm specific HSM rule [discovered id], (2) Disarm specific HSM rule, (3) Cancel HSM Rule Alert for that rule, (4) Arm All HSM Rules. Verify round-trip by reading the rule back.",
   "teardown_prompt": "Delete the rule."
 }
 ```
@@ -813,7 +817,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create virtual devices: BAT-RM-Garage (driver: Virtual Garage Door Opener), BAT-RM-Lock (driver: Virtual Lock), BAT-RM-Valve (driver: Virtual Valve). Verify none of them are production devices.",
-  "test_prompt": "Create rule 'BAT-RM-GarageLockValve-DoNotRun' paused with a year-2099 Certain Time trigger (so actions never fire). Actions: (1) Open BAT-RM-Garage, (2) Close BAT-RM-Garage, (3) Lock BAT-RM-Lock, (4) Unlock BAT-RM-Lock, (5) Open BAT-RM-Valve, (6) Close BAT-RM-Valve. Verify all six round-trip via hub_get_app_config. Rule must stay paused; actions must NOT fire against the virtual devices.",
+  "test_prompt": "Create rule 'BAT-RM-GarageLockValve-DoNotRun' paused with a year-2099 Certain Time trigger (so actions never fire). Actions: (1) Open BAT-RM-Garage, (2) Close BAT-RM-Garage, (3) Lock BAT-RM-Lock, (4) Unlock BAT-RM-Lock, (5) Open BAT-RM-Valve, (6) Close BAT-RM-Valve. Verify all six round-trip by reading the rule back. Rule must stay paused; actions must NOT fire against the virtual devices.",
   "teardown_prompt": "Delete rule and all three virtual devices."
 }
 ```
@@ -957,7 +961,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "No device creation needed — Z-Wave polling is hub-level.",
-  "test_prompt": "Create rule 'BAT-RM-ZWavePoll-DoNotRun' paused, year-2099 trigger. Actions: (1) Start Z-Wave Polling, (2) Stop Z-Wave Polling. Verify both round-trip via hub_get_app_config. Rule must stay paused.",
+  "test_prompt": "Create rule 'BAT-RM-ZWavePoll-DoNotRun' paused, year-2099 trigger. Actions: (1) Start Z-Wave Polling, (2) Stop Z-Wave Polling. Verify both round-trip by reading the rule back. Rule must stay paused.",
   "teardown_prompt": "Delete the rule. Verify Z-Wave polling state is unchanged from pre-test via hub_manage_diagnostics or equivalent."
 }
 ```
@@ -993,24 +997,24 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create virtual switches BAT-RM-UpdSw1 and BAT-RM-UpdSw2. Create rule 'BAT-RM-T377-Update' (unique name) with Certain Time trigger and one action: turn BAT-RM-UpdSw1 on. Capture the rule ID.",
-  "test_prompt": "Call hub_set_rule (with appId=BAT-RM-T377-Update's ruleId, using replaceActions) to replace actions with: (1) turn BAT-RM-UpdSw1 off, (2) turn BAT-RM-UpdSw2 on, (3) toggle BAT-RM-UpdSw1. Read the rule back and confirm the new 3-action list is in place and the old action is gone.",
+  "test_prompt": "Replace the rule's action list wholesale with: (1) turn BAT-RM-UpdSw1 off, (2) turn BAT-RM-UpdSw2 on, (3) toggle BAT-RM-UpdSw1. Read the rule back and confirm the new 3-action list is in place and the old action is gone.",
   "teardown_prompt": "Delete the rule and both virtual switches."
 }
 ```
 
-**Expected**: `hub_set_rule` (edit path) returns success. `hub_get_app_config.actions.length === 3` with new commands; old single-action list is gone. [INV-1] `configPage.error == null`. [INV-2] `statusJson.eventSubscriptions.length > 0` still true.
+**Expected**: `hub_set_rule` (edit path, `replaceActions`) returns success. `hub_get_app_config.actions.length === 3` with new commands; old single-action list is gone. [INV-1] `configPage.error == null`. [INV-2] `statusJson.eventSubscriptions.length > 0` still true.
 
 ### T378 — Delete rule (soft) then delete with force
 
 ```json
 {
   "setup_prompt": "Create virtual switch BAT-RM-DelSw. Create rule 'BAT-RM-T378-Delete' (unique name) with Certain Time trigger and one action: turn BAT-RM-DelSw on. Capture rule ID.",
-  "test_prompt": "Call hub_delete_native_app without force on BAT-RM-T378-Delete; expect success. Attempt hub_get_app_config on that ID; expect 404/not-found. Then, for a second scenario, re-create the rule and call hub_delete_native_app with force=true and confirm it also returns success and the rule is gone.",
+  "test_prompt": "Delete BAT-RM-T378-Delete with a normal (non-forced) delete; expect success. Attempt to read that rule's config by its ID; expect 404/not-found. Then, for a second scenario, re-create the rule and force-delete it and confirm it also returns success and the rule is gone.",
   "teardown_prompt": "Ensure no BAT-RM-T378-Delete rule remains via hub_list_rules. Delete the virtual switch."
 }
 ```
 
-**Expected**: First delete returns `{success:true}`, subsequent `hub_get_app_config` returns not-found. Force-delete path also succeeds. Both paths confirmed gone via `hub_list_rules`.
+**Expected**: First `hub_delete_native_app` (no force) returns `{success:true}`, subsequent `hub_get_app_config` returns not-found. The `force=true` path also succeeds. Both paths confirmed gone via `hub_list_rules`.
 
 ### T379 — Mega-compound rule: switches + dimmers + color + message + log
 
@@ -1041,19 +1045,19 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create virtual switches BAT-RM-OrdA, BAT-RM-OrdB, BAT-RM-OrdC. Create rule 'BAT-RM-Order' with Certain Time trigger and actions in order [A on, B on, C on].",
-  "test_prompt": "Call hub_set_rule (with appId=BAT-RM-Order's ruleId, using replaceActions) reordering actions to [C on, A on, B on]. Read back and verify the new order matches exactly. Then update again to [B on, C on, A on]. Read back and verify.",
+  "test_prompt": "Reorder the rule's actions (a wholesale action-list replacement) to [C on, A on, B on]. Read back and verify the new order matches exactly. Then reorder again to [B on, C on, A on]. Read back and verify.",
   "teardown_prompt": "Delete the rule and all three virtual switches."
 }
 ```
 
-**Expected**: `hub_get_app_config.actions[0/1/2].deviceId` matches the requested order after each update. No phantom action duplication or reshuffling. [INV-1] `configPage.error == null`.
+**Expected**: Each reorder is a `hub_set_rule` (edit, `replaceActions`) call; `hub_get_app_config.actions[0/1/2].deviceId` matches the requested order after each update. No phantom action duplication or reshuffling. [INV-1] `configPage.error == null`.
 
 ### T382 — Device IDs round-trip as strings (not coerced to int)
 
 ```json
 {
   "setup_prompt": "Create virtual switch BAT-RM-StrId. Note its deviceId as a string.",
-  "test_prompt": "Create rule 'BAT-RM-IdStr' with Certain Time trigger. Action: turn BAT-RM-StrId on. Read back via hub_get_app_config. Confirm the deviceId on the action, when compared via string equality with the ID captured in setup, is equal (i.e. no numeric coercion lossy behavior, no leading-zero stripping, no scientific notation).",
+  "test_prompt": "Create rule 'BAT-RM-IdStr' with Certain Time trigger. Action: turn BAT-RM-StrId on. Read the rule back. Confirm the deviceId on the action, when compared via string equality with the ID captured in setup, is equal (i.e. no numeric coercion lossy behavior, no leading-zero stripping, no scientific notation).",
   "teardown_prompt": "Delete the rule and virtual switch."
 }
 ```
@@ -1065,7 +1069,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create virtual contact sensor BAT-RM-ContactSub.",
-  "test_prompt": "Create rule 'BAT-RM-Sub' triggered by BAT-RM-ContactSub contact changing to open. Action: log 'sub fired'. After creation, query hub_get_app_config and assert statusJson.eventSubscriptions.length > 0 (because the rule has a device trigger). Then call hub_set_rule (with appId=BAT-RM-Sub's ruleId) removing the trigger (swap to Certain Time year-2099) and confirm eventSubscriptions becomes 0 or empty for device subscriptions.",
+  "test_prompt": "Create rule 'BAT-RM-Sub' triggered by BAT-RM-ContactSub contact changing to open. Action: log 'sub fired'. After creation, read the rule back and assert statusJson.eventSubscriptions.length > 0 (because the rule has a device trigger). Then edit the rule to remove the trigger (swap to Certain Time year-2099) and confirm eventSubscriptions becomes 0 or empty for device subscriptions.",
   "teardown_prompt": "Delete the rule and virtual contact sensor."
 }
 ```
@@ -1088,7 +1092,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 ```json
 {
-  "test_prompt": "Call hub_manage_rule_machine.hub_get_app_config with appId=99999999 (non-existent). AI should report the tool returned not-found / error and not fabricate a rule."
+  "test_prompt": "Show me the configuration of the app with ID 99999999 (a non-existent ID). AI should report the tool returned not-found / error and not fabricate a rule."
 }
 ```
 
@@ -1099,19 +1103,19 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create virtual switch BAT-RM-Clear. Create rule 'BAT-RM-ClearActions' with Certain Time trigger and 3 actions (any valid switch/toggle/flash).",
-  "test_prompt": "Call hub_set_rule (with appId=BAT-RM-ClearActions' ruleId, using replaceActions=[]) to set actions to an empty list []. Read back and confirm actions is empty AND the rule still exists AND configPage.error is null.",
+  "test_prompt": "Clear all of the rule's actions — replace its action list with an empty list. Read back and confirm actions is empty AND the rule still exists AND configPage.error is null.",
   "teardown_prompt": "Delete the rule and virtual switch."
 }
 ```
 
-**Expected**: `hub_get_app_config.actions.length === 0`. Rule still present in `hub_list_rules`. No configPage errors.
+**Expected**: AI calls `hub_set_rule` (edit, `replaceActions=[]`). `hub_get_app_config.actions.length === 0`. Rule still present in `hub_list_rules`. No configPage errors.
 
 ### T387 — hub_set_rule with empty actions list succeeds
 
 ```json
 {
   "setup_prompt": "No devices needed.",
-  "test_prompt": "Create rule 'BAT-RM-EmptyActions' with a Certain Time year-2099 trigger and actions=[] (empty list). Confirm creation succeeds and hub_get_app_config shows 0 actions. This is legal per RM 5.1.",
+  "test_prompt": "Create rule 'BAT-RM-EmptyActions' with a Certain Time year-2099 trigger and an empty action list. Confirm creation succeeds and reading the rule back shows 0 actions. This is legal per RM 5.1.",
   "teardown_prompt": "Delete the rule."
 }
 ```
@@ -1307,7 +1311,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "No setup — test creates everything fresh.",
-  "test_prompt": "Create rule 'BAT-RM-VarTypes' with five local variables: BAT-RM-LocalNum (number, 42), BAT-RM-LocalDec (decimal, 3.14), BAT-RM-LocalStr (string, 'hello'), BAT-RM-LocalBool (boolean, true), BAT-RM-LocalDT (datetime, 2026-04-24 12:00). Trigger: Periodic daily 06:00. Action: log 'vars loaded'. Then hub_set_rule(appId=<id>): (a) change BAT-RM-LocalNum value to 99, (b) delete BAT-RM-LocalStr. Read back and verify: 4 local vars remain, BAT-RM-LocalNum=99, types for the remaining four are preserved correctly.",
+  "test_prompt": "Create rule 'BAT-RM-VarTypes' with five local variables: BAT-RM-LocalNum (number, 42), BAT-RM-LocalDec (decimal, 3.14), BAT-RM-LocalStr (string, 'hello'), BAT-RM-LocalBool (boolean, true), BAT-RM-LocalDT (datetime, 2026-04-24 12:00). Trigger: Periodic daily 06:00. Action: log 'vars loaded'. Then edit the rule to: (a) change BAT-RM-LocalNum value to 99, (b) delete BAT-RM-LocalStr. Read back and verify: 4 local vars remain, BAT-RM-LocalNum=99, types for the remaining four are preserved correctly.",
   "teardown_prompt": "Force-delete 'BAT-RM-VarTypes'."
 }
 ```
@@ -1391,7 +1395,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a virtual switch 'BAT-RM-GateSw' and a virtual contact 'BAT-RM-CrossTrig'.",
-  "test_prompt": "Create TWO rules. Rule B first: 'BAT-RM-Cross-B' with Required Expression 'Rule BAT-RM-Cross-B Private Boolean is true', trigger BAT-RM-GateSw changed, action log 'B fired'. Then Rule A: 'BAT-RM-Cross-A' triggered by BAT-RM-CrossTrig opens, with actions: IF (BAT-RM-CrossTrig is open) THEN Set Private Boolean on rule 'BAT-RM-Cross-B' = true; ELSE Set Private Boolean on rule 'BAT-RM-Cross-B' = false; END-IF. Read both rules back and verify: (a) Rule A's two Set PB actions reference Rule B's app ID (not self), (b) Rule B's required expression references its own PB. Then use hub_set_rule_private_boolean on Rule B to confirm the existing single-PB tool still works as a third path.",
+  "test_prompt": "Create TWO rules. Rule B first: 'BAT-RM-Cross-B' with Required Expression 'Rule BAT-RM-Cross-B Private Boolean is true', trigger BAT-RM-GateSw changed, action log 'B fired'. Then Rule A: 'BAT-RM-Cross-A' triggered by BAT-RM-CrossTrig opens, with actions: IF (BAT-RM-CrossTrig is open) THEN Set Private Boolean on rule 'BAT-RM-Cross-B' = true; ELSE Set Private Boolean on rule 'BAT-RM-Cross-B' = false; END-IF. Read both rules back and verify: (a) Rule A's two Set PB actions reference Rule B's app ID (not self), (b) Rule B's required expression references its own PB. Then directly set Rule B's Private Boolean using the dedicated single-Private-Boolean setter (not a rule action), to confirm that path still works as a third route.",
   "teardown_prompt": "Force-delete both 'BAT-RM-Cross-A' and 'BAT-RM-Cross-B'. Remove BAT-RM-GateSw and BAT-RM-CrossTrig."
 }
 ```
@@ -1403,12 +1407,12 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a virtual switch 'BAT-RM-DefPB'.",
-  "test_prompt": "Create rule 'BAT-RM-PBDefault' with trigger BAT-RM-DefPB changed, action Set Private Boolean (self) = false. Run the rule actions once via hub_manage_rule_machine.hub_call_rule to drive PB to false. Verify PB is now false (via hub_get_app_config or reading state). Then press the rule's Start button (lifecycle verb — via hub_manage_rule_machine or a hub_set_rule lifecycle action). Verify PB has reset to true (RM's documented behavior: Start always resets PB to true).",
+  "test_prompt": "Create rule 'BAT-RM-PBDefault' with trigger BAT-RM-DefPB changed, action Set Private Boolean (self) = false. Run the rule's actions once directly (without waiting for the trigger) to drive PB to false. Verify PB is now false by reading the rule back. Then press the rule's Start button (a lifecycle verb). Verify PB has reset to true (RM's documented behavior: Start always resets PB to true).",
   "teardown_prompt": "Force-delete 'BAT-RM-PBDefault'. Remove BAT-RM-DefPB."
 }
 ```
 
-**Expected**: PB observed as false after running actions, then true after Start. Confirms Start-resets-PB-to-true documented behavior.
+**Expected**: AI runs the actions via `hub_call_rule(action='actions')` and presses Start via the lifecycle path (`hub_call_rule(action='start')`). PB observed as false after running actions, then true after Start. Confirms Start-resets-PB-to-true documented behavior.
 
 ### T424 — Kitchen-sink rule: IF/ELSE + variable-sourced Delay + per-mode action + Exit
 
@@ -1427,7 +1431,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create virtual switches 'BAT-RM-UpdA', 'BAT-RM-UpdB', 'BAT-RM-UpdC'. No cross-test dependency: this test is fully self-contained.",
-  "test_prompt": "Create rule 'BAT-RM-T425-Update' (unique name) with Required Expression 'BAT-RM-UpdA is on', trigger BAT-RM-UpdA changed, one local variable BAT-RM-Counter (number, 0), action log '%BAT-RM-Counter% fires'. Then call hub_set_rule(appId=<ruleId>) with a patch that: (a) changes Required Expression to 'BAT-RM-UpdA is on AND BAT-RM-UpdB is on', (b) appends a second action 'Set BAT-RM-Counter = BAT-RM-Counter + 1' (arithmetic), (c) changes BAT-RM-Counter initial value to 10. Read back and confirm all three changes applied atomically and the rule still has exactly one trigger.",
+  "test_prompt": "Create rule 'BAT-RM-T425-Update' (unique name) with Required Expression 'BAT-RM-UpdA is on', trigger BAT-RM-UpdA changed, one local variable BAT-RM-Counter (number, 0), action log '%BAT-RM-Counter% fires'. Then edit the rule with a single patch that: (a) changes Required Expression to 'BAT-RM-UpdA is on AND BAT-RM-UpdB is on', (b) appends a second action 'Set BAT-RM-Counter = BAT-RM-Counter + 1' (arithmetic), (c) changes BAT-RM-Counter initial value to 10. Read back and confirm all three changes applied atomically and the rule still has exactly one trigger.",
   "teardown_prompt": "Force-delete 'BAT-RM-T425-Update'. Remove BAT-RM-UpdA, BAT-RM-UpdB, BAT-RM-UpdC."
 }
 ```
@@ -1439,19 +1443,19 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a virtual switch 'BAT-RM-DelSw'.",
-  "test_prompt": "Create rule 'BAT-RM-DelTest' with trigger BAT-RM-DelSw changed and one log action. Try hub_delete_native_app(force=false) — should succeed because rule has no children. Then recreate the same rule. Finally hub_delete_native_app(force=true) — should succeed regardless (uses /installedapp/forcedelete/.../quiet endpoint, always 302). Verify post-delete the rule no longer appears in hub_list_rules.",
+  "test_prompt": "Create rule 'BAT-RM-DelTest' with trigger BAT-RM-DelSw changed and one log action. Try a soft (non-forced) delete — should succeed because the rule has no children. Then recreate the same rule. Finally a force delete — should succeed regardless (uses the /installedapp/forcedelete/.../quiet endpoint, always 302). Verify post-delete the rule no longer appears in the rules list.",
   "teardown_prompt": "Remove BAT-RM-DelSw. Confirm no BAT-RM-DelTest remains."
 }
 ```
 
-**Expected**: Soft delete returns `{success:true, message:...}`. Force delete returns success via 302 redirect. `hub_list_rules` confirms rule gone both times.
+**Expected**: The soft `hub_delete_native_app` (force=false) returns `{success:true, message:...}`. The `force=true` call returns success via 302 redirect. `hub_list_rules` confirms rule gone both times.
 
 ### T427 — Operator precedence round-trip with mixed AND/OR/XOR (left-to-right equal)
 
 ```json
 {
   "setup_prompt": "Create virtual switches BAT-RM-P1, BAT-RM-P2, BAT-RM-P3, BAT-RM-P4.",
-  "test_prompt": "Create rule 'BAT-RM-Precedence' with Required Expression 'BAT-RM-P1 is on AND BAT-RM-P2 is on OR BAT-RM-P3 is on XOR BAT-RM-P4 is on' (no parens — tests left-to-right equal precedence of AND/OR/XOR). Trigger: any of the four. Action: log 'precedence hit'. Read back and verify operator evaluation order is preserved exactly left-to-right (RM spec: AND/OR/XOR have equal precedence, left-to-right), and hub_get_app_config returns the four conditions in the same sequence with the three operators in-between in the same order.",
+  "test_prompt": "Create rule 'BAT-RM-Precedence' with Required Expression 'BAT-RM-P1 is on AND BAT-RM-P2 is on OR BAT-RM-P3 is on XOR BAT-RM-P4 is on' (no parens — tests left-to-right equal precedence of AND/OR/XOR). Trigger: any of the four. Action: log 'precedence hit'. Read back and verify operator evaluation order is preserved exactly left-to-right (RM spec: AND/OR/XOR have equal precedence, left-to-right), and reading the rule back returns the four conditions in the same sequence with the three operators in-between in the same order.",
   "teardown_prompt": "Force-delete 'BAT-RM-Precedence'. Remove BAT-RM-P1..P4."
 }
 ```
@@ -1475,7 +1479,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "No setup.",
-  "test_prompt": "Call hub_set_rule with name 'BAT-RM-BadRule' and a malformed Required Expression 'BAT-RM-Ghost is on AND AND BAT-RM-Other is off' (double AND, undefined devices). The tool should reject this with a validation error before writing to the hub, or — if it reaches the hub — the returned configPage.error should be non-null and no rule should be created. Confirm via hub_list_rules that 'BAT-RM-BadRule' is not present.",
+  "test_prompt": "Create a rule named 'BAT-RM-BadRule' with a malformed Required Expression 'BAT-RM-Ghost is on AND AND BAT-RM-Other is off' (double AND, referencing undefined devices). This should be rejected with a validation error before writing to the hub, or — if it reaches the hub — the returned configPage.error should be non-null and no rule should be created. Confirm that 'BAT-RM-BadRule' is not present in the rules list.",
   "teardown_prompt": "If the rule did get partially created, force-delete 'BAT-RM-BadRule'. Otherwise no teardown."
 }
 ```
@@ -1487,7 +1491,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "No setup.",
-  "test_prompt": "Create a Rule Machine rule named 'BAT-RM-T430b-BugC' with: (1) a Certain Time trigger at 3:00 AM, (2) a Required Expression with two Switch conditions joined by AND -- Condition A: switch device 1063 is on; Condition B: switch device 1080 is off. After creation, call hub_get_app_config(appId=<ruleId>, includeSettings=true) and report ALL paragraph text from the mainPage. Confirm the render does NOT contain '(unused)' and does NOT contain 'Define Required Expression'.",
+  "test_prompt": "Create a Rule Machine rule named 'BAT-RM-T430b-BugC' with: (1) a Certain Time trigger at 3:00 AM, (2) a Required Expression with two Switch conditions joined by AND -- Condition A: switch device 1063 is on; Condition B: switch device 1080 is off. After creation, read the rule back including its settings and report ALL paragraph text from the mainPage. Confirm the render does NOT contain '(unused)' and does NOT contain 'Define Required Expression'.",
   "teardown_prompt": "Force-delete BAT-RM-T430b-BugC."
 }
 ```
@@ -1499,7 +1503,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "No setup.",
-  "test_prompt": "Create a Rule Machine rule named 'BAT-RM-T431b-BugD' with: (1) a Certain Time trigger at 3:15 AM, (2) a Required Expression with Switch device 1063 is on AND Switch device 1080 is off, (3) a plain switch-on action on device 1063. After creation, call hub_get_app_config(appId=<ruleId>) and report ALL paragraph text. Confirm the action renders as 'On: <device name>' NOT as 'IF (**Broken Condition**) ...'.",
+  "test_prompt": "Create a Rule Machine rule named 'BAT-RM-T431b-BugD' with: (1) a Certain Time trigger at 3:15 AM, (2) a Required Expression with Switch device 1063 is on AND Switch device 1080 is off, (3) a plain switch-on action on device 1063. After creation, read the rule back and report ALL paragraph text. Confirm the action renders as 'On: <device name>' NOT as 'IF (**Broken Condition**) ...'.",
   "teardown_prompt": "Force-delete BAT-RM-T431b-BugD."
 }
 ```
@@ -1511,7 +1515,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "No setup.",
-  "test_prompt": "Create a Rule Machine rule named 'BAT-RM-T432b-BugE' with: (1) a Certain Time trigger at 4:00 AM, (2) four sequential runCommand actions -- action 1: device 1072 setDisplay('on'), action 2: device 1121 setChildLock('on'), action 3: device 1072 setDisplay('off'), action 4: device 1121 setChildLock('off'). After creation, call hub_get_app_config(appId=<ruleId>, includeSettings=true) and report ALL paragraph text from mainPage and the settingsApplied/settingsSkipped counts for each action. Confirm that all four actions render with their parameter (e.g., 'on' or 'off') and none show empty/missing parameter text.",
+  "test_prompt": "Create a Rule Machine rule named 'BAT-RM-T432b-BugE' with: (1) a Certain Time trigger at 4:00 AM, (2) four sequential runCommand actions -- action 1: device 1072 setDisplay('on'), action 2: device 1121 setChildLock('on'), action 3: device 1072 setDisplay('off'), action 4: device 1121 setChildLock('off'). After creation, read the rule back including its settings and report ALL paragraph text from mainPage and the settingsApplied/settingsSkipped counts for each action. Confirm that all four actions render with their parameter (e.g., 'on' or 'off') and none show empty/missing parameter text.",
   "teardown_prompt": "Force-delete BAT-RM-T432b-BugE."
 }
 ```
@@ -1537,7 +1541,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a helper rule BAT-RM-T431-Target via hub_set_rule with a simple delayed log action. Note its ruleId.",
-  "test_prompt": "Create 'BAT-RM-T431-Endpoint' whose only trigger is a Local End Point configured to stop the actions of the helper rule (/stopRuleAct=<id>). Then call hub_get_app_config and show me the endpoint URL and the verb.",
+  "test_prompt": "Create 'BAT-RM-T431-Endpoint' whose only trigger is a Local End Point configured to stop the actions of the helper rule (/stopRuleAct=<id>). Then read the rule back and show me the endpoint URL and the verb.",
   "teardown_prompt": "Force-delete both BAT-RM-T431-* rules. Verify hub_list_rules is clean and no orphan children remain under the RM parent."
 }
 ```
@@ -1561,7 +1565,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create helper rule BAT-RM-T433-Target that uses Private Boolean in a condition. Note its ruleId.",
-  "test_prompt": "Create 'BAT-RM-T433-PBTrue' with Local End Point trigger /setRuleBooleanTrue=<target_id> and 'BAT-RM-T433-PBFalse' with /setRuleBooleanFalse=<target_id>. Confirm both endpoint URLs via hub_get_app_config.",
+  "test_prompt": "Create 'BAT-RM-T433-PBTrue' with Local End Point trigger /setRuleBooleanTrue=<target_id> and 'BAT-RM-T433-PBFalse' with /setRuleBooleanFalse=<target_id>. Confirm both endpoint URLs by reading the rules back.",
   "teardown_prompt": "Force-delete all three BAT-RM-T433-* rules. Verify cleanup."
 }
 ```
@@ -1573,7 +1577,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create BAT-RM-T434-Target with a simple log action.",
-  "test_prompt": "Create 'BAT-RM-T434-Legacy' with a Local End Point trigger that uses the legacy /runRule=<id> verb (not runRuleAct). After creation, call hub_get_app_config and confirm the URL uses the legacy path.",
+  "test_prompt": "Create 'BAT-RM-T434-Legacy' with a Local End Point trigger that uses the legacy /runRule=<id> verb (not runRuleAct). After creation, read the rule back and confirm the URL uses the legacy path.",
   "teardown_prompt": "Force-delete both BAT-RM-T434-* rules."
 }
 ```
@@ -1584,7 +1588,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 ```json
 {
-  "test_prompt": "Create a rule 'BAT-RM-T435-GetList' with a Local End Point trigger that calls /getRuleList (the verb that returns a JSON map of all rules). Call hub_get_app_config and verify the generated URL ends with /getRuleList and that no rule-id parameter is required.",
+  "test_prompt": "Create a rule 'BAT-RM-T435-GetList' with a Local End Point trigger that calls /getRuleList (the verb that returns a JSON map of all rules). Read the rule back and verify the generated URL ends with /getRuleList and that no rule-id parameter is required.",
   "teardown_prompt": "Force-delete BAT-RM-T435-GetList. Verify cleanup."
 }
 ```
@@ -1596,7 +1600,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a hub variable named 'batT436Var' (number, initial 0) via manage_hub_variables.",
-  "test_prompt": "Create 'BAT-RM-T436-SetHubVar' with a Local End Point trigger configured with the /setHubVariable verb targeting batT436Var. Call hub_get_app_config and confirm the generated URL shows /setHubVariable=batT436Var:<value> pattern in the rule config.",
+  "test_prompt": "Create 'BAT-RM-T436-SetHubVar' with a Local End Point trigger configured with the /setHubVariable verb targeting batT436Var. Read the rule back and confirm the generated URL shows /setHubVariable=batT436Var:<value> pattern in the rule config.",
   "teardown_prompt": "Force-delete BAT-RM-T436-SetHubVar. Delete the batT436Var hub variable. Verify both are gone."
 }
 ```
@@ -1608,7 +1612,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a hub variable literally named 'my test var' (with spaces) via manage_hub_variables.",
-  "test_prompt": "Create 'BAT-RM-T437-EncodedVar' with a Local End Point trigger using /setHubVariableEncoded targeting the variable 'my test var'. Because the name has spaces, the generated URL must URL-encode both the name and value placeholders. Call hub_get_app_config and confirm the encoded path.",
+  "test_prompt": "Create 'BAT-RM-T437-EncodedVar' with a Local End Point trigger using /setHubVariableEncoded targeting the variable 'my test var'. Because the name has spaces, the generated URL must URL-encode both the name and value placeholders. Read the rule back and confirm the encoded path.",
   "teardown_prompt": "Force-delete BAT-RM-T437-EncodedVar and delete the 'my test var' hub variable."
 }
 ```
@@ -1620,7 +1624,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a legacy global variable (or reuse a suitable hub variable) named 'batT438Legacy'.",
-  "test_prompt": "Create 'BAT-RM-T438-SetGV' with a Local End Point trigger using the legacy /setGlobalVariable=<name>:<value> verb. Call hub_get_app_config and confirm the URL uses /setGlobalVariable (not /setHubVariable).",
+  "test_prompt": "Create 'BAT-RM-T438-SetGV' with a Local End Point trigger using the legacy /setGlobalVariable=<name>:<value> verb. Read the rule back and confirm the URL uses /setGlobalVariable (not /setHubVariable).",
   "teardown_prompt": "Force-delete BAT-RM-T438-SetGV. Remove the test variable."
 }
 ```
@@ -1631,7 +1635,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 ```json
 {
-  "test_prompt": "Create 'BAT-RM-T439-ValuePassthrough' with a Local End Point trigger configured so that any arbitrary trailing URL string (not matching a known verb like runRuleAct/pauseRule/etc.) populates the built-in %value% variable. Then give it an action that logs '%value%'. Call hub_get_app_config and confirm the endpoint is configured as a catch-all (no verb binding).",
+  "test_prompt": "Create 'BAT-RM-T439-ValuePassthrough' with a Local End Point trigger configured so that any arbitrary trailing URL string (not matching a known verb like runRuleAct/pauseRule/etc.) populates the built-in %value% variable. Then give it an action that logs '%value%'. Read the rule back and confirm the endpoint is configured as a catch-all (no verb binding).",
   "teardown_prompt": "Force-delete BAT-RM-T439-ValuePassthrough."
 }
 ```
@@ -1643,7 +1647,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Confirm the hub has cloud access configured (Hubitat login registered).",
-  "test_prompt": "Create 'BAT-RM-T440-Cloud' with a Cloud End Point trigger using /runRuleAct=<self> (pointed at the rule itself). After creation, call hub_get_app_config and confirm the URL starts with https://cloud.hubitat.com (or the equivalent cloud host), NOT the local http://<hub-ip>:8080 prefix.",
+  "test_prompt": "Create 'BAT-RM-T440-Cloud' with a Cloud End Point trigger using /runRuleAct=<self> (pointed at the rule itself). After creation, read the rule back and confirm the URL starts with https://cloud.hubitat.com (or the equivalent cloud host), NOT the local http://<hub-ip>:8080 prefix.",
   "teardown_prompt": "Force-delete BAT-RM-T440-Cloud. Verify cleanup."
 }
 ```
@@ -1655,7 +1659,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create BAT-RM-T441-TargetA and BAT-RM-T441-TargetB (two simple log-only rules). Note both ruleIds.",
-  "test_prompt": "Create 'BAT-RM-T441-Switchable' with a Local End Point trigger bound to /runRuleAct=<TargetA_id>. Call hub_get_app_config and record the URL. Then use hub_set_rule(appId=ruleId) to switch the binding to /runRuleAct=<TargetB_id>. Call hub_get_app_config again and confirm the URL now references TargetB, and that the old TargetA subscription is gone from eventSubscriptions.",
+  "test_prompt": "Create 'BAT-RM-T441-Switchable' with a Local End Point trigger bound to /runRuleAct=<TargetA_id>. Read the rule back and record the URL. Then edit the rule to switch the binding to /runRuleAct=<TargetB_id>. Read it back again and confirm the URL now references TargetB, and that the old TargetA subscription is gone from eventSubscriptions.",
   "teardown_prompt": "Force-delete all three BAT-RM-T441-* rules."
 }
 ```
@@ -1667,7 +1671,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Record baseline: call hub_list_rules and note the count N. Also hub_get_app_config on the Rule Machine PARENT app and note its hasChildren count M. Also enable MCP debug logging (set_log_level=debug) so we can capture the tool's internal trace.",
-  "test_prompt": "Attempt to create a rule 'BAT-RM-T442-Orphan' with a trigger that will PASS pre-validation (e.g., valid Motion trigger on an existing BAT-created virtual motion sensor) BUT configure an action that can only be validated server-side by posting it (e.g., reference a scene/app/rule ID that doesn't exist, or a custom command that the target device doesn't support — something that `createchild` will accept but the subsequent action-configuration POST to `/installedapp/update/json` will reject). The create must reach the `createchild` step (so a child app IS allocated server-side) and then fail during action configuration. Verify via MCP debug logs that: (a) `/installedapp/createchild/hubitat/Rule-5.1/parent/<rmParentId>` returned a 302 with a NEW child app ID, (b) the subsequent update/json or btn POST returned an error, (c) the tool then issued `/installedapp/forcedelete/<newChildId>/quiet` to clean up. All three steps MUST appear in the trace. After the error, call hub_list_rules and hub_get_app_config on the RM parent — count must still be N and M respectively. A tool that pre-validates client-side and never calls createchild would 'pass' the count check but FAIL this test — the trace evidence of the three-step cycle is what proves the cleanup path works.",
+  "test_prompt": "Attempt to create a rule 'BAT-RM-T442-Orphan' with a trigger that will PASS pre-validation (e.g., valid Motion trigger on an existing BAT-created virtual motion sensor) BUT configure an action that can only be validated server-side by posting it (e.g., reference a scene/app/rule ID that doesn't exist, or a custom command that the target device doesn't support — something that `createchild` will accept but the subsequent action-configuration POST to `/installedapp/update/json` will reject). The create must reach the `createchild` step (so a child app IS allocated server-side) and then fail during action configuration. Verify via MCP debug logs that: (a) `/installedapp/createchild/hubitat/Rule-5.1/parent/<rmParentId>` returned a 302 with a NEW child app ID, (b) the subsequent update/json or btn POST returned an error, (c) the tool then issued `/installedapp/forcedelete/<newChildId>/quiet` to clean up. All three steps MUST appear in the trace. After the error, read the rules list and the RM parent app's config — count must still be N and M respectively. A tool that pre-validates client-side and never calls createchild would 'pass' the count check but FAIL this test — the trace evidence of the three-step cycle is what proves the cleanup path works.",
   "teardown_prompt": "If for any reason an orphan persists, list installed apps filtered by name prefix 'BAT-RM-T442' and force-delete anything found. Re-verify counts match baseline. Reset log level if changed."
 }
 ```
@@ -1679,7 +1683,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Ensure at least three virtual switches exist: list_virtual_devices; if fewer than 3 'BAT-SW-*' virtuals exist, create enough via hub_manage_virtual_device.",
-  "test_prompt": "Create 'BAT-RM-T443-MultiSwitch' with a single Switch trigger bound to THREE virtual switches (multi-device, any of them turning on/off fires the rule). After creation, call hub_get_app_config (with includeSettings=true) and assert THREE things: (a) the tDev<N> setting lists all 3 device IDs, (b) appSettings[tDev<N>].type == 'capability.switch', (c) appSettings[tDev<N>].multiple == true. If multiple is false, this is the Phase 1 flag-poisoning regression — stop and report.",
+  "test_prompt": "Create 'BAT-RM-T443-MultiSwitch' with a single Switch trigger bound to THREE virtual switches (multi-device, any of them turning on/off fires the rule). After creation, read the rule back including its settings and assert THREE things: (a) the tDev<N> setting lists all 3 device IDs, (b) appSettings[tDev<N>].type == 'capability.switch', (c) appSettings[tDev<N>].multiple == true. If multiple is false, this is the Phase 1 flag-poisoning regression — stop and report.",
   "teardown_prompt": "Force-delete BAT-RM-T443-MultiSwitch. Verify cleanup."
 }
 ```
@@ -1691,7 +1695,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create three BAT-prefixed virtual switches via hub_manage_virtual_device: BAT-T444-Sw1, BAT-T444-Sw2, BAT-T444-Sw3. Record their IDs. Create a new rule named 'BAT-RM-T444-MultiSwitch' via hub_set_rule with a single Switch trigger bound to all three virtual switches (multi-device). Verify at creation time that appSettings[tDev<N>].multiple == true as a baseline precondition.",
-  "test_prompt": "Call hub_set_rule(appId=ruleId) on BAT-RM-T444-MultiSwitch to REMOVE one of the three trigger devices (leaving BAT-T444-Sw1 and BAT-T444-Sw2). Immediately after the update, re-read appSettings[tDev<N>] and confirm multiple is STILL true (not silently rewritten to false during the update). Also call hub_get_app_config and confirm it renders without any 'Command size is not supported by device' RM rendering error. This test guards the update-path regression of the flag-poisoning bug described in the Phase 1 findings on #120.",
+  "test_prompt": "Edit BAT-RM-T444-MultiSwitch to REMOVE one of the three trigger devices (leaving BAT-T444-Sw1 and BAT-T444-Sw2). Immediately after the update, re-read appSettings[tDev<N>] and confirm multiple is STILL true (not silently rewritten to false during the update). Also read the rule back and confirm it renders without any 'Command size is not supported by device' RM rendering error. This test guards the update-path regression of the flag-poisoning bug described in the Phase 1 findings on #120.",
   "teardown_prompt": "Force-delete BAT-RM-T444-MultiSwitch via hub_delete_native_app(appId=ruleId, force=true). Delete all three BAT-T444-Sw* virtual devices."
 }
 ```
@@ -1715,19 +1719,19 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create 'BAT-RM-T446-EditCond' with a multi-device trigger.",
-  "test_prompt": "This is a defensive test for Phase 1 finding — stuck `state.editCond` after a button-handler exception (stale state.editCond). After creation, if by construction state.editCond is ever stuck (inspect via hub_get_app_config with includeSettings=true — look for state.editCond in the state map), the tool should detect this on the NEXT hub_set_rule(appId=ruleId) call and call /installedapp/btn with name=updateRule to clear it. Attempt two back-to-back hub_set_rule(appId=ruleId) calls that touch trigger config. Verify the final state.editCond is null/unset AND configPage.error is null. If the new tool design makes editCond-stuckness impossible to reach, note that and mark aspirational.",
+  "test_prompt": "This is a defensive test for Phase 1 finding — stuck `state.editCond` after a button-handler exception (stale state.editCond). After creation, if by construction state.editCond is ever stuck (inspect by reading the rule's state/settings — look for state.editCond in the state map), the tool should detect this on the NEXT rule edit and POST /installedapp/btn with name=updateRule to clear it. Attempt two back-to-back edits that touch trigger config. Verify the final state.editCond is null/unset AND configPage.error is null. If the new tool design makes editCond-stuckness impossible to reach, note that and mark aspirational.",
   "teardown_prompt": "Force-delete BAT-RM-T446-EditCond. Final check: no rule with prefix 'BAT-RM-T446' appears in hub_list_rules."
 }
 ```
 
-**Expected**: Tool detects stuck `state.editCond` if present and POSTs `updateRule` to clear. Post-test `state.editCond` is null. [INV-1] `configPage.error == null`. If unreachable by design, test is aspirational — both conditions (editCond clear AND final config error null) still asserted as preconditions for teardown.
+**Expected**: On the next `hub_set_rule` (edit), the tool detects stuck `state.editCond` if present and POSTs `updateRule` to clear. Post-test `state.editCond` is null. [INV-1] `configPage.error == null`. If unreachable by design, test is aspirational — both conditions (editCond clear AND final config error null) still asserted as preconditions for teardown.
 
 ### T447 — Concurrent update race (same rule, rapid updates)
 
 ```json
 {
   "setup_prompt": "Create 'BAT-RM-T447-Race' with a single Switch trigger on one virtual switch and a simple log action.",
-  "test_prompt": "Fire two hub_set_rule(appId=ruleId) calls in rapid succession on the same ruleId: call A sets the rule's comment to 'update-A', call B sets it to 'update-B'. Issue both without waiting for the first to return if the client supports it. After both complete, call hub_get_app_config and confirm: (a) both calls returned success (no 500/race error), (b) the final comment is either 'update-A' or 'update-B' (deterministic last-writer-wins, not a corrupted mix), (c) configPage.error is null, (d) eventSubscriptions is still populated.",
+  "test_prompt": "Fire two edits in rapid succession on the same rule: edit A sets the rule's comment to 'update-A', edit B sets it to 'update-B'. Issue both without waiting for the first to return if the client supports it. After both complete, read the rule back and confirm: (a) both calls returned success (no 500/race error), (b) the final comment is either 'update-A' or 'update-B' (deterministic last-writer-wins, not a corrupted mix), (c) configPage.error is null, (d) eventSubscriptions is still populated.",
   "teardown_prompt": "Force-delete BAT-RM-T447-Race."
 }
 ```
@@ -1739,7 +1743,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Simulate a fresh MCP install: via hub_manage_diagnostics or an equivalent reset path, clear the cached state.rmParentId (if the tool exposes it) OR confirm that on a fresh hub this value starts unset. Record current value.",
-  "test_prompt": "With state.rmParentId unset, attempt to create 'BAT-RM-T448-FirstRun' with a minimal trigger + action. The tool should internally call hub_list_apps, filter for the Rule Machine parent app (name 'Rule Machine' / type matches), cache its id into state.rmParentId, then proceed with /installedapp/createchild. Verify: (a) the rule is created successfully, (b) state.rmParentId is now populated. Then create a second rule 'BAT-RM-T448-FirstRun-2' and verify the tool uses the cached value (no second hub_list_apps call for parent discovery — confirm via mcpLog or a debug trace if available).",
+  "test_prompt": "With state.rmParentId unset, attempt to create 'BAT-RM-T448-FirstRun' with a minimal trigger + action. On this first run the tool must discover the Rule Machine parent app (by listing installed apps and matching name 'Rule Machine' / type), cache its id into state.rmParentId, then proceed with /installedapp/createchild. Verify: (a) the rule is created successfully, (b) state.rmParentId is now populated. Then create a second rule 'BAT-RM-T448-FirstRun-2' and verify the tool uses the cached value (no second parent-discovery lookup — confirm via mcpLog or a debug trace if available).",
   "teardown_prompt": "Force-delete both BAT-RM-T448-FirstRun* rules via hub_delete_native_app. The cached state.rmParentId can stay set (that's the expected post-first-run state)."
 }
 ```
@@ -1751,7 +1755,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "This test requires either a hub where Rule Machine is NOT installed, or simulating that state by pointing the tool at an rmParentId that doesn't exist. If the live hub has RM installed and it cannot be safely uninstalled for the test, mark this as environment-dependent.",
-  "test_prompt": "Attempt to create 'BAT-RM-T449-NoRM' via hub_set_rule. Because Rule Machine is not installed (or the parent app is missing), the tool should return a clean error message pointing the user to 'Install Rule Machine from Apps → Add Built-In App'. It must NOT fabricate a success response, NOT create orphan state, and NOT silently pick some other app as the parent.",
+  "test_prompt": "Attempt to create a Rule Machine rule named 'BAT-RM-T449-NoRM'. Because Rule Machine is not installed (or the parent app is missing), the tool should return a clean error message pointing the user to 'Install Rule Machine from Apps → Add Built-In App'. It must NOT fabricate a success response, NOT create orphan state, and NOT silently pick some other app as the parent.",
   "teardown_prompt": "No teardown needed — the create should have failed cleanly with no orphans. As a sanity check, call hub_list_apps and confirm no 'BAT-RM-T449-*' entries exist."
 }
 ```
@@ -1762,7 +1766,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 ```json
 {
-  "test_prompt": "Call hub_manage_rule_machine.hub_set_rule with appId=99999999 and a harmless patch (e.g. change comments to 'x'). Because the rule does not exist, the tool MUST return a clean error response — NOT silently succeed, NOT create a new rule with that ID, NOT fabricate success. Report the error message verbatim."
+  "test_prompt": "Edit the rule with ID 99999999 — change its comments to 'x'. Because no rule with that ID exists, the tool MUST return a clean error response — NOT silently succeed, NOT create a new rule with that ID, NOT fabricate success. Report the error message verbatim."
 }
 ```
 
@@ -1772,7 +1776,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 ```json
 {
-  "test_prompt": "Call hub_manage_native_rules_and_apps.hub_delete_native_app with appId=99999999 and force=false. Then call again with force=true. In both cases, the tool MUST return a clean response — either `{success:false, error:<not-found>}` or (if the framework's underlying endpoint returns 302/success for nonexistent IDs) `{success:true, note:<no-op>}` with a clear indication that no deletion actually occurred. The tool must NOT claim to have deleted something that did not exist, and must NOT throw an unhandled exception."
+  "test_prompt": "Delete the app with ID 99999999 — first with a normal (non-forced) delete, then with a force delete. In both cases, the tool MUST return a clean response — either `{success:false, error:<not-found>}` or (if the framework's underlying endpoint returns 302/success for nonexistent IDs) `{success:true, note:<no-op>}` with a clear indication that no deletion actually occurred. The tool must NOT claim to have deleted something that did not exist, and must NOT throw an unhandled exception."
 }
 ```
 
@@ -1794,7 +1798,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 ```json
 {
-  "test_prompt": "Create a Basic Rule named 'BAT-BasicRule' via hub_manage_native_rules_and_apps.hub_set_native_app with appType='basic_rule'. Capture the returned appId, then read it back with hub_get_app_config and report the app's type name.",
+  "test_prompt": "Create a Basic Rule named 'BAT-BasicRule'. Capture the returned appId, then read it back and report the app's type name.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -1806,19 +1810,19 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a Basic Rule named 'BAT-BR-Edit' via hub_set_native_app(appType='basic_rule') and remember its id.",
-  "test_prompt": "Write the Notes field on that Basic Rule via hub_set_native_app(appId=ruleId, settings={comments: 'BAT note'}). Then read it back with hub_get_app_config and confirm the page has no rendering error.",
+  "test_prompt": "Write the Notes field on that Basic Rule, setting its comments/notes to 'BAT note'. Then read it back and confirm the page has no rendering error.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
 
-**Expected**: The settings write succeeds and `configPageError` is null/absent — specifically it must NOT contain "For input string: \"updateRule\"". Basic Rule is a submitOnChange app (registry `commitButton: null`), so no spurious `updateRule` button click fires after the write. Post-test invariant: [INV-1] `configPage.error == null` after the edit.
+**Expected**: The `hub_set_native_app` settings write (comments) succeeds and `configPageError` is null/absent — specifically it must NOT contain "For input string: \"updateRule\"". Basic Rule is a submitOnChange app (registry `commitButton: null`), so no spurious `updateRule` button click fires after the write. Post-test invariant: [INV-1] `configPage.error == null` after the edit.
 
 ### T455 — Create a Button Rule through its controller via buttonRule (issue #185 item 2)
 
 ```json
 {
   "setup_prompt": "Create a Virtual Button device labeled 'BAT-BtnDev' via hub_manage_virtual_device. Create a Button Controller via hub_set_native_app(appType='button_controller', name='BAT-BtnCtrl'), then assign the virtual button to it with hub_set_native_app(appId=controllerId, settings={buttonDev: [deviceId]}). Remember the controllerId and deviceId.",
-  "test_prompt": "Create a Button Rule for button 1 pushed under that controller via hub_set_native_app(buttonRule={controllerId: <controllerId>, buttonNumber: 1, event: 'pushed'}). Capture the returned buttonRuleId, then add a log action to it with hub_set_rule(appId=buttonRuleId, addAction={capability:'log', message:'BAT button rule'}). Read the rule back with hub_get_app_config and confirm it renders cleanly.",
+  "test_prompt": "Create a Button Rule for button 1 pushed under that controller. Capture the returned buttonRuleId, then add a log action to it with the message 'BAT button rule'. Read the rule back and confirm it renders cleanly.",
   "teardown_prompt": "Delete the controller via hub_delete_native_app(appId=controllerId, force=true) (this cascades to its button rules), then delete the virtual button device."
 }
 ```
@@ -1830,31 +1834,31 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a minimal empty rule named 'BAT-HealthSrc' via hub_set_rule and remember its appId.",
-  "test_prompt": "Call hub_get_rule_health(appId=ruleId) (default source=auto) and report ok, broken, and source. Then call hub_get_rule_health(appId=ruleId, source='configPage') and report broken and source.",
+  "test_prompt": "Check the rule's health (let it pick the best source automatically) and report ok, broken, and source. Then check its health again, restricted to the config-page render as the source, and report broken and source.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
 
-**Expected**: The auto call returns `ok: true`, `broken: false` (the authoritative boolean read from GET /app/ruleBuilderJson), and `source` containing `ruleBuilderJson` (typically `ruleBuilderJson+configPage`). The `source='configPage'` call returns `broken: null` (the HTML render scan does not produce the compiled-state boolean) and `source: configPage`. Neither path is dropped.
+**Expected**: The auto `hub_get_rule_health` call returns `ok: true`, `broken: false` (the authoritative boolean read from GET /app/ruleBuilderJson), and `source` containing `ruleBuilderJson` (typically `ruleBuilderJson+configPage`). The `hub_get_rule_health(source='configPage')` call returns `broken: null` (the HTML render scan does not produce the compiled-state boolean) and `source: configPage`. Neither path is dropped.
 
 ### T457 — hub_get_rule_health reports broken:true on a genuinely broken rule (issue #254 verification)
 
 ```json
 {
   "setup_prompt": "Create a rule named 'BAT-BrokenProbe' via hub_set_rule with a trigger on a BAT virtual device, then delete that BAT device so the rule's trigger reference dangles (RM marks the rule *BROKEN*). Use ONLY BAT-prefixed devices.",
-  "test_prompt": "Call hub_get_rule_health(appId=ruleId) and report ok, broken, source, and issues.",
+  "test_prompt": "Check the rule's health and report ok, broken, source, and issues.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
 
-**Expected**: `broken: true` (the compiled-state boolean from ruleBuilderJson), `ok: false`, and an `issues` entry naming the broken state. `source` includes `ruleBuilderJson`. This confirms the boolean fires both ways (the open verification item from the issue). SAFETY: only BAT-prefixed devices/rules are touched.
+**Expected**: `hub_get_rule_health` returns `broken: true` (the compiled-state boolean from ruleBuilderJson), `ok: false`, and an `issues` entry naming the broken state. `source` includes `ruleBuilderJson`. This confirms the boolean fires both ways (the open verification item from the issue). SAFETY: only BAT-prefixed devices/rules are touched.
 
 ### T458 — hub_get_rule_health covers Visual Rules Builder rules (issue #254)
 
 ```json
 {
   "setup_prompt": "Create a Visual Rules Builder rule named 'BAT-VRB-Health' via hub_set_visual_rule with a simple trigger on a BAT virtual device. Remember its appId and format.",
-  "test_prompt": "Call hub_get_rule_health(appId=ruleId) and report ruleFormat, broken, source, and issues. Also report whether the hub_set_visual_rule create response carried a `health` block.",
+  "test_prompt": "Check the rule's health and report ruleFormat, broken, source, and issues. Also report whether the create response for the Visual Rules Builder rule carried a `health` block.",
   "teardown_prompt": "Delete the rule via hub_delete_visual_rule(appId=ruleId, confirm=true)."
 }
 ```
@@ -1866,7 +1870,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a Basic Rule named 'BAT-RH-Basic' and a Button Controller named 'BAT-RH-Btn' via hub_set_native_app. Remember both appIds.",
-  "test_prompt": "Call hub_get_rule_health(appId=...) for each. Report ruleFormat, broken, source, configPageError, and multipleFlagPoison for both.",
+  "test_prompt": "Check the health of each. Report ruleFormat, broken, source, configPageError, and multipleFlagPoison for both.",
   "teardown_prompt": "Delete both via hub_delete_native_app(appId=..., force=true)."
 }
 ```

--- a/tests/BAT-rm-native-crud.md
+++ b/tests/BAT-rm-native-crud.md
@@ -120,7 +120,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-ReqExpr Flag' and remember its id.",
-  "test_prompt": "Enable the Required Expression feature on the rule (the useST flag). Read the rule back and confirm useST is true AND that the required-expression editor sub-page/section is now present in the config.",
+  "test_prompt": "Enable the Required Expression feature on the rule. Read the rule back and confirm useST is true AND that the required-expression editor sub-page/section is now present in the config.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -132,7 +132,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Function Mode' and remember its id.",
-  "test_prompt": "Mark the rule as a function (isFunction=true). Verify by reading it back that isFunction round-trips as true.",
+  "test_prompt": "Mark the rule as a function. Verify by reading it back that isFunction round-trips as true.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -144,7 +144,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Logging Combo' and remember its id.",
-  "test_prompt": "Set the rule's logging options to include all three values ['Events', 'Triggers', 'Actions'] and also enable Display Current Values (dValues=true). Read back and confirm: (a) logging contains all three entries, (b) dValues is true.",
+  "test_prompt": "Set the rule's logging options to include all three values ['Events', 'Triggers', 'Actions'] and also enable Display Current Values. Read back and confirm: (a) logging contains all three entries, (b) dValues is true.",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -156,7 +156,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch native RM rule via hub_set_rule(name='BAT-RM-Full Create', confirm=true) (omit appId to create). Capture the returned appId.",
-  "test_prompt": "STEP 1 (populate in one edit): In a single edit, populate the rule with every rule-level field at once — comments 'Created with every rule-level field populated', enable Required Expression (useST), isFunction false, logging ['Triggers','Actions'], and Display Current Values (dValues). Verify the edit reports no config-page error and that all five fields were applied.\n\nSTEP 2 (read-back #1): Read the rule back including its settings. Assert every one of these round-trips: app.label === 'BAT-RM-Full Create'; settings.comments === the exact string; settings.useST === 'true'; settings.isFunction === 'false'; settings.logging is a JSON array === ['Triggers','Actions'] (length 2, NOT collapsed to CSV); settings.dValues === 'true'. The page paragraphs MUST include 'Define Required Expression' — this proves useST=true actually exposed the required-expression editor section.\n\nSTEP 3 (force a re-init): Press the rule's 'Update Rule' button to force it to re-initialize. Verify there is no config-page error.\n\nSTEP 4 (read-back #2, post re-init): Read the rule back again including its settings. Assert ALL fields from STEP 2 are still present with the same values and logging is STILL a 2-element array. This is the wire-format regression guard — enum-multi persisted from the in-memory write must survive the updateRule re-marshal.\n\nReport any field whose read value does not match what was sent, either after STEP 2 or after STEP 4.",
+  "test_prompt": "STEP 1 (populate in one edit): In a single edit, populate the rule with every rule-level field at once — comments 'Created with every rule-level field populated', enable the Required Expression feature, mark it NOT a function, logging ['Triggers','Actions'], and enable Display Current Values. Verify the edit reports no config-page error and that all five fields were applied.\n\nSTEP 2 (read-back #1): Read the rule back including its settings. Assert every one of these round-trips: app.label === 'BAT-RM-Full Create'; settings.comments === the exact string; settings.useST === 'true'; settings.isFunction === 'false'; settings.logging is a JSON array === ['Triggers','Actions'] (length 2, NOT collapsed to CSV); settings.dValues === 'true'. The page paragraphs MUST include 'Define Required Expression' — this proves useST=true actually exposed the required-expression editor section.\n\nSTEP 3 (force a re-init): Press the rule's 'Update Rule' button to force it to re-initialize. Verify there is no config-page error.\n\nSTEP 4 (read-back #2, post re-init): Read the rule back again including its settings. Assert ALL fields from STEP 2 are still present with the same values and logging is STILL a 2-element array. This is the wire-format regression guard — enum-multi persisted from the in-memory write must survive the updateRule re-marshal.\n\nReport any field whose read value does not match what was sent, either after STEP 2 or after STEP 4.",
   "teardown_prompt": "Force-delete the rule via hub_delete_native_app(appId=<id>, force=true, confirm=true)."
 }
 ```
@@ -237,7 +237,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create a scratch rule via hub_set_rule with name='BAT-RM-Update Btn' with one trigger on 'BAT-RM Switch 1'. Remember the rule id.",
-  "test_prompt": "Modify the rule (e.g., toggle dValues=true) AND also trigger the 'Update Rule' button action so subscriptions are re-initialized in place. Verify by reading it back that dValues round-trips AND that statusJson.eventSubscriptions.length > 0 (subscription not dropped by the re-init).",
+  "test_prompt": "Modify the rule (e.g., turn Display Current Values on) AND also trigger the 'Update Rule' button action so subscriptions are re-initialized in place. Verify by reading it back that dValues round-trips AND that statusJson.eventSubscriptions.length > 0 (subscription not dropped by the re-init).",
   "teardown_prompt": "Delete the rule via hub_delete_native_app(appId=ruleId, force=true)."
 }
 ```
@@ -1045,7 +1045,7 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 ```json
 {
   "setup_prompt": "Create virtual switches BAT-RM-OrdA, BAT-RM-OrdB, BAT-RM-OrdC. Create rule 'BAT-RM-Order' with Certain Time trigger and actions in order [A on, B on, C on].",
-  "test_prompt": "Reorder the rule's actions (a wholesale action-list replacement) to [C on, A on, B on]. Read back and verify the new order matches exactly. Then reorder again to [B on, C on, A on]. Read back and verify.",
+  "test_prompt": "Reorder the rule's actions to [C on, A on, B on] by replacing the whole action list in one operation (not by moving actions one at a time). Read back and verify the new order matches exactly. Then reorder the same way to [B on, C on, A on]. Read back and verify.",
   "teardown_prompt": "Delete the rule and all three virtual switches."
 }
 ```

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -27,6 +27,14 @@ Each test is a JSON scenario with optional `setup_prompt`, required `test_prompt
 }
 ```
 
+### Prompt style — goal-first
+
+BAT tests are run by an orchestrating/grading agent: it reads the entry, sets it up, feeds the `test_prompt` to a **sub-agent under test**, then grades whether that sub-agent found and used the right tool. The whole point is *discovery*, so:
+
+- The `test_prompt` states the scenario + goal in plain language and does **not** name any MCP tool, gateway, or call arg. Tool names belong in the test title, **Expected**, and failure-mode text — the grading scaffolding — never in the prompt fed to the sub-agent.
+- `setup_prompt` / `teardown_prompt` are orchestrator infrastructure, not under test — they MAY name tools directly for reliability.
+- Per-test edge case: a test whose *subject is* the MCP surface itself — wrong-gateway routing, a tool name that is off `tools/list`, deliberately mutually-exclusive or malformed call shapes under regression — may still name that surface in its `test_prompt`, because the scenario cannot be expressed without it.
+
 ### Pass/Fail Criteria
 
 - **Pass**: AI completes the task, calls the expected tools, returns correct information
@@ -196,7 +204,7 @@ These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0
 ```json
 {
   "setup_prompt": "Create a virtual switch called 'BAT Poll OR Test'. Leave it in whatever state it defaults to (off).",
-  "test_prompt": "Poll the switch attribute of 'BAT Poll OR Test' waiting for it to be in EITHER the 'on' or 'off' state. Use expectedValues=['on','off'] and a 2-second timeout. Report whether the poll succeeded.",
+  "test_prompt": "Poll the switch attribute of 'BAT Poll OR Test' waiting for it to be in EITHER the 'on' or 'off' state, with a 2-second timeout. Report whether the poll succeeded.",
   "teardown_prompt": "Delete the virtual device 'BAT Poll OR Test'."
 }
 ```
@@ -232,7 +240,7 @@ These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0
 ```json
 {
   "setup_prompt": "Create a virtual switch called 'BAT NE Test' and turn it on.",
-  "test_prompt": "Poll the switch attribute of 'BAT NE Test' waiting for it to be NOT 'off' (use comparator ne, expectedValue 'off', a 3-second timeout). Report whether it succeeded and the final value.",
+  "test_prompt": "Poll the switch attribute of 'BAT NE Test' waiting for it to read anything OTHER than 'off', with a 3-second timeout. Report whether it succeeded and the final value.",
   "teardown_prompt": "Delete the virtual device 'BAT NE Test'."
 }
 ```
@@ -244,7 +252,7 @@ These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0
 ```json
 {
   "setup_prompt": "Create two virtual switches 'BAT Multi A' and 'BAT Multi B' and turn both on.",
-  "test_prompt": "Wait until BOTH 'BAT Multi A' and 'BAT Multi B' have switch 'on' in a single call (poll both device IDs together, mode all, 5-second timeout). Then turn 'BAT Multi B' off and wait until EITHER one is 'on' (mode any). Report convergedCount for each.",
+  "test_prompt": "In a single call, wait until BOTH 'BAT Multi A' and 'BAT Multi B' have switch 'on', with a 5-second timeout. Then turn 'BAT Multi B' off and wait until EITHER one of the two is 'on'. Report how many devices converged for each wait.",
   "teardown_prompt": "Delete the virtual devices 'BAT Multi A' and 'BAT Multi B'."
 }
 ```
@@ -256,7 +264,7 @@ These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0
 ```json
 {
   "setup_prompt": "Create a virtual switch called 'BAT Debounce Test' and turn it off.",
-  "test_prompt": "Turn on 'BAT Debounce Test', and wait for the switch attribute to read 'on' and stay 'on' continuously for at least 500 milliseconds before confirming (use waitFor with stableForMs=500 and a 5-second timeout). Report whether it converged.",
+  "test_prompt": "Turn on 'BAT Debounce Test', and wait for the switch attribute to read 'on' and stay 'on' continuously for at least 500 milliseconds before confirming, allowing up to 5 seconds overall. Report whether it converged.",
   "teardown_prompt": "Delete the virtual device 'BAT Debounce Test'."
 }
 ```
@@ -477,7 +485,7 @@ These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0
 
 ```json
 {
-  "test_prompt": "Show me the tool guide section about device authorization rules."
+  "test_prompt": "Pull up the server's reference documentation section that covers its device authorization rules."
 }
 ```
 
@@ -550,7 +558,7 @@ These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0
 ```json
 {
   "setup_prompt": "Use hub_read_apps_code(tool='hub_list_drivers') to find any installed custom driver. If none are installed, skip this test and say 'no custom drivers available'.",
-  "test_prompt": "Create a virtual device using the first available custom driver (use its namespace and name), label it 'BAT Custom Driver Success Test' (include confirm=true). Then delete it.",
+  "test_prompt": "Create a virtual device using the first available custom driver (use its namespace and name), label it 'BAT Custom Driver Success Test', and confirm the creation. Then delete it.",
   "teardown_prompt": "Delete the virtual device 'BAT Custom Driver Success Test' if it still exists."
 }
 ```
@@ -891,7 +899,7 @@ On v0.7.7 these tools are directly available — this section tests whether v0.8
 
 ```json
 {
-  "test_prompt": "Pull the last hour of hub logs and show me only entries where the message mentions 'error' or 'failed' -- case-insensitive. Use the pattern filter, not just the level filter."
+  "test_prompt": "Pull the last hour of hub logs and show me only entries where the message text mentions 'error' or 'failed' -- case-insensitive, matching on the message text itself, not just filtering by log level."
 }
 ```
 
@@ -1506,7 +1514,7 @@ Per Finding #4 (shipped in commit `95654ad`), `success` and `partial` are orthog
 ```json
 {
   "setup_prompt": "Create a virtual switch called 'BAT Partial Test Switch'. Note its device ID.",
-  "test_prompt": "Using hub_set_rule with addAction, add a 'Switch: on' action targeting 'BAT Partial Test Switch' to a new RM rule called 'BAT Finding4 Rule'. The addAction response may return partial=true -- interpret this response correctly and report whether the action was successfully added to the rule.",
+  "test_prompt": "Create a new RM rule called 'BAT Finding4 Rule' and add a 'Switch: on' action targeting 'BAT Partial Test Switch' to it. The response may flag a partial result -- interpret it correctly and report whether the action was successfully added to the rule.",
   "teardown_prompt": "Delete the rule 'BAT Finding4 Rule'. Delete the virtual switch 'BAT Partial Test Switch'."
 }
 ```
@@ -2585,7 +2593,7 @@ These operations are too destructive for automated testing. Test manually with e
 
 All 117 distinct tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
 
-Sections 1-9 use explicit or semi-explicit tool references. Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
+Sections 1-9 each target a specific tool — named in the test's title and **Expected** criteria while the `test_prompt` stays goal-first (see Prompt style above). Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
 
 **Total: 262 test scenarios** (124 explicit + 65 natural language + 21 built-in-app integration + 9 library management + 2 reveal-walker coverage + 3 deviceId normalization + 1 subExpression rejection + 1 reveal-fallback sentinel + 1 compareToDevice fallback + 1 Between-two-times sunrise/sunset + 10 periodic-frequency completeness + 3 Visual Rules Builder + 1 device swap + 2 installed-app read modes + 2 enum-attribute state-change comparator + 4 replaceRequiredExpression in-place RE replace + 3 rule-local variable lifecycle/namespace + 5 read-side convergence + 1 multi-device convergence + 3 MCP device-access scope) plus 13 excluded destructive operations documented for manual testing
 
@@ -2770,7 +2778,7 @@ Tools in this section have mixed gate requirements. `hub_list_apps` (scope=insta
 ```json
 {
   "setup_prompt": "Use hub_list_apps (scope=instances) to find the Hubitat Package Manager app ID.",
-  "test_prompt": "Use hub_get_app_config to list ALL packages installed via Hubitat Package Manager."
+  "test_prompt": "Read HPM's configuration pages to list ALL packages installed via Hubitat Package Manager."
 }
 ```
 
@@ -2813,7 +2821,7 @@ Tools in this section have mixed gate requirements. `hub_list_apps` (scope=insta
 ```json
 {
   "setup_prompt": "the Read master is enabled. Use hub_list_apps (scope=instances) to find the Hubitat Package Manager app and note its app ID.",
-  "test_prompt": "I want to inspect HPM's configuration but I don't know the page names. Use hub_list_app_pages to discover what pages are available for the HPM app you just found."
+  "test_prompt": "I want to inspect HPM's configuration but I don't know the page names. Discover what configuration pages are available for the HPM app you just found."
 }
 ```
 
@@ -2882,7 +2890,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled, the Write master is enabled, recent backup exists. Note the current value of debugLogging via hub_get_info or by reading state.",
-  "test_prompt": "Use hub_update_mcp_settings to set debugLogging to true. Then verify the change took effect."
+  "test_prompt": "Flip the MCP server app's own debugLogging setting to true. Then verify the change took effect."
 }
 ```
 
@@ -2893,7 +2901,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled and the Write master is enabled.",
-  "test_prompt": "Use hub_update_mcp_settings to set enableHubAdminWrite to false."
+  "test_prompt": "Turn off the MCP server app's own enableHubAdminWrite setting."
 }
 ```
 
@@ -2904,7 +2912,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled and the Write master is enabled.",
-  "test_prompt": "Use hub_update_mcp_settings to set both enableHubAdminRead=true and enableBuiltinApp=true in a single call."
+  "test_prompt": "Turn on both the enableHubAdminRead and enableBuiltinApp settings on the MCP server app, in one single change."
 }
 ```
 
@@ -2915,7 +2923,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled.",
-  "test_prompt": "Use hub_update_mcp_settings to flip enableCustomRuleEngine to false, then back to true."
+  "test_prompt": "Flip the MCP server app's enableCustomRuleEngine setting to false, then back to true."
 }
 ```
 
@@ -2926,7 +2934,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled, the Write master is enabled, recent backup exists. Note whether the server is currently in gateway mode or flat mode (useGateways).",
-  "test_prompt": "Use hub_update_mcp_settings to flip useGateways to the OPPOSITE of its current value. Report the response message, then explain what the user must do for the new tool surface to take effect.",
+  "test_prompt": "Flip the MCP server app's useGateways setting to the OPPOSITE of its current value. Report the response message, then explain what the user must do for the new tool surface to take effect.",
   "teardown_prompt": "Use hub_update_mcp_settings to set useGateways back to its original value, then reconnect (/mcp refresh) so the tool list matches the server again."
 }
 ```
@@ -2938,7 +2946,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled, the Write master is enabled, recent backup exists, and the server is in gateway mode (useGateways ON). publishOutputSchemas is OFF (its default).",
-  "test_prompt": "Use hub_update_mcp_settings to set publishOutputSchemas to true. Report the response message, then explain what changes about the advertised tool list and why a strict client like Claude Desktop could be affected.",
+  "test_prompt": "Turn on the MCP server app's publishOutputSchemas setting. Report the response message, then explain what changes about the advertised tool list and why a strict client like Claude Desktop could be affected.",
   "teardown_prompt": "Use hub_update_mcp_settings to set publishOutputSchemas back to false, then reconnect (/mcp refresh) so the advertised tool schema matches the server again."
 }
 ```
@@ -2950,7 +2958,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "the Write master is enabled, recent backup exists. Use hub_set_variable to create a temporary variable named BAT_E2E_DELETE_TEST with value 'scratch'.",
-  "test_prompt": "We don't need BAT_E2E_DELETE_TEST any more. Use hub_delete_variable to remove it, then confirm via hub_get_variable that it's gone."
+  "test_prompt": "We don't need BAT_E2E_DELETE_TEST any more. Delete that hub variable, then read it back to confirm it's gone."
 }
 ```
 
@@ -2961,7 +2969,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "the Write master is enabled. Manually create a Hub Variable named TEST_CONNECTOR_VAR via Settings → Hub Variables UI (this lives in the connector namespace, not rule_engine).",
-  "test_prompt": "Use hub_delete_variable to remove TEST_CONNECTOR_VAR."
+  "test_prompt": "Delete the hub variable TEST_CONNECTOR_VAR."
 }
 ```
 
@@ -2972,7 +2980,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "the Write master is enabled, recent backup exists. Use hub_set_variable to create BAT_E2E_NO_CONFIRM with value 'safe'.",
-  "test_prompt": "Use hub_delete_variable to remove BAT_E2E_NO_CONFIRM. Don't pass confirm — let's see what happens."
+  "test_prompt": "Delete the hub variable BAT_E2E_NO_CONFIRM, but do NOT confirm the destructive action — let's see what happens."
 }
 ```
 
@@ -2983,7 +2991,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled, the Write master is enabled, recent backup exists. List every hub device with hub_list_devices(scope='all') and pick one device that is currently mcpAuthorized=false (NOT already in the MCP scope). Note the full set of currently-authorized device IDs.",
-  "test_prompt": "Add that unauthorized device to the MCP server's device-access scope with hub_update_mcp_settings({settings:{selectedDevices:{mode:'add', ids:['<id>']}}}), confirm it now reads back as authorized via hub_list_devices(scope='all'), then remove it again (mode:'remove') so the scope returns to exactly what it was.",
+  "test_prompt": "Add that unauthorized device to the MCP server's device-access scope, confirm it now reads back as authorized in the all-devices listing, then remove it from the scope again so the scope returns to exactly what it was.",
   "teardown_prompt": "Verify via hub_list_devices(scope='all') that the authorized set matches the original noted set (the add+remove was a net no-op)."
 }
 ```
@@ -2995,7 +3003,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled, the Write master is enabled, recent backup exists.",
-  "test_prompt": "Try to add device id 999999999 (which does not exist on this hub) to the MCP device-access scope via hub_update_mcp_settings({settings:{selectedDevices:{mode:'add', ids:['999999999']}}})."
+  "test_prompt": "Try to add device id 999999999 (which does not exist on this hub) to the MCP device-access scope."
 }
 ```
 
@@ -3006,7 +3014,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled, the Write master is enabled, recent backup exists. Note the currently-authorized device IDs.",
-  "test_prompt": "Use hub_update_mcp_settings({settings:{selectedDevices:{mode:'replace', ids:[]}}}) with an empty id list (do NOT pass allowEmpty). This should be refused."
+  "test_prompt": "Replace the MCP server's device-access scope with an EMPTY device list, without passing any special override flag for emptying it. This should be refused."
 }
 ```
 
@@ -3017,7 +3025,7 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 ```json
 {
   "setup_prompt": "Developer Mode is enabled, the Write master is enabled, recent backup exists, and bypassDeviceAllowlist is OFF (the default). List every hub device with hub_list_devices(scope='all') and pick one that is currently mcpAuthorized=false (NOT in the MCP scope). Confirm hub_get_device on that id returns 'Device not found'.",
-  "test_prompt": "Turn on the device-allowlist bypass with hub_update_mcp_settings({settings:{bypassDeviceAllowlist:true}}), then read that same unauthorized device with hub_get_device(deviceId='<id>') and report whether it is now reachable.",
+  "test_prompt": "Turn on the MCP server app's device-allowlist bypass setting (bypassDeviceAllowlist), then read that same unauthorized device's details and report whether it is now reachable.",
   "teardown_prompt": "Turn the bypass back OFF with hub_update_mcp_settings({settings:{bypassDeviceAllowlist:false}}) and confirm hub_get_device on that id returns 'Device not found' again."
 }
 ```
@@ -3108,7 +3116,7 @@ All tests below require the Write master enabled and a recent backup. Tests are 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists. Write a minimal driver stub to File Manager: hub_write_file(fileName='bat-test-driver.groovy', content='metadata { definition(name: \"BAT_DriverCodeLifecycle\", namespace: \"bat\", author: \"test\") { } }').",
-  "test_prompt": "Install the driver using hub_create_driver with sourceFile='bat-test-driver.groovy' and confirm=true. Report the new driver ID.",
+  "test_prompt": "Install the driver from the File Manager file 'bat-test-driver.groovy' — do not paste the source inline — and confirm the install. Report the new driver ID.",
   "teardown_prompt": "Delete the driver installed in this test using hub_delete_item (type=driver) with the driverId returned above and confirm=true. Also delete the File Manager file bat-test-driver.groovy using hub_delete_file."
 }
 ```
@@ -3120,7 +3128,7 @@ All tests below require the Write master enabled and a recent backup. Tests are 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists. This test intentionally installs broken Groovy source -- the hub creates a stub slot in an error state (BAT_BrokenInstallStub). Note the driver ID returned for cleanup.",
-  "test_prompt": "Install a driver with deliberately broken syntax using hub_create_driver(source='this is not valid groovy {{ }}', confirm=true). Report what happens.",
+  "test_prompt": "Install a driver whose source is deliberately broken Groovy — literally 'this is not valid groovy {{ }}' — confirming the install. Report what happens.",
   "teardown_prompt": "Delete the error-state driver slot created in this test using hub_delete_item (type=driver) with the driverId returned and confirm=true."
 }
 ```
@@ -3132,7 +3140,7 @@ All tests below require the Write master enabled and a recent backup. Tests are 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists. Install two minimal BAT_ driver stubs via hub_create_driver: (1) source='metadata { definition(name: \"BAT_BulkUpdate1\", namespace: \"bat\", author: \"test\") { } }' and (2) source='metadata { definition(name: \"BAT_BulkUpdate2\", namespace: \"bat\", author: \"test\") { } }'. Note both driverIds. Write updated source for each to File Manager with a version comment appended: hub_write_file(fileName='bat-bulk-1.groovy', content='...updated source...') and similarly for bat-bulk-2.groovy.",
-  "test_prompt": "Update both drivers in a single call using hub_update_driver with updates=[{driverId: '<id1>', sourceFile: 'bat-bulk-1.groovy'}, {driverId: '<id2>', sourceFile: 'bat-bulk-2.groovy'}] and confirm=true.",
+  "test_prompt": "Update both drivers in a single call — driver <id1> from the File Manager file 'bat-bulk-1.groovy' and driver <id2> from 'bat-bulk-2.groovy' — confirming the update.",
   "teardown_prompt": "Delete both BAT_ drivers using hub_delete_item (type=driver) with confirm=true for each driverId. Also delete the File Manager files bat-bulk-1.groovy and bat-bulk-2.groovy using hub_delete_file."
 }
 ```
@@ -3154,7 +3162,7 @@ All tests below require the Write master enabled and a recent backup. Tests are 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists. Write two minimal driver stubs to File Manager: hub_write_file(fileName='bat-bulk-install-1.groovy', content='metadata { definition(name: \"BAT_BulkInstall1\", namespace: \"bat\", author: \"test\") { } }') and hub_write_file(fileName='bat-bulk-install-2.groovy', content='metadata { definition(name: \"BAT_BulkInstall2\", namespace: \"bat\", author: \"test\") { } }').",
-  "test_prompt": "Install both drivers in a single call using hub_create_driver with installs=[{sourceFile: 'bat-bulk-install-1.groovy'}, {sourceFile: 'bat-bulk-install-2.groovy'}] and confirm=true. Report the driver IDs returned.",
+  "test_prompt": "Install both drivers in a single call — one from the File Manager file 'bat-bulk-install-1.groovy' and the other from 'bat-bulk-install-2.groovy' — confirming the install. Report the driver IDs returned.",
   "teardown_prompt": "Delete both BAT_ drivers installed above using hub_delete_item (type=driver) with confirm=true for each driverId. Also delete the File Manager files bat-bulk-install-1.groovy and bat-bulk-install-2.groovy using hub_delete_file."
 }
 ```
@@ -3166,7 +3174,7 @@ All tests below require the Write master enabled and a recent backup. Tests are 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists. Write one driver stub to File Manager: hub_write_file(fileName='bat-bulk-partial.groovy', content='metadata { definition(name: \"BAT_BulkPartial\", namespace: \"bat\", author: \"test\") { } }'). Do NOT write 'bat-bulk-missing.groovy'.",
-  "test_prompt": "Install two drivers in a single bulk call: hub_create_driver with installs=[{sourceFile: 'bat-bulk-partial.groovy'}, {sourceFile: 'bat-bulk-missing.groovy'}] and confirm=true. Report what happens for each item.",
+  "test_prompt": "Install two drivers in a single bulk call — one from the File Manager file 'bat-bulk-partial.groovy' and one from 'bat-bulk-missing.groovy' — confirming the install. Report what happens for each item.",
   "teardown_prompt": "Delete the successfully installed BAT_BulkPartial driver using hub_delete_item (type=driver) with confirm=true. Delete the File Manager file bat-bulk-partial.groovy using hub_delete_file."
 }
 ```
@@ -3200,7 +3208,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 ```json
 {
   "setup_prompt": "Check Hubitat web UI (FOR DEVELOPERS > Libraries code) for an installed library ID, or install a test library first using hub_create_library.",
-  "test_prompt": "Get the source of the first library returned by hub2/userLibraries. Use hub_read_apps_code -> hub_get_source with type=library."
+  "test_prompt": "Show me the source code of the first Groovy library installed on the hub."
 }
 ```
 
@@ -3223,7 +3231,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists. Use hub_create_library to create a library named 'BATTestLibUpdate', namespace='bat_test', with method `v1Method()` returning 'v1'.",
-  "test_prompt": "Update the BATTestLibUpdate library to add a `v2Method()` that returns 'v2'. Use hub_update_library with source mode.",
+  "test_prompt": "Update the BATTestLibUpdate library to add a `v2Method()` that returns 'v2', supplying the full updated source inline.",
   "teardown_prompt": "Delete BATTestLibUpdate library."
 }
 ```
@@ -3235,7 +3243,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists. A library named 'BATTestLibResave' exists (install it if not).",
-  "test_prompt": "Use hub_update_library with resave=true on BATTestLibResave to trigger recompilation without changing the source.",
+  "test_prompt": "Recompile the BATTestLibResave library in place, without changing or re-supplying its source.",
   "teardown_prompt": "Delete BATTestLibResave library."
 }
 ```
@@ -3259,7 +3267,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 ```json
 {
   "setup_prompt": "the Write master enabled.",
-  "test_prompt": "Try to install a library with valid source but without setting confirm=true. Observe the error."
+  "test_prompt": "Try to install a library with valid source but WITHOUT confirming the action. Observe the error."
 }
 ```
 
@@ -3269,7 +3277,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 
 ```json
 {
-  "test_prompt": "Try to get library source for libraryId='999999'. What does the tool return?"
+  "test_prompt": "Try to fetch the source of library ID 999999. What comes back?"
 }
 ```
 
@@ -3280,7 +3288,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists. Install 'BATTestLibSourceFile' library. Upload a file named 'bat-lib-update.groovy' to File Manager via hub_write_file with updated library source.",
-  "test_prompt": "Update BATTestLibSourceFile library using hub_update_library with sourceFile='bat-lib-update.groovy'.",
+  "test_prompt": "Update the BATTestLibSourceFile library from the File Manager file 'bat-lib-update.groovy'.",
   "teardown_prompt": "Delete BATTestLibSourceFile library. Delete bat-lib-update.groovy from File Manager."
 }
 ```
@@ -3298,7 +3306,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists. Identify the raw URL of a bundle .zip the hub can reach (e.g. this repo's bundles/mcp-libraries.zip on a public GitHub raw URL). The bundle ships the McpRoomsLib and McpBundlesLib libraries.",
-  "test_prompt": "Install the bundle from that .zip URL using hub_install_bundle (confirm=true), then verify the bundle's libraries are present with hub_list_libraries.",
+  "test_prompt": "Install the bundle from that .zip URL (confirming the install), then verify the bundle's libraries now appear in the hub's library list.",
   "teardown_prompt": "Optionally delete a library if it was newly created (note: removing McpRoomsLib or McpBundlesLib would break the server's #include on next save, so leave them in place on the live server)."
 }
 ```
@@ -3310,7 +3318,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 ```json
 {
   "setup_prompt": "the Write master enabled.",
-  "test_prompt": "Try to install a bundle from a .zip URL without setting confirm=true. Observe the error."
+  "test_prompt": "Try to install a bundle from a .zip URL WITHOUT confirming the action. Observe the error."
 }
 ```
 
@@ -3321,7 +3329,7 @@ Write tools (`hub_create_library`, `hub_update_library`, `hub_delete_item` with 
 ```json
 {
   "setup_prompt": "the Write master enabled, recent backup exists.",
-  "test_prompt": "Try to install a bundle with importUrl='mcp-libraries.zip' (a bare filename, no scheme) and confirm=true. What does the tool say?"
+  "test_prompt": "Try to install a bundle from just the bare filename 'mcp-libraries.zip' (no http/https URL), confirming the action. What error do you get?"
 }
 ```
 
@@ -3468,7 +3476,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create an RM rule called 'BAT SetVariable Test'. Also ensure at least one hub connector variable exists (use hub_manage_variables hub_set_variable to create 'bat_setvar_test' = 0 if it does not exist).",
-  "test_prompt": "Add an action to the 'BAT SetVariable Test' rule: capability='setVariable', variable='bat_setvar_test', value=99. Then call hub_get_rule_health on the rule and confirm no broken markers are present.",
+  "test_prompt": "Add an action to the 'BAT SetVariable Test' rule that sets the hub variable 'bat_setvar_test' to 99. Then check the rule's health and confirm no broken markers are present.",
   "teardown_prompt": "Delete the 'BAT SetVariable Test' rule. Delete the hub variable 'bat_setvar_test'."
 }
 ```
@@ -3482,7 +3490,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Note the hub's current mode names via hub_list_modes. Create an RM rule called 'BAT ModeName Test'.",
-  "test_prompt": "Add an action to 'BAT ModeName Test': capability='mode', modeName='<any valid mode name from hub_list_modes>'. Then call hub_get_rule_health and confirm no broken markers.",
+  "test_prompt": "Add an action to 'BAT ModeName Test' that changes the hub's location mode, referring to the mode by its NAME (any valid mode name from the hub's mode list), not its numeric ID. Then check the rule's health and confirm no broken markers.",
   "teardown_prompt": "Delete the 'BAT ModeName Test' rule."
 }
 ```
@@ -3496,7 +3504,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master enabled. Create hub variable 'bat_cpvar_test' (numeric, value 50). Create a virtual switch device named 'BAT RunCmd Switch' via hub_manage_virtual_device. Create RM rule 'BAT RunCommand Variable Param'.",
-  "test_prompt": "Add an action: capability='runCommand', command='setLevel', deviceIds=[<BAT RunCmd Switch id>], parameters=[{type:'number', variable:'bat_cpvar_test'}]. Then call hub_get_rule_health.",
+  "test_prompt": "Add an action that runs the custom command 'setLevel' on 'BAT RunCmd Switch', passing one number parameter sourced from the hub variable 'bat_cpvar_test' (not a literal value). Then check the rule's health.",
   "teardown_prompt": "Delete 'BAT RunCommand Variable Param' rule. Delete bat_cpvar_test variable. Delete virtual device 'BAT RunCmd Switch'."
 }
 ```
@@ -3510,7 +3518,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create hub variables 'bat_sv_src' (numeric, value 77) and 'bat_sv_dst' (numeric, value 0). Create RM rule 'BAT SetVariable Source Test'.",
-  "test_prompt": "Add an action to 'BAT SetVariable Source Test': capability='setVariable', variable='bat_sv_dst', sourceVariable='bat_sv_src'. Then call hub_get_rule_health and confirm no broken markers.",
+  "test_prompt": "Add an action to 'BAT SetVariable Source Test' that sets the hub variable 'bat_sv_dst' by copying the value of the hub variable 'bat_sv_src'. Then check the rule's health and confirm no broken markers.",
   "teardown_prompt": "Delete 'BAT SetVariable Source Test'. Delete hub variables bat_sv_src and bat_sv_dst."
 }
 ```
@@ -3524,7 +3532,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create hub variable 'bat_sv_fd' (numeric, value 0). Note a BAT_E2E_ virtual temperature sensor device id (or any device exposing a numeric 'temperature' attribute). Create RM rule 'BAT SetVariable FromDevice Test'.",
-  "test_prompt": "Add an action to 'BAT SetVariable FromDevice Test': capability='setVariable', variable='bat_sv_fd', fromDevice={deviceId:<temperature sensor id>, attribute:'temperature'}. Then call hub_get_rule_health and confirm no broken markers.",
+  "test_prompt": "Add an action to 'BAT SetVariable FromDevice Test' that sets the hub variable 'bat_sv_fd' from a device attribute — the 'temperature' attribute of device <temperature sensor id>. Then check the rule's health and confirm no broken markers.",
   "teardown_prompt": "Delete 'BAT SetVariable FromDevice Test'. Delete hub variable bat_sv_fd."
 }
 ```
@@ -3538,7 +3546,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create hub variable 'bat_sv_math' (numeric, value 0). Create RM rule 'BAT SetVariable Math Test'.",
-  "test_prompt": "Add a binary-math action to 'BAT SetVariable Math Test': capability='setVariable', variable='bat_sv_math', math={left:'bat_sv_math', op:'+', right:10}. Then add a unary-math action: capability='setVariable', variable='bat_sv_math', math={left:'bat_sv_math', op:'absolute'}. Then call hub_get_rule_health and confirm no broken markers.",
+  "test_prompt": "Add a variable-math action to 'BAT SetVariable Math Test' that sets the hub variable 'bat_sv_math' to bat_sv_math + 10 (a binary operation). Then add a second math action that sets 'bat_sv_math' to the absolute value of bat_sv_math (a unary operation). Then check the rule's health and confirm no broken markers.",
   "teardown_prompt": "Delete 'BAT SetVariable Math Test'. Delete hub variable bat_sv_math."
 }
 ```
@@ -3552,7 +3560,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create hub variable 'bat_re_walker_var' (numeric, value 0). Note the hub's modes via hub_list_modes -- pick one valid mode name and the hub variable name. Create RM rule 'BAT Walker Parity Test'.",
-  "test_prompt": "First, add a Required Expression to 'BAT Walker Parity Test' using addRequiredExpression: conditions=[{capability:'Mode', state:'<valid mode name>'}, {capability:'Variable', variable:'bat_re_walker_var', comparator:'>', value:0}], operator='AND'. Then add an ifThen action: capability='ifThen', expression={conditions:[{capability:'Mode', state:'<valid mode name>'}]}. Then call hub_get_rule_health and confirm no broken markers.",
+  "test_prompt": "First, add a Required Expression to 'BAT Walker Parity Test' with two conditions joined by AND: the hub mode is <valid mode name>, AND the hub variable 'bat_re_walker_var' is greater than 0. Then add an IF-THEN action whose condition is that same mode check. Then check the rule's health and confirm no broken markers.",
   "teardown_prompt": "Delete 'BAT Walker Parity Test'. Delete hub variable bat_re_walker_var."
 }
 ```
@@ -3566,7 +3574,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Between Two Times Test'.",
-  "test_prompt": "Add a Required Expression to 'BAT Between Two Times Test' using addRequiredExpression: conditions=[{capability:'Between two times', start:{type:'clock', time:'08:00'}, end:{type:'clock', time:'22:00'}}]. Then call hub_get_rule_health and confirm no broken markers.",
+  "test_prompt": "Add a Required Expression to 'BAT Between Two Times Test' restricting it to between two clock times: 08:00 and 22:00. Then check the rule's health and confirm no broken markers.",
   "teardown_prompt": "Delete 'BAT Between Two Times Test'."
 }
 ```
@@ -3646,7 +3654,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Reveal Fallback'. Identify one mode name (e.g. 'Night') on the hub.",
-  "test_prompt": "Add a Required Expression to 'BAT Reveal Fallback' using addRequiredExpression: {conditions:[{capability:'Mode', state:'Night'}]}. After it commits, inspect result.settingsSkipped -- if the firmware exposes modes<N> always-visible (static schema rather than progressive disclosure), the entry should include {key: '<pattern>', reason: 'reveal_fallback_to_existing_field', condIdx: 0}. If the firmware exposes modes<N> only after the rCapab='Mode' write (progressive disclosure -- typical on current firmware), no sentinel fires and the entry is absent. Confirm result.success=true and result.partial!=true in BOTH cases -- the sentinel is informational and does NOT degrade.",
+  "test_prompt": "Add a Required Expression to 'BAT Reveal Fallback' requiring the hub mode to be 'Night'. After it commits, inspect result.settingsSkipped -- if the firmware exposes modes<N> always-visible (static schema rather than progressive disclosure), the entry should include {key: '<pattern>', reason: 'reveal_fallback_to_existing_field', condIdx: 0}. If the firmware exposes modes<N> only after the rCapab='Mode' write (progressive disclosure -- typical on current firmware), no sentinel fires and the entry is absent. Confirm result.success=true and result.partial!=true in BOTH cases -- the sentinel is informational and does NOT degrade.",
   "teardown_prompt": "Delete 'BAT Reveal Fallback'."
 }
 ```
@@ -3668,7 +3676,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT CompareToDevice'. Identify two Temperature-capable devices on the hub (deviceA + deviceB)."
 ,
-  "test_prompt": "Add a Required Expression to 'BAT CompareToDevice' using addRequiredExpression: {conditions:[{capability:'Temperature', deviceIds:[<deviceA>], comparator:'>', compareToDevice:{deviceId:<deviceB>, attribute:'temperature', offset:-2}}]}. Inspect the rule paragraph on mainPage and result.partial / result.settingsApplied / result.settingsSkipped.",
+  "test_prompt": "Add a Required Expression to 'BAT CompareToDevice': deviceA's temperature is greater than deviceB's temperature minus 2 (a device-relative comparison with a -2 offset, not a literal threshold). Inspect the rule paragraph on mainPage and result.partial / result.settingsApplied / result.settingsSkipped.",
   "teardown_prompt": "Delete 'BAT CompareToDevice'."
 }
 ```
@@ -3687,7 +3695,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 {
   "setup_prompt": "the Write master is enabled. Hub timezone is set (Settings > Location and Modes). Create RM rule 'BAT Between Sunrise'."
 ,
-  "test_prompt": "Add a Required Expression to 'BAT Between Sunrise' using addRequiredExpression: {conditions:[{capability:'Between two times', start:{type:'clock', time:'08:00'}, end:{type:'sunset', offset:-30}}]}. Inspect the rule paragraph on mainPage.",
+  "test_prompt": "Add a Required Expression to 'BAT Between Sunrise' restricting it to between 08:00 (a clock time) and 30 minutes BEFORE sunset. Inspect the rule paragraph on mainPage.",
   "teardown_prompt": "Delete 'BAT Between Sunrise'."
 }
 ```
@@ -3703,7 +3711,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create two hub variables (number type) named 'BatVarA' and 'BatVarB'. Create RM rule 'BAT VarVsVar'.",
-  "test_prompt": "Add a Required Expression to 'BAT VarVsVar' using addRequiredExpression: {conditions:[{capability:'Variable', variable:'BatVarA', comparator:'>', compareToVariable:'BatVarB'}]}. Then inspect the rule paragraph on mainPage and result.settingsApplied.",
+  "test_prompt": "Add a Required Expression to 'BAT VarVsVar' comparing two hub variables: BatVarA is greater than the value of BatVarB (variable versus variable, not a literal number). Then inspect the rule paragraph on mainPage and result.settingsApplied.",
   "teardown_prompt": "Delete 'BAT VarVsVar' and remove BatVarA / BatVarB."
 }
 ```
@@ -3738,7 +3746,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT CtdAction'. Identify two Temperature-capable devices on the hub (deviceA + deviceB)."
 ,
-  "test_prompt": "Add an IF-THEN action to 'BAT CtdAction' using addAction: {capability:'ifThen', expression:{conditions:[{capability:'Temperature', deviceIds:[<deviceA>], comparator:'>', compareToDevice:{deviceId:<deviceB>, attribute:'temperature', offset:-2}}]}}. Inspect the rule paragraph on mainPage and result.partial / result.settingsApplied / result.settingsSkipped.",
+  "test_prompt": "Add an IF-THEN action to 'BAT CtdAction' whose condition is: deviceA's temperature is greater than deviceB's temperature minus 2 (a device-relative comparison with a -2 offset, not a literal threshold). Inspect the rule paragraph on mainPage and result.partial / result.settingsApplied / result.settingsSkipped.",
   "teardown_prompt": "Delete 'BAT CtdAction'."
 }
 ```
@@ -3756,7 +3764,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Identify a device exposing a custom attribute (e.g. a sensor with a 'water' attribute). Create RM rule 'BAT CustomChanged'.",
-  "test_prompt": "Add a trigger to 'BAT CustomChanged' using addTrigger: {capability:'Custom Attribute', deviceIds:[<deviceId>], attribute:'water', comparator:'*changed*'}. Inspect result.partial and result.settingsSkipped.",
+  "test_prompt": "Add a trigger to 'BAT CustomChanged' using RM's 'Custom Attribute' capability on device <deviceId>'s 'water' attribute, firing on ANY change of the attribute. Inspect result.partial and result.settingsSkipped.",
   "teardown_prompt": "Delete 'BAT CustomChanged'."
 }
 ```
@@ -3772,7 +3780,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Periodic Seconds'.",
-  "test_prompt": "Add a trigger to 'BAT Periodic Seconds' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Seconds', everyN:5}}. Inspect the trigger paragraph on mainPage.",
+  "test_prompt": "Add a periodic-schedule trigger to 'BAT Periodic Seconds' that fires every 5 seconds. Inspect the trigger paragraph on mainPage.",
   "teardown_prompt": "Delete 'BAT Periodic Seconds'."
 }
 ```
@@ -3788,7 +3796,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Periodic Minutes'.",
-  "test_prompt": "Add a trigger to 'BAT Periodic Minutes' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Minutes', everyN:15}}. Inspect the trigger paragraph on mainPage.",
+  "test_prompt": "Add a periodic-schedule trigger to 'BAT Periodic Minutes' that fires every 15 minutes. Inspect the trigger paragraph on mainPage.",
   "teardown_prompt": "Delete 'BAT Periodic Minutes'."
 }
 ```
@@ -3804,7 +3812,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Periodic Weekly'.",
-  "test_prompt": "Add a trigger to 'BAT Periodic Weekly' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Weekly', daysOfWeek:['Monday','Friday'], startingTime:'08:00'}}. Inspect the trigger paragraph on mainPage.",
+  "test_prompt": "Add a periodic-schedule trigger to 'BAT Periodic Weekly' that fires weekly on Monday and Friday at 08:00. Inspect the trigger paragraph on mainPage.",
   "teardown_prompt": "Delete 'BAT Periodic Weekly'."
 }
 ```
@@ -3820,7 +3828,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Periodic Monthly'.",
-  "test_prompt": "Add a trigger to 'BAT Periodic Monthly' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Monthly', dayOfMonth:15, everyNMonths:2, startingTime:'09:30'}}. Inspect the trigger paragraph on mainPage.",
+  "test_prompt": "Add a periodic-schedule trigger to 'BAT Periodic Monthly' that fires on day 15 of every 2 months, starting at 09:30. Inspect the trigger paragraph on mainPage.",
   "teardown_prompt": "Delete 'BAT Periodic Monthly'."
 }
 ```
@@ -3836,7 +3844,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Periodic Yearly'.",
-  "test_prompt": "Add a trigger to 'BAT Periodic Yearly' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Yearly', months:'December', weekOfMonth:'First', dayOfWeek:'Monday', startingTime:'08:00'}}. Inspect the trigger paragraph on mainPage.",
+  "test_prompt": "Add a periodic-schedule trigger to 'BAT Periodic Yearly' that fires yearly on the First Monday of December at 08:00. Inspect the trigger paragraph on mainPage.",
   "teardown_prompt": "Delete 'BAT Periodic Yearly'."
 }
 ```
@@ -3852,7 +3860,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Periodic Cron'.",
-  "test_prompt": "Add a trigger to 'BAT Periodic Cron' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Cron String', cronString:'0 0 12 * * ?'}}. Inspect the trigger paragraph on mainPage.",
+  "test_prompt": "Add a periodic-schedule trigger to 'BAT Periodic Cron' driven by the cron expression '0 0 12 * * ?'. Inspect the trigger paragraph on mainPage.",
   "teardown_prompt": "Delete 'BAT Periodic Cron'."
 }
 ```
@@ -3868,7 +3876,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Periodic Enum'.",
-  "test_prompt": "Add a trigger to 'BAT Periodic Enum' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Minutes', everyN:7}}. Observe the tool's response.",
+  "test_prompt": "Add a periodic-schedule trigger to 'BAT Periodic Enum' that fires every 7 minutes. Observe the response.",
   "teardown_prompt": "Delete 'BAT Periodic Enum'."
 }
 ```
@@ -3884,7 +3892,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Periodic Monthly Nth'.",
-  "test_prompt": "Add a trigger to 'BAT Periodic Monthly Nth' using addTrigger: {capability:'Periodic Schedule', periodic:{frequency:'Monthly', weekOfMonth:'Second', dayOfWeek:'Monday', everyNMonths:1, startingTime:'08:00'}}. Inspect the trigger paragraph on mainPage.",
+  "test_prompt": "Add a periodic-schedule trigger to 'BAT Periodic Monthly Nth' that fires on the Second Monday of every month at 08:00. Inspect the trigger paragraph on mainPage.",
   "teardown_prompt": "Delete 'BAT Periodic Monthly Nth'."
 }
 ```
@@ -3916,7 +3924,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create RM rule 'BAT Two Periodic'.",
-  "test_prompt": "Add TWO triggers to 'BAT Two Periodic': first addTrigger {capability:'Periodic Schedule', periodic:{frequency:'Minutes', everyN:5}}, then addTrigger {capability:'Periodic Schedule', periodic:{frequency:'Daily', everyN:1, startingTime:'07:00'}}. Inspect both trigger paragraphs on mainPage.",
+  "test_prompt": "Add TWO periodic-schedule triggers to 'BAT Two Periodic': first one that fires every 5 minutes, then a second that fires daily at 07:00. Inspect both trigger paragraphs on mainPage.",
   "teardown_prompt": "Delete 'BAT Two Periodic'."
 }
 ```
@@ -3932,7 +3940,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "The Write master is enabled. Create a virtual switch named 'BAT Bundle Switch' via hub_manage_virtual_device and note its device ID.",
-  "test_prompt": "In a SINGLE hub_set_rule call (omit appId so it creates), create a new Rule Machine rule named 'BAT Bundle Create' AND bundle its first trigger and action in the same call: addTriggers=[{capability:'Switch', deviceIds:[<BAT Bundle Switch id>], state:'on'}] and addActions=[{capability:'Switch', deviceIds:[<BAT Bundle Switch id>], command:'off'}]. Do NOT make a second hub_set_rule edit call. Report the returned appId and confirm the bundled trigger and action both baked.",
+  "test_prompt": "In ONE single call, create a new Rule Machine rule named 'BAT Bundle Create' complete with its first trigger ('BAT Bundle Switch' turns on) AND its first action (turn 'BAT Bundle Switch' off) bundled into that same call. Do NOT create the rule first and edit it with a second call. Report the returned appId and confirm the bundled trigger and action both baked.",
   "teardown_prompt": "Delete the 'BAT Bundle Create' rule. Delete the virtual switch 'BAT Bundle Switch'."
 }
 ```
@@ -3948,7 +3956,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Identify a device whose attribute name the hub treats as an ENUM (e.g. a switch's 'switch' attribute -- use hub_list_virtual_devices to find a virtual switch). Create RM rule 'BAT CustomEnumAttr'.",
-  "test_prompt": "Add a trigger to 'BAT CustomEnumAttr' using addTrigger: {capability:'Custom Attribute', deviceIds:[<deviceId>], attribute:'switch', comparator:'=', state:'on'}. Inspect result.partial, result.settingsApplied, and result.settingsSkipped.",
+  "test_prompt": "Add a trigger to 'BAT CustomEnumAttr' using RM's 'Custom Attribute' capability (not the native Switch capability) on device <deviceId>'s 'switch' attribute, firing when it equals 'on'. Inspect result.partial, result.settingsApplied, and result.settingsSkipped.",
   "teardown_prompt": "Delete 'BAT CustomEnumAttr'."
 }
 ```
@@ -3962,7 +3970,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Identify a device whose attribute name the hub treats as an ENUM (e.g. a switch's 'switch' attribute -- use hub_list_virtual_devices to find a virtual switch). Create RM rule 'BAT CustomEnumCond'.",
-  "test_prompt": "Add a conditional trigger to 'BAT CustomEnumCond' using addTrigger: {capability:'Switch', deviceIds:[<deviceId>], state:'on', condition:{capability:'Custom Attribute', deviceIds:[<deviceId>], attribute:'switch', comparator:'=', state:'on'}}. Inspect result.partial, result.settingsApplied, and result.settingsSkipped.",
+  "test_prompt": "Add a conditional trigger to 'BAT CustomEnumCond': trigger on device <deviceId>'s switch turning on, gated by a 'Custom Attribute' condition on that same device's 'switch' attribute equalling 'on'. Inspect result.partial, result.settingsApplied, and result.settingsSkipped.",
   "teardown_prompt": "Delete 'BAT CustomEnumCond'."
 }
 ```
@@ -3976,7 +3984,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Identify a device whose attribute name the hub treats as an ENUM (e.g. a virtual switch's 'switch' attribute). Create RM rule 'BAT CustomEnumChanged'.",
-  "test_prompt": "Add a trigger to 'BAT CustomEnumChanged' using addTrigger: {capability:'Custom Attribute', deviceIds:[<switchDeviceId>], attribute:'switch', comparator:'*changed*'}. Inspect result.success, result.partial, result.settingsApplied, and the rendered trigger on mainPage.",
+  "test_prompt": "Add a trigger to 'BAT CustomEnumChanged' using RM's 'Custom Attribute' capability on the switch's 'switch' attribute, firing on ANY change of the attribute. Inspect result.success, result.partial, result.settingsApplied, and the rendered trigger on mainPage.",
   "teardown_prompt": "Delete 'BAT CustomEnumChanged'."
 }
 ```
@@ -3990,7 +3998,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Identify a device whose attribute name the hub treats as an ENUM whose Required-Expression value picker offers ONLY discrete states (e.g. on/off) and NO change option. Create RM rule 'BAT WalkEnumChanged'.",
-  "test_prompt": "Add a Required Expression to 'BAT WalkEnumChanged' using addRequiredExpression: {conditions:[{capability:'Custom Attribute', deviceIds:[<switchDeviceId>], attribute:'switch', comparator:'*changed*'}]}. Inspect result.partial, result.settingsApplied, result.settingsSkipped, and result.repairHints.",
+  "test_prompt": "Add a Required Expression to 'BAT WalkEnumChanged' using RM's 'Custom Attribute' capability on the switch's 'switch' attribute with the any-change comparator (no specific value). Inspect result.partial, result.settingsApplied, result.settingsSkipped, and result.repairHints.",
   "teardown_prompt": "Delete 'BAT WalkEnumChanged'."
 }
 ```
@@ -4004,7 +4012,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Identify a device whose attribute name the hub treats as an ENUM (e.g. a switch's 'switch' attribute -- use hub_list_virtual_devices to find a virtual switch). Create RM rule 'BAT WalkEnumAttr'.",
-  "test_prompt": "Add a Required Expression to 'BAT WalkEnumAttr' using addRequiredExpression: {conditions:[{capability:'Custom Attribute', deviceIds:[<deviceId>], attribute:'switch', comparator:'=', state:'on'}]}. Inspect result.success, result.partial, result.settingsApplied, and result.settingsSkipped.",
+  "test_prompt": "Add a Required Expression to 'BAT WalkEnumAttr' using RM's 'Custom Attribute' capability on device <deviceId>'s 'switch' attribute equalling 'on'. Inspect result.success, result.partial, result.settingsApplied, and result.settingsSkipped.",
   "teardown_prompt": "Delete 'BAT WalkEnumAttr'."
 }
 ```
@@ -4018,7 +4026,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Create RM rule 'BAT CustomFetchFallback'.",
-  "test_prompt": "Add a trigger to 'BAT CustomFetchFallback' on a FREE-valued Custom Attribute (e.g. a custom driver's 'fixtureMode'): addTrigger {capability:'Custom Attribute', deviceIds:[<deviceId>], attribute:'fixtureMode', comparator:'=', state:'bright'}. Inspect result.success and result.settingsApplied.",
+  "test_prompt": "Add a trigger to 'BAT CustomFetchFallback' on a FREE-valued Custom Attribute (e.g. a custom driver's 'fixtureMode' on device <deviceId>), firing when it equals 'bright'. Inspect result.success and result.settingsApplied.",
   "teardown_prompt": "Delete 'BAT CustomFetchFallback'."
 }
 ```
@@ -4032,7 +4040,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "Hub Admin Write and Built-in App Tools are enabled. Identify a device whose attribute name the hub treats as an ENUM (e.g. a switch's 'switch' attribute -- use hub_list_virtual_devices to find a virtual switch). Create RM rule 'BAT WalkEnumAction'.",
-  "test_prompt": "Add an IF/THEN action to 'BAT WalkEnumAction' using addAction: {capability:'ifThen', expression:{conditions:[{capability:'Custom Attribute', deviceIds:[<deviceId>], attribute:'switch', comparator:'=', state:'on'}]}}. Inspect result.success, result.partial, result.settingsApplied, and result.settingsSkipped.",
+  "test_prompt": "Add an IF/THEN action to 'BAT WalkEnumAction' whose condition uses RM's 'Custom Attribute' capability on device <deviceId>'s 'switch' attribute equalling 'on'. Inspect result.success, result.partial, result.settingsApplied, and result.settingsSkipped.",
   "teardown_prompt": "Delete 'BAT WalkEnumAction'."
 }
 ```
@@ -4049,7 +4057,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 {
   "setup_prompt": "the Write master is enabled. Identify a virtual switch on the hub (use hub_list_virtual_devices)."
 ,
-  "test_prompt": "Create a new RM rule in ONE call with hub_set_rule (NO appId): {name:'BAT CreateRE', addRequiredExpression:{conditions:[{capability:'Switch', deviceIds:[<switchId>], state:'on'}]}, confirm:true}. Inspect result.appId and result.requiredExpression.",
+  "test_prompt": "In ONE single call, create a new RM rule named 'BAT CreateRE' complete with a Required Expression requiring switch <switchId> to be on — do not create the rule first and add the expression after. Inspect result.appId and result.requiredExpression.",
   "teardown_prompt": "Delete 'BAT CreateRE'."
 }
 ```
@@ -4080,7 +4088,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Note the hub's modes via hub_list_modes -- pick TWO distinct valid mode names (call them ModeA and ModeB). Create RM rule 'BAT Replace RE Test'. Add a Required Expression to it using addRequiredExpression: conditions=[{capability:'Mode', state:'<ModeA>'}]. Confirm the mainPage paragraph renders 'Mode is <ModeA>' (not the 'Define Required Expression' placeholder).",
-  "test_prompt": "Replace the Required Expression on 'BAT Replace RE Test' using replaceRequiredExpression: conditions=[{capability:'Mode', state:'<ModeB>'}]. Then call hub_get_app_config and hub_get_rule_health.",
+  "test_prompt": "Replace the Required Expression on 'BAT Replace RE Test' in place, so its only condition becomes: the hub mode is <ModeB>. Then read the rule's rendered config back and check its health.",
   "teardown_prompt": "Delete 'BAT Replace RE Test'."
 }
 ```
@@ -4094,7 +4102,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Note one valid mode name via hub_list_modes. Create RM rule 'BAT Replace No RE Test' with NO Required Expression.",
-  "test_prompt": "Call replaceRequiredExpression on 'BAT Replace No RE Test': conditions=[{capability:'Mode', state:'<valid mode name>'}]. Inspect the result.",
+  "test_prompt": "REPLACE the Required Expression on 'BAT Replace No RE Test' (which has none) with: the hub mode is <valid mode name>. Ask for a replace, not an add. Inspect the result.",
   "teardown_prompt": "Delete 'BAT Replace No RE Test'."
 }
 ```
@@ -4108,7 +4116,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled and a hub backup exists within 24h. Note two valid mode names via hub_list_modes (ModeA, ModeB). Note a valid switch device ID. Create RM rule 'BAT Replace Restore Test' and add a Required Expression: conditions=[{capability:'Mode', state:'<ModeA>'}]. Confirm the mainPage paragraph renders 'Mode is <ModeA>'.",
-  "test_prompt": "Call replaceRequiredExpression on 'BAT Replace Restore Test' with a spec whose new condition will FAIL TO BAKE -- conditions=[{capability:'Switch', deviceIds:[<the valid switch id>], state:'definitely_not_a_valid_state'}] (a bogus state value the Switch capability does not accept, so RM accepts the field writes but the expression does not commit). Inspect the result envelope, then call hub_get_app_config to see the mainPage paragraph.",
+  "test_prompt": "Replace the Required Expression on 'BAT Replace Restore Test' with a new condition that will FAIL TO BAKE: switch <the valid switch id> in the state 'definitely_not_a_valid_state' (a bogus state value the Switch capability does not accept, so RM accepts the field writes but the expression does not commit). Inspect the result envelope, then read the rule's rendered config to see the mainPage paragraph.",
   "teardown_prompt": "Delete 'BAT Replace Restore Test'."
 }
 ```
@@ -4124,7 +4132,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled and a hub backup exists within 24h. Note a valid switch device ID and two valid mode names (ModeA, ModeB) via hub_list_modes. Create RM rule 'BAT Patch Replace Scope' and add a Required Expression: conditions=[{capability:'Mode', state:'<ModeA>'}]. Confirm the mainPage paragraph renders 'Mode is <ModeA>'.",
-  "test_prompt": "Call hub_set_rule on 'BAT Patch Replace Scope' with patches=[{addAction:{capability:'switch', deviceIds:[<switch id>], command:'on'}}, {replaceRequiredExpression:{conditions:[{capability:'Switch', deviceIds:[<switch id>], state:'definitely_not_a_valid_state'}]}}] and confirm=true (the replace op's new condition will FAIL TO BAKE). Inspect the patches[] results, then call hub_get_app_config.",
+  "test_prompt": "In ONE batched call against 'BAT Patch Replace Scope', apply two changes in order: (1) add an action turning switch <switch id> on, then (2) replace the Required Expression with a condition that will FAIL TO BAKE — switch <switch id> in the bogus state 'definitely_not_a_valid_state'. Inspect the per-change results, then read the rule's rendered config back.",
   "teardown_prompt": "Delete 'BAT Patch Replace Scope'."
 }
 ```
@@ -4140,7 +4148,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create an RM rule called 'BAT LocalVar Test'.",
-  "test_prompt": "On 'BAT LocalVar Test': (1) add a local variable via hub_set_rule addLocalVariable={name:'batLocal', type:'Number', value:0}. (2) List the rule's local variables with hub_list_rule_local_variables (in hub_read_rules) and confirm 'batLocal' appears. (3) Add an action setLocalVariable={variable:'batLocal', value:7} and note the actionIndex it returns. (4) Remove the action you just added (removeAction using that returned actionIndex), then remove the local with hub_set_rule removeLocalVariable={name:'batLocal'}. (5) List local variables again and confirm 'batLocal' is gone. Then call hub_get_rule_health and confirm no broken markers.",
+  "test_prompt": "On 'BAT LocalVar Test': (1) Add a rule-local variable named 'batLocal' (Number type, initial value 0). (2) List the rule's local variables and confirm 'batLocal' appears. (3) Add an action that sets the LOCAL variable 'batLocal' to 7 and note the action index it returns. (4) Remove the action you just added (by that returned index), then remove the local variable 'batLocal'. (5) List the rule's local variables again and confirm 'batLocal' is gone. Then check the rule's health and confirm no broken markers.",
   "teardown_prompt": "Delete the 'BAT LocalVar Test' rule."
 }
 ```
@@ -4156,7 +4164,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create an RM rule called 'BAT LocalVar Broken Test'; add a NUMERIC local variable 'refLocal' (type Number, value 0) to it, then add an action setLocalVariable={variable:'refLocal', value:9} that references it. Leave the referencing action in place.",
-  "test_prompt": "On 'BAT LocalVar Broken Test': call hub_set_rule removeLocalVariable={name:'refLocal'} WITHOUT first removing the referencing action. Report success, variable.deleted, error, health.ok, and any repairHints. Then list local variables and confirm 'refLocal' is gone.",
+  "test_prompt": "On 'BAT LocalVar Broken Test': remove the rule-local variable 'refLocal' WITHOUT first removing the action that references it. Report success, variable.deleted, error, health.ok, and any repairHints. Then list the rule's local variables and confirm 'refLocal' is gone.",
   "teardown_prompt": "Delete the 'BAT LocalVar Broken Test' rule."
 }
 ```
@@ -4172,7 +4180,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "the Write master is enabled. Create a hub connector variable 'batShared' = 0 and a numeric hub connector variable 'batOperand' = 5 via hub_manage_variables. Create an RM rule called 'BAT LocalVar Namespace Test'; add a NUMERIC local variable 'batNum' (type Number, value 0) to it, but do NOT add a local named 'batShared'.",
-  "test_prompt": "On 'BAT LocalVar Namespace Test': (1) add an action setLocalVariable={variable:'batShared', value:1} and observe it is rejected. (2) Then add an action setLocalVariable={variable:'batNum', math:{left:'batOperand', op:'negate'}} -- the math operand 'batOperand' is a HUB global -- and observe it is accepted.",
+  "test_prompt": "On 'BAT LocalVar Namespace Test': (1) Add an action that sets the rule-LOCAL variable 'batShared' to 1 and observe it is rejected (only a hub global by that name exists). (2) Then add an action that sets the local variable 'batNum' via variable math to the NEGATED value of 'batOperand' -- that math operand is a HUB global -- and observe it is accepted.",
   "teardown_prompt": "Delete the 'BAT LocalVar Namespace Test' rule. Delete the hub variables 'batShared' and 'batOperand'."
 }
 ```
@@ -4188,7 +4196,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "The Read master is enabled. Pick any installed app id from hub_list_apps (scope='instances') — e.g. the MCP Rule Server itself.",
-  "test_prompt": "Call hub_get_app_config with that appId and summary=true. Inspect the result: it must carry the app's identity fields (id, name/label, type, disabled) and must NOT contain a rendered config page (no configPage/sections). Then call it again WITHOUT summary and confirm the full mode still returns the rendered page.",
+  "test_prompt": "Fetch just a thin identity summary of that app — id, name/label, type, disabled — WITHOUT the rendered config page (no configPage/sections in the result). Then fetch the app's config again in full mode and confirm the rendered page is still returned.",
   "teardown_prompt": "Nothing to clean up (read-only)."
 }
 ```
@@ -4204,7 +4212,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "The Write master is enabled and a hub backup exists (<24h). Create two virtual switches through the HUB UI (Devices > Add Device > Virtual, driver 'Virtual Switch'): 'BAT Swap Source' and 'BAT Swap Target' — or pick two existing compatible FREE-STANDING test devices. Do NOT create them via hub_manage_virtual_device: MCP-created virtual devices are child devices of the MCP app, and the hub's Swap Device tool excludes app-owned child/component devices from BOTH its pickers, so the scenario would fail with the eligibility error. Note both device IDs. Then create RM rule 'BAT Swap Rule' with hub_set_rule using addTrigger {capability:'Switch', deviceIds:[<BAT Swap Source id>], state:'on'}.",
-  "test_prompt": "Preview which apps reference 'BAT Swap Source' with hub_list_device_dependents — 'BAT Swap Rule' must be listed. Then call hub_call_device_swap with from_device_id=<BAT Swap Source id>, to_device_id=<BAT Swap Target id>, confirm=true. Inspect result.success, result.swapped, result.appsRewired, and result.remainingDependents. Verify the swap took: hub_list_device_dependents on 'BAT Swap Source' no longer lists 'BAT Swap Rule', hub_list_device_dependents on 'BAT Swap Target' now does, and hub_get_app_config on 'BAT Swap Rule' shows the trigger device is now 'BAT Swap Target'.",
+  "test_prompt": "I'm replacing 'BAT Swap Source' with 'BAT Swap Target'. First preview which apps currently reference 'BAT Swap Source' — 'BAT Swap Rule' must be listed. Then move every app reference off 'BAT Swap Source' and onto 'BAT Swap Target' in one operation, confirming the change. Inspect result.success, result.swapped, result.appsRewired, and result.remainingDependents. Verify the swap took: 'BAT Swap Source' no longer lists 'BAT Swap Rule' as a dependent, 'BAT Swap Target' now does, and 'BAT Swap Rule''s config shows its trigger device is now 'BAT Swap Target'.",
   "teardown_prompt": "Delete the rule 'BAT Swap Rule' with hub_delete_native_app. Delete both UI-created virtual switches 'BAT Swap Source' and 'BAT Swap Target' with hub_delete_device (confirm=true) — hub_manage_virtual_device only deletes MCP child devices and cannot remove them."
 }
 ```
@@ -4252,7 +4260,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "The Read master is enabled. Pick an installed app likely to have emitted events recently (the MCP Rule Server instance, or a BAT rule that just fired).",
-  "test_prompt": "Call hub_list_device_events with appId=<that app's id> (no deviceId). Inspect the result: source must be 'app', the events list rows carry {name, value, description, date}, and a limit parameter is respected. Then call it with BOTH deviceId and appId and confirm it is rejected as invalid arguments.",
+  "test_prompt": "Show me the recent events emitted by that app (app <that app's id> — the app itself, not one of its devices), capping the number of rows returned. Inspect the result: source must be 'app', the events list rows carry {name, value, description, date}, and the row cap is respected. Then ask for events for BOTH that app AND a specific device in the same single request and confirm it is rejected as invalid.",
   "teardown_prompt": "Nothing to clean up (read-only)."
 }
 ```
@@ -4268,7 +4276,7 @@ Tools in this section require **the Read master** and HPM itself must be install
 ```json
 {
   "setup_prompt": "Create a BAT virtual switch (hub_manage_virtual_device, deviceType 'Virtual Switch'). Toggle it on, then off, so it has a couple of recent events.",
-  "test_prompt": "Call hub_list_device_events for the BAT switch with hoursBack=1 and note the most recent event's `date`. Now toggle the switch again (one more command). Then call hub_list_device_events for the same device passing `since` = that recorded `date`. Confirm the response returns ONLY the events that happened after the bookmark (not the pre-bookmark ones), that `sinceMode` is 'explicit', that `since` is echoed back, and that no `hoursBack` field is present. Finally call it once with `since` set to a clearly future timestamp and confirm an empty events list (count 0, not an error).",
+  "test_prompt": "Fetch the last hour of events for the BAT switch and note the most recent event's `date`. Now toggle the switch again (one more command). Then fetch the same device's events again asking only for events SINCE that recorded date (use it as a bookmark). Confirm the response returns ONLY the events that happened after the bookmark (not the pre-bookmark ones), that `sinceMode` is 'explicit', that the bookmark is echoed back, and that no hours-window field is present. Finally repeat once with the bookmark set to a clearly future timestamp and confirm an empty events list (count 0, not an error).",
   "teardown_prompt": "Delete the BAT virtual switch (hub_manage_virtual_device action='delete')."
 }
 ```
@@ -4294,7 +4302,7 @@ The Visual Rules Builder tools live in the `hub_manage_rule_machine` gateway (th
 ```json
 {
   "setup_prompt": "The Write master is enabled and a hub backup was created within the last 24 hours (call hub_create_backup if unsure). Create a virtual switch named 'BAT VRB Switch' via hub_manage_virtual_device and note its device ID.",
-  "test_prompt": "Create a Visual Rules Builder rule named 'BAT VRB Create' with hub_set_visual_rule (confirm=true): when 'BAT VRB Switch' turns on, turn it off. Use the classic definition format: {whenNodes:[{triggerType:'switch', switches:[<id>], deviceIds:[<id>], switchEvent:'Turns on', index:0, type:'when'}], thenNodes:[{actionType:'turnOff', switches:[<id>], deviceIds:[<id>], index:0, type:'then'}], elseNodes:[]}. Then read it back with hub_get_visual_rule and report the appId, format, and whether the persisted definition matches what was sent.",
+  "test_prompt": "Create a Visual Rules Builder rule named 'BAT VRB Create' (confirming the creation): when 'BAT VRB Switch' turns on, turn it off. Author it in the classic when/then-nodes definition format. Then read the rule back and report the appId, format, and whether the persisted definition matches what was sent.",
   "teardown_prompt": "Delete the Visual Rule 'BAT VRB Create' with hub_delete_visual_rule (confirm=true). Delete the virtual switch 'BAT VRB Switch'."
 }
 ```
@@ -4308,7 +4316,7 @@ The Visual Rules Builder tools live in the `hub_manage_rule_machine` gateway (th
 ```json
 {
   "setup_prompt": "The Write master is enabled and a recent backup exists. Create a virtual switch 'BAT VRB PauseSwitch' and a Visual Rule named 'BAT VRB Pause' via hub_set_visual_rule (classic definition: when the switch turns on, turn it off). Note the returned appId.",
-  "test_prompt": "First pause the Visual Rule 'BAT VRB Pause' (hub_set_visual_rule with its appId, paused=true, confirm=true) and verify rulePaused=true via hub_get_visual_rule. Then rename it to 'BAT VRB Renamed' and resume it in one call (name + paused=false, NO definition). Verify via hub_get_visual_rule that the name changed, rulePaused=false, and the whenNodes/thenNodes are UNCHANGED from setup.",
+  "test_prompt": "First pause the Visual Rule 'BAT VRB Pause' (confirming the change) and verify it reads back as paused. Then rename it to 'BAT VRB Renamed' and resume it in ONE call — without re-sending or touching its definition. Verify by reading it back that the name changed, it is no longer paused, and the when/then nodes are UNCHANGED from setup.",
   "teardown_prompt": "Delete the Visual Rule 'BAT VRB Renamed' with hub_delete_visual_rule (confirm=true). Delete the virtual switch 'BAT VRB PauseSwitch'."
 }
 ```
@@ -4322,7 +4330,7 @@ The Visual Rules Builder tools live in the `hub_manage_rule_machine` gateway (th
 ```json
 {
   "setup_prompt": "The Write master is enabled and a recent backup exists. Create (1) a virtual switch 'BAT VRB DelSwitch', (2) a Visual Rule named 'BAT VRB Delete' via hub_set_visual_rule (classic definition over that switch), and (3) a Rule Machine rule named 'BAT VRB NotVisual' via hub_set_rule. Note both appIds.",
-  "test_prompt": "First call hub_delete_visual_rule on the RM rule 'BAT VRB NotVisual' (confirm=true) and report what happens. Then delete the Visual Rule 'BAT VRB Delete' with hub_delete_visual_rule (confirm=true) and report the verified flag and whether the response includes the pre-delete definition.",
+  "test_prompt": "First try deleting the RM rule 'BAT VRB NotVisual' AS IF it were a Visual Rule — go through the Visual Rule delete path, confirming — and report what happens. Then delete the actual Visual Rule 'BAT VRB Delete' (confirming) and report whether the delete was verified and whether the response includes the pre-delete definition.",
   "teardown_prompt": "Delete the RM rule 'BAT VRB NotVisual' with hub_delete_native_app (confirm=true). Delete the virtual switch 'BAT VRB DelSwitch'. Confirm via hub_get_visual_rule (list mode) that no rule named 'BAT VRB Delete' remains."
 }
 ```

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -485,7 +485,7 @@ These tools appear directly on `tools/list` in both v0.7.7 (all 74 tools) and v0
 
 ```json
 {
-  "test_prompt": "Pull up the server's reference documentation section that covers its device authorization rules."
+  "test_prompt": "Pull up the section of the server's built-in guide that covers its device authorization rules — I want the actual guide content, not a from-memory summary."
 }
 ```
 
@@ -1670,9 +1670,9 @@ Run these prompts on BOTH v0.7.7 (all 74 on tools/list) and v0.8.0 (11 flat + 19
 
 ## Section 10: Natural Language Discovery Tests
 
-These tests cover the same tool capabilities as earlier sections, but use **purely conversational prompts**. No tool names, no parameter names, no implementation-specific terms. The LLM must figure out which tool(s) to use from context alone.
+These tests cover the same tool capabilities as earlier sections, but use **purely conversational prompts**. No tool names, no parameter names, no implementation-specific terms. The LLM must figure out which tool(s) to use from context alone. (Sections 1-9 are also goal-first, but they state goals in precise domain vocabulary; this section restates the same coverage the way a non-technical user would phrase it.)
 
-**Purpose**: Measure whether the LLM can map real user intent to the correct MCP tools without being told which tools exist. Compare results with the explicit-tool versions in earlier sections.
+**Purpose**: Measure whether the LLM can map real user intent to the correct MCP tools without being told which tools exist. Compare results with the same tools' technically-phrased tests in earlier sections.
 
 **Rules**:
 - `test_prompt` MUST NOT contain any tool names, gateway names, or parameter names
@@ -2544,7 +2544,7 @@ These operations are too destructive for automated testing. Test manually with e
 2. Setup → Test → Teardown all happen in the **same session**
 3. Record metrics per the tracking table
 4. For Section 8 (Comparison): run same prompts on v0.7.7 and v0.8.0
-5. For Section 10 (NL Discovery): compare results with the equivalent explicit tests from earlier sections — same tool should be triggered, but the LLM must discover it without hints
+5. For Section 10 (NL Discovery): compare results with the equivalent tests from earlier sections — the same tool should be triggered from the casual phrasing as from the precise goal phrasing
 
 ### Results Template
 
@@ -2875,6 +2875,8 @@ These tests exercise the Developer Mode self-administration surface — the `hub
 3. Click Done.
 
 ### T219 — hub_update_mcp_settings refuses when Developer Mode toggle is OFF
+
+> Prompt-style carve-out: the prompt names the tool deliberately. With the Developer Mode toggle OFF the self-admin tool is hidden from `tools/list`, so only a by-name (cached-client) call can exercise the refusal path — a goal-first phrasing ("change the MCP log level") would route to `hub_set_log_level` and never hit it.
 
 ```json
 {


### PR DESCRIPTION
﻿## Summary

- Reframes every BAT `test_prompt` that named an MCP tool, gateway, or transcribed call args into a plain-language scenario + goal, so the suite tests tool *discovery* rather than transcription — 154 prompts total (83 in `tests/BAT-v2.md`, 71 in `tests/BAT-rm-native-crud.md`). Tool names stay in each test's title/**Expected** grading text.
- 23 prompts intentionally still name the surface because their subject IS the surface (wrong-gateway routing, tool-name-off-tools/list routing, mutually-exclusive or deliberately malformed call shapes, gateway-override catalog visibility) — the per-test edge case the issue carves out.
- Codifies the rule as a "Prompt style — goal-first" section in both active BAT files, and fixes the now-stale "prompts use the shipped tool names" note in `BAT-rm-native-crud.md`. `tests/BAT.md` (superseded v1) was audited and left untouched as a historical snapshot — it's essentially compliant (1 real violation, 11 carve-outs).

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [x] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- Closes #311.
- `tests/BAT-v2.md`: 83 `test_prompt`s reframed goal-first; new "Prompt style — goal-first" guidance under Test Format; coverage-summary wording updated ("Sections 1-9 use explicit tool references" no longer true); where a reframe displaced grading detail, it was moved into **Expected**.
- `tests/BAT-rm-native-crud.md`: 71 `test_prompt`s reframed; header tool-names note corrected; same guidance section added; **Expected** blocks updated to carry the tool paths the prompts no longer name.
- Setup/teardown prompts untouched (orchestrator scaffolding — allowed to name tools). No test IDs or titles changed (`e2e_test.py` references T642/T703 by ID).

## Release Notes

- Acceptance-test suite improvements only — no functional changes to the app.

## Testing

- `python tests/sandbox_lint.py` — all checks passed (BAT-v2 is in scope of its tool-count doc check).
- Markdown-only change to manual test-scenario docs; no runtime surface. Verified the two carve-out prompts remaining in `BAT-rm-native-crud.md` and ~21 in `BAT-v2.md` are all deliberate surface-subject tests.

## Checklist

- [ ] **Unit tests added for any new MCP tools, regressions, or bug fixes** (N/A — docs-only change to test scenarios)
- [ ] **e2e tests added for new tools and/or regression tests added for any bug fix** (N/A — no tool behaviour change)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms — no Groovy touched; CI will confirm)
- [x] Live-hub BAT tests updated if tool behaviour changed (this PR is the BAT update)
- [x] Documentation updated if user-facing behaviour or tool surface changed (guidance sections added)
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (N/A)

