### PR TITLE
fix: route waitEvents Mode events to the mode picker, not tstate

### DIFF
--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -723,7 +723,7 @@ For machine-readable per-field schemas (with `action` enums and per-action requi
   - `repeat` + `hours`/`minutes`/`seconds` + optional `times` + `stoppable`
   - `repeatWhile` + `expression={conditions:[...], operator?:..., operators?:[...]}` + optional `hours`/`minutes`/`seconds`/`times`/`stoppable`
   - `waitExpression` + `expression={...}` + optional `delay={hours,minutes,seconds}` + `useDuration=true|false`
-  - `waitEvents` + `events=[{capability, deviceIds, state, andStays?}, ...]`. A **Mode** event uses `{capability:'Mode', state:<mode name or list of names>}` or `{capability:'Mode', modeIds:[...]}` (no `deviceIds`; the mode is written to RM's mode picker, not `tstate`). **LIMIT**: only ONE `waitEvents` action per rule; RM 5.1 stores wait events in global per-rule settings (not per-action), so a second `waitEvents` action silently overwrites the first. Combine multiple waits into one action's `events` array, or split into chained sub-rules.
+  - `waitEvents` + `events=[{capability, deviceIds, state, andStays?}, ...]`. A **Mode** event uses `{capability:'Mode', state:<mode name or list of names>}` or `{capability:'Mode', modeIds:[...]}` (`deviceIds` is rejected on a Mode event; the mode is written to RM's mode picker, not `tstate`). **LIMIT**: only ONE `waitEvents` action per rule; RM 5.1 stores wait events in global per-rule settings (not per-action), so a second `waitEvents` action silently overwrites the first. Combine multiple waits into one action's `events` array, or split into chained sub-rules.
   - `ifThen` + `expression={...}` (opens IF block; close with `endIf`)
   - `elseIf` + `expression={...}` (continues IF block; needs preceding `ifThen`)
   - `else` (no fields; needs preceding `ifThen` or `elseIf`)

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -723,7 +723,7 @@ For machine-readable per-field schemas (with `action` enums and per-action requi
   - `repeat` + `hours`/`minutes`/`seconds` + optional `times` + `stoppable`
   - `repeatWhile` + `expression={conditions:[...], operator?:..., operators?:[...]}` + optional `hours`/`minutes`/`seconds`/`times`/`stoppable`
   - `waitExpression` + `expression={...}` + optional `delay={hours,minutes,seconds}` + `useDuration=true|false`
-  - `waitEvents` + `events=[{capability, deviceIds, state, andStays?}, ...]`. **LIMIT**: only ONE `waitEvents` action per rule; RM 5.1 stores wait events in global per-rule settings (not per-action), so a second `waitEvents` action silently overwrites the first. Combine multiple waits into one action's `events` array, or split into chained sub-rules.
+  - `waitEvents` + `events=[{capability, deviceIds, state, andStays?}, ...]`. A **Mode** event uses `{capability:'Mode', state:<mode name or list of names>}` or `{capability:'Mode', modeIds:[...]}` (no `deviceIds`; the mode is written to RM's mode picker, not `tstate`). **LIMIT**: only ONE `waitEvents` action per rule; RM 5.1 stores wait events in global per-rule settings (not per-action), so a second `waitEvents` action silently overwrites the first. Combine multiple waits into one action's `events` array, or split into chained sub-rules.
   - `ifThen` + `expression={...}` (opens IF block; close with `endIf`)
   - `elseIf` + `expression={...}` (continues IF block; needs preceding `ifThen`)
   - `else` (no fields; needs preceding `ifThen` or `elseIf`)

--- a/docs/rm_action_subtype_schemas.md
+++ b/docs/rm_action_subtype_schemas.md
@@ -437,7 +437,7 @@ Note: only ONE `waitEvents` action is supported per rule (RM 5.1 platform limita
 
 | Field | Type | Notes |
 |---|---|---|
-| `events` | List\<Map\> | Required. Each device event: `{capability, deviceIds, state, andStays?}`. A **Mode** event is the exception: `{capability:'Mode', state:'Night'}` or `{capability:'Mode', state:['Away','Night']}` (mode names, case-insensitive) or `{capability:'Mode', modeIds:['3']}` / `modeIds:['3','5']` (IDs from `hub_list_modes`). A Mode event takes no `deviceIds`; the mode value is written to the discovered mode picker (`modesX-<N>` family, keyed by mode ID), never to `tstate-<N>`. The resolved IDs are validated against the live picker options -- an unknown mode or an ID the picker does not offer fails loud. |
+| `events` | List\<Map\> | Required. Each device event: `{capability, deviceIds, state, andStays?}`. A **Mode** event is the exception: `{capability:'Mode', state:'Night'}` or `{capability:'Mode', state:['Away','Night']}` (mode name(s) -- must match an existing hub mode) or `{capability:'Mode', modeIds:['3']}` / `modeIds:['3','5']` (IDs from `hub_list_modes`). A Mode event rejects `deviceIds` (it is hub-state, not device-based); the mode value is written to the discovered mode picker (`modesX-<N>` family, keyed by mode ID), never to `tstate-<N>`. The resolved IDs are validated against the live picker options (or `location.modes` IDs when the picker exposes no options) -- an unknown mode or an ID no real hub mode carries fails loud. |
 | `rawSettings` | Map | |
 
 ### ifThen

--- a/docs/rm_action_subtype_schemas.md
+++ b/docs/rm_action_subtype_schemas.md
@@ -437,7 +437,7 @@ Note: only ONE `waitEvents` action is supported per rule (RM 5.1 platform limita
 
 | Field | Type | Notes |
 |---|---|---|
-| `events` | List\<Map\> | Required. Each: `{capability, deviceIds, state, andStays?}` |
+| `events` | List\<Map\> | Required. Each device event: `{capability, deviceIds, state, andStays?}`. A **Mode** event is the exception: `{capability:'Mode', state:'Night'}` or `{capability:'Mode', state:['Away','Night']}` (mode names, case-insensitive) or `{capability:'Mode', modeIds:['3']}` / `modeIds:['3','5']` (IDs from `hub_list_modes`). A Mode event takes no `deviceIds`; the mode value is written to the discovered mode picker (`modesX-<N>` family, keyed by mode ID), never to `tstate-<N>`. The resolved IDs are validated against the live picker options -- an unknown mode or an ID the picker does not offer fails loud. |
 | `rawSettings` | Map | |
 
 ### ifThen

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6262,7 +6262,7 @@ For the live machine-readable per-field schema (action enums, required and optio
   - `repeat` + `hours`/`minutes`/`seconds` + optional `times` + `stoppable`
   - `repeatWhile` + `expression={conditions:[...], operator?:..., operators?:[...]}` + optional `hours`/`minutes`/`seconds`/`times`/`stoppable`
   - `waitExpression` + `expression={...}` + optional `delay={hours,minutes,seconds}` + `useDuration=true|false`
-  - `waitEvents` + `events=[{capability, deviceIds, state, andStays?}, ...]`. A **Mode** event uses `{capability:'Mode', state:<mode name or list of names>}` or `{capability:'Mode', modeIds:[...]}` (no `deviceIds`; the mode is written to RM's mode picker, not `tstate`). **LIMIT**: only ONE `waitEvents` action per rule; RM 5.1 stores wait events in global per-rule settings (not per-action), so a second `waitEvents` action silently overwrites the first. Combine multiple waits into one action's `events` array, or split into chained sub-rules.
+  - `waitEvents` + `events=[{capability, deviceIds, state, andStays?}, ...]`. A **Mode** event uses `{capability:'Mode', state:<mode name or list of names>}` or `{capability:'Mode', modeIds:[...]}` (`deviceIds` is rejected on a Mode event; the mode is written to RM's mode picker, not `tstate`). **LIMIT**: only ONE `waitEvents` action per rule; RM 5.1 stores wait events in global per-rule settings (not per-action), so a second `waitEvents` action silently overwrites the first. Combine multiple waits into one action's `events` array, or split into chained sub-rules.
   - `ifThen` + `expression={...}` (opens IF block; close with `endIf`)
   - `elseIf` + `expression={...}` (continues IF block; needs preceding `ifThen`)
   - `else` (no fields; needs preceding `ifThen` or `elseIf`)

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -6262,7 +6262,7 @@ For the live machine-readable per-field schema (action enums, required and optio
   - `repeat` + `hours`/`minutes`/`seconds` + optional `times` + `stoppable`
   - `repeatWhile` + `expression={conditions:[...], operator?:..., operators?:[...]}` + optional `hours`/`minutes`/`seconds`/`times`/`stoppable`
   - `waitExpression` + `expression={...}` + optional `delay={hours,minutes,seconds}` + `useDuration=true|false`
-  - `waitEvents` + `events=[{capability, deviceIds, state, andStays?}, ...]`. **LIMIT**: only ONE `waitEvents` action per rule; RM 5.1 stores wait events in global per-rule settings (not per-action), so a second `waitEvents` action silently overwrites the first. Combine multiple waits into one action's `events` array, or split into chained sub-rules.
+  - `waitEvents` + `events=[{capability, deviceIds, state, andStays?}, ...]`. A **Mode** event uses `{capability:'Mode', state:<mode name or list of names>}` or `{capability:'Mode', modeIds:[...]}` (no `deviceIds`; the mode is written to RM's mode picker, not `tstate`). **LIMIT**: only ONE `waitEvents` action per rule; RM 5.1 stores wait events in global per-rule settings (not per-action), so a second `waitEvents` action silently overwrites the first. Combine multiple waits into one action's `events` array, or split into chained sub-rules.
   - `ifThen` + `expression={...}` (opens IF block; close with `endIf`)
   - `elseIf` + `expression={...}` (continues IF block; needs preceding `ifThen`)
   - `else` (no fields; needs preceding `ifThen` or `elseIf`)

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -3255,7 +3255,7 @@ private Map _rmActionSchemaForDiscover() {
                 name: "waitEvents",
                 family: "flow",
                 requiredFields: [
-                    [name: "events", type: "List<Map>", description: "Each: {capability, deviceIds, state, andStays?}"]
+                    [name: "events", type: "List<Map>", description: "Each: {capability, deviceIds, state, andStays?}. Mode event: {capability:'Mode', state:<mode name or list of names>} or {capability:'Mode', modeIds:[...]} -- no deviceIds; the mode value is written to the mode picker, not tstate."]
                 ],
                 optionalFields: [
                     [name: "rawSettings", type: "Map"]
@@ -5742,7 +5742,10 @@ private Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = fal
     //   repeatActs/getWhile — Repeat While Expression
     //   delayActs/getWaitRule — Wait for Expression
     // Wait for Events: walk each event row using tCapab-<N>/tDev-<N>/
-    // tstate-<N> (dash-separated index). After tstate-<N> is written,
+    // tstate-<N> (dash-separated index). A Mode event is the exception:
+    // it uses a discovered modesX-<N>-family picker (mode IDs) with no
+    // tDev-<N>/tstate-<N>, same as the trigger/condition Mode paths.
+    // After the event's value field is written,
     // a hasAll button appears ("Done with this Wait Event"). Click it
     // to commit the event and reveal tCapab-<N+1> for the next event.
     // Without the hasAll click, multi-event rules fail because tCapab-2
@@ -5782,12 +5785,93 @@ private Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = fal
             if (!canon) {
                 throw new IllegalArgumentException("waitEvents.events[${evIdx}].capability '${evCap}' not in option list. Valid: ${opts.collect { it.toString() }.sort().join(', ')}")
             }
-            _rmWriteSettingOnPage(appId, "doActPage", "tCapab-${n}", canon, applied, null, skipped)
-            if (ev.deviceIds != null) {
-                _rmWriteSettingOnPage(appId, "doActPage", "tDev-${n}", ev.deviceIds, applied, null, skipped)
+            // A Mode event is resolved + validated BEFORE any wizard write:
+            // resolve its mode input up front so an invalid or absent mode fails
+            // loud before the tCapab-<N> POST, never leaving a half-written event
+            // row. Resolution needs only location.modes, not the revealed schema,
+            // so it can run ahead of the tCapab write.
+            def isMode = canon.toString().equalsIgnoreCase("Mode")
+            def modeIds = null
+            if (isMode) {
+                // Mode is hub-state, not device-based -- reject deviceIds rather
+                // than silently ignoring them (matches the trigger/condition Mode
+                // paths' no-tDev rule and the fail-loud theme).
+                if (ev.deviceIds != null) {
+                    throw new IllegalArgumentException("waitEvents.events[${evIdx}]: a Mode event is hub-state, not device-based -- remove 'deviceIds'.")
+                }
+                if (ev.modeIds != null) {
+                    modeIds = _rmResolveModeIds((ev.modeIds instanceof List) ? (ev.modeIds as List) : [ev.modeIds])
+                } else if (ev.state != null) {
+                    modeIds = _rmResolveModeIds((ev.state instanceof List) ? (ev.state as List) : [ev.state])
+                }
+                if (!modeIds) {
+                    throw new IllegalArgumentException("waitEvents.events[${evIdx}]: Mode event requires a non-empty 'state' (mode name or list of names) or 'modeIds' (list of mode IDs).")
+                }
             }
-            if (ev.state != null) {
-                _rmWriteSettingOnPage(appId, "doActPage", "tstate-${n}", ev.state, applied, null, skipped)
+            _rmWriteSettingOnPage(appId, "doActPage", "tCapab-${n}", canon, applied, null, skipped)
+            if (isMode) {
+                // Mode event: RM does NOT use tstate-<N>. Writing tCapab-<N>=Mode
+                // reveals a mode picker keyed by mode ID (dash-indexed for the
+                // waitEvents row, mirroring the trigger's modesX<N> and the
+                // condition's modes<N>). Writing tstate-<N> here is silently
+                // ignored, leaving the event with no mode selected -- the wait
+                // renders with a dangling OR and that event effectively drops.
+                // The exact field name is firmware-assigned. DISCOVER it from the
+                // post-tCapab schema rather than hardcoding, because a firmware
+                // rename then fails loud (below) instead of silently dropping the
+                // event. The reveal-trigger write (tCapab-<N>=Mode) was already
+                // issued above, so a direct re-fetch finds the now-visible picker
+                // -- no _rmRevealStep round-trip is needed here. Same retry
+                // rationale as the tCapab-<N> discovery (the prior write's
+                // re-render can lag one fetch behind the click that reveals it).
+                def modeField = null
+                def modeOptions = null
+                def modeInputs = []
+                for (int attempt = 0; attempt < 4; attempt++) {
+                    def modeCfg = _rmFetchConfigJson(appId, "doActPage")
+                    modeInputs = (modeCfg?.configPage?.sections ?: []).collectMany { it?.input ?: [] }
+                    def modeInput = modeInputs.find { it?.name?.toString()?.matches("modes[A-Za-z]*-${n}".toString()) }
+                    if (modeInput) { modeField = modeInput.name.toString(); modeOptions = modeInput.options; break }
+                    if (attempt < 3) pauseExecution(250)
+                }
+                if (!modeField) {
+                    throw new IllegalStateException("waitEvents.events[${evIdx}]: Mode picker (expected a modesX-${n} family field) did not appear after writing tCapab-${n}=Mode. Schema seen: ${modeInputs.empty ? "(none returned)" : modeInputs.collect { it?.name }.findAll { it }.join(', ')}")
+                }
+                // Cross-check each resolved mode ID against the discovered picker's
+                // options (the option keys ARE the mode IDs). _rmResolveModeIds
+                // passes integer IDs through unvalidated, so an ID the picker does
+                // not offer would otherwise be silently skipped -- committing a
+                // Mode row with no mode selected, the same dangling-OR drop the
+                // discovery guard prevents. Validate against the PICKER options
+                // (not location.modes) so a valid ID the hub offers still works.
+                def pickerIds = []
+                if (modeOptions instanceof Map) {
+                    pickerIds = (modeOptions as Map).keySet().collect { it?.toString() }
+                } else if (modeOptions instanceof List) {
+                    (modeOptions as List).each { o ->
+                        if (o instanceof Map) { if (o.id != null) pickerIds << o.id.toString() }
+                        else if (o != null) pickerIds << o.toString()
+                    }
+                }
+                // Fail SAFE: only validate when the picker actually exposed its options.
+                // On a live hub the mode picker can reveal with an empty/not-yet-populated
+                // options list; treating that as "no valid IDs" would false-reject every
+                // legitimate mode. Skip the cross-check when we could not read any option.
+                def badIds = pickerIds.isEmpty() ? [] : modeIds.findAll { !pickerIds.contains(it?.toString()) }
+                if (!badIds.isEmpty()) {
+                    throw new IllegalArgumentException("waitEvents.events[${evIdx}]: mode ID(s) ${badIds.join(', ')} not offered by the ${modeField} picker. Valid IDs: ${pickerIds.sort().join(', ')}")
+                }
+                // Mode is hub-state, not device-based -- no tDev-<N> (matches the
+                // trigger and condition Mode paths). Write the resolved mode ID
+                // list to the discovered picker.
+                _rmWriteSettingOnPage(appId, "doActPage", modeField, modeIds, applied, null, skipped)
+            } else {
+                if (ev.deviceIds != null) {
+                    _rmWriteSettingOnPage(appId, "doActPage", "tDev-${n}", ev.deviceIds, applied, null, skipped)
+                }
+                if (ev.state != null) {
+                    _rmWriteSettingOnPage(appId, "doActPage", "tstate-${n}", ev.state, applied, null, skipped)
+                }
             }
             // Optional 'and stays for' duration.
             if (ev.andStays == true) {

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -1855,6 +1855,12 @@ private Map _rmAddTrigger(Integer appId, Map triggerSpec) {
         if (rawModeIds.isEmpty()) {
             throw new IllegalArgumentException("addTrigger Mode: no mode IDs resolved -- pass state with valid mode name(s) or modeIds with mode ID(s)")
         }
+        // A directly-passed integer ID skips the name-resolution check above, so
+        // reject any ID no hub mode carries before it commits a mode-less row.
+        def modeCheck = _rmBadModeIds(rawModeIds, null)
+        if (modeCheck.bad) {
+            throw new IllegalArgumentException("addTrigger Mode: mode ID(s) ${modeCheck.bad.join(', ')} not offered by ${modeCheck.source}. Valid IDs: ${modeCheck.valid.sort().join(', ')}")
+        }
         writeIfPresent("modesX${idx}", rawModeIds)
     } else {
         // tstate<N> covers both enum-state ("on"/"active") and numeric value
@@ -3255,7 +3261,7 @@ private Map _rmActionSchemaForDiscover() {
                 name: "waitEvents",
                 family: "flow",
                 requiredFields: [
-                    [name: "events", type: "List<Map>", description: "Each: {capability, deviceIds, state, andStays?}. Mode event: {capability:'Mode', state:<mode name or list of names>} or {capability:'Mode', modeIds:[...]} -- no deviceIds; the mode value is written to the mode picker, not tstate."]
+                    [name: "events", type: "List<Map>", description: "Each: {capability, deviceIds, state, andStays?}. Mode event: {capability:'Mode', state:<mode name or list of names>} or {capability:'Mode', modeIds:[...]} -- deviceIds is rejected on a Mode event; the mode value is written to the mode picker, not tstate."]
                 ],
                 optionalFields: [
                     [name: "rawSettings", type: "Map"]
@@ -4385,6 +4391,28 @@ private List _rmResolveModeIds(Collection keys) {
         throw new IllegalArgumentException("Unknown mode '${s}' -- must be an integer mode ID or one of: ${nameToId.keySet().sort().join(', ')}")
     }
     return out
+}
+
+// Cross-check already-resolved mode IDs against the valid set so a raw integer
+// ID that no hub mode carries fails loud instead of committing a Mode row with
+// no mode selected. Prefer the picker's option keys when the caller discovered a
+// non-empty set; otherwise fall back to the hub's location.modes IDs. Returns
+// the offending IDs, the valid set, and a human-readable source for the message.
+private Map _rmBadModeIds(List resolvedIds, Object pickerOptions) {
+    def pickerIds = []
+    if (pickerOptions instanceof Map) {
+        pickerIds = (pickerOptions as Map).keySet().collect { it?.toString() }
+    } else if (pickerOptions instanceof List) {
+        (pickerOptions as List).each { o ->
+            if (o instanceof Map) { if (o.id != null) pickerIds << o.id.toString() }
+            else if (o != null) pickerIds << o.toString()
+        }
+    }
+    def hasPicker = !pickerIds.isEmpty()
+    def validIds = hasPicker ? pickerIds : (location?.modes ?: []).collect { it?.id?.toString() }.findAll { it }
+    def source = hasPicker ? "the mode picker" : "hub modes"
+    def bad = resolvedIds.findAll { !validIds.contains(it?.toString()) }
+    return [valid: validIds, bad: bad, source: source]
 }
 
 // Resolve a collection of mode keys (IDs or names) into a List of mode NAMES
@@ -5785,11 +5813,14 @@ private Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = fal
             if (!canon) {
                 throw new IllegalArgumentException("waitEvents.events[${evIdx}].capability '${evCap}' not in option list. Valid: ${opts.collect { it.toString() }.sort().join(', ')}")
             }
-            // A Mode event is resolved + validated BEFORE any wizard write:
-            // resolve its mode input up front so an invalid or absent mode fails
-            // loud before the tCapab-<N> POST, never leaving a half-written event
-            // row. Resolution needs only location.modes, not the revealed schema,
-            // so it can run ahead of the tCapab write.
+            // A Mode event's INPUT checks (neither-provided, deviceIds-rejection,
+            // mode NAME resolution) run BEFORE the tCapab-<N> POST -- they need
+            // only location.modes, not the revealed schema, so an invalid or
+            // absent mode fails loud without leaving a half-written event row.
+            // The schema-dependent guards (the picker-missing throw and the
+            // resolved-ID cross-check) necessarily run AFTER the tCapab-<N>=Mode
+            // write, since they need the revealed picker; both stay fail-loud, and
+            // a backup exists.
             def isMode = canon.toString().equalsIgnoreCase("Mode")
             def modeIds = null
             if (isMode) {
@@ -5837,13 +5868,17 @@ private Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = fal
                 if (!modeField) {
                     throw new IllegalStateException("waitEvents.events[${evIdx}]: Mode picker (expected a modesX-${n} family field) did not appear after writing tCapab-${n}=Mode. Schema seen: ${modeInputs.empty ? "(none returned)" : modeInputs.collect { it?.name }.findAll { it }.join(', ')}")
                 }
-                // Cross-check each resolved mode ID against the discovered picker's
-                // options (the option keys ARE the mode IDs). _rmResolveModeIds
-                // passes integer IDs through unvalidated, so an ID the picker does
-                // not offer would otherwise be silently skipped -- committing a
-                // Mode row with no mode selected, the same dangling-OR drop the
-                // discovery guard prevents. Validate against the PICKER options
-                // (not location.modes) so a valid ID the hub offers still works.
+                // Cross-check each resolved mode ID against the valid ID set.
+                // _rmResolveModeIds passes integer IDs through unvalidated, so an
+                // ID no real mode carries would otherwise be silently skipped --
+                // committing a Mode row with no mode selected, the same dangling-OR
+                // drop the discovery guard prevents. Two-tier validation, fail SAFE:
+                // prefer the discovered picker's options (the option keys ARE the
+                // mode IDs). On a live hub the picker can reveal with an empty/
+                // not-yet-populated options list; rather than skip the check (which
+                // would let a bogus integer ID through), fall back to the hub's own
+                // location.modes IDs. Names are already resolved+validated above, so
+                // the fallback only needs to catch raw integer IDs passed directly.
                 def pickerIds = []
                 if (modeOptions instanceof Map) {
                     pickerIds = (modeOptions as Map).keySet().collect { it?.toString() }
@@ -5853,13 +5888,18 @@ private Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = fal
                         else if (o != null) pickerIds << o.toString()
                     }
                 }
-                // Fail SAFE: only validate when the picker actually exposed its options.
-                // On a live hub the mode picker can reveal with an empty/not-yet-populated
-                // options list; treating that as "no valid IDs" would false-reject every
-                // legitimate mode. Skip the cross-check when we could not read any option.
-                def badIds = pickerIds.isEmpty() ? [] : modeIds.findAll { !pickerIds.contains(it?.toString()) }
+                def validIds
+                def validSource
+                if (!pickerIds.isEmpty()) {
+                    validIds = pickerIds.collect { it?.toString() }
+                    validSource = "${modeField} picker"
+                } else {
+                    validIds = (location?.modes ?: []).collect { it?.id?.toString() }.findAll { it }
+                    validSource = "hub modes"
+                }
+                def badIds = modeIds.findAll { !validIds.contains(it?.toString()) }
                 if (!badIds.isEmpty()) {
-                    throw new IllegalArgumentException("waitEvents.events[${evIdx}]: mode ID(s) ${badIds.join(', ')} not offered by the ${modeField} picker. Valid IDs: ${pickerIds.sort().join(', ')}")
+                    throw new IllegalArgumentException("waitEvents.events[${evIdx}]: mode ID(s) ${badIds.join(', ')} not offered by the ${validSource}. Valid IDs: ${validIds.sort().join(', ')}")
                 }
                 // Mode is hub-state, not device-based -- no tDev-<N> (matches the
                 // trigger and condition Mode paths). Write the resolved mode ID
@@ -9431,6 +9471,14 @@ private void _rmWalkConditionReveal(Integer appId, Map ctx, Map cond, Integer cI
             throw new IllegalStateException("conditions[${condIdx}]: Mode: expected modes<N> picker after rCapab='Mode' but it did not appear. Visible fields: ${visible}")
         }
         def modesField = modesReveal.input.name.toString()
+        // A directly-passed integer ID skips _rmResolveModeIds' name check, so
+        // reject any ID the revealed picker (or location.modes) does not offer
+        // before it commits a mode-less condition row.
+        def modeCheck = _rmBadModeIds(modeIdsToWrite, modesReveal.input.options)
+        if (modeCheck.bad) {
+            cancelInFlightCond()
+            throw new IllegalArgumentException("conditions[${condIdx}]: Mode: mode ID(s) ${modeCheck.bad.join(', ')} not offered by ${modeCheck.source}. Valid IDs: ${modeCheck.valid.sort().join(', ')}")
+        }
         writeST(hrefParams, modesField, modeIdsToWrite)
         if (cond.not == true) {
             writeST(hrefParams, "not${cIdx}".toString(), true)

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -17505,9 +17505,10 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
     def "addTrigger Mode + modeIds list writes modesX<N> directly without name resolution"() {
         given:
         enableWrite()
-        // Pass IDs directly -- location.modes is NOT consulted (no name resolution).
-        // Even if location.modes is empty, the write should succeed.
-        sharedLocation.modes = []  // would cause NPE/error if consulted
+        // Pass IDs directly -- no name resolution. The integer IDs are still
+        // cross-checked against location.modes (an ID no mode carries is rejected),
+        // so the fixture lists the modes whose IDs (3, 5) are supplied below.
+        sharedLocation.modes = [[id: "3", name: "Night"], [id: "5", name: "Day"]]
 
         def modesXWritten = []
         def fetchCount = 0
@@ -17669,6 +17670,111 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
         and: "modesX WAS written"
         !modesXWrites.isEmpty()
+    }
+
+    def "addTrigger Mode with an integer modeId no hub mode carries fails loud, naming it and the hub-mode IDs"() {
+        // Parity with the waitEvents/condition Mode paths: a directly-passed
+        // integer ID skips name resolution, so it must be cross-checked against
+        // the valid set before modesX1 commits a mode-less (Broken) trigger row.
+        // location.modes offers 1/2/3; id 9 belongs to no mode. Both-ways pending (orchestrator).
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        def modesXWritten = []
+        def fetchCount = 0
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            fetchCount++
+            // tCapab1 is enough to reach the Mode block; the direct-ID validation
+            // throws before modesX1 would ever be written, so no modesX1 reveal.
+            def inputs = fetchCount >= 2
+                ? [[name: "tCapab1", type: "enum", options: ["Mode", "Switch"]],
+                   [name: "isCondTrig.1", type: "bool"],
+                   [name: "hasAll", type: "button"]]
+                : []
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "selectTriggers", title: "T", install: false, error: null,
+                             sections: [[title: "", input: inputs,
+                                         paragraphs: ["fetch ${fetchCount}".toString()]]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v -> if (k?.toString()?.startsWith("settings[modesX")) modesXWritten << [key: k, value: v] }
+            [status: 200, location: null, data: '']
+        }
+
+        when: "an integer modeId that no hub mode carries is passed"
+        script._rmAddTrigger(100, [capability: "Mode", modeIds: [9]])
+
+        then: "the unknown ID fails loud, naming it, the hub-modes source, and the valid IDs"
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("9")
+        ex.message.contains("not offered")
+        // No picker is discovered on the trigger path, so the message names the
+        // location.modes fallback as the source and lists its IDs -- dropping the
+        // fallback (or the cross-check) is caught here.
+        ex.message.contains("hub modes")
+        ex.message.contains("1, 2, 3")
+
+        and: "no modesX write was issued for the rejected trigger (no silent mode-less commit)"
+        modesXWritten.isEmpty()
+    }
+
+    def "addTrigger Mode with a valid integer modeId still writes modesX<N> (anti-regression companion)"() {
+        // Must-NOT-catch pair for the reject spec above: modeIds:[2] IS a real hub
+        // mode, so the cross-check must ACCEPT it and write the picker -- never
+        // false-reject a legitimate directly-passed ID. Both-ways pending (orchestrator).
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        def modesXWritten = []
+        def fetchCount = 0
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectTriggers') { params ->
+            fetchCount++
+            def inputs = []
+            if (fetchCount >= 2) {
+                inputs = [[name: "tCapab1", type: "enum", options: ["Mode", "Switch"]],
+                          [name: "isCondTrig.1", type: "bool"],
+                          [name: "hasAll", type: "button"]]
+            }
+            if (fetchCount >= 3) {
+                inputs = [[name: "tCapab1", type: "enum", options: ["Mode", "Switch"]],
+                          [name: "modesX1", type: "enum", multiple: true,
+                           options: ["1": "Home", "2": "Away", "3": "Night"]],
+                          [name: "isCondTrig.1", type: "bool"],
+                          [name: "hasAll", type: "button"]]
+            }
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "selectTriggers", title: "T", install: false, error: null,
+                             sections: [[title: "", input: inputs,
+                                         paragraphs: ["fetch ${fetchCount}".toString()]]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v -> if (k?.toString()?.startsWith("settings[modesX")) modesXWritten << [key: k, value: v] }
+            [status: 200, location: null, data: '']
+        }
+
+        when: "a valid integer modeId is passed"
+        script._rmAddTrigger(100, [capability: "Mode", modeIds: [2]])
+
+        then: "the valid ID passes the cross-check and lands on modesX1 (exact JSON wire form)"
+        modesXWritten.any { it.value?.toString() == '["2"]' }
     }
 
     // ---------- waitEvents Mode event: mode picker (modesX-N) not tstate-N ----------
@@ -18081,6 +18187,244 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
         and: "no mode-picker write was issued for the rejected event (no silent applied+partial commit)"
         modesXWritten.isEmpty()
+    }
+
+    def "waitEvents Mode event with a multi-NAME state list writes every resolved ID to the picker"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"],
+            [name: "anotherWait", type: "button"],
+            [name: "doneWaits", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def modesXWritten = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[modesX-")) modesXWritten << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when: "the caller passes a list of two mode names"
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", state: ["Away", "Night"]]]])
+
+        then: "both names resolve (Away->2, Night->3) and land on modesX-1 in insertion order (exact JSON wire form)"
+        modesXWritten.any { it.value == '["2","3"]' }
+    }
+
+    def "waitEvents Mode event with empty picker options falls back to location.modes and rejects an unknown ID"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        // The picker reveals (name matches modesX-1) but exposes NO options -- the
+        // live edge case the fail-safe was added for. modeIds:[9] passes the
+        // integer passthrough; with no picker options, validation must fall back to
+        // location.modes IDs (1/2/3), which lack 9, and fail loud rather than skip.
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: [:]],
+            [name: "hasAll", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def modesXWritten = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[modesX-")) modesXWritten << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", modeIds: [9]]]])
+
+        then: "with no picker options exposed, the location.modes fallback rejects the unknown ID"
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("9")
+        ex.message.contains("not offered")
+
+        and: "the message names the location.modes fallback as the source and lists its IDs -- distinguishes the fallback from a bare empty-picker reject, so dropping the fallback is caught here too"
+        ex.message.contains("hub modes")
+        ex.message.contains("1, 2, 3")
+
+        and: "no mode-picker write was issued for the rejected event"
+        modesXWritten.isEmpty()
+    }
+
+    def "waitEvents Mode event with empty picker options still writes a VALID location.modes ID (no false-reject)"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        // Same empty-picker edge case, but modeIds:[3] IS a real hub mode. The
+        // fallback must ACCEPT it and write the picker -- the empty-options path
+        // must not false-reject a legitimate ID.
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: [:]],
+            [name: "hasAll", type: "button"],
+            [name: "anotherWait", type: "button"],
+            [name: "doneWaits", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def modesXWritten = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[modesX-")) modesXWritten << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", modeIds: [3]]]])
+
+        then: "id 3 is a real hub mode, so the empty-picker fallback accepts it and writes modesX-1"
+        modesXWritten.any { it.value == '["3"]' }
+    }
+
+    def "waitEvents with two Mode events writes each to its own dash-indexed picker and advances the loop"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        // Both Mode rows present statically: event 1 uses modesX-1, event 2 uses
+        // modesX-2. Neither may touch tstate. The loop must advance (one anotherWait
+        // between two hasAll commits) so event 2 is not dropped.
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "tCapab-2", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-2", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"],
+            [name: "anotherWait", type: "button"],
+            [name: "doneWaits", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def writes = []
+        def clicks = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/btn") clicks << body?.name?.toString()
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[")) writes << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [
+            [capability: "Mode", state: "Home"],
+            [capability: "Mode", state: "Night"]
+        ]])
+
+        then: "event 1 (Mode) wrote modesX-1=[1] and event 2 (Mode) wrote modesX-2=[3]"
+        writes.any { it.key == "settings[modesX-1]" && it.value == '["1"]' }
+        writes.any { it.key == "settings[modesX-2]" && it.value == '["3"]' }
+
+        and: "neither Mode event wrote tstate"
+        !writes.any { it.key.startsWith("settings[tstate-") }
+
+        and: "the loop advanced across both events (one anotherWait between two hasAll commits)"
+        clicks.count { it == "anotherWait" } == 1
+        clicks.count { it == "hasAll" } == 2
+    }
+
+    def "waitEvents with a Mode event FIRST then a device event writes the picker then tstate (order-independent)"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        // Mode event is event 1 (modesX-1), device event is event 2 (tDev-2/
+        // tstate-2). Reverses the existing device-first ordering to prove the Mode
+        // branch is index-driven, not position-driven.
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "tCapab-2", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "tDev-2", type: "enum", multiple: true, options: ["8": "M1"]],
+            [name: "tstate-2", type: "enum", options: ["active": "active", "inactive": "inactive"]],
+            [name: "hasAll", type: "button"],
+            [name: "anotherWait", type: "button"],
+            [name: "doneWaits", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        hubGet.register('/device/fullJson/8') { params -> '{"id":"8","name":"M1"}' }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def writes = []
+        def clicks = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/btn") clicks << body?.name?.toString()
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[")) writes << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [
+            [capability: "Mode", state: "Night"],
+            [capability: "Motion", deviceIds: [8], state: "active"]
+        ]])
+
+        then: "event 1 (Mode) wrote modesX-1 -- never tstate-1"
+        writes.any { it.key == "settings[modesX-1]" && it.value == '["3"]' }
+        !writes.any { it.key == "settings[tstate-1]" }
+
+        and: "event 2 (device) wrote tstate-2 and did NOT enter the Mode branch"
+        writes.any { it.key == "settings[tstate-2]" && it.value == "active" }
+        !writes.any { it.key.startsWith("settings[modesX-") && it.key.endsWith("-2]") }
+
+        and: "the loop advanced across both events"
+        clicks.count { it == "anotherWait" } == 1
+        clicks.count { it == "hasAll" } == 2
     }
 
     // ---------- Pattern 1 (mirror): settingsLanded in _rmWriteSubPageField ----------
@@ -24601,6 +24945,174 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
 
         and: "state_1 was NOT written for Mode-by-modeIds (picker write, not state_N) -- parity with doActPage sibling"
         !writtenFields.containsKey("state_1")
+    }
+
+    def "addRequiredExpression Mode condition with an integer modeId the picker does not offer fails loud"() {
+        // Parity with the waitEvents/trigger Mode paths: a directly-passed integer
+        // ID skips name resolution, so it must be cross-checked against the revealed
+        // picker before modes1 commits a mode-less Broken Condition. The picker
+        // offers 1/3; id 9 is not among them. Both-ways pending (orchestrator).
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Day"], [id: "3", name: "Night"]]
+        def rCapabWritten = false
+        def writtenFields = [:]
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/update/json" && body["_action_previous"] != "Done") {
+                body.each { k, v ->
+                    def key = _settingKeyOf(k)
+                    if (key != null) {
+                        writtenFields[key] = v
+                        if (key == "rCapab_1") rCapabWritten = true
+                    }
+                }
+            }
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params ->
+            ruleConfigJson(100, "r", [[name: "useST", type: "bool"]])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params ->
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "mainPage", title: "Edit Rule", install: true, error: null,
+                             sections: [[title: "", input: [[name: "useST", type: "bool"]],
+                                         body: [[element: "paragraph", description: "IF Mode is 9"]]]]],
+                settings: [useST: "true"], childApps: []
+            ])
+        }
+        def stFetchSeq = 0
+        hubGet.register('/installedapp/configure/json/100/STPage') { params ->
+            stFetchSeq++
+            def inputs = [
+                [name: "cond", type: "enum", options: ["a": "New condition"]],
+                [name: "rCapab_1", type: "enum", options: ["Mode", "Switch"]],
+                [name: "hasAll", type: "button"],
+                [name: "doneST", type: "button"]
+            ]
+            if (rCapabWritten) {
+                // Picker offers ids 1/3 only -- id 9 must be rejected.
+                inputs = inputs + [[name: "modes1", type: "enum", options: ["1": "Day", "3": "Night"]]]
+            }
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "STPage", title: "Required Expression", install: false, error: null,
+                             sections: [[title: "", input: inputs, paragraphs: ["seq ${stFetchSeq}".toString()]]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params ->
+            ruleConfigJson(100, "r", [[name: "N", type: "button"]])
+        }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params ->
+            ruleConfigJson(100, "r", [
+                [name: "actType.1", type: "enum", options: ["condActs": "Conditional Actions"]],
+                [name: "actSubType.1", type: "enum", options: ["getIfThen": "IF Expression THEN"]],
+                [name: "actionCancel", type: "button"]
+            ])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+
+        when: "an integer modeId the revealed picker does not offer is passed"
+        def result = script.toolSetRule([
+            appId: 100,
+            addRequiredExpression: [conditions: [[capability: "Mode", modeIds: [9]]]],
+            confirm: true
+        ])
+
+        then: "fail-loud surfaces as success:false, naming the bad ID, the picker source, and the valid IDs"
+        // Reaches modes1 (picker revealed with options), so the source is the mode
+        // picker -- distinct from the trigger path's location.modes fallback.
+        result.success == false
+        result.error?.toString()?.contains("9")
+        result.error?.toString()?.contains("not offered")
+        result.error?.toString()?.contains("the mode picker")
+        result.error?.toString()?.contains("1, 3")
+
+        and: "no modes1 write was issued for the rejected condition (no silent mode-less commit)"
+        !writtenFields.containsKey("modes1")
+    }
+
+    def "addRequiredExpression Mode condition with a valid integer modeId still writes the picker (anti-regression companion)"() {
+        // Must-NOT-catch pair for the reject spec above: modeIds:[3] IS offered by
+        // the revealed picker, so the cross-check must ACCEPT it and write modes1 --
+        // never false-reject a legitimate directly-passed ID. Both-ways pending (orchestrator).
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Day"], [id: "3", name: "Night"]]
+        def rCapabWritten = false
+        def writtenFields = [:]
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/update/json" && body["_action_previous"] != "Done") {
+                body.each { k, v ->
+                    def key = _settingKeyOf(k)
+                    if (key != null) {
+                        writtenFields[key] = v
+                        if (key == "rCapab_1") rCapabWritten = true
+                    }
+                }
+            }
+            [status: 200, location: null, data: '']
+        }
+        hubGet.register('/installedapp/configure/json/100') { params ->
+            ruleConfigJson(100, "r", [[name: "useST", type: "bool"]])
+        }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params ->
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "mainPage", title: "Edit Rule", install: true, error: null,
+                             sections: [[title: "", input: [[name: "useST", type: "bool"]],
+                                         body: [[element: "paragraph", description: "IF Mode is Night"]]]]],
+                settings: [useST: "true"], childApps: []
+            ])
+        }
+        def stFetchSeq = 0
+        hubGet.register('/installedapp/configure/json/100/STPage') { params ->
+            stFetchSeq++
+            def inputs = [
+                [name: "cond", type: "enum", options: ["a": "New condition"]],
+                [name: "rCapab_1", type: "enum", options: ["Mode", "Switch"]],
+                [name: "hasAll", type: "button"],
+                [name: "doneST", type: "button"]
+            ]
+            if (rCapabWritten) {
+                inputs = inputs + [[name: "modes1", type: "enum", options: ["1": "Day", "3": "Night"]]]
+            }
+            JsonOutput.toJson([
+                app: [id: 100, name: "Rule-5.1", label: "r", trueLabel: "r", installed: true,
+                      appType: [name: "Rule-5.1", namespace: "hubitat"]],
+                configPage: [name: "STPage", title: "Required Expression", install: false, error: null,
+                             sections: [[title: "", input: inputs, paragraphs: ["seq ${stFetchSeq}".toString()]]]],
+                settings: [:], childApps: []
+            ])
+        }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params ->
+            ruleConfigJson(100, "r", [[name: "N", type: "button"]])
+        }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params ->
+            ruleConfigJson(100, "r", [
+                [name: "actType.1", type: "enum", options: ["condActs": "Conditional Actions"]],
+                [name: "actSubType.1", type: "enum", options: ["getIfThen": "IF Expression THEN"]],
+                [name: "actionCancel", type: "button"]
+            ])
+        }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+
+        when: "a valid integer modeId (offered by the picker) is passed"
+        def result = script.toolSetRule([
+            appId: 100,
+            addRequiredExpression: [conditions: [[capability: "Mode", modeIds: [3]]]],
+            confirm: true
+        ])
+
+        then: "success and the valid ID lands on modes1 (exact JSON wire form)"
+        result.success == true
+        writtenFields["modes1"] == '["3"]'
     }
 
     def "addRequiredExpression Mode condition: fail-loud when modes picker not revealed"() {

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -17671,6 +17671,418 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         !modesXWrites.isEmpty()
     }
 
+    // ---------- waitEvents Mode event: mode picker (modesX-N) not tstate-N ----------
+    //
+    // A Mode event inside a waitEvents action does NOT use tstate-<N>. After
+    // tCapab-<N>=Mode is written, RM exposes a dash-indexed mode picker
+    // (modesX-<N> family) keyed by mode ID. The pre-fix code wrote the mode NAME
+    // to tstate-<N>, which RM silently ignores -- the event rendered with no mode
+    // selected (a dangling OR) and effectively dropped. The fix resolves the mode
+    // name(s)/ID(s) via _rmResolveModeIds and writes the DISCOVERED picker field,
+    // never tstate-<N>, and skips tDev-<N> (Mode is hub-state, not device-based).
+    //
+    // These specs assert the WIRE writes (which field, which value). The mock
+    // supplies the field name 'modesX-<N>'; only the live e2e can confirm the
+    // real firmware field name and that the committed rule renders both events
+    // without a dangling OR. The invariant under test: a Mode event inside a
+    // waitEvents action must write the mode picker, never tstate -- a wire-format
+    // contract the mock cannot self-prove against real firmware.
+
+    def "waitEvents Mode event writes the discovered mode picker (modesX-N) with resolved IDs, never tstate-N"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        // Static doActPage schema: every field the waitEvents Mode path touches is
+        // present on every fetch, so each schema-gated write issues its POST. The
+        // mode picker uses the dash-indexed modesX-1 (the waitEvents row's dash
+        // convention applied to the trigger's modesX<N> family).
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "tDev-1", type: "enum", multiple: true, options: [:]],
+            [name: "tstate-1", type: "enum", options: ["active": "active"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"],
+            [name: "anotherWait", type: "button"],
+            [name: "doneWaits", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def modesXWritten = []
+        def tstateWritten = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[modesX-")) modesXWritten << [key: ks, value: v?.toString()]
+                if (ks?.startsWith("settings[tstate-")) tstateWritten << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", state: "Night"]]])
+
+        then: "the resolved mode ID list landed on modesX-1 (exact JSON wire form)"
+        // Exact-equality wire-value check: production writes the multi-enum as a
+        // JSON list ['3']. A loose .contains('3') would also match '30'/'13'.
+        modesXWritten.any { it.value == '["3"]' }
+
+        and: "tstate-1 was NEVER written for the Mode event -- writing tstate for a Mode event silently drops it"
+        tstateWritten.isEmpty()
+    }
+
+    def "waitEvents with a device event AND a Mode event writes BOTH -- second event is not dropped"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        // Both event rows present statically: event 1 (device: Motion) uses
+        // tDev-1/tstate-1; event 2 (Mode) uses modesX-2. If the Mode event were
+        // dropped (old behaviour: tstate-2=<name>, silently ignored), modesX-2
+        // would never be written -- that is the dangling-OR regression.
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "tDev-1", type: "enum", multiple: true, options: ["8": "M1"]],
+            [name: "tstate-1", type: "enum", options: ["active": "active", "inactive": "inactive"]],
+            [name: "tCapab-2", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "tDev-2", type: "enum", multiple: true, options: [:]],
+            [name: "tstate-2", type: "enum", options: ["active": "active"]],
+            [name: "modesX-2", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"],
+            [name: "anotherWait", type: "button"],
+            [name: "doneWaits", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        hubGet.register('/device/fullJson/8') { params -> '{"id":"8","name":"M1"}' }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def writes = []
+        def clicks = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            if (path == "/installedapp/btn") clicks << body?.name?.toString()
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[")) writes << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [
+            [capability: "Motion", deviceIds: [8], state: "active"],
+            [capability: "Mode", state: "Night"]
+        ]])
+
+        then: "event 1 (device) wrote its state to tstate-1"
+        writes.any { it.key == "settings[tstate-1]" && it.value == "active" }
+
+        and: "event 1 (device) did NOT enter the Mode branch (no modesX for event 1)"
+        !writes.any { it.key.startsWith("settings[modesX-") && it.key.endsWith("-1]") }
+
+        and: "event 2 (Mode) wrote the mode ID list to modesX-2 -- NOT tstate-2"
+        writes.any { it.key == "settings[modesX-2]" && it.value == '["3"]' }
+        !writes.any { it.key == "settings[tstate-2]" }
+
+        and: "the loop advanced across both events (one anotherWait between two hasAll commits)"
+        clicks.count { it == "anotherWait" } == 1
+        clicks.count { it == "hasAll" } == 2
+    }
+
+    def "waitEvents Mode event with an unknown mode name throws listing valid modes"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", state: "NotAMode"]]])
+
+        then: "the resolution error names the bad mode and lists EVERY valid mode"
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("NotAMode")
+        ex.message.contains("Home")
+        ex.message.contains("Away")
+        ex.message.contains("Night")
+    }
+
+    def "waitEvents Mode event with neither state nor modeIds throws requiring one of them"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        // Same static doActPage schema as the sibling Mode specs so tCapab-1=Mode
+        // writes; the guard fires before any mode picker is touched, so the Mode
+        // event carrying NEITHER state nor modeIds must be rejected up front.
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode"]]])
+
+        then: "a Mode event lacking both state and modeIds is rejected before any write"
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("Mode event requires a non-empty")
+    }
+
+    def "waitEvents Mode event with an empty state collection is rejected up front"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", state: []]]])
+
+        then: "an empty mode collection resolves to no IDs and is rejected as non-empty-required"
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("Mode event requires a non-empty")
+    }
+
+    def "waitEvents Mode event with deviceIds is rejected -- Mode is hub-state, not device-based"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 -> [status: 200, location: null, data: ''] }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", state: "Night", deviceIds: [8]]]])
+
+        then: "a Mode event carrying deviceIds is rejected rather than silently ignored"
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("hub-state, not device-based")
+    }
+
+    def "waitEvents Mode event with modeIds writes the resolved IDs to the picker, never tstate"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def modesXWritten = []
+        def tstateWritten = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[modesX-")) modesXWritten << [key: ks, value: v?.toString()]
+                if (ks?.startsWith("settings[tstate-")) tstateWritten << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", modeIds: [3]]]])
+
+        then: "the modeIds input landed on modesX-1 (exact JSON wire form), no name resolution needed"
+        modesXWritten.any { it.value == '["3"]' }
+
+        and: "tstate-1 was never written for the Mode event"
+        tstateWritten.isEmpty()
+    }
+
+    def "waitEvents Mode event with a multi-ID modeIds list writes every ID to the picker"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "3", name: "Night"], [id: "5", name: "Vacation"]]
+
+        // Picker offers ids 1/3/5 so the [3,5] list validates against the live
+        // options; the wire value must carry BOTH ids in insertion order.
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "3": "Night", "5": "Vacation"]],
+            [name: "hasAll", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def modesXWritten = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[modesX-")) modesXWritten << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", modeIds: [3, 5]]]])
+
+        then: "both IDs landed on modesX-1 in insertion order (exact JSON wire form)"
+        modesXWritten.any { it.value == '["3","5"]' }
+    }
+
+    def "waitEvents Mode event fails loud when the mode picker never appears -- no silent tstate fallback"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        // doActPage schema with tCapab-1=Mode present but NO modes*-1 picker field
+        // -- the firmware-field-rename signature the discovery guard exists to
+        // catch. tstate-1 IS present, so a (wrong) fallback write into it would be
+        // observable on the wire; the guard must throw instead.
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "tstate-1", type: "enum", options: ["Home": "Home", "Away": "Away", "Night": "Night"]],
+            [name: "hasAll", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def tstateWritten = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[tstate-")) tstateWritten << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", state: "Night"]]])
+
+        then: "the missing picker fails loud rather than falling back to a tstate write"
+        def ex = thrown(IllegalStateException)
+        ex.message.contains("did not appear")
+
+        and: "the mode name was NEVER written to tstate-1 (no silent fallback drop)"
+        !tstateWritten.any { it.value == "Night" }
+    }
+
+    def "waitEvents Mode event fails loud when a resolved mode ID is not offered by the picker"() {
+        given:
+        enableWrite()
+        sharedLocation.modes = [[id: "1", name: "Home"], [id: "2", name: "Away"], [id: "3", name: "Night"]]
+
+        // Picker offers ids 1/2/3 only. modeIds:[9] passes _rmResolveModeIds
+        // (integer passthrough) but is NOT in the live picker options, so the
+        // options cross-check must reject it before the row commits -- otherwise
+        // the write is silently skipped and the Mode row dangles with no mode.
+        def doActInputs = [
+            [name: "actType.1", type: "enum", options: ["delayActs": "Delay, Wait, Exit or Comment"]],
+            [name: "actSubType.1", type: "enum", options: ["getWaitEvents": "Wait for Events"]],
+            [name: "tCapab-1", type: "enum", options: ["Mode", "Switch", "Motion"]],
+            [name: "modesX-1", type: "enum", multiple: true, options: ["1": "Home", "2": "Away", "3": "Night"]],
+            [name: "hasAll", type: "button"]
+        ]
+        hubGet.register('/installedapp/configure/json/100') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/configure/json/100/selectActions') { params -> ruleConfigJson(100, "r", [[name: "N", type: "button"]]) }
+        hubGet.register('/installedapp/configure/json/100/doActPage') { params -> ruleConfigJson(100, "r", doActInputs) }
+        hubGet.register('/installedapp/configure/json/100/mainPage') { params -> ruleConfigJson(100, "r", []) }
+        hubGet.register('/installedapp/statusJson/100') { params -> statusJson(100) }
+        script.metaClass.uploadHubFile = { String fn, byte[] b -> }
+
+        def modesXWritten = []
+        script.metaClass.hubInternalPostForm = { String path, Map body, Integer t = 420 ->
+            body?.each { k, v ->
+                def ks = k?.toString()
+                if (ks?.startsWith("settings[modesX-")) modesXWritten << [key: ks, value: v?.toString()]
+            }
+            [status: 200, location: null, data: '']
+        }
+
+        when:
+        script._rmAddAction(100, [capability: "waitEvents", events: [[capability: "Mode", modeIds: [9]]]])
+
+        then: "the invalid ID fails loud, naming it and the valid picker IDs"
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("9")
+        ex.message.contains("not offered")
+
+        and: "no mode-picker write was issued for the rejected event (no silent applied+partial commit)"
+        modesXWritten.isEmpty()
+    }
+
     // ---------- Pattern 1 (mirror): settingsLanded in _rmWriteSubPageField ----------
     //
     // The same wizard-consumed-field false-positive that was fixed in

--- a/tests/BAT-rm-native-crud.md
+++ b/tests/BAT-rm-native-crud.md
@@ -1282,6 +1282,18 @@ Each section below lives in its own `## Section N` heading. Sections are appende
 
 **Expected**: Action 1 (single waitEvents with `events: [{capability: 'Contact', deviceIds: [<WC1>], state: 'open'}, {capability: 'Contact', deviceIds: [<WC2>], state: 'open'}]`) commits cleanly. [INV-1] `configPage.error == null`. [INV-3] **CRITICAL**: contact-sensor inputs preserve `multiple == true` flags (Wait-for-Events multi-device slots are a flag-poisoning vector on the action side, same bug class as tDev triggers). The second `addAction(waitEvents=...)` call returns `success: false` with `error` containing `"RM 5.1 platform limitation: only one Wait for Events action is supported per rule"` — verifying the fail-loud guard. **Why one action, not multiple**: RM 5.1 has no per-action storage for Wait for Events configuration; every waitEvents action shares global per-rule scratch settings (`tCapab-N`/`tDev-N`/`tstate-N`). Adding a second waitEvents action causes its wizard to inherit action 1's events as defaults, and any field change silently overwrites action 1's events. The Hubitat web UI exhibits the same bug — verified live 2026-05-04 via Chrome XHR capture. Until Hubitat fixes this at the platform level, the MCP tool refuses the second addition rather than corrupt the rule. **Variants NOT covered here** (timeout, And-Stays duration, Elapsed Time only, "All of these" semantics): each requires its own rule (one waitEvents action per rule, by RM 5.1 design), so cover them as separate scenarios T412a/T412b/etc. when needed.
 
+### T412b — Wait for Events: mixed device + Mode event array (mode picker, never tstate)
+
+```json
+{
+  "setup_prompt": "Create a virtual switch BAT-RM-WSw. Note an existing hub mode name (e.g. 'Night') from hub_list_modes.",
+  "test_prompt": "Create rule 'BAT-RM-WaitEventsMode' triggered by BAT-RM-WSw turning on. Action 1: Wait for Events with two events in one array — (a) BAT-RM-WSw turns off (device event), (b) the hub Mode becomes 'Night' (Mode event, any-of semantics). Read back and verify BOTH events are bound: the device event and the Mode event.",
+  "teardown_prompt": "Force-delete 'BAT-RM-WaitEventsMode'. Remove BAT-RM-WSw."
+}
+```
+
+**Expected**: Action 1 commits cleanly with `events: [{capability: 'Switch', deviceIds: [<WSw>], state: 'off'}, {capability: 'Mode', state: 'Night'}]`. [INV-1] `configPage.error == null`. The Mode event writes the discovered mode-picker field (`modesX-<N>` family, keyed by mode ID) carrying the resolved mode ID — NOT `tstate-<N>` (writing the mode name to `tstate` is silently ignored by RM and drops the event with a dangling OR). No `tstate` field holds the mode name. Both events render without a dangling OR / Broken marker. `modeIds:[...]` is accepted as an alternative to `state` (IDs from `hub_list_modes`). An unknown mode name, or a mode ID the live picker does not offer, fails loud before the row commits.
+
 ### T413 — Wait for Expression: basic, timeout, Use Duration
 
 ```json

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3825,6 +3825,82 @@ class TestRunner:
             self._delete_native(app_id)
 
     @test("native_apps")
+    def test_set_rule_wait_events_mode_event(self) -> None:
+        # Wire-format invariant: a Mode event inside a waitEvents action must write
+        # RM's mode picker (modesX-<N> family, keyed by mode ID), NOT tstate-<N> (mode
+        # name). Writing the mode NAME to tstate-<N> is silently
+        # ignored, leaving the wait event with no mode selected -- a dangling OR that
+        # drops the event. Spock proves the routing against a mocked schema; only this
+        # live run confirms the REAL firmware mode-picker field name and that both events
+        # commit without a dangling OR.
+        sw = int(self.get_test_switch_id())
+        modes = self.client.call_tool("hub_list_modes").get("modes") or []
+        assert modes, "hub_list_modes returned no modes -- cannot exercise a Mode wait event"
+        mode = modes[0]
+        mode_name = mode.get("name")
+        mode_id = str(mode.get("id"))
+        assert mode_name and mode_id, f"first mode missing name/id: {mode}"
+
+        app_id = self._create_native_rule("WaitEventsMode")
+        try:
+            # Two events: a device event (Switch) THEN a Mode event. The device event
+            # exercises the unchanged tstate-<N> path; the Mode event exercises the fix.
+            res = self._rm_call_soft({
+                "appId": app_id,
+                "addAction": {"capability": "waitEvents", "events": [
+                    {"capability": "Switch", "deviceIds": [sw], "state": "on"},
+                    {"capability": "Mode", "state": mode_name},
+                ]},
+                "confirm": True,
+            }, strict=True)
+            assert res.get("success") is not False, f"addAction waitEvents reported failure: {res}"
+            # A dropped Mode event would flag the write partial (mode field skipped) -- the
+            # fix writes the discovered mode picker so the action commits cleanly.
+            assert not res.get("partial"), f"waitEvents action falsely flagged partial: {res}"
+
+            # Read the committed settings back: the mode-picker field (modesX-<N> family,
+            # discovered live) carries the mode ID, and NO tstate field holds the mode
+            # NAME (the old-bug signature / dangling OR).
+            cfg = self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_app_config", "args": {"appId": app_id, "includeSettings": True}})
+            settings = cfg.get("settings") or {}
+            mode_setting_keys = [k for k in settings if k.startswith("modes") and "-" in k]
+            assert mode_setting_keys, \
+                f"no mode-picker setting persisted for the Mode wait event (mode written to tstate instead of the picker drops the event): {sorted(settings)}"
+
+            # Exact per-value match, not a substring of a joined string: a loose
+            # `mode_id in " ".join(...)` would let id "1" pass on a picker holding
+            # "11"/"12". Normalize each modes*-<N> value (a JSON-list like ["3"] or a
+            # bare scalar) to a list of string ids and require an exact element match.
+            def _mode_id_values(raw: Any) -> list[str]:
+                if isinstance(raw, list):
+                    return [str(x) for x in raw]
+                s = str(raw).strip()
+                if s.startswith("["):
+                    try:
+                        parsed = json.loads(s)
+                    except (ValueError, TypeError):
+                        parsed = None
+                    if isinstance(parsed, list):
+                        return [str(x) for x in parsed]
+                return [s]
+
+            mode_id_carried = any(
+                mode_id in _mode_id_values(settings[k]) for k in mode_setting_keys)
+            assert mode_id_carried, \
+                f"no mode-picker setting exactly carries the selected mode id {mode_id}: " \
+                f"{ {k: settings[k] for k in mode_setting_keys} }"
+            tstate_holds_mode_name = [k for k in settings
+                                      if k.startswith("tstate-") and str(settings[k]) == mode_name]
+            assert not tstate_holds_mode_name, \
+                f"mode name leaked into a tstate field (a Mode event must write the mode picker, never tstate): {tstate_holds_mode_name}"
+
+            # Both events committed with no dangling OR / broken marker.
+            self._assert_rule_healthy(app_id)
+        finally:
+            self._delete_native(app_id)
+
+    @test("native_apps")
     def test_set_rule_remove_referenced_local_breaks_rule(self) -> None:
         # removeLocalVariable broken-after-delete contract: RM does NOT refuse to delete a
         # local that an action still references -- it DELETES the local and leaves the


### PR DESCRIPTION
## Summary

- A `Mode`-becomes event inside a `waitEvents` action was silently dropped: the
  per-event builder wrote the mode name to `tstate-<N>`, which Rule Machine ignores,
  so the event committed with no mode selected (a dangling `OR`).
- The waitEvents Mode event now resolves mode name(s)/id(s) to mode IDs and writes
  them to the wizard's mode-picker field — discovered from the post-`tCapab` schema,
  fail-loud if it never appears — matching how the trigger and condition Mode paths work.
- Part of the RM-recreation-sweep findings in #333 (finding F5).

## Type of change

- [ ] `feat`
- [x] `fix`
- [ ] `chore`
- [ ] `refactor`
- [ ] `docs`
- [ ] `test`
- [ ] `ci`

## Changes

- `_rmAddAction` waitEvents event loop (`libraries/mcp-native-rules-lib.groovy`):
  - Mode events route to the discovered mode-picker field (`modesX-<N>` family) instead
    of `tstate-<N>`; mode name(s)/id(s) resolved via the shared `_rmResolveModeIds`.
  - The mode name(s)/id(s) are resolved and validated up front: an invalid or absent mode,
    or a `deviceIds` on a Mode event, fails loud **before** the `tCapab` write. The two
    schema-dependent guards (picker-missing, unoffered-ID) necessarily run **after** the
    `tCapab-<N>=Mode` post since they need the revealed picker — both stay fail-loud with a
    backup available.
  - Each resolved ID is **cross-checked against the picker's offered options** — or the hub's
    `location.modes` IDs when the picker reveals no options — so an ID no real mode carries
    fails loud instead of committing a Mode row with no mode selected.
  - Fail-loud if the picker field never appears (firmware rename) or an ID isn't offered;
    `tstate`/`tDev` skipped for Mode; `deviceIds` on a Mode event rejected.
- **Sibling Mode paths (self-review):** the trigger and condition Mode paths wrote integer
  `modeIds` unvalidated — the same dangling-row gap. Added a shared `_rmBadModeIds` helper
  and validation on both (before the picker write; the condition path cancels the in-flight
  wizard before throwing), with reject + valid-still-writes specs for each.
- Tests: Spock specs covering picker routing, both-events-not-dropped, `modeIds` (single +
  multi), unknown-mode / neither-field / empty-collection, the picker-missing fail-loud, and
  the unoffered-ID guard; a live e2e scenario; and a `BAT-v2` T412b scenario.
- Docs: the `hub_set_rule` guide, discover-schema, `TOOL_GUIDE.md`, and
  `docs/rm_action_subtype_schemas.md` updated with the Mode-event shape.

## Release Notes

- Fixed: a `Mode` event inside a `Wait for Events` action is no longer silently dropped —
  `hub_set_rule` now writes the mode into RM's mode picker instead of the ignored state
  field, so the wait fires on the mode change as intended.

## Testing

- Spock: new specs in `ToolRmNativeCrudSpec`; full `./gradlew test` green (4866).
- Both-ways: each new fail-loud guard reverted individually turns exactly its pinning
  spec(s) red; restored, all pass.
- `python tests/sandbox_lint.py`: 0 errors.
- e2e: `test_set_rule_wait_events_mode_event` (native_apps) — the live proof of the
  discovered mode-picker field name.

## Checklist

- [x] Unit tests added — Spock specs for every guard path
- [x] e2e / regression tests added — Spock + a live e2e scenario
- [x] Sandbox lint passes
- [x] `./gradlew test` passes locally
- [x] Live-hub BAT tests — added T412b
- [x] Documentation — guide / discover-schema / TOOL_GUIDE / rm_action_subtype_schemas updated
- [ ] New/renamed MCP tools follow AGENTS.md — n/a (no new tools)

