### PR TITLE
docs: note the follow-up-label recovery for a release cut without its tag

### DIFF
--- a/docs/release-automation-design.md
+++ b/docs/release-automation-design.md
@@ -95,6 +95,8 @@ If a contributor wants richer prose than their PR title, they add a `## Release 
 
 The release label is NOT required to merge. Unlabeled PRs merge normally — they just don't trigger a version bump. The next labeled PR merge produces a release whose notes include all PRs merged since the previous `vX.Y.Z` tag (labeled and unlabeled alike).
 
+If a release-worthy change merges unlabeled and you want it shipped as its own version, open a small follow-up PR carrying the intended `release:*` label — its merge cuts the tag and the release notes still cover the earlier unlabeled PR (everything since the last tag), so nothing is lost.
+
 Flow:
 - **Labeled PR merge** → bot gathers all PRs merged since last tag, writes CHANGELOG entry, propagates to manifest + README, bumps versions, tags.
 - **Unlabeled PR merge** → code lands on main, no version bump; PR is picked up in the next labeled release's notes.


### PR DESCRIPTION
## Summary

- Document the recovery path when a release-worthy PR merges without a `release:*` label (no version bump or tag fires on its own): open a small follow-up PR carrying the intended `release:*` label.
- This PR is itself that follow-up for #344, which merged unlabeled — so merging it cuts the tag that #344 should have produced.

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

- `docs/release-automation-design.md`: add a note under "No release label requirement" describing the follow-up-label recovery — the follow-up's merge cuts the tag and the release notes still cover the earlier unlabeled PR (everything since the last tag), so nothing is lost.
- Part of #344.

## Release Notes

<!-- intentionally blank — documentation-only, no user-facing HPM note -->

## Testing

- Documentation-only change; no code paths touched. No hub-relevant files changed, so the e2e gate posts green without running; `guard` (no bookkeeping files touched) and `unit-tests` pass.

## Checklist

- [ ] **Unit tests added** — n/a (documentation only)
- [ ] **e2e tests added** — n/a (documentation only)
- [ ] Sandbox lint passes — n/a (no Groovy changed)
- [ ] `./gradlew test` passes locally (or CI confirms) — n/a (no code changed)
- [ ] Live-hub BAT tests updated — n/a (no tool behaviour change)
- [x] Documentation updated if user-facing behaviour or tool surface changed
- [ ] New/renamed MCP tools follow `AGENTS.md` — n/a (no tools)
