### PR TITLE
ci: honor manual re-runs in lane-gate (attempt > 1 overrides the frozen no-op decision)

### DIFF
--- a/.github/scripts/lane_gate.js
+++ b/.github/scripts/lane_gate.js
@@ -18,14 +18,15 @@
 // the same frozen payload. A human clicking "Re-run all jobs" is an explicit request for a run,
 // not a label webhook; honor it (GITHUB_RUN_ATTEMPT > 1 -> run; the gate step still picks the lane
 // from the LIVE label list). This needs "Re-run all jobs" -- re-running only the skipped e2e job
-// keeps the prior lane-gate outputs and still skips. Concurrency stays safe: a no-op label run's
-// group was isolated-<run_id> at trigger time and a re-run keeps its run_id, so it can never
+// keeps the prior lane-gate outputs and still skips. Concurrency stays safe: hub-e2e.yml routes
+// EVERY re-run (github.run_attempt > 1) to the isolated per-run group, so a re-run can never
 // cancel or evict another run, and the e2e job still queues FIFO in hub-e2e-serialized.
 //
 // This MUST stay in lockstep with the concurrency GROUP expression in hub-e2e.yml: its "shares the
 // per-branch group" test keys on the same first-full-label set and must remain a strict SUBSET of
 // this decision (so a shared run never cancels a run that then skips) -- the re-run override only
-// WIDENS the decision, so the subset invariant holds. cancel-in-progress is `true`.
+// WIDENS the decision, and the group expression's attempt==1 guard only SHRINKS the shared set,
+// so the subset invariant holds. cancel-in-progress is `true`.
 const FULL = ['release:patch', 'release:minor', 'release:major', 'e2e:full'];
 
 function decide(eventName, payload, runAttempt) {

--- a/.github/scripts/lane_gate.js
+++ b/.github/scripts/lane_gate.js
@@ -1,6 +1,6 @@
 'use strict';
-// Lane-gate decision: should this event re-run e2e? A pure function of (eventName, event payload),
-// called by the `lane-gate` job in .github/workflows/hub-e2e.yml and unit-tested by
+// Lane-gate decision: should this event re-run e2e? A pure function of (eventName, event payload,
+// run attempt), called by the `lane-gate` job in .github/workflows/hub-e2e.yml and unit-tested by
 // tests/lane_gate_test.js. A wrong decision either LOSES a full run (the required "Full e2e (runs
 // with label)" gate never re-posts, blocking merge) or RE-RUNS when it shouldn't and double-books
 // the single shared test hub -- so it gets a regression guard like the other .github/scripts logic.
@@ -11,13 +11,28 @@
 // for `unlabeled`) so the decision doesn't depend on whether the webhook's pull_request.labels
 // already reflects this event.
 //
+// MANUAL RE-RUN OVERRIDE (attempt > 1): the no-op decision above is a pure function of the event
+// payload, which is FROZEN at trigger time -- so re-running a skipped no-op label run re-derives
+// skip, forever. That is a trap: the PR checks tab shows the NEWEST check run per name, so after a
+// redundant-label event the visible "e2e (run)" is the skipped one, and its Re-run button re-fires
+// the same frozen payload. A human clicking "Re-run all jobs" is an explicit request for a run,
+// not a label webhook; honor it (GITHUB_RUN_ATTEMPT > 1 -> run; the gate step still picks the lane
+// from the LIVE label list). This needs "Re-run all jobs" -- re-running only the skipped e2e job
+// keeps the prior lane-gate outputs and still skips. Concurrency stays safe: a no-op label run's
+// group was isolated-<run_id> at trigger time and a re-run keeps its run_id, so it can never
+// cancel or evict another run, and the e2e job still queues FIFO in hub-e2e-serialized.
+//
 // This MUST stay in lockstep with the concurrency GROUP expression in hub-e2e.yml: its "shares the
 // per-branch group" test keys on the same first-full-label set and must remain a strict SUBSET of
-// this decision (so a shared run never cancels a run that then skips). cancel-in-progress is `true`.
+// this decision (so a shared run never cancels a run that then skips) -- the re-run override only
+// WIDENS the decision, so the subset invariant holds. cancel-in-progress is `true`.
 const FULL = ['release:patch', 'release:minor', 'release:major', 'e2e:full'];
 
-function decide(eventName, payload) {
+function decide(eventName, payload, runAttempt) {
   payload = payload || {};
+  // Manual re-run override: attempt > 1 means a human clicked "Re-run all jobs" on this run -- an
+  // explicit ask for e2e that the frozen event payload could otherwise never grant (see header).
+  if (Number(runAttempt) > 1) return true;
   const action = payload.action;
   // Non-label events (opened/synchronize/reopened/dispatch) always run.
   if (eventName !== 'pull_request_target' || (action !== 'labeled' && action !== 'unlabeled')) {
@@ -39,7 +54,8 @@ module.exports = { decide, FULL };
 if (require.main === module) {
   const fs = require('fs');
   const payload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
-  const run = decide(process.env.GITHUB_EVENT_NAME, payload) ? 'true' : 'false';
-  console.log(`lane-gate: event=${process.env.GITHUB_EVENT_NAME} action=${payload.action} label=${payload.label && payload.label.name} -> run=${run}`);
+  const attempt = Number(process.env.GITHUB_RUN_ATTEMPT || '1');
+  const run = decide(process.env.GITHUB_EVENT_NAME, payload, attempt) ? 'true' : 'false';
+  console.log(`lane-gate: event=${process.env.GITHUB_EVENT_NAME} action=${payload.action} label=${payload.label && payload.label.name} attempt=${attempt} -> run=${run}`);
   fs.appendFileSync(process.env.GITHUB_OUTPUT, `run=${run}\n`);
 }

--- a/.github/scripts/lane_gate.js
+++ b/.github/scripts/lane_gate.js
@@ -30,8 +30,9 @@ const FULL = ['release:patch', 'release:minor', 'release:major', 'e2e:full'];
 
 function decide(eventName, payload, runAttempt) {
   payload = payload || {};
-  // Manual re-run override: attempt > 1 means a human clicked "Re-run all jobs" on this run -- an
-  // explicit ask for e2e that the frozen event payload could otherwise never grant (see header).
+  // Manual re-run override: attempt > 1 means this run was manually re-run (EVERY re-run type
+  // increments the counter; any re-run that re-executes this gate is an explicit ask for e2e that
+  // the frozen event payload could otherwise never grant -- see header).
   if (Number(runAttempt) > 1) return true;
   const action = payload.action;
   // Non-label events (opened/synchronize/reopened/dispatch) always run.

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -113,15 +113,24 @@ permissions:
 # last full label re-runs focused in its OWN isolated group (never evicted); it does not cancel the
 # in-flight full run, just queues behind it in the e2e job's hub-e2e-serialized group and posts the
 # pending gate after it.
+# MANUAL RE-RUNS (github.run_attempt > 1) take the ISOLATED group too, for EVERY event type: a
+# re-run replays a FROZEN payload, so an old superseded commit run re-entering the shared per-branch
+# group would cancel the CURRENT head's in-flight run (cancel-in-progress) or evict a pending one
+# (queue:single) -- an obsolete run must never displace a live one. Isolated, the re-run cancels
+# nothing and just queues FIFO in the e2e job's hub-e2e-serialized group; lane-gate honors it via
+# the attempt>1 override in lane_gate.js. The attempt==1 guard only SHRINKS the shared set, so the
+# subset invariant above still holds. If run_attempt were ever stale at re-run time the expression
+# degrades to the old per-event grouping -- never a new hazard.
 concurrency:
   group: >-
-    ${{ (github.event_name != 'pull_request_target'
+    ${{ (github.run_attempt == 1
+    && (github.event_name != 'pull_request_target'
     || (github.event.action != 'labeled' && github.event.action != 'unlabeled')
     || (github.event.action == 'labeled' && (
     (github.event.label.name == 'release:patch' && !contains(github.event.pull_request.labels.*.name, 'release:minor') && !contains(github.event.pull_request.labels.*.name, 'release:major') && !contains(github.event.pull_request.labels.*.name, 'e2e:full'))
     || (github.event.label.name == 'release:minor' && !contains(github.event.pull_request.labels.*.name, 'release:patch') && !contains(github.event.pull_request.labels.*.name, 'release:major') && !contains(github.event.pull_request.labels.*.name, 'e2e:full'))
     || (github.event.label.name == 'release:major' && !contains(github.event.pull_request.labels.*.name, 'release:patch') && !contains(github.event.pull_request.labels.*.name, 'release:minor') && !contains(github.event.pull_request.labels.*.name, 'e2e:full'))
-    || (github.event.label.name == 'e2e:full' && !contains(github.event.pull_request.labels.*.name, 'release:patch') && !contains(github.event.pull_request.labels.*.name, 'release:minor') && !contains(github.event.pull_request.labels.*.name, 'release:major')))))
+    || (github.event.label.name == 'e2e:full' && !contains(github.event.pull_request.labels.*.name, 'release:patch') && !contains(github.event.pull_request.labels.*.name, 'release:minor') && !contains(github.event.pull_request.labels.*.name, 'release:major'))))))
     && format('hub-e2e-{0}-{1}', github.event.pull_request.head.repo.full_name || github.repository, github.head_ref || github.ref_name)
     || format('hub-e2e-{0}-{1}-isolated-{2}', github.event.pull_request.head.repo.full_name || github.repository, github.head_ref || github.ref_name, github.run_id) }}
   cancel-in-progress: true

--- a/tests/lane_gate_test.js
+++ b/tests/lane_gate_test.js
@@ -11,12 +11,12 @@
 'use strict';
 const { decide } = require('../.github/scripts/lane_gate.js');
 
-function run(eventName, action, prLabels, evLabel) {
+function run(eventName, action, prLabels, evLabel, attempt) {
   return decide(eventName, {
     action,
     label: evLabel ? { name: evLabel } : null,
     pull_request: { labels: (prLabels || []).map(n => ({ name: n })) },
-  }) ? 'true' : 'false';
+  }, attempt) ? 'true' : 'false';
 }
 
 let fail = 0;
@@ -40,6 +40,14 @@ check('unlabeled LAST full -> demote',    run('pull_request_target', 'unlabeled'
 check('unlabeled LAST full webhook-incl', run('pull_request_target', 'unlabeled', ['e2e:full'], 'e2e:full'), 'true');
 check('unlabeled one-of-many remains',    run('pull_request_target', 'unlabeled', ['release:patch'], 'e2e:full'), 'false');
 check('unlabeled non-lane (bug)',         run('pull_request_target', 'unlabeled', ['e2e:full'], 'bug'), 'false');
+
+// Manual re-run override (attempt > 1): a human clicking "Re-run all jobs" on a skipped no-op
+// label run is an explicit ask for e2e -- the frozen event payload must not re-derive skip.
+// Both-ways: the attempt-1 rows above pin that the override does NOT leak into first runs.
+check('RERUN attempt=2 redundant 2nd full',  run('pull_request_target', 'labeled', ['e2e:full', 'release:patch'], 'release:patch', 2), 'true');
+check('RERUN attempt=2 non-lane (bug)',      run('pull_request_target', 'labeled', ['e2e:full', 'bug'], 'bug', 2), 'true');
+check('RERUN attempt=3 unlabeled remains',   run('pull_request_target', 'unlabeled', ['release:patch'], 'e2e:full', 3), 'true');
+check('attempt=1 explicit stays no-op',      run('pull_request_target', 'labeled', ['e2e:full', 'release:patch'], 'release:patch', 1), 'false');
 
 console.log(fail === 0 ? '\nlane-gate decision guard: PASS' : `\nlane-gate decision guard: FAIL (${fail})`);
 process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- Re-running a skipped no-op label run could never produce an e2e run: the lane decision is a pure function of the event payload, which is frozen at trigger time, so every re-run re-derived skip.
- The PR checks tab shows the newest check run per name, so after a redundant-label event the visible `e2e (run)` is the skipped run -- its Re-run button was a permanent dead end (observed on #346: attempt 2 of a redundant `release:patch` run skipped again).
- Same frozen-payload trap on the concurrency side: "Re-run all jobs" on an old superseded commit run re-entered the shared per-branch group, cancelling the current head's in-flight run (cancel-in-progress) or evicting a pending one (queue:single).

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `ci` — CI/CD pipeline change

## Changes

- `.github/scripts/lane_gate.js`: `decide()` now takes the run attempt; `GITHUB_RUN_ATTEMPT > 1` returns `run=true` -- a manual "Re-run all jobs" is an explicit ask for e2e, not a label webhook. The gate step still picks the lane (focused/full) from the live label list.
- `.github/workflows/hub-e2e.yml`: the workflow-level concurrency group routes every re-run (`github.run_attempt > 1`) to the isolated per-run group -- an obsolete run's re-run can no longer cancel or evict a live run; it queues FIFO in `hub-e2e-serialized`. The attempt==1 guard only shrinks the shared set, so the subset invariant holds (the lane-gate override only widens the decision).
- The script header documents the trap and the constraint that re-running only the skipped `e2e (run)` job keeps the prior lane-gate outputs and still skips -- "Re-run all jobs" is the working path.
- Concurrency is safe by construction: a no-op label run's group was `isolated-<run_id>` at trigger time and a re-run keeps its run_id, so it can never cancel or evict another run; the e2e job still queues FIFO in `hub-e2e-serialized`. The concurrency-expression subset invariant holds -- the override only widens the decision.
- `tests/lane_gate_test.js`: 4 new cases -- re-runs of a redundant full label, a non-lane label, and a remaining-label demote all run; an explicit attempt=1 stays a no-op.

## Release Notes

## Testing

- `node tests/lane_gate_test.js` -- 18/18 pass (runs in-PR via `lane-gate-test.yml`).
- Workflow-file change validated with the dispatch dance: `probe_only` dispatch on the branch green on attempt 1 (shared-group branch) and on its manual re-run, attempt 2 (isolated re-run branch) -- both branches of the new concurrency expression evaluate live.
- Under `pull_request_target` the lane-gate job executes the base branch's script, so this PR's own e2e run exercises main's old logic; the unit suite is the in-PR proof and the behaviour goes live on merge.

## Checklist

- [x] **Unit tests added for any new MCP tools, regressions, or bug fixes** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes)
- [ ] **e2e tests added for new tools and/or regression tests added for any bug fix** (see `tests/e2e_test.py`) — n/a (CI decision script; no hub surface)
- [ ] Sandbox lint passes: `python tests/sandbox_lint.py` — n/a (no Groovy touched)
- [ ] `./gradlew test` passes locally (or CI confirms) — n/a (no Groovy touched)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`) — n/a
- [ ] Documentation updated if user-facing behaviour or tool surface changed — n/a (behaviour documented in the script header)
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema) — n/a (no tools)

