### PR TITLE
feat: opToken response replay + cloud-relay self-budget for slow writes

### DIFF
--- a/.github/scripts/e2e_scope.py
+++ b/.github/scripts/e2e_scope.py
@@ -24,11 +24,11 @@ TEST_FILE = "tests/e2e_test.py"
 
 # Changed file -> e2e @test group(s) it exercises. Best-effort; refine as the suite evolves.
 FILE_GROUP_MAP = {
-    "libraries/mcp-native-rules-lib.groovy":    ["native_apps"],
+    "libraries/mcp-native-rules-lib.groovy":    ["native_apps", "op_replay"],
     "libraries/mcp-visual-rules-lib.groovy":    ["visual_rules"],
     "libraries/mcp-custom-rules-lib.groovy":    ["rule_crud", "trigger_types", "condition_types", "action_types", "complex_patterns"],
     "hubitat-mcp-rule.groovy":                  ["rule_crud", "trigger_types", "condition_types", "action_types", "complex_patterns"],
-    "libraries/mcp-diagnostics-lib.groovy":     ["diagnostics", "system_tools"],
+    "libraries/mcp-diagnostics-lib.groovy":     ["diagnostics", "system_tools", "op_replay"],
     "libraries/mcp-debug-logging-lib.groovy":   ["developer_mode", "diagnostics"],
     "libraries/mcp-system-lib.groovy":          ["system_tools", "infrastructure"],
     "libraries/mcp-self-admin-lib.groovy":      ["developer_mode", "best_practice_gating"],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hubitat MCP Server
 
-A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 117 MCP tools (36 on `tools/list` via category gateways).
+A native [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that runs directly on your Hubitat Elevation hub. Instead of running a separate Node.js server on another machine, this runs natively on the hub itself — with a built-in rule engine and 118 MCP tools (36 on `tools/list` via category gateways).
 
 > **BETA SOFTWARE**: This project is ~99% AI-generated ("vibe coded") using Claude. It's a work in progress — contributions and [bug reports](https://github.com/kingpanther13/Hubitat-local-MCP-server/issues) are welcome!
 
@@ -24,7 +24,7 @@ This app lets AI assistants like Claude control your Hubitat smart home through 
 
 > "What's the hub's health status?"
 
-Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 117 tools total — 13 core tools are always visible, while the rest are organized behind 23 domain-named gateways to keep the tool list manageable. If your client handles long tool lists well, you can disable the gateways via the **Consolidate tools behind category gateways** setting and every tool is exposed individually instead. (Counts here describe the shipped catalog; the runtime count on `tools/list` varies based on enabled settings.)
+Behind the scenes, the AI uses MCP tools to control devices, create automation rules, manage rooms, query system state, and administer the hub. The server exposes 118 tools total — 13 core tools are always visible, while the rest are organized behind 23 domain-named gateways to keep the tool list manageable. If your client handles long tool lists well, you can disable the gateways via the **Consolidate tools behind category gateways** setting and every tool is exposed individually instead. (Counts here describe the shipped catalog; the runtime count on `tools/list` varies based on enabled settings.)
 
 ## Requirements
 
@@ -267,9 +267,9 @@ For free remote access without a Hubitat Cloud subscription:
 
 ## Features
 
-### MCP Tools (117 total — 36 on tools/list)
+### MCP Tools (118 total — 36 on tools/list)
 
-The server has 117 tools total. To keep the MCP `tools/list` manageable, **13 core tools** are always visible and the remaining tools are organized behind **23 domain-named gateways** (8 read-only `hub_read_*` gateways + 15 write-bearing `hub_manage_*` gateways). The AI sees 36 items on `tools/list` (13 + 23 gateways). A tool may appear under more than one gateway — read tools inside a mixed `hub_manage_*` gateway are also surfaced in a pure-read `hub_read_*` gateway. Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
+The server has 118 tools total. To keep the MCP `tools/list` manageable, **13 core tools** are always visible and the remaining tools are organized behind **23 domain-named gateways** (8 read-only `hub_read_*` gateways + 15 write-bearing `hub_manage_*` gateways). The AI sees 36 items on `tools/list` (13 + 23 gateways). A tool may appear under more than one gateway — read tools inside a mixed `hub_manage_*` gateway are also surfaced in a pure-read `hub_read_*` gateway. Each gateway's description includes tool summaries (always visible to the AI), and calling a gateway with no arguments returns full parameter schemas on demand.
 
 #### Core Tools (13) — Always visible on tools/list
 
@@ -359,11 +359,12 @@ Call a gateway with no arguments to see full parameter schemas. Call with `tool=
 </details>
 
 <details>
-<summary><b>hub_read_diagnostics</b> (9) — Diagnostics, metrics, memory, radio details (read-only)</summary>
+<summary><b>hub_read_diagnostics</b> (10) — Diagnostics, metrics, memory, radio details (read-only)</summary>
 
 | Tool | Description |
 |------|-------------|
 | `hub_get_logs` | Hub log entries (most recent first) with level/source/regex filters, multi-pattern AND/OR, time-window (since/until, max 30d relative -- throws if exceeded; use ISO-8601 for longer ranges), and server-side deviceId/appId scoping. `pattern` matches the message field only; pathological regex like `(.*)*` may hang the matcher. (Device/location event *history* is in `hub_list_device_events` via `hoursBack`.) |
+| `hub_get_op_result` | Fetch the buffered result of a slow write by the idempotency token (`opToken`) passed on it, after a dropped/timed-out cloud-relay response. Returns `status` unknown/running/complete. |
 | `hub_get_performance_stats` | Device/app performance stats (count, % busy, total ms, state size, events, large-state flag) |
 | `hub_get_jobs` | Scheduled jobs, running jobs, and hub actions |
 | `hub_get_debug_logs` | Retrieve MCP debug log entries. Pass `mode='status'` to get logging system status and capacity instead. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hubitat-mcp-server
-description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 117 tools (36 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver/library management, installed-app visibility, Rule Machine interoperability, native rule CRUD, Easy and legacy Hubitat® Dashboard CRUD, HPM package state introspection, and Developer Mode self-administration.
+description: Guide for developing and maintaining the Hubitat MCP Rule Server — a Groovy-based MCP server running natively on Hubitat Elevation hubs, exposing 118 tools (36 on tools/list via category gateway proxy) for device control, virtual device management, room management, rule automation, hub admin, file management, app/driver/library management, installed-app visibility, Rule Machine interoperability, native rule CRUD, Easy and legacy Hubitat® Dashboard CRUD, HPM package state introspection, and Developer Mode self-administration.
 license: MIT
 ---
 
@@ -93,12 +93,12 @@ New code should be placed in the appropriate section. New sections should follow
 
 ### Category Gateway Proxy (v0.8.0+)
 
-The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 117 items to 36. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways. Gateways come in two flavors: `hub_read_<noun>` gateways whose every sub-tool is read-only, and `hub_manage_<noun>` gateways that contain at least one write (mixed read+write or write-only). A tool MAY appear in more than one gateway (multi-membership) — reads are listed in BOTH their mixed `manage_` gateway AND a pure-read `read_` gateway.
+The server uses a **category gateway proxy** pattern to reduce the MCP `tools/list` from 118 items to 36. This keeps frequently-used tools immediately accessible while organizing lesser-used tools behind domain-named gateways. Gateways come in two flavors: `hub_read_<noun>` gateways whose every sub-tool is read-only, and `hub_manage_<noun>` gateways that contain at least one write (mixed read+write or write-only). A tool MAY appear in more than one gateway (multi-membership) — reads are listed in BOTH their mixed `manage_` gateway AND a pure-read `read_` gateway.
 
 **Architecture:**
 - `getGatewayConfig()` — defines 23 gateways, each with a description, tools list, and summaries map
 - `getToolDefinitions()` — returns 13 core tools + 23 gateway tool definitions (client-visible)
-- `getAllToolDefinitions()` — returns all 117 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
+- `getAllToolDefinitions()` — returns all 118 tool definitions (used internally by gateway catalog and `executeTool()` dispatch)
 - `handleGateway(gatewayName, toolName, toolArgs)` — catalog mode (no args → full schemas) or execute mode (tool + args → dispatch)
 
 **Gateway calling convention:**
@@ -112,7 +112,7 @@ Read gateways (`hub_read_*`, every sub-tool read-only):
 |---------|-------|--------|
 | `hub_read_apps_code` | 11 | List apps/drivers/libraries/bundles, get source, backups (list/get), device-in-use-by lookup, app config inspection, page-name directory, HPM package state (read-only) |
 | `hub_read_devices` | 5 | List/get devices, device attributes, device events, compatible-device catalog search (read-only) |
-| `hub_read_diagnostics` | 9 | Logs, performance stats, hub jobs, debug logs, metrics, memory history, device health, radio details (zwave/zigbee), captured states (read-only) |
+| `hub_read_diagnostics` | 10 | Logs, op-result recovery, performance stats, hub jobs, debug logs, metrics, memory history, device health, radio details (zwave/zigbee), captured states (read-only) |
 | `hub_read_files` | 2 | File Manager list + read (read-only) |
 | `hub_read_rooms` | 2 | Room list + get (read-only) |
 | `hub_read_rules` | 6 | Custom-engine rule get/test, native rule list, rule health, rule local variables, Visual Rules Builder rule list/read (read-only) |

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -1150,11 +1150,14 @@ Surfaced via `hub_get_tool_guide(section='slow_ops')`. A slow write invoked over
 
 The slow write tools (`hub_set_rule`, `hub_set_native_app`, the code save/update tools, `hub_install_bundle`, `hub_update_package`, `hub_create_backup`, `hub_restore_backup`) accept an optional `opToken` the caller invents (8-128 chars of `A-Za-z0-9._-`). The server records it before running the write and buffers the result on completion. If the response drops, call `hub_get_op_result(opToken=<yours>)` instead of re-issuing. Re-issuing the same tokened call while it is still running is refused (status `running`) rather than double-committed; after completion it replays the original result with `replayed: true` and does not run the write again.
 
-### `hub_get_op_result` tri-state
+### `hub_get_op_result` statuses
 
 - `unknown` — no operation with this token ever started; the original call never arrived (safe to re-issue with the same token).
 - `running` — still executing; poll again shortly and do NOT re-issue (the write commits even though the response dropped).
-- `complete` — the original result is under `result`, with `isError` and `finishedAt`. Buffered results are swept after ~24h; a later poll returns `unknown` with a note to verify state via reads.
+- `complete` — the original result is under `result`, with `isError` and `finishedAt`.
+- `indeterminate` — the operation completed here but its buffered result is gone (buffering failed, or swept opportunistically once older than ~24h; the sweep runs on later tokened writes, so expiry is not prompt). Do NOT re-issue blindly; verify current state via reads first. Only `unknown` means the call never arrived.
+
+A replayed result whose `status` is `in_progress` carries `replayNote`: it is the original paused envelope, not new progress — a spent token cannot drive a resume; re-issue the remaining work with a fresh token.
 
 ### in_progress resume (multi-step writes only)
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -4,7 +4,7 @@ Detailed reference for MCP Rule Server tools. Consult this when tool description
 
 ## Category Gateway Proxy (v0.8.0+)
 
-As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 36 items (13 core + 23 gateways) covering 117 total tools. Use `hub_search_tools` to find any tool by natural language query.
+As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used tools behind gateway tools. The MCP `tools/list` shows 36 items (13 core + 23 gateways) covering 118 total tools. Use `hub_search_tools` to find any tool by natural language query.
 
 **How to use a gateway:**
 1. Call the gateway with no arguments to see full parameter schemas for all its tools
@@ -12,7 +12,7 @@ As of v0.8.0, the server uses **domain-named gateways** to organize lesser-used 
 
 Gateway verbs encode mutation: **`hub_read_*`** gateways are pure-read (every sub-tool read-only), **`hub_manage_*`** gateways contain at least one write. A read tool may appear in BOTH a `hub_read_*` gateway and a mixed `hub_manage_*` gateway (multi-membership).
 
-**Read gateways (8):** `hub_read_apps_code` (11), `hub_read_dashboards` (2), `hub_read_devices` (5), `hub_read_diagnostics` (9), `hub_read_files` (2), `hub_read_rooms` (2), `hub_read_rules` (6), `hub_read_variables` (3)
+**Read gateways (8):** `hub_read_apps_code` (11), `hub_read_dashboards` (2), `hub_read_devices` (5), `hub_read_diagnostics` (10), `hub_read_files` (2), `hub_read_rooms` (2), `hub_read_rules` (6), `hub_read_variables` (3)
 
 **Manage gateways (15):** `hub_manage_backup` (4), `hub_manage_code` (10), `hub_manage_custom_rules` (8), `hub_manage_dashboards` (6), `hub_manage_destructive_ops` (4), `hub_manage_devices` (9), `hub_manage_diagnostics` (7), `hub_manage_files` (4), `hub_manage_logs` (6), `hub_manage_mcp` (1), `hub_manage_native_rules_and_apps` (11), `hub_manage_radio` (6), `hub_manage_rooms` (5), `hub_manage_rule_machine` (11), `hub_manage_variables` (8)
 
@@ -1141,3 +1141,21 @@ To move EXISTING devices into an existing room, set each device's room via hub_u
 ### hub_update_room
 
 Renaming a room preserves device assignments, but may require updating automations/dashboards that reference the room by name.
+
+## Slow ops over the cloud relay (opToken recovery + in_progress resume)
+
+Surfaced via `hub_get_tool_guide(section='slow_ops')`. A slow write invoked over the cloud relay can outlive the relay's fixed response ceiling: the hub still runs the operation to completion and commits it, but the RESPONSE is lost and the client sees an opaque transport error (a gateway/timeout error). Retrying blindly risks a double commit. Two mechanisms make it recoverable.
+
+### Idempotency token (`opToken`)
+
+The slow write tools (`hub_set_rule`, `hub_set_native_app`, the code save/update tools, `hub_install_bundle`, `hub_update_package`, `hub_create_backup`, `hub_restore_backup`) accept an optional `opToken` the caller invents (8-128 chars of `A-Za-z0-9._-`). The server records it before running the write and buffers the result on completion. If the response drops, call `hub_get_op_result(opToken=<yours>)` instead of re-issuing. Re-issuing the same tokened call while it is still running is refused (status `running`) rather than double-committed; after completion it replays the original result with `replayed: true` and does not run the write again.
+
+### `hub_get_op_result` tri-state
+
+- `unknown` — no operation with this token ever started; the original call never arrived (safe to re-issue with the same token).
+- `running` — still executing; poll again shortly and do NOT re-issue (the write commits even though the response dropped).
+- `complete` — the original result is under `result`, with `isError` and `finishedAt`. Buffered results are swept after ~24h; a later poll returns `unknown` with a note to verify state via reads.
+
+### in_progress resume (multi-step writes only)
+
+`hub_set_rule` / `hub_set_native_app` multi-step edits pause BETWEEN steps once the relay time budget is reached and return a success-shaped `status: "in_progress"` envelope — completed steps are already committed. A paused `walkStep(operation='drive')` returns `pausedAtStep`, `stepsRemaining`, and `page` (resume the drive with `steps = stepsRemaining` and that `page`); a paused patch edit returns `patchResults` plus `patchesRemaining` (resume the edit with `patches = patchesRemaining`; the rule finalize/`updateRule` runs when the remaining patches complete). Attach the same `opToken` on a resume only if the original call carried none, else use a fresh token. The budget is the advanced `relayBudgetMs` setting (default 8000 ms, 0 disables); LAN requests and a 0 budget never pause.

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -1148,7 +1148,7 @@ Surfaced via `hub_get_tool_guide(section='slow_ops')`. A slow write invoked over
 
 ### Idempotency token (`opToken`)
 
-The slow write tools (`hub_set_rule`, `hub_set_native_app`, the code save/update tools, `hub_install_bundle`, `hub_update_package`, `hub_create_backup`, `hub_restore_backup`) accept an optional `opToken` the caller invents (8-128 chars of `A-Za-z0-9._-`). The server records it before running the write and buffers the result on completion. If the response drops, call `hub_get_op_result(opToken=<yours>)` instead of re-issuing. Re-issuing the same tokened call while it is still running is refused (status `running`) rather than double-committed; after completion it replays the original result with `replayed: true` and does not run the write again.
+EVERY write tool accepts an optional `opToken` the caller invents (8-128 chars of `A-Za-z0-9._-`); the known-slow class advertises it in its schemas (`hub_set_rule`, `hub_set_native_app`, the code save/update tools, `hub_install_bundle`, `hub_update_package`, `hub_create_backup`, `hub_restore_backup`, `hub_delete_variable`). The server records it before running the write and buffers the result on completion. If the response drops, call `hub_get_op_result(opToken=<yours>)` instead of re-issuing. Re-issuing the same tokened call while it is still running is refused (status `running`) rather than double-committed; after completion it replays the original result with `replayed: true` and does not run the write again.
 
 ### `hub_get_op_result` statuses
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1119,9 +1119,15 @@ def _advertisesOutputSchema(toolName) {
 // from that: (1) a caller-supplied idempotency token buffers the result so a lost
 // response is replayable and a blind retry is deduped; (2) slow multi-step writes
 // self-budget and return a resumable in_progress envelope BEFORE the ceiling. The
-// token bookkeeping persists through atomicState (thread-safe across the
-// concurrent requests this app instance serves); the buffered result lives in the
-// File Manager under the reserved mcp-op-result- prefix.
+// token bookkeeping persists through atomicState -- durable, NOT compare-and-set:
+// the dedup read and the started-mark write are separate operations, so two truly
+// simultaneous calls carrying the same token can both pass the gate, and two
+// overlapping DIFFERENT-token writes can last-writer-win the whole map (losing the
+// other's record; its result file then sits orphaned -- the prune sweeps map
+// entries, not the file prefix). The token targets the sequential-retry pattern
+// (response lost, client retries seconds later), where the persisted mark
+// refuses/replays the retry race-free. The buffered result lives in the File
+// Manager under the reserved mcp-op-result- prefix.
 
 // True only when THIS request arrived over the cloud relay. requestSource is a
 // mapped-endpoint property ("local"|"cloud"); any access failure (older firmware,
@@ -1132,7 +1138,7 @@ def _isCloudRequest() {
 }
 
 // Relay time budget in ms. 0 disables self-budgeting; unset defaults to 8000,
-// comfortably under the observed relay ceiling. The ceiling is a setting, never a
+// comfortably under the observed relay ceiling. The budget is a setting, never a
 // literal elsewhere -- read it here.
 def _relayBudgetMs() {
     return settings.relayBudgetMs != null ? (settings.relayBudgetMs as Long) : 8000L
@@ -1168,9 +1174,8 @@ def _validateOpToken(String opToken) {
 
 def _opTokenResultFile(String opToken) { "mcp-op-result-${opToken}.json" }
 
-// Parse the buffered result for a completed token, preferring the File Manager
-// copy and falling back to the inline copy kept when an upload failed for a small
-// payload. Returns null when nothing readable remains (swept file, failed buffer)
+// Parse the buffered result for a completed token: the inline copy (kept when an
+// upload failed for a small payload) wins, else the File Manager copy. Returns null when nothing readable remains (swept file, failed buffer)
 // so callers surface the "verify state" shape rather than a stale result.
 def _opTokenReadResult(rec) {
     if (!(rec instanceof Map)) return null
@@ -1197,13 +1202,18 @@ def _opTokenDeleteResultFile(rec) {
 // Amortized prune of the token map (mutates in place): drop entries past the 24h
 // TTL (deleting their result files) and cap the map at 50, oldest-first. The TTL
 // sweep is the reserved-prefix cleanup; a token left "running" by an unbuffered
-// internal error self-heals here.
+// internal error self-heals here. The size cap evicts TERMINAL records only: an
+// evicted live token would read back as "unknown -- safe to retry" while its op
+// commits, the exact double-commit the token exists to prevent. Stuck "running"
+// records are the TTL sweep's job, so the cap cannot wedge on them for long.
 def _opTokenPrune(Map tokens) {
     long cutoff = now() - 86400000L
     def expiredKeys = tokens.findAll { k, v -> (v instanceof Map) && (((v.startedAt as Long) ?: 0L) < cutoff) }.keySet().toList()
     expiredKeys.each { k -> _opTokenDeleteResultFile(tokens[k]); tokens.remove(k) }
     if (tokens.size() > 50) {
-        def ordered = tokens.entrySet().toList().sort { e -> (e.value instanceof Map) ? ((e.value.startedAt as Long) ?: 0L) : 0L }
+        def ordered = tokens.entrySet().toList()
+            .findAll { e -> !((e.value instanceof Map) && e.value.state == "running") }
+            .sort { e -> (e.value instanceof Map) ? ((e.value.startedAt as Long) ?: 0L) : 0L }
         int over = tokens.size() - 50
         ordered.take(over).each { e -> _opTokenDeleteResultFile(e.value); tokens.remove(e.key) }
     }
@@ -1231,12 +1241,13 @@ def _opTokenComplete(String opToken, String jsonText, boolean isErrorBool) {
     def prev = (tokens[opToken] instanceof Map) ? tokens[opToken] : [:]
     def rec = [state: "complete", tool: prev.tool, startedAt: prev.startedAt, finishedAt: now(), isError: isErrorBool]
     def fileName = _opTokenResultFile(opToken)
+    byte[] resultBytes = jsonText?.getBytes("UTF-8")
     try {
-        uploadHubFile(fileName, jsonText.getBytes("UTF-8"))
+        uploadHubFile(fileName, resultBytes)
         rec.file = fileName
     } catch (Exception e) {
         mcpLog("warn", "op-token", "Buffering op-result for ${opToken} to the File Manager failed: ${e.message}")
-        if (jsonText != null && jsonText.getBytes("UTF-8").length <= 2048) {
+        if (resultBytes != null && resultBytes.length <= 2048) {
             rec.inline = jsonText
         } else {
             rec.state = "failed_buffer"
@@ -1264,12 +1275,22 @@ def _opTokenDedup(String opToken, origToolName) {
     }
     def parsed = _opTokenReadResult(rec)
     if (parsed == null) {
+        // Distinct from "unknown": the op DID complete here, so a re-issue is NOT
+        // safe -- the wire status must never read as the safe-to-retry shape.
         return [isError: true, result: [
-            success: false, isError: true, status: "unknown", opToken: opToken,
-            note: "This token completed earlier but its buffered result has expired or could not be read. Verify current state via reads before retrying. See hub_get_tool_guide(section='slow_ops')."
+            success: false, isError: true, status: "indeterminate", opToken: opToken,
+            note: "This token completed earlier but its buffered result has expired or could not be read. Do not re-issue blindly -- verify current state via reads first. See hub_get_tool_guide(section='slow_ops')."
         ]]
     }
-    if (parsed instanceof Map) parsed.replayed = true
+    if (parsed instanceof Map) {
+        parsed.replayed = true
+        if (parsed.status == "in_progress") {
+            // A spent token cannot drive a resume: this replay is the ORIGINAL paused
+            // envelope, not new progress. Without the warning a client that reused the
+            // token would loop on the identical response forever.
+            parsed.replayNote = "REPLAY of the original paused result -- the resume did NOT run. Re-issue the remaining work with a FRESH opToken to continue."
+        }
+    }
     return [isError: (rec.isError == true), result: parsed]
 }
 
@@ -7023,7 +7044,10 @@ The slow write tools (hub_set_rule, hub_set_native_app, the code save/update too
 
 - `status: "unknown"` -- no operation with this token ever started here; the original call never arrived. Safe to (re-)issue the original call with the same token.
 - `status: "running"` -- still executing. Poll again in a few seconds. The write commits even though your response dropped, so do NOT re-issue.
-- `status: "complete"` -- the original result is under `result`, with `isError` and `finishedAt`. Buffered results are swept after ~24 hours; a poll after that returns "unknown" with a note to verify current state via reads.
+- `status: "complete"` -- the original result is under `result`, with `isError` and `finishedAt`.
+- `status: "indeterminate"` -- the operation completed here but its buffered result is gone (buffering failed, or swept opportunistically once older than ~24 hours -- the sweep runs on later tokened writes, so expiry is not prompt). Do NOT re-issue blindly; verify current state via reads first. Only "unknown" means the call never arrived.
+
+A replayed result whose `status` is "in_progress" carries `replayNote`: it is the ORIGINAL paused envelope, not new progress -- a spent token cannot drive a resume; re-issue the remaining work with a fresh token.
 
 ### in_progress resume (multi-step writes only)
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -892,10 +892,19 @@ def handleToolsCall(msg) {
             // Only WRITE leaves process the token; a read silently ignores it entirely
             // (including a malformed one -- no validation, no throw, no marker), so the
             // read/write partition is checked BEFORE validating the token shape.
-            if (rawToken != null && !getReadOnlyToolNames().contains(reactiveToolName)) {
-                opToken = rawToken.toString()
-                _validateOpToken(opToken)
-                opTokenActive = true
+            if (!getReadOnlyToolNames().contains(reactiveToolName)) {
+                // The token is consumed HERE, so strip it before dispatch: write leaves
+                // never need it, and several validate their args strictly and would
+                // reject the unknown key -- stripping makes EVERY write tokenable, not
+                // just the ones whose schema advertises the param. Reads keep their args
+                // untouched (hub_get_op_result takes opToken as a real parameter).
+                args.remove('opToken')
+                if (args.args instanceof Map) args.args.remove('opToken')
+                if (rawToken != null) {
+                    opToken = rawToken.toString()
+                    _validateOpToken(opToken)
+                    opTokenActive = true
+                }
             }
         }
         if (opTokenActive) {
@@ -7033,7 +7042,7 @@ A slow write invoked over the cloud relay can outlive the relay's fixed response
 
 ### Idempotency token (opToken)
 
-The slow write tools (hub_set_rule, hub_set_native_app, the code save/update tools, hub_install_bundle, hub_update_package, hub_create_backup, hub_restore_backup) accept an optional `opToken` you invent: 8-128 characters of A-Za-z0-9._-. Pass the SAME token on the call and, if the response drops, on your recovery poll.
+EVERY write tool accepts an optional `opToken` you invent: 8-128 characters of A-Za-z0-9._- (the schemas of the known-slow class advertise it explicitly: hub_set_rule, hub_set_native_app, the code save/update tools, hub_install_bundle, hub_update_package, hub_create_backup, hub_restore_backup, hub_delete_variable). Pass the SAME token on the call and, if the response drops, on your recovery poll.
 
 - The server records the token before running the write and buffers the result when it finishes.
 - If the response is lost, call `hub_get_op_result(opToken=<yours>)` instead of re-issuing the write.

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -411,6 +411,12 @@ def advancedOverridesPage() {
                   description: "Leave OFF (default). ON: gateway-mode base tools and the gateway catalog advertise outputSchema (wire form, no required arrays) and successful results carry structuredContent per the MCP spec. The flat tool list never advertises outputSchema regardless of this setting.",
                   defaultValue: false
         }
+        section("Cloud relay budget") {
+            paragraph "The cloud relay severs a slow /mcp call at a fixed ceiling while the hub keeps running the operation to completion. When a slow multi-step write is running over the relay, the server pauses BEFORE this budget and returns a resumable in_progress envelope so no step is lost. Set 0 to disable (behaviour is unchanged for LAN requests either way)."
+            input "relayBudgetMs", "number", title: "Cloud-relay time budget (ms, 0 = off)",
+                  description: "Pause a slow multi-step write over the cloud relay once this many ms have elapsed (default: 8000, under the ~10s relay ceiling).",
+                  defaultValue: 8000, range: "0..30000", required: false
+        }
         section {
             def dt = (settings.disabled_tools ?: []).size()
             def dg = (settings.disabled_gateways ?: []).size()
@@ -856,7 +862,63 @@ def handleToolsCall(msg) {
         return jsonRpcError(msg.id, -32602, "Invalid params: tool name required")
     }
 
+    // ---- Cloud-relay self-budget clock ----
+    // Capture wall-clock at handler entry; the delta from the actual request
+    // entry is sub-millisecond. Threaded into the dispatched args so a slow
+    // multi-step write can pause before the relay ceiling and return a resumable
+    // in_progress envelope. LAN requests / budget=0 short-circuit the check, so
+    // this is inert unless a cloud relay is in play.
+    long reqT0 = now()
+
+    // Idempotency-token state, declared out here so the completion-buffering
+    // finally can see it; resolved + validated INSIDE the try so a bad token maps
+    // to -32602 via the IllegalArgumentException catch (not the generic -32603).
+    String opToken = null
+    boolean opTokenActive = false
+    // Buffer the terminal result under the token on every exit path (finally), so
+    // a dropped transport response is recoverable via hub_get_op_result and no
+    // token is left eternally "running". Each terminal path sets opCompletionText.
+    String opCompletionText = null
+    boolean opCompletionIsError = false
     try {
+        // ---- Idempotency token: resolve, validate, dedup, mark ----
+        // All token bookkeeping happens ONCE here, never in executeTool -- a gateway
+        // re-enters executeTool per sub-tool and would double-process. The token is
+        // honoured only for WRITE leaves (a read replay is pointless and reads are
+        // already idempotent); a read silently ignores the arg. reactiveToolName is
+        // the resolved leaf (args.tool on a gateway call, the leaf on a flat call).
+        if (args instanceof Map) {
+            def rawToken = args.opToken ?: (args.args instanceof Map ? args.args.opToken : null)
+            // Only WRITE leaves process the token; a read silently ignores it entirely
+            // (including a malformed one -- no validation, no throw, no marker), so the
+            // read/write partition is checked BEFORE validating the token shape.
+            if (rawToken != null && !getReadOnlyToolNames().contains(reactiveToolName)) {
+                opToken = rawToken.toString()
+                _validateOpToken(opToken)
+                opTokenActive = true
+            }
+        }
+        if (opTokenActive) {
+            def dedup = _opTokenDedup(opToken, reactiveToolName)
+            if (dedup != null) {
+                // Already running (refuse the duplicate) or already complete (replay
+                // the buffered result). Short-circuit BEFORE dispatch so neither the
+                // write nor the completion buffer runs again (opCompletionText stays
+                // null, so the finally does not re-buffer).
+                return jsonRpcResult(msg.id, [
+                    content: [[type: "text", text: groovy.json.JsonOutput.toJson(dedup.result)]],
+                    isError: dedup.isError
+                ])
+            }
+            _opTokenMark(opToken, reactiveToolName)
+        }
+        // Thread the budget clock into the dispatched args -- ONLY for the leaves
+        // whose loops consume it. Several tools validate their args strictly and
+        // reject unknown keys, so a blanket injection breaks them; the budget-aware
+        // set is the injection allowlist. (Map guard: a malformed non-object
+        // arguments falls through and simply forgoes the budget.)
+        if (args instanceof Map && _budgetAwareTools().contains(reactiveToolName)) args.__reqT0 = reqT0
+
         def result = executeTool(toolName, args)
         // Null result is always an internal tool bug -- surface it as a structured
         // isError envelope instead of letting JsonOutput render the literal string
@@ -867,10 +929,12 @@ def handleToolsCall(msg) {
             mcpLog("error", "server", "Tool ${reactiveToolName} returned null -- internal tool bug", null, [
                 details: [tool: reactiveToolName, gateway: (reactiveToolName != toolName) ? toolName : null]
             ])
+            def nullErrText = groovy.json.JsonOutput.toJson([
+                isError: true, error: "Tool ${reactiveToolName} returned no result", tool: reactiveToolName
+            ])
+            if (opTokenActive) { opCompletionText = nullErrText; opCompletionIsError = true }
             return jsonRpcResult(msg.id, [
-                content: [[type: "text", text: groovy.json.JsonOutput.toJson([
-                    isError: true, error: "Tool ${reactiveToolName} returned no result", tool: reactiveToolName
-                ])]],
+                content: [[type: "text", text: nullErrText]],
                 isError: true
             ])
         }
@@ -900,16 +964,25 @@ def handleToolsCall(msg) {
             mcpLog("error", "server", "Tool ${reactiveToolName} returned a non-serializable result: ${serErr.message}", null, [
                 details: [tool: reactiveToolName, gateway: (reactiveToolName != toolName) ? toolName : null, resultType: result?.class?.name, error: serErr.message]
             ])
+            def serErrText = groovy.json.JsonOutput.toJson([
+                isError: true,
+                error: "Tool ${reactiveToolName} returned a result the JSON serializer cannot encode",
+                cause: serErr.message,
+                resultType: result?.class?.name,
+                note: "Internal tool bug -- report with the tool name and arguments used."
+            ])
+            if (opTokenActive) { opCompletionText = serErrText; opCompletionIsError = true }
             return jsonRpcResult(msg.id, [
-                content: [[type: "text", text: groovy.json.JsonOutput.toJson([
-                    isError: true,
-                    error: "Tool ${reactiveToolName} returned a result the JSON serializer cannot encode",
-                    cause: serErr.message,
-                    resultType: result?.class?.name,
-                    note: "Internal tool bug -- report with the tool name and arguments used."
-                ])]],
+                content: [[type: "text", text: serErrText]],
                 isError: true
             ])
+        }
+        // Buffer the successful (or returned-error) result under the token. Captured
+        // here so BOTH the normal return and the oversize fallback below replay the
+        // real result rather than the too-large envelope.
+        if (opTokenActive) {
+            opCompletionText = jsonText
+            opCompletionIsError = (result instanceof Map && result.isError == true)
         }
         // Measure the wire-encoded response (text-escape + content/JSON-RPC envelope)
         // rather than the raw inner result, so the guard threshold maps directly onto
@@ -994,6 +1067,10 @@ def handleToolsCall(msg) {
                 mcpLog("warn", "server", "Reactive BPS hint failed for ${reactiveToolName}: ${bpErr.message}", null, [details: [tool: reactiveToolName, gateway: (reactiveToolName != toolName) ? toolName : null]])
             }
         }
+        if (opTokenActive) {
+            opCompletionText = groovy.json.JsonOutput.toJson([isError: true, error: "Invalid params: ${msgText}", tool: reactiveToolName])
+            opCompletionIsError = true
+        }
         return jsonRpcError(msg.id, -32602, "Invalid params: ${msgText}")
     } catch (Exception e) {
         mcpLog("error", "server", "Tool execution error in ${reactiveToolName}: ${e.message}", null, [
@@ -1004,8 +1081,20 @@ def handleToolsCall(msg) {
         // exception object as a 2nd arg throws MissingMethodException, masking the real error
         // (and creating cascading log.error failures). mcpLog above already captured the stack trace.
         log.error "Tool execution error: ${e.message} (${e.class.simpleName})"
+        if (opTokenActive) {
+            opCompletionText = groovy.json.JsonOutput.toJson([isError: true, error: "Tool error: ${e.message}", tool: reactiveToolName])
+            opCompletionIsError = true
+        }
         // MCP spec: tool execution errors are returned as successful results with isError flag
         return jsonRpcResult(msg.id, [content: [[type: "text", text: "Tool error: ${e.message}"]], isError: true])
+    } finally {
+        // Buffer the terminal result under the token so a dropped transport response
+        // is replayable via hub_get_op_result. Reached on every path that set the
+        // text (success, oversize, validation error, runtime error, null/non-serializable).
+        if (opTokenActive && opCompletionText != null) {
+            try { _opTokenComplete(opToken, opCompletionText, opCompletionIsError) }
+            catch (Exception ce) { mcpLog("warn", "op-token", "Recording op-result completion for ${opToken} failed: ${ce.message}") }
+        }
     }
 }
 
@@ -1021,6 +1110,167 @@ def _advertisesOutputSchema(toolName) {
     if (gwConfig.containsKey(toolName)) return false
     if (gwConfig.values().any { it.tools?.contains(toolName) }) return false
     return getAllToolDefinitions().find { it.name == toolName }?.outputSchema != null
+}
+
+// ==================== Cloud-relay budget + idempotency tokens ====================
+// The cloud relay severs any /mcp call at a fixed ceiling while the hub handler
+// runs to completion and commits -- only the RESPONSE is lost, and the client
+// sees an opaque transport 5xx the server cannot reshape. Two mechanisms recover
+// from that: (1) a caller-supplied idempotency token buffers the result so a lost
+// response is replayable and a blind retry is deduped; (2) slow multi-step writes
+// self-budget and return a resumable in_progress envelope BEFORE the ceiling. The
+// token bookkeeping persists through atomicState (thread-safe across the
+// concurrent requests this app instance serves); the buffered result lives in the
+// File Manager under the reserved mcp-op-result- prefix.
+
+// True only when THIS request arrived over the cloud relay. requestSource is a
+// mapped-endpoint property ("local"|"cloud"); any access failure (older firmware,
+// non-request context) reads as local so the budget stays inert on LAN.
+def _isCloudRequest() {
+    try { return request?.requestSource?.toString() == "cloud" }
+    catch (Exception e) { return false }
+}
+
+// Relay time budget in ms. 0 disables self-budgeting; unset defaults to 8000,
+// comfortably under the observed relay ceiling. The ceiling is a setting, never a
+// literal elsewhere -- read it here.
+def _relayBudgetMs() {
+    return settings.relayBudgetMs != null ? (settings.relayBudgetMs as Long) : 8000L
+}
+
+// The leaves whose partial-commit loops consume the __reqT0 budget clock. This is
+// the injection allowlist for handleToolsCall/handleGateway: tools outside it never
+// see the key (several validate their args strictly and reject unknown keys).
+def _budgetAwareTools() {
+    return ["hub_set_rule", "hub_set_native_app"] as Set
+}
+
+// True when a partial-commit loop should pause and hand back a resumable
+// in_progress envelope: a positive budget, a cloud-relayed request, and the
+// elapsed time since request entry (t0) has reached the budget. LAN requests and
+// budget=0 short-circuit, so non-relay behaviour is byte-identical to before.
+def _relayBudgetExceeded(Long t0) {
+    if (t0 == null) return false
+    Long budget = _relayBudgetMs()
+    if (budget <= 0) return false
+    if (!_isCloudRequest()) return false
+    return (now() - t0) >= budget
+}
+
+// Idempotency-token shape guard. The token becomes a File Manager filename
+// component, so it is bounded to the filename-safe charset and a sane length. A
+// bad shape throws (-> -32602) like any other bad argument.
+def _validateOpToken(String opToken) {
+    if (!(opToken ==~ /^[A-Za-z0-9._-]{8,128}$/)) {
+        throw new IllegalArgumentException("Invalid opToken (must be 8-128 characters of A-Za-z0-9._- -- it becomes a File Manager filename component). See hub_get_tool_guide(section='slow_ops').")
+    }
+}
+
+def _opTokenResultFile(String opToken) { "mcp-op-result-${opToken}.json" }
+
+// Parse the buffered result for a completed token, preferring the File Manager
+// copy and falling back to the inline copy kept when an upload failed for a small
+// payload. Returns null when nothing readable remains (swept file, failed buffer)
+// so callers surface the "verify state" shape rather than a stale result.
+def _opTokenReadResult(rec) {
+    if (!(rec instanceof Map)) return null
+    if (rec.inline != null) {
+        try { return new groovy.json.JsonSlurper().parseText(rec.inline.toString()) }
+        catch (Exception e) { return null }
+    }
+    if (rec.file) {
+        try {
+            def bytes = downloadHubFile(rec.file.toString())
+            if (bytes == null) return null
+            return new groovy.json.JsonSlurper().parseText(new String(bytes, "UTF-8"))
+        } catch (Exception e) { return null }
+    }
+    return null
+}
+
+// Best-effort delete of a token's buffered result file (prune sweep only).
+def _opTokenDeleteResultFile(rec) {
+    try { if (rec instanceof Map && rec.file) deleteHubFile(rec.file.toString()) }
+    catch (Exception e) { /* best-effort: a stray result file is swept next pass */ }
+}
+
+// Amortized prune of the token map (mutates in place): drop entries past the 24h
+// TTL (deleting their result files) and cap the map at 50, oldest-first. The TTL
+// sweep is the reserved-prefix cleanup; a token left "running" by an unbuffered
+// internal error self-heals here.
+def _opTokenPrune(Map tokens) {
+    long cutoff = now() - 86400000L
+    def expiredKeys = tokens.findAll { k, v -> (v instanceof Map) && (((v.startedAt as Long) ?: 0L) < cutoff) }.keySet().toList()
+    expiredKeys.each { k -> _opTokenDeleteResultFile(tokens[k]); tokens.remove(k) }
+    if (tokens.size() > 50) {
+        def ordered = tokens.entrySet().toList().sort { e -> (e.value instanceof Map) ? ((e.value.startedAt as Long) ?: 0L) : 0L }
+        int over = tokens.size() - 50
+        ordered.take(over).each { e -> _opTokenDeleteResultFile(e.value); tokens.remove(e.key) }
+    }
+}
+
+// Mark a token running just before dispatch, pruning as we go. Whole-map reassign
+// -- a nested atomicState mutation does not persist.
+def _opTokenMark(String opToken, toolName) {
+    def tokens = [:]
+    if (atomicState.opTokens instanceof Map) tokens.putAll(atomicState.opTokens)
+    // Add the new marker BEFORE pruning so the size cap counts it -- otherwise a
+    // 50-entry map would grow to 51 (the cap check runs at 50 and passes).
+    tokens[opToken] = [state: "running", tool: toolName?.toString(), startedAt: now()]
+    _opTokenPrune(tokens)
+    atomicState.opTokens = tokens
+}
+
+// Buffer a token's terminal result (called once, on the request's terminal path).
+// Uploads the wire JSON to the reserved File Manager file; on upload failure keeps
+// a small result inline, else marks it failed_buffer so a replay tells the caller
+// to verify state rather than trust a missing file.
+def _opTokenComplete(String opToken, String jsonText, boolean isErrorBool) {
+    def tokens = [:]
+    if (atomicState.opTokens instanceof Map) tokens.putAll(atomicState.opTokens)
+    def prev = (tokens[opToken] instanceof Map) ? tokens[opToken] : [:]
+    def rec = [state: "complete", tool: prev.tool, startedAt: prev.startedAt, finishedAt: now(), isError: isErrorBool]
+    def fileName = _opTokenResultFile(opToken)
+    try {
+        uploadHubFile(fileName, jsonText.getBytes("UTF-8"))
+        rec.file = fileName
+    } catch (Exception e) {
+        mcpLog("warn", "op-token", "Buffering op-result for ${opToken} to the File Manager failed: ${e.message}")
+        if (jsonText != null && jsonText.getBytes("UTF-8").length <= 2048) {
+            rec.inline = jsonText
+        } else {
+            rec.state = "failed_buffer"
+            rec.note = "Operation committed but its result could not be buffered (upload failed, payload too large to inline). Re-read current state to confirm."
+        }
+    }
+    tokens[opToken] = rec
+    atomicState.opTokens = tokens
+}
+
+// Dedup gate consulted before dispatch. Returns null to proceed, or a
+// [result, isError] pair to short-circuit: a "running" refusal (a duplicate write
+// in flight) or a replay of the already-buffered result (adds replayed:true). A
+// completed-but-unreadable buffer degrades to the "verify state" unknown shape.
+def _opTokenDedup(String opToken, origToolName) {
+    def toks = atomicState.opTokens
+    def rec = (toks instanceof Map && toks[opToken] instanceof Map) ? toks[opToken] : null
+    if (rec == null) return null
+    if (rec.state == "running") {
+        return [isError: true, result: [
+            success: false, isError: true, status: "running", opToken: opToken,
+            tool: rec.tool, startedAt: rec.startedAt,
+            note: "An operation with this token is already executing on the hub. Do not re-issue the write; poll hub_get_op_result with this token until it reports complete, then read the buffered result. See hub_get_tool_guide(section='slow_ops')."
+        ]]
+    }
+    def parsed = _opTokenReadResult(rec)
+    if (parsed == null) {
+        return [isError: true, result: [
+            success: false, isError: true, status: "unknown", opToken: opToken,
+            note: "This token completed earlier but its buffered result has expired or could not be read. Verify current state via reads before retrying. See hub_get_tool_guide(section='slow_ops')."
+        ]]
+    }
+    if (parsed instanceof Map) parsed.replayed = true
+    return [isError: (rec.isError == true), result: parsed]
 }
 
 // Returned in place of the real result when handleToolsCall trips the size guard. Shape
@@ -1354,9 +1604,10 @@ def getGatewayConfig() {
         ],
         hub_read_diagnostics: [
             description: "Read-only hub health, logs, and diagnostics: system logs, performance stats, scheduled jobs, MCP debug logs, hub metrics, free-memory/CPU history, device health/staleness, Z-Wave/Zigbee radio details, and saved state snapshots. All operations are read-only; the matching writes (gc, Z-Wave repair, clear logs, set log level, delete snapshots) live in hub_manage_logs / hub_manage_diagnostics.",
-            tools: ["hub_get_logs", "hub_get_performance_stats", "hub_get_jobs", "hub_get_debug_logs", "hub_get_metrics", "hub_get_memory_history", "hub_get_device_health", "hub_get_radio_details", "hub_list_captured_states"],
+            tools: ["hub_get_logs", "hub_get_op_result", "hub_get_performance_stats", "hub_get_jobs", "hub_get_debug_logs", "hub_get_metrics", "hub_get_memory_history", "hub_get_device_health", "hub_get_radio_details", "hub_list_captured_states"],
             summaries: [
                 hub_get_logs: "Get Hubitat system logs, most recent first. Args: level, source, pattern/patterns, since/until, deviceId|appId, limit",
+                hub_get_op_result: "Fetch the buffered result of a slow write by its idempotency token after a dropped/timed-out response. Args: opToken. Returns status unknown|running|complete.",
                 hub_get_performance_stats: "Get device/app performance stats (count, % busy, total ms, state size, events). Args: type, sortBy, limit",
                 hub_get_jobs: "Get scheduled jobs, running jobs, and hub actions",
                 hub_get_debug_logs: "Get MCP internal debug logs (mode='logs') or logging status (mode='status'). Args: mode, level, component (e.g. server/rule), ruleId, limit",
@@ -1368,6 +1619,7 @@ def getGatewayConfig() {
             ],
             searchHints: [
                 hub_get_logs: "errors warnings messages trace syslog output recent latest device app scope regex pattern filter time window since until",
+                hub_get_op_result: "idempotency token operation result replay recover dropped timeout 504 gateway error transport committed poll in progress resume slow write",
                 hub_get_performance_stats: "slow cpu busy resource usage hog bottleneck",
                 hub_get_jobs: "scheduled cron timer recurring what is running next automation",
                 hub_get_debug_logs: "mcp internal troubleshoot trace logging status buffer capacity level",
@@ -1890,7 +2142,7 @@ def annotationsForGateway(List visibleSubTools, Set readOnlyNames, Set idempoten
     return ann
 }
 
-def handleGateway(gatewayName, toolName, toolArgs) {
+def handleGateway(gatewayName, toolName, toolArgs, reqT0 = null) {
     def gwConfig = getGatewayConfig()
     def config = gwConfig[gatewayName]
     if (!config) {
@@ -1982,6 +2234,13 @@ def handleGateway(gatewayName, toolName, toolArgs) {
     // fires only on an ABSENT key, so a present-but-invalid value (e.g. confirm:false)
     // still reaches the handler's own richer runtime message in both modes.
     def safeArgs = toolArgs ?: [:]
+    // Thread the relay-budget clock from the outer request into the sub-tool's args
+    // (handleToolsCall injected it on the gateway envelope; the gateway strips a
+    // layer, so re-inject on the leaf args here). Guarded by the same budget-aware
+    // allowlist as the outer injection -- strict-arg leaves must never see the key.
+    // Only a Map can carry it; a present value is never overwritten.
+    if (reqT0 != null && safeArgs instanceof Map && safeArgs.__reqT0 == null
+            && _budgetAwareTools().contains(toolName)) safeArgs.__reqT0 = reqT0
     // Read this tool's required-param list from the memoized map. Computing the
     // memo key walks the catalog once per gateway call; the memo saves the per-tool
     // map re-derivation, not the catalog walk. A missing key means the tool has no
@@ -2499,6 +2758,7 @@ def executeTool(toolName, args) {
 
         // Monitoring Tools
         case "hub_get_logs": return toolGetHubLogs(args)
+        case "hub_get_op_result": return toolGetOpResult(args)
         case "hub_get_performance_stats": return toolGetPerformanceStats(args)
         case "hub_get_jobs": return toolGetHubJobs(args)
         case "hub_get_metrics": return toolGetHubPerformance(args)
@@ -2652,7 +2912,7 @@ def executeTool(toolName, args) {
                     hint: hint
                 ]
             }
-            return handleGateway(toolName, args.tool, args.args)
+            return handleGateway(toolName, args.tool, args.args, (args instanceof Map) ? args.__reqT0 : null)
 
         default:
             throw new IllegalArgumentException("Unknown tool: ${toolName}")
@@ -4898,7 +5158,7 @@ private String _classicAppFormat(Map cfg) {
  * _rmBuildUpdateErrorResponse, toolSetVisualRule) attach this report to
  * mutation success AND error responses so an LLM sees broken state immediately.
  */
-private Map _rmCheckRuleHealth(Integer appId, String source = "auto") {
+Map _rmCheckRuleHealth(Integer appId, String source = "auto") {
     // Defensive guard: error paths (_rmBuildUpdateErrorResponse and friends) can call in with a
     // null appId if the failure happened before the id resolved. Reading rule state for a null id
     // would fire redundant HTTP calls (/app/ruleBuilderJson/null, /installedapp/configure/json/null)
@@ -6744,6 +7004,36 @@ To move EXISTING devices into an existing room, set each device's room via hub_u
 ### hub_update_room
 
 Renaming a room preserves device assignments, but may require updating automations/dashboards that reference the room by name.
+''',
+
+        slow_ops: '''## Slow ops over the cloud relay (opToken recovery + in_progress resume)
+
+A slow write invoked over the cloud relay can outlive the relay's fixed response ceiling. When that happens the hub still runs the operation to completion and commits it -- only the RESPONSE is lost, and your client surfaces an opaque transport error (a gateway/timeout error, often worded as "try again"). Retrying blindly risks a DOUBLE COMMIT. Two mechanisms make this recoverable.
+
+### Idempotency token (opToken)
+
+The slow write tools (hub_set_rule, hub_set_native_app, the code save/update tools, hub_install_bundle, hub_update_package, hub_create_backup, hub_restore_backup) accept an optional `opToken` you invent: 8-128 characters of A-Za-z0-9._-. Pass the SAME token on the call and, if the response drops, on your recovery poll.
+
+- The server records the token before running the write and buffers the result when it finishes.
+- If the response is lost, call `hub_get_op_result(opToken=<yours>)` instead of re-issuing the write.
+- If you DO re-issue the same tokened call while it is still running, the server refuses the duplicate (status "running") rather than committing twice. If it already finished, the server replays the original result with `replayed: true` and does NOT run the write again.
+- A token is SPENT once its operation completes -- errors included. A replayed result carrying an error means that attempt failed; to retry with corrected arguments, invent a FRESH token. Never reuse a token for a different or corrected operation.
+
+### hub_get_op_result tri-state
+
+- `status: "unknown"` -- no operation with this token ever started here; the original call never arrived. Safe to (re-)issue the original call with the same token.
+- `status: "running"` -- still executing. Poll again in a few seconds. The write commits even though your response dropped, so do NOT re-issue.
+- `status: "complete"` -- the original result is under `result`, with `isError` and `finishedAt`. Buffered results are swept after ~24 hours; a poll after that returns "unknown" with a note to verify current state via reads.
+
+### in_progress resume (multi-step writes only)
+
+hub_set_rule and hub_set_native_app run multi-step wizard edits. Over the relay, once the time budget is reached BETWEEN steps they stop early and return a SUCCESS-shaped envelope with `status: "in_progress"` -- every completed step is already committed. The envelope carries the remaining work so you can resume:
+
+- A paused `walkStep(operation='drive')` returns `pausedAtStep`, `stepsRemaining` (the unrun step specs), and `page`. Re-issue the drive with `steps = stepsRemaining` and `page` set to the returned page to continue.
+- A paused patch edit returns `patchResults` so far and `patchesRemaining`. Re-issue the hub_set_rule / hub_set_native_app edit with `patches = patchesRemaining`. The rule finalize (updateRule) runs when the remaining patches complete, not on the paused call.
+- Attach the same `opToken` on a resume ONLY if the original call carried none; otherwise use a fresh token for the resume.
+
+The budget is the advanced `relayBudgetMs` setting (default 8000 ms, 0 disables). LAN requests and a 0 budget never pause -- behaviour there is unchanged.
 '''
     ]
 }

--- a/libraries/mcp-bundles-lib.groovy
+++ b/libraries/mcp-bundles-lib.groovy
@@ -382,13 +382,14 @@ def _getAllToolDefinitions_partBundles() {
     return [
         [
             name: "hub_install_bundle",
-            description: "Install a Hubitat code bundle (.zip) from a URL the way Hubitat Package Manager does -- the hub fetches the zip and unpacks it into Libraries/Apps/Drivers Code (how a package delivers the libraries an app #includes). Use it to prove on the real hub that a package installs the HPM way before users update. Requires Write master + confirm=true + a recent backup; the hub does not deep-validate the zip.[[FLAT_TRIM]] Verify the result with hub_list_libraries / hub_get_source. Uses /bundle2/uploadZipFromUrl on firmware >= 2.3.8.108, else legacy /bundle/uploadZipFromUrl.[[/FLAT_TRIM]]",
+            description: "Install a Hubitat code bundle (.zip) from a URL the way Hubitat Package Manager does -- the hub fetches the zip and unpacks it into Libraries/Apps/Drivers Code (how a package delivers the libraries an app #includes). Use it to prove on the real hub that a package installs the HPM way before users update. Requires Write master + confirm=true + a recent backup; the hub does not deep-validate the zip.[[FLAT_TRIM]] Verify the result with hub_list_libraries / hub_get_source. Uses /bundle2/uploadZipFromUrl on firmware >= 2.3.8.108, else legacy /bundle/uploadZipFromUrl.[[/FLAT_TRIM]][[FLAT_TRIM]] Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this install; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]",
             inputSchema: [
                 type: "object",
                 properties: [
                     importUrl: [type: "string", description: "URL of the bundle .zip the hub fetches and installs (http:// or https://)."],
                     installer: [type: "boolean", description: "OPTIONAL. Mark the bundle's contents as installed-by-this-package (HPM's installer/private flag). Default false."],
-                    confirm: [type: "boolean", description: "REQUIRED: must be true. Confirms a recent backup exists and the user approved installing this bundle."]
+                    confirm: [type: "boolean", description: "REQUIRED: must be true. Confirms a recent backup exists and the user approved installing this bundle."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["importUrl", "confirm"]
             ],

--- a/libraries/mcp-code-management-lib.groovy
+++ b/libraries/mcp-code-management-lib.groovy
@@ -2601,7 +2601,11 @@ Supply the code via exactly one of source / sourceFile / importUrl (mutually exc
 After the code installs, create a running instance with a SECOND call: hub_create_app(codeAppId: <newAppId>, confirm: true).
 [[/FLAT_TRIM]]
 
-Verifies the install compiled -- returns success=false with the error if it didn't. Requires Write master + confirm + backup <24h. Returns the new app ID.""",
+Verifies the install compiled -- returns success=false with the error if it didn't. Requires Write master + confirm + backup <24h. Returns the new app ID.
+[[FLAT_TRIM]]
+Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this write; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]
+""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -2609,7 +2613,8 @@ Verifies the install compiled -- returns success=false with the error if it didn
                     sourceFile: [type: "string", description: "File Manager filename (write it first via hub_write_file), e.g. my-app.groovy."],
                     importUrl: [type: "string", description: "URL the hub fetches directly (http/https)."],
                     codeAppId: [type: "integer", description: "Second-step mode: instantiate already-installed code (codeAppId from a prior call) and commit the install; not combinable with source/sourceFile/importUrl."],
-                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
+                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["confirm"]
             ],
@@ -2642,7 +2647,11 @@ Verifies the install compiled -- returns success=false with the error if it didn
 
 Supply the code via exactly one of source / sourceFile / importUrl (mutually exclusive; see each param). For >1 driver use BULK mode (the installs param).
 
-Verifies the install compiled: returns success=false with the error if the hub accepted the request but the driver failed to compile. Requires Write master + confirm + backup <24h. Returns new driver ID(s).""",
+Verifies the install compiled: returns success=false with the error if the hub accepted the request but the driver failed to compile. Requires Write master + confirm + backup <24h. Returns new driver ID(s).
+[[FLAT_TRIM]]
+Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this write; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]
+""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -2661,7 +2670,8 @@ Verifies the install compiled: returns success=false with the error if the hub a
                             ]
                         ]
                     ],
-                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
+                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["confirm"]
             ],
@@ -2699,7 +2709,11 @@ Supply the new code via exactly one of source / sourceFile / importUrl, or resav
 
 Auto-backs up before modifying. Requires Write master + confirm + backup <24h.[[FLAT_TRIM]]
 
-Self-update guard: refuses to overwrite the MCP server's own app source or OAuth unless Developer Mode is on.[[/FLAT_TRIM]]""",
+Self-update guard: refuses to overwrite the MCP server's own app source or OAuth unless Developer Mode is on.[[/FLAT_TRIM]]
+[[FLAT_TRIM]]
+Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this write; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]
+""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -2711,7 +2725,8 @@ Self-update guard: refuses to overwrite the MCP server's own app source or OAuth
                     expectedVersion: [type: "integer", description: "OPTIONAL optimistic-lock guard; aborts with conflict:true on mismatch.[[FLAT_TRIM]] Stringified integers coerced; explicit null rejected.[[/FLAT_TRIM]]"],
                     triggerUpdated: [type: "integer", description: "OPTIONAL: running instance appId to fire updated() after save."],
                     oauth: [type: "object", description: "OPTIONAL: enable/configure OAuth on this app (apps only); e.g. {enabled:true}. Full shape: hub_get_tool_guide(section='hub_admin_write')."],
-                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
+                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["appId", "confirm"]
             ],
@@ -2744,7 +2759,11 @@ Self-update guard: refuses to overwrite the MCP server's own app source or OAuth
 
 Supply the new code via exactly one of source / sourceFile / importUrl, or resave to recompile in place (see each param). For >1 driver use BULK mode (the updates param).
 
-Auto-backs up before modifying. Requires Write master + confirm + backup <24h.""",
+Auto-backs up before modifying. Requires Write master + confirm + backup <24h.
+[[FLAT_TRIM]]
+Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this write; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]
+""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -2770,7 +2789,8 @@ Auto-backs up before modifying. Requires Write master + confirm + backup <24h.""
                             required: ["driverId"]
                         ]
                     ],
-                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
+                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["confirm"]
             ],
@@ -2844,14 +2864,19 @@ Tell the user the item name/ID, warn it's permanent, get confirmation. Requires 
 
 Provide exactly one of source / sourceFile / importUrl (see each param).
 
-Source must include a library() block with name/namespace/author/description (all required). The hub does NOT compile-check libraries at install -- syntax errors surface only when an app/driver #includes it. Requires Write master + confirm + backup <24h. Returns new libraryId.""",
+Source must include a library() block with name/namespace/author/description (all required). The hub does NOT compile-check libraries at install -- syntax errors surface only when an app/driver #includes it. Requires Write master + confirm + backup <24h. Returns new libraryId.
+[[FLAT_TRIM]]
+Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this write; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]
+""",
             inputSchema: [
                 type: "object",
                 properties: [
                     source: [type: "string", description: "Inline source (stubs only)."],
                     sourceFile: [type: "string", description: "File Manager filename (write it first via hub_write_file), e.g. my-code.groovy."],
                     importUrl: [type: "string", description: "URL the hub fetches directly (http/https)."],
-                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
+                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["confirm"]
             ],
@@ -2878,7 +2903,11 @@ Source must include a library() block with name/namespace/author/description (al
 
 Supply the new code via exactly one of source / sourceFile / importUrl, or resave to recompile in place (see each param). Not compile-checked at save (see hub_create_library).
 
-Auto-backs up before modifying. Requires Write master + confirm + backup <24h.""",
+Auto-backs up before modifying. Requires Write master + confirm + backup <24h.
+[[FLAT_TRIM]]
+Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this write; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]
+""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -2887,7 +2916,8 @@ Auto-backs up before modifying. Requires Write master + confirm + backup <24h.""
                     sourceFile: [type: "string", description: "File Manager filename (write it first via hub_write_file), e.g. my-code.groovy."],
                     importUrl: [type: "string", description: "URL the hub fetches directly (http/https)."],
                     resave: [type: "boolean", description: "Re-save the current source without changes. Runs entirely on-hub."],
-                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."]
+                    confirm: [type: "boolean", description: "REQUIRED: Must be true. Confirms backup was created and user approved."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["libraryId", "confirm"]
             ],

--- a/libraries/mcp-diagnostics-lib.groovy
+++ b/libraries/mcp-diagnostics-lib.groovy
@@ -1981,8 +1981,75 @@ def toolDeleteCapturedState(args) {
     return stateId ? deleteCapturedState(stateId) : clearAllCapturedStates()
 }
 
+// hub_get_op_result: recover the outcome of a slow write whose response was lost
+// (cloud-relay drop / gateway timeout). The idempotency-token bookkeeping lives in
+// the main app (opToken machinery); this read returns its tri-state view. Reuses
+// the app's _validateOpToken / _opTokenReadResult helpers (resolved after the
+// #include inline).
+def toolGetOpResult(args) {
+    def opToken = (args instanceof Map && args.opToken != null) ? args.opToken.toString() : null
+    if (!opToken) throw new IllegalArgumentException("opToken is required (the idempotency token you passed on the original write). See hub_get_tool_guide(section='slow_ops').")
+    _validateOpToken(opToken)
+    def toks = atomicState.opTokens
+    def rec = (toks instanceof Map && toks[opToken] instanceof Map) ? toks[opToken] : null
+    if (rec == null) {
+        return [
+            status: "unknown", opToken: opToken,
+            note: "No operation with this token ever started on this hub -- the original call never arrived. Safe to retry the original call with the same token. See hub_get_tool_guide(section='slow_ops')."
+        ]
+    }
+    if (rec.state == "running") {
+        def started = (rec.startedAt != null) ? (rec.startedAt as Long) : null
+        return [
+            status: "running", opToken: opToken, tool: rec.tool, startedAt: rec.startedAt,
+            elapsedMs: (started != null) ? (now() - started) : null,
+            note: "Still executing. Poll again in a few seconds. Writes commit even when the transport drops -- do not re-issue the original call. See hub_get_tool_guide(section='slow_ops')."
+        ]
+    }
+    def parsed = _opTokenReadResult(rec)
+    if (parsed == null) {
+        return [
+            status: "unknown", opToken: opToken, tool: rec.tool,
+            note: "This token completed but its buffered result has expired or could not be read. Verify current state via reads before retrying. See hub_get_tool_guide(section='slow_ops')."
+        ]
+    }
+    return [
+        status: "complete", opToken: opToken, tool: rec.tool,
+        isError: (rec.isError == true), finishedAt: rec.finishedAt, result: parsed
+    ]
+}
+
 def _getAllToolDefinitions_partDiagnostics() {
     return [
+        [
+            name: "hub_get_op_result",
+            description: """Fetch a slow write's committed result by its idempotency token (opToken) after a dropped/timed-out response. Read-only; safe to poll.
+[[FLAT_TRIM]]
+Use when a slow write over the cloud relay returned a transport error and you don't know whether it landed. Returns one of three shapes by `status`: "unknown" (no such token ever ran here -- the original call never arrived, so re-issue it with the same token), "running" (still executing -- poll again shortly; the write commits even though your response dropped, so do NOT re-issue), or "complete" (the original result under `result`, plus `isError` and `finishedAt`). Buffered results are swept after ~24h. Full protocol: hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]""",
+            inputSchema: [
+                type: "object",
+                properties: [
+                    opToken: [type: "string", description: "The idempotency token you invented and passed on the original slow write (8-128 chars, A-Za-z0-9._-)."]
+                ],
+                required: ["opToken"]
+            ],
+            outputSchema: [
+                type: "object",
+                properties: [
+                    status: [type: "string", description: "unknown | running | complete"],
+                    opToken: [type: "string", description: "Echoed token"],
+                    tool: [type: "string", description: "The write tool this token was attached to; present once the operation has started"],
+                    startedAt: [type: "integer", description: "Epoch ms when the operation started; present for running"],
+                    elapsedMs: [type: ["integer", "null"], description: "Ms elapsed since start; present for running (null if the start time is unknown)"],
+                    finishedAt: [type: "integer", description: "Epoch ms when the operation completed; present for complete"],
+                    isError: [type: "boolean", description: "Whether the buffered result was an error; present for complete"],
+                    result: [type: "object", description: "The original tool result object; present for complete"],
+                    note: [type: "string", description: "Recovery guidance; present for unknown/running"]
+                ],
+                required: ["status", "opToken"]
+            ]
+        ],
         [
             name: "hub_get_logs",
             description: """Get Hubitat system logs, most recent first. Requires Read master.""",
@@ -2533,6 +2600,8 @@ def _readOnlyToolNames_partDiagnostics() {
         "hub_list_captured_states",
         // Diagnostics + logs (read)
         "hub_get_logs", "hub_get_performance_stats", "hub_get_jobs", "hub_get_memory_history", "hub_get_radio_details",
+        // Idempotency-token result recovery (pure read of buffered op results)
+        "hub_get_op_result",
         // hub_get_metrics is read by default (recordSnapshot defaults false;
         // pass recordSnapshot=true to also persist a CSV snapshot to File Manager).
         "hub_get_metrics",
@@ -2573,6 +2642,7 @@ def _toolDisplayMeta_partDiagnostics() {
     return [
         // Diagnostics + logs
         hub_get_logs: [title: "Get Hub Logs", summary: "Hub log entries with level, source, regex, and time-window filters."],
+        hub_get_op_result: [title: "Get Operation Result", summary: "Fetch a slow write's buffered result by its idempotency token after a dropped response."],
         hub_get_performance_stats: [title: "Get Performance Stats", summary: "Device and app performance statistics."],
         hub_get_jobs: [title: "Get Scheduled Jobs", summary: "Scheduled jobs, running jobs, and hub actions."],
         hub_get_metrics: [title: "Get Hub Metrics", summary: "Hub metrics with CSV trend history."],

--- a/libraries/mcp-diagnostics-lib.groovy
+++ b/libraries/mcp-diagnostics-lib.groovy
@@ -2008,9 +2008,11 @@ def toolGetOpResult(args) {
     }
     def parsed = _opTokenReadResult(rec)
     if (parsed == null) {
+        // Distinct from "unknown": the op DID run to completion here, so the
+        // safe-to-retry status must never be emitted for this case.
         return [
-            status: "unknown", opToken: opToken, tool: rec.tool,
-            note: "This token completed but its buffered result has expired or could not be read. Verify current state via reads before retrying. See hub_get_tool_guide(section='slow_ops')."
+            status: "indeterminate", opToken: opToken, tool: rec.tool,
+            note: "This token completed but its buffered result has expired or could not be read. Do not re-issue blindly -- verify current state via reads first. See hub_get_tool_guide(section='slow_ops')."
         ]
     }
     return [
@@ -2025,7 +2027,7 @@ def _getAllToolDefinitions_partDiagnostics() {
             name: "hub_get_op_result",
             description: """Fetch a slow write's committed result by its idempotency token (opToken) after a dropped/timed-out response. Read-only; safe to poll.
 [[FLAT_TRIM]]
-Use when a slow write over the cloud relay returned a transport error and you don't know whether it landed. Returns one of three shapes by `status`: "unknown" (no such token ever ran here -- the original call never arrived, so re-issue it with the same token), "running" (still executing -- poll again shortly; the write commits even though your response dropped, so do NOT re-issue), or "complete" (the original result under `result`, plus `isError` and `finishedAt`). Buffered results are swept after ~24h. Full protocol: hub_get_tool_guide(section='slow_ops').
+Use when a slow write over the cloud relay returned a transport error and you don't know whether it landed. `status` is one of: "unknown" (no such token ever ran here -- the original call never arrived, so re-issue it with the same token), "running" (still executing -- poll again shortly; the write commits even though your response dropped, so do NOT re-issue), "complete" (the original result under `result`, plus `isError` and `finishedAt`), or "indeterminate" (it completed but the buffered result is gone -- do NOT re-issue blindly; verify state via reads). Buffered results are swept opportunistically once older than ~24h. Full protocol: hub_get_tool_guide(section='slow_ops').
 [[/FLAT_TRIM]]""",
             inputSchema: [
                 type: "object",
@@ -2037,7 +2039,7 @@ Use when a slow write over the cloud relay returned a transport error and you do
             outputSchema: [
                 type: "object",
                 properties: [
-                    status: [type: "string", description: "unknown | running | complete"],
+                    status: [type: "string", description: "unknown | running | complete | indeterminate (completed but buffered result unreadable -- verify state before any retry)"],
                     opToken: [type: "string", description: "Echoed token"],
                     tool: [type: "string", description: "The write tool this token was attached to; present once the operation has started"],
                     startedAt: [type: "integer", description: "Epoch ms when the operation started; present for running"],

--- a/libraries/mcp-discovery-lib.groovy
+++ b/libraries/mcp-discovery-lib.groovy
@@ -249,7 +249,7 @@ def _getAllToolDefinitions_partDiscovery() {
             inputSchema: [
                 type: "object",
                 properties: [
-                    section: [type: "string", description: "REQUIRED for efficiency: pass one section key (see enum). Omit only to fetch the full guide / discover the available keys.", enum: ["device_authorization", "best_practice_reference", "hub_admin_write", "virtual_devices", "update_device", "rules", "backup", "file_manager", "performance", "builtin_app_tools", "set_rule_reference", "set_rule_create_reference", "visual_rule_reference", "variables", "dashboards", "bundles", "rooms"]]
+                    section: [type: "string", description: "REQUIRED for efficiency: pass one section key (see enum). Omit only to fetch the full guide / discover the available keys.", enum: ["device_authorization", "best_practice_reference", "hub_admin_write", "virtual_devices", "update_device", "rules", "backup", "file_manager", "performance", "builtin_app_tools", "set_rule_reference", "set_rule_create_reference", "visual_rule_reference", "variables", "dashboards", "bundles", "rooms", "slow_ops"]]
                 ]
             ],
             outputSchema: [

--- a/libraries/mcp-item-backups-lib.groovy
+++ b/libraries/mcp-item-backups-lib.groovy
@@ -806,7 +806,11 @@ def _getAllToolDefinitions_partItemBackups() {
         // ==================== Hub-DB (whole-hub) backup tools — issue #259 item #1 ====================
         [
             name: "hub_create_backup",
-            description: """Create a full hub-database backup (whole-hub .lzf). REQUIRED before any Write master op (24h validity).[[FLAT_TRIM]] Optionally set the automatic-backup schedule via `schedule` (scheduleOnly=true sets the schedule only). The only write tool needing no prior backup.[[/FLAT_TRIM]]""",
+            description: """Create a full hub-database backup (whole-hub .lzf). REQUIRED before any Write master op (24h validity).[[FLAT_TRIM]] Optionally set the automatic-backup schedule via `schedule` (scheduleOnly=true sets the schedule only). The only write tool needing no prior backup.[[/FLAT_TRIM]]
+[[FLAT_TRIM]]
+Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this write; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]
+""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -819,7 +823,8 @@ def _getAllToolDefinitions_partItemBackups() {
                         cloudBackupFrequency: [type: "integer", enum: [0, 1, 2, 3, 5, 7, 14, 21, 28], description: "Cloud backup interval in DAYS (0=off); kept if omitted"],
                         cloudBackupPassword: [type: "string", description: "Cloud-backup encryption password. Required when cloud backup is/stays enabled."]
                     ]],
-                    scheduleOnly: [type: "boolean", description: "With schedule: set schedule only, no backup now."]
+                    scheduleOnly: [type: "boolean", description: "With schedule: set schedule only, no backup now."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["confirm"]
             ],
@@ -951,7 +956,11 @@ def _getAllToolDefinitions_partItemBackups() {
         ],
         [
             name: "hub_restore_backup",
-            description: """⚠️ Restore a backup — tell the user first; hub-DB scopes REBOOT the hub.[[FLAT_TRIM]] scope=source (default): an app/driver/rule by backupKey (deleted code → hub_create_*; deleted rules DO recreate). scope=hub_local/hub_cloud: restore the WHOLE hub DB (hub_local→fileName; hub_cloud→path+cloudBackupPassword). scope=hub_uploaded: upload an external .lzf from backupUrl, then restore (open-world).[[/FLAT_TRIM]] Write master + confirm.""",
+            description: """⚠️ Restore a backup — tell the user first; hub-DB scopes REBOOT the hub.[[FLAT_TRIM]] scope=source (default): an app/driver/rule by backupKey (deleted code → hub_create_*; deleted rules DO recreate). scope=hub_local/hub_cloud: restore the WHOLE hub DB (hub_local→fileName; hub_cloud→path+cloudBackupPassword). scope=hub_uploaded: upload an external .lzf from backupUrl, then restore (open-world).[[/FLAT_TRIM]] Write master + confirm.
+[[FLAT_TRIM]]
+Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this write; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]
+""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -961,7 +970,8 @@ def _getAllToolDefinitions_partItemBackups() {
                     path: [type: "string", description: "scope=hub_cloud: the cloud backup `path` from hub_list_backups."],
                     cloudBackupPassword: [type: "string", description: "scope=hub_cloud: cloud backup encryption password."],
                     backupUrl: [type: "string", description: "scope=hub_uploaded: http(s) URL to the .lzf to upload+restore."],
-                    confirm: [type: "boolean", description: "REQUIRED true. Confirms the restore (hub-DB scopes reboot)."]
+                    confirm: [type: "boolean", description: "REQUIRED true. Confirms the restore (hub-DB scopes reboot)."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["confirm"]
             ],

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -116,7 +116,9 @@ def _getAllToolDefinitions_partNativeRM() {
             name: "hub_set_native_app",
             description: """Create OR edit a classic native automation app on the hub — one generic upsert tool for any classic SmartApp instance (Room Lighting, Button Controller, Notifier, Group, Scene, Visual Rule, etc.): omit appId to CREATE (appType + name), provide appId to EDIT via settings/button. For Rule Machine RULES use hub_set_rule.
 
-Requires the Write master + confirm=true + recent hub backup.""",
+Requires the Write master + confirm=true + recent hub backup.
+
+Slow multi-step calls over a cloud relay may return status:'in_progress' with resume instructions, or the transport may drop with a gateway error while the hub still commits — see hub_get_tool_guide(section='slow_ops') for the recovery protocol.""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -129,6 +131,7 @@ Requires the Write master + confirm=true + recent hub backup.""",
                     stateAttribute: [type: "string", description: "Optional state attribute value for the button click."],
                     buttonRule: [type: "object", description: "Create a Button Rule under an existing Button Controller.", properties: [controllerId: [type: "integer", description: "Button Controller-5.1 appId"], buttonNumber: [type: "integer", description: "button number (>=1)"], event: [type: "string", enum: ["pushed", "held", "doubleTapped", "released"]]]],
                     walkStep: [type: "object", description: "Advanced multi-page classic-app walker — EDIT-only (requires appId; rejected on create).[[FLAT_TRIM]] Generic classic-dynamicPage walker for stateful apps: introspect/write/click/navigate/done one step per call, or operation='drive' with steps=[...] to run the whole sequence in one call. Same shape as hub_set_rule's walkStep.[[/FLAT_TRIM]]"],
+                    opToken: [type: "string", description: "Optional idempotency token you invent (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call."],
                     confirm: [type: "boolean", description: "Must be true. Safety gate for Write master operations."]
                 ],
                 required: ["confirm"]
@@ -171,7 +174,9 @@ Shortcuts, each orchestrating the full RM 5.1 wizard in one call: addTrigger, ad
 
 Partial-success (every shortcut): success:true can pair with partial:true — inspect partial/repairHints. A rejected trailing updateRule leaves the change written-but-not-live (subscriptionsNotLive / expressionNotLive / variableNotLive / patchesNotLive); retry hub_set_rule(button='updateRule', confirm=true). If wizardStuck:true, first hub_set_rule(button='cancelCapab', pageName=<page>, confirm=true) — restoreHint carries the exact command. On CREATE the new appId is returned even if a bundled item only partially bakes (partialTriggers/partialActions).
 
-Deep reference (per-capability field specs, extended condition shapes, periodic schedules, the raw settings/button flow, worked examples): pass guide:true to get it inline, or hub_get_tool_guide(section='set_rule_reference'); full create + repair protocol: hub_get_tool_guide(section='set_rule_create_reference'). Pass {discover:true} on addTrigger/addAction for the live machine-readable schema.""",
+Deep reference (per-capability field specs, extended condition shapes, periodic schedules, the raw settings/button flow, worked examples): pass guide:true to get it inline, or hub_get_tool_guide(section='set_rule_reference'); full create + repair protocol: hub_get_tool_guide(section='set_rule_create_reference'). Pass {discover:true} on addTrigger/addAction for the live machine-readable schema.
+
+Slow multi-step calls over a cloud relay may return status:'in_progress' with resume instructions, or the transport may drop with a gateway error while the hub still commits — see hub_get_tool_guide(section='slow_ops') for the recovery protocol.""",
             inputSchema: [
                 type: "object",
                 properties: [
@@ -252,6 +257,7 @@ Deep reference (per-capability field specs, extended condition shapes, periodic 
                     ],
                     guide: [type: "boolean", description: "Set true to return the full hub_set_rule capability reference inline (same content as hub_get_tool_guide(section='set_rule_reference')), without a separate call. Makes NO change to any rule."],
                     buttonRule: [type: "object", description: "Create a Button Rule under an existing Button Controller: {controllerId, buttonNumber, event}. Returns buttonRuleId with the Button trigger auto-seeded — then author actions via addAction on that appId. The controller must already have a button device.", properties: [controllerId: [type: "integer", description: "Button Controller-5.1 appId"], buttonNumber: [type: "integer", description: "button number (>=1)"], event: [type: "string", enum: ["pushed", "held", "doubleTapped", "released"]]]],
+                    opToken: [type: "string", description: "Optional idempotency token you invent (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call."],
                     confirm: [type: "boolean", description: "Must be true."]
                 ],
                 required: ["confirm"]
@@ -4875,7 +4881,7 @@ private boolean _rmRollbackInFlightExpressionAction(Integer appId, Integer idx, 
 //
 // Returns: [success, actionIndex, capability, action, settingsApplied,
 // configPageError]
-private Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = false) {
+Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = false) {
     if (!(actionSpec instanceof Map)) throw new IllegalArgumentException("addAction requires a Map spec")
     // Discover mode -- return static schema without touching the hub.
     // No capability field required; no Write master gate; no backup.
@@ -7785,7 +7791,7 @@ private Map _rmCollectWalkSchema(Map configPage, Map liveSettings = null) {
 //
 // For "introspect" the call only fetches the schema — no mutation. The
 // `before` snapshot is the same as `after` and `diff` is empty.
-private Map _rmWalkStep(Integer appId, Map spec) {
+Map _rmWalkStep(Integer appId, Map spec) {
     // "drive" runs an ordered sequence of single-step operations in ONE call --
     // the progressive flow that replaces the manual introspect -> navigate ->
     // write each field -> done -> finalize loop the caller used to issue as N
@@ -8122,6 +8128,11 @@ private Map _rmDriveWalkSteps(Integer appId, Map spec) {
     def currentPage = spec?.page?.toString()?.trim()
     def allOk = true
     def lastStepOperation = null
+    // Cloud-relay self-budget: set when the budget is reached BETWEEN steps so the
+    // post-loop path returns an in_progress envelope with the unrun steps instead of
+    // the normal fail-loud rollup. Null on every non-cloud / within-budget run.
+    Integer pausedAtStep = null
+    List stepsRemaining = null
     // Pre-flight: validate every step's SHAPE before issuing ANY live POST. A drive is
     // partial-commit by nature (each write/click is a live POST), so a structural mistake
     // -- a non-object step, or a nested drive -- must reject the whole drive up front,
@@ -8139,6 +8150,18 @@ private Map _rmDriveWalkSteps(Integer appId, Map spec) {
     int idx = 0
     for (def rawStep : steps) {
         idx++
+        // Cloud-relay self-budget checkpoint -- BETWEEN steps only. Never before the
+        // first step (idx > 1) and never after a step already failed (allOk), so a
+        // pause always represents a clean partial: every earlier step committed and
+        // nothing failed. Each step is a live POST, so stopping here and handing back
+        // the unrun steps lets the caller resume before the relay drops the response.
+        if (idx > 1 && allOk && _relayBudgetExceeded(spec?.__reqT0 as Long)) {
+            pausedAtStep = idx
+            stepsRemaining = steps.subList(idx - 1, steps.size()).collect { rem ->
+                (rem instanceof Map) ? ((Map) rem).findAll { k, v -> k != "__reqT0" } : rem
+            }
+            break
+        }
         def step = new LinkedHashMap((Map) rawStep)
         def stepOp = step.operation?.toString()?.trim() ?: "introspect"
         // Inherit the page the previous step ended on when this step omits one.
@@ -8189,6 +8212,28 @@ private Map _rmDriveWalkSteps(Integer appId, Map spec) {
         }
     }
     def finalHealth = _rmCheckRuleHealth(appId)
+    // Paused (cloud-relay budget reached between steps): return an in_progress envelope
+    // and skip the fail-loud rollup below -- a pause is NOT an error. success:true holds
+    // because the pause guard only trips when nothing has failed; every completed step is
+    // committed and its per-step signals ride in steps[].
+    if (pausedAtStep != null) {
+        return [
+            success: true,
+            status: "in_progress",
+            operation: "drive",
+            page: currentPage,
+            stepsRequested: steps.size(),
+            stepsRun: stepResults.size(),
+            pausedAtStep: pausedAtStep,
+            stepsRemaining: stepsRemaining,
+            lastStepOperation: lastStepOperation,
+            steps: stepResults,
+            health: finalHealth,
+            resume: [
+                note: "Relay time budget reached; all completed steps are committed. Re-issue walkStep operation='drive' with steps = stepsRemaining (page inheritance: set page = this result's page) to continue. Attach the same opToken ONLY if the original call carried none; otherwise use a fresh token."
+            ]
+        ]
+    }
     def result = [
         success: allOk && finalHealth.ok,
         operation: "drive",
@@ -8313,7 +8358,7 @@ private Map _rmSubmitFullPageForm(Integer appId, String pageName, Map cfg, Map s
 // Entries get type="rm-rule" so hub_list_backups + hub_restore_backup
 // (the existing tools) handle them too — no separate RM-only backup
 // tools. Backup key pattern: rm-rule_<ruleId>_<yyyyMMdd-HHmmss>.
-private Map _rmBackupRuleSnapshot(Integer ruleId, String reason) {
+Map _rmBackupRuleSnapshot(Integer ruleId, String reason) {
     def config
     def status
     try {
@@ -8681,9 +8726,14 @@ def toolSetRule(args) {
     // the rest of this handler and gateway mode stay one code path. A probe (op +
     // empty args) returns that op's schema with NO mutation and returns early.
     if (args instanceof Map && args.operation != null) {
+        // _setRuleFromEnvelope rebuilds args from scratch (dropping unknown keys); carry the
+        // request-entry clock across so the drive/patches cloud-relay self-budget still sees it
+        // for envelope-form calls (the direct canonical form keeps it via straight pass-through).
+        def reqT0 = args.__reqT0
         def rekeyed = _setRuleFromEnvelope(args)
         if (rekeyed.containsKey('_schema')) return rekeyed._schema
         args = rekeyed.args
+        if (reqT0 != null && args instanceof Map) args.__reqT0 = reqT0
     }
     // Button Controllers are an RM-family classic app, and their grandchild
     // Button Rules are RM-wire-format -- so creating a Button Rule is exposed
@@ -12439,7 +12489,16 @@ def _applyNativeAppEdit(args) {
     // not-yet-mapped capability handlers, future RM features).
     if (walkStepSpec) {
         try {
-            def result = _rmWalkStep(appId, walkStepSpec)
+            // operation='drive' self-budgets between steps under a cloud relay; hand it the
+            // request-entry clock (read as spec.__reqT0). Threaded only for drive (single
+            // steps don't budget) and via a copy so the caller's args.walkStep is never
+            // mutated and __reqT0 can't leak into a single-step result echo.
+            def wsSpec = walkStepSpec
+            if (args?.__reqT0 != null && walkStepSpec?.operation?.toString()?.trim() == "drive") {
+                wsSpec = new LinkedHashMap(walkStepSpec)
+                wsSpec.__reqT0 = args.__reqT0
+            }
+            def result = _rmWalkStep(appId, wsSpec)
             result.appId = appId
             result.backup = backup
             // Click mainPage Done as the final step — only if the walk's
@@ -13058,10 +13117,39 @@ def _applyNativeAppEdit(args) {
         // on the intermediate, not the original). Track it to refuse the second.
         def seenReplaceRE = false
         try {
-            patchesList.eachWithIndex { p, pi ->
+            // Indexed for-loop (not eachWithIndex) so the cloud-relay budget checkpoint can
+            // cleanly break/return between ops -- a Groovy closure can't break out of a loop.
+            int pi = -1
+            for (def p : patchesList) {
+                pi++
+                // Cloud-relay self-budget checkpoint -- BETWEEN patch ops only, never before
+                // the first (pi > 0) and never after an op already failed (patches don't abort
+                // on a per-op failure, so a clean-partial pause requires every op so far ok --
+                // this keeps the in_progress success:true truthful). Each op is a live POST;
+                // stopping here and handing back the unprocessed specs lets the caller resume
+                // before the relay drops the response. CRITICAL: return BEFORE the batch-end
+                // trailing updateRule below so it does NOT fire -- the ops so far are committed
+                // at the settings level but not yet baked; the resume call's own batch-end
+                // updateRule bakes them once the remaining patches complete.
+                if (pi > 0 && patchResults.every { it?.success != false } && _relayBudgetExceeded(args?.__reqT0 as Long)) {
+                    def patchesRemaining = patchesList.subList(pi, patchesList.size()).collect { rem ->
+                        (rem instanceof Map) ? ((Map) rem).findAll { k, v -> k != "__reqT0" } : rem
+                    }
+                    return [
+                        success: true,
+                        status: "in_progress",
+                        appId: appId,
+                        backup: backup,
+                        patchResults: patchResults,
+                        patchesRemaining: patchesRemaining,
+                        resume: [
+                            note: "Relay time budget reached; all completed patch ops are committed but NOT yet baked into the running rule. Re-issue hub_set_rule edit with patches = patchesRemaining to continue; the rule finalize/updateRule runs when the remaining patches complete. Attach the same opToken ONLY if the original call carried none; otherwise use a fresh token."
+                        ]
+                    ]
+                }
                 if (!(p instanceof Map)) {
                     patchResults << [success: false, error: "patches[${pi}] is not a Map", spec: p]
-                    return
+                    continue
                 }
                 def pm = p as Map
                 try {
@@ -13110,7 +13198,7 @@ def _applyNativeAppEdit(args) {
                         if (seenReplaceRE) {
                             patchResults << [success: false, op: "replaceRequiredExpression",
                                 error: "patches[${pi}]: a rule has a single Required Expression; only one replaceRequiredExpression is valid per patches batch -- the second would replace the first. Remove the duplicate, or issue the second replace as a separate hub_set_rule call."]
-                            return
+                            continue
                         }
                         seenReplaceRE = true
                         // Per-op snapshot, NOT the pre-batch `backup`: replaceRequiredExpression
@@ -13271,7 +13359,7 @@ def _applyNativeAppEdit(args) {
                     // structured envelope (scoped to the top-level clearActions
                     // / replaceActions path), but the raw marker shouldn't leak
                     // into per-patch error / warn-log either. Local name distinct
-                    // from the outer-closure `patchErr` so the top-level result
+                    // from the outer-scope `patchErr` so the top-level result
                     // envelope still drives off the post-trailing-updateRule
                     // aggregate, not the per-patch exception text.
                     def cleanedPatchErr = subExc.message?.replace(getAsyncCommitMarker(), "") ?: subExc.message

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -12505,9 +12505,14 @@ def _applyNativeAppEdit(args) {
             // final operation was 'done' (meaning the wizard flow is complete):
             // a single-step 'done', or a 'drive' whose last step was 'done'.
             // For introspect/write/click/navigate ops in the middle of a
-            // multi-step walk, skip Done since the caller is mid-flow.
+            // multi-step walk, skip Done since the caller is mid-flow. A relay-budget
+            // paused drive is ALSO mid-flow even when its last-run step was 'done'
+            // (lastStepOperation names the last step that RAN, not the flow's end) --
+            // finalizing there would run the update lifecycle on a half-configured
+            // app and spend a page round-trip after deciding to beat the ceiling.
             def wsOp = walkStepSpec?.operation?.toString()
-            if (wsOp == "done" || (wsOp == "drive" && result?.lastStepOperation == "done")) {
+            if ((wsOp == "done" || (wsOp == "drive" && result?.lastStepOperation == "done"))
+                    && result?.status != "in_progress") {
                 def walkDone = null
                 try { walkDone = _rmSubmitMainPageDone(appId) }
                 catch (Exception doneExc) { mcpLog("warn", "rm-native", "walkStep: trailing mainPage Done click failed for app ${appId}: ${doneExc.message} -- in-flight state markers may linger and corrupt subsequent edits") }

--- a/libraries/mcp-native-rules-lib.groovy
+++ b/libraries/mcp-native-rules-lib.groovy
@@ -146,7 +146,7 @@ Slow multi-step calls over a cloud relay may return status:'in_progress' with re
                     controllerId: [type: "integer", description: "buttonRule: parent Button Controller appId"],
                     appType: [type: "string", description: "create: app type created"],
                     name: [type: "string", description: "create: requested app label"],
-                    labelApplied: [type: "boolean", description: "create: true if the requested name became the display label (verified for rule_machine only; false for partial-support appTypes -- see note)"],
+                    labelApplied: [type: "boolean", description: "create: true when the requested name verifiably became the display label (assumed for rule_machine, read back from the committed page for other appTypes; false when unverifiable -- see note)"],
                     partialTriggers: [type: "array", description: "create: indices of bundled triggers that failed to fully bake (always empty for this generic tool -- no trigger sugar)", items: [type: "integer"]],
                     partialActions: [type: "array", description: "create: indices of bundled actions that failed to fully bake (always empty for this generic tool -- no action sugar)", items: [type: "integer"]],
                     parentAppId: [type: "integer", description: "create: parent app ID"],
@@ -337,7 +337,7 @@ Slow multi-step calls over a cloud relay may return status:'in_progress' with re
                     requiredExpression: [type: "object", description: "create: outcome of a bundled addRequiredExpression (success/partial/error + conditionIndices/settingsSkipped); present only when addRequiredExpression was passed on CREATE"],
                     appType: [type: "string", description: "create: app type created (rule_machine)"],
                     name: [type: "string", description: "create: rule label"],
-                    labelApplied: [type: "boolean", description: "create: true if the requested name became the display label (always true for rule_machine)"],
+                    labelApplied: [type: "boolean", description: "create: true when the requested name verifiably became the display label (assumed for rule_machine, read back for other appTypes)"],
                     parentAppId: [type: "integer", description: "create: parent (Rule Machine) app ID"],
                     statusSummary: [type: "object", description: "create: eventSubscriptions and scheduledJobs counts"],
                     orphanCleanup: [type: "string", description: "create: present when a failed create's half-built shell was cleaned up"]
@@ -5159,6 +5159,11 @@ Map _rmAddAction(Integer appId, Map actionSpec, boolean intraBatch = false) {
                 }
                 break
             default:
+                // 'command' is the device-command tools' field name; steer the mix-up
+                // by name instead of leaving a bare "Unknown switch action 'null'".
+                if (action == null && actionSpec.command != null) {
+                    throw new IllegalArgumentException("switch actions use the 'action' field, not 'command' (got command='${actionSpec.command}'). Supported: on, off, toggle, flash, setPerMode, choosePerMode")
+                }
                 throw new IllegalArgumentException("Unknown switch action '${action}' -- supported: on, off, toggle, flash, setPerMode, choosePerMode")
         }
     } else if (cap == "dimmer") {
@@ -9174,6 +9179,19 @@ def _createNativeAppShell(args) {
             repairHints << "Repair pattern: 1) hub_get_app_config(${newId}, includeSettings=true) to inspect current state. 2) For each partial trigger/action, follow its repairHints. 3) hub_set_rule(walkStep={...}) for incremental field writes; replaceActions(...) or removeAction(index) + addAction(...) for whole-action retries. 4) hub_set_rule(button='updateRule') after fixes to commit. 5) Re-run hub_get_rule_health to verify. Don't conclude failure until tool-only repair attempts are exhausted."
             repairHints << "Full trigger/action field reference: call hub_set_rule(guide:true), or hub_get_tool_guide(section='set_rule_create_reference')."
         }
+        // Verify the label instead of assuming by appType: rule_machine reliably
+        // copies origLabel->label on commit; for every other type read the committed
+        // label back and compare (startsWith tolerates RM-style live suffixes). An
+        // unreadable page keeps the conservative false + the honesty note below.
+        def labelApplied = (appType == "rule_machine")
+        if (!labelApplied && name) {
+            try {
+                def committedLabel = _rmFetchConfigJson(newId)?.app?.label?.toString()
+                labelApplied = (committedLabel != null && committedLabel.startsWith(name.toString()))
+            } catch (Exception labelExc) {
+                logDebug("create ${appType} ${newId}: label verify fetch failed: ${labelExc.message}")
+            }
+        }
         def result = [
             success: health.ok && !partialTriggers && !partialActions && !reFailed && !rePartial,
             partial: (partialTriggers || partialActions || reFailed || rePartial) as Boolean,
@@ -9183,7 +9201,7 @@ def _createNativeAppShell(args) {
             appId: newId,
             appType: appType,
             name: name,
-            labelApplied: (appType == "rule_machine"),
+            labelApplied: labelApplied,
             parentAppId: parentId,
             statusSummary: [
                 eventSubscriptions: (status?.eventSubscriptions?.size() ?: 0),
@@ -9233,14 +9251,12 @@ def _createNativeAppShell(args) {
             if (reResult?.updateRuleFailed) result.updateRuleFailed = true
             if (reResult?.updateRuleError != null) result.updateRuleError = reResult.updateRuleError
         }
-        // Honesty caveat: only rule_machine reliably copies origLabel -> the
-        // installed-app display label on commit. For other (partial-support)
-        // appTypes the requested name may NOT become the visible label, so flag
-        // it via labelApplied + a note rather than letting the {success, name}
-        // envelope imply the label landed.
-        if (appType != "rule_machine") {
+        // Honesty caveat, now only when the label VERIFIABLY did not land (or the
+        // verify read failed): labelApplied above is read back from the committed
+        // page for non-RM types, so a clean create no longer carries a false alarm.
+        if (!labelApplied) {
             result.note = ((result.note ?: "") +
-                " NOTE: appType '${appType}' is partial-support -- the requested name may NOT have been applied as the app's display label (only rule_machine is verified to copy origLabel->label on commit). Verify via hub_get_app_config(appId=${newId}) and rename in the Hubitat UI if needed.").toString().trim()
+                " NOTE: the requested name could not be verified as the app's display label. Verify via hub_get_app_config(appId=${newId}) and rename in the Hubitat UI if needed.").toString().trim()
         }
         return result
     } catch (Exception e) {

--- a/libraries/mcp-self-admin-lib.groovy
+++ b/libraries/mcp-self-admin-lib.groovy
@@ -774,14 +774,19 @@ def _getAllToolDefinitions_partSelfAdmin() {
             name: "hub_update_package",
             description: """Developer Mode self-deploy: full HPM-repair of the MCP package at a git ref in one call -- OVERRIDES whatever is installed, anchored to packageManifest.json AT `ref` so an UNMERGED PR installs.[[FLAT_TRIM]] (Plain HPM Repair only reads the PUBLISHED manifest, so it can't reach an unmerged PR's artifacts.)[[/FLAT_TRIM]]
 
-Gated on enableDeveloperMode[[FLAT_TRIM]] (the tool is hidden from tools/list when Developer Mode is off)[[/FLAT_TRIM]] + the Write master + confirm=true + a recent backup. Use dryRun=true to fetch + parse + plan with ZERO writes (no confirm/backup needed)[[FLAT_TRIM]] and see exactly which bundles and apps would deploy[[/FLAT_TRIM]].""",
+Gated on enableDeveloperMode[[FLAT_TRIM]] (the tool is hidden from tools/list when Developer Mode is off)[[/FLAT_TRIM]] + the Write master + confirm=true + a recent backup. Use dryRun=true to fetch + parse + plan with ZERO writes (no confirm/backup needed)[[FLAT_TRIM]] and see exactly which bundles and apps would deploy[[/FLAT_TRIM]].
+[[FLAT_TRIM]]
+Over a cloud relay the transport may drop the response with a gateway error while the hub still commits this deploy; pass opToken and recover the committed result via hub_get_op_result -- see hub_get_tool_guide(section='slow_ops').
+[[/FLAT_TRIM]]
+""",
             inputSchema: [
                 type: "object",
                 properties: [
                     ref: [type: "string", description: "Branch, tag, or commit SHA to deploy (e.g. 'main' or a PR head SHA)."],
                     dryRun: [type: "boolean", description: "OPTIONAL. When true, report the deploy plan with NO writes (skips the confirm/backup gate). Default false."],
                     baseUrl: [type: "string", description: "OPTIONAL raw-source base override (no trailing slash); defaults to the canonical repo.[[FLAT_TRIM]] Per-call URLs are built as <baseUrl>/<ref>/<path>. Use for forks / CI branches on a different remote.[[/FLAT_TRIM]]"],
-                    confirm: [type: "boolean", description: "REQUIRED for a real deploy (omit for dryRun). Must be true; confirms a recent backup exists and the user approved the self-deploy."]
+                    confirm: [type: "boolean", description: "REQUIRED for a real deploy (omit for dryRun). Must be true; confirms a recent backup exists and the user approved the self-deploy."],
+                    opToken: [type: "string", description: "Optional idempotency token.[[FLAT_TRIM]] You invent it (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call. See hub_get_tool_guide(section='slow_ops').[[/FLAT_TRIM]]"]
                 ],
                 required: ["ref"]
             ],

--- a/libraries/mcp-variables-lib.groovy
+++ b/libraries/mcp-variables-lib.groovy
@@ -986,13 +986,14 @@ def _getAllToolDefinitions_partVariables() {
         ],
         [
             name: "hub_delete_variable",
-            description: "Permanently delete a variable (DESTRUCTIVE — no undo). Auto-detects whether the target is a hub variable (also deletes its connector device when one exists) or a rule_engine variable. Gated on the Write master + confirm=true + a recent backup.[[FLAT_TRIM]]\n\n**Reference safety:** the tool scans every child rule app for serialized references to this variable name (in triggers/conditions/actions) and refuses by default if any are found. To proceed anyway, pass `force=true` after acknowledging the breakage. The response includes a `brokenConsumers` field listing the affected rules when force=true.[[/FLAT_TRIM]]",
+            description: "Permanently delete a variable (DESTRUCTIVE — no undo). Auto-detects whether the target is a hub variable (also deletes its connector device when one exists) or a rule_engine variable. Gated on the Write master + confirm=true + a recent backup.[[FLAT_TRIM]]\n\n**Reference safety:** the tool scans every child rule app for serialized references to this variable name (in triggers/conditions/actions) and refuses by default if any are found. To proceed anyway, pass `force=true` after acknowledging the breakage. The response includes a `brokenConsumers` field listing the affected rules when force=true.\n\nThe consumer scan makes this call slow; over a cloud relay the transport may drop with a gateway error while the hub still commits -- see hub_get_tool_guide(section='slow_ops') for the opToken recovery protocol.[[/FLAT_TRIM]]",
             inputSchema: [
                 type: "object",
                 properties: [
                     name: [type: "string", description: "Variable name to delete"],
                     confirm: [type: "boolean", description: "REQUIRED: must be true to confirm the deletion"],
-                    force: [type: "boolean", description: "OPTIONAL: must be true to proceed when one or more child rule apps reference this variable. Without force, the tool refuses and lists the consumers."]
+                    force: [type: "boolean", description: "OPTIONAL: must be true to proceed when one or more child rule apps reference this variable. Without force, the tool refuses and lists the consumers."],
+                    opToken: [type: "string", description: "Optional idempotency token you invent (8-128 chars, A-Za-z0-9._-). If the transport drops the response, poll hub_get_op_result with this token to fetch the committed result instead of re-issuing the call."]
                 ],
                 required: ["name", "confirm"]
             ],

--- a/src/test/groovy/server/McpToolAnnotationsSpec.groovy
+++ b/src/test/groovy/server/McpToolAnnotationsSpec.groovy
@@ -90,6 +90,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
             'hub_get_app_config',
             'hub_list_hpm_packages',
             'hub_list_rules', 'hub_get_rule_health',
+            'hub_get_op_result',
             'hub_get_tool_guide'
         ]
     }
@@ -507,6 +508,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
             'hub_list_hpm_packages',
             'hub_list_rules', 'hub_get_rule_health', 'hub_list_rule_local_variables', 'hub_get_visual_rule',
             'hub_list_dashboards', 'hub_get_dashboard',
+            'hub_get_op_result',
             'hub_get_tool_guide'
             // hub_search_tools is in getReadOnlyToolNames() but suppressed in flat mode.
         ] as Set
@@ -587,7 +589,7 @@ class McpToolAnnotationsSpec extends ToolSpecBase {
         names.size() == (names as Set).size()
 
         and: 'no chunk dropped — the full surface is present (bump on intentional add/remove)'
-        names.size() == 117
+        names.size() == 118
 
         and: 'sentinels from the first and last chunks survive the concatenation chain'
         names.contains('hub_list_devices')   // first chunk

--- a/src/test/groovy/server/OpTokenReplaySpec.groovy
+++ b/src/test/groovy/server/OpTokenReplaySpec.groovy
@@ -253,11 +253,13 @@ class OpTokenReplaySpec extends ToolSpecBase {
         new String(store[FILE_PREFIX + 'bigtoken123.json'], 'UTF-8').contains(bigPayload)
     }
 
-    def "the token nested in gateway inner args is extracted (args.args.opToken)"() {
-        given:
+    def "the token nested in gateway inner args is extracted (args.args.opToken) and stripped before dispatch"() {
+        given: 'gateway mode pinned -- this test exercises the gateway-nested token shape'
+        settingsMap.useGateways = true
         settingsMap.enableWrite = true
         installFileStore()
-        script.metaClass.toolCreateRoom = { a -> [success: true, roomId: 3] }
+        def received = [:]
+        script.metaClass.toolCreateRoom = { a -> received.args = a; [success: true, roomId: 3] }
 
         when: 'a gateway-wrapped write whose opToken rides in the inner args'
         def response = mcpDriver.callTool('hub_manage_rooms',
@@ -266,6 +268,10 @@ class OpTokenReplaySpec extends ToolSpecBase {
         then: 'the token was processed -- a marker exists for it'
         response.error == null
         atomicStateMap.opTokens['gwtoken123']?.state == 'complete'
+
+        and: 'the leaf never sees the consumed token (strict-arg tools stay tokenable)'
+        received.args instanceof Map
+        !received.args.containsKey('opToken')
     }
 
     @spock.lang.Unroll

--- a/src/test/groovy/server/OpTokenReplaySpec.groovy
+++ b/src/test/groovy/server/OpTokenReplaySpec.groovy
@@ -1,0 +1,349 @@
+package server
+
+import support.ToolSpecBase
+
+/**
+ * Spec for the opToken idempotency machinery (issue #348, section A) in
+ * hubitat-mcp-server.groovy::handleToolsCall. Token processing happens ONCE per
+ * request in handleToolsCall (never in executeTool, which gateway re-entry would
+ * double-process), so these drive the full envelope via mcpDriver.callTool and
+ * assert on the returned inner result + the atomicState.opTokens marker + the
+ * buffered File-Manager result file.
+ *
+ * Contract under test:
+ *   - extract opToken from args.opToken OR the gateway inner args.args.opToken
+ *   - validate 8-128 chars, charset [A-Za-z0-9._-]; invalid -> IAE -> -32602
+ *   - process the token ONLY when the resolved leaf is a WRITE tool (reads ignore it)
+ *   - dedup: running -> isError status:running (do NOT re-run the write);
+ *            complete -> replay the buffered result + replayed:true (no re-run);
+ *            complete-but-file-swept -> status:unknown
+ *   - a started marker is written before the tool runs and completed on EVERY
+ *     terminal path (success, thrown IAE, generic throw)
+ *   - _opTokenMark prunes >24h entries (deleting their result files) and caps at 50
+ *   - _opTokenComplete buffers the result to mcp-op-result-<token>.json (with an
+ *     inline / failed_buffer fallback when the upload fails)
+ *
+ * Mocking strategy (see docs/testing.md): uploadHubFile / downloadHubFile /
+ * deleteHubFile are stubbed per-test on script.metaClass, exactly like the
+ * McpFilesLib specs. A write tool is stubbed via metaClass (toolCreateRoom) so the
+ * token machinery is exercised without wiring the room tool's own hub calls; the
+ * central Write master (enableWrite default ON) still lets the write through.
+ */
+class OpTokenReplaySpec extends ToolSpecBase {
+
+    private static final String FILE_PREFIX = 'mcp-op-result-'
+    private static final long FIXED_NOW = 1234567890000L
+    private static final long DAY_MS = 24L * 60L * 60L * 1000L
+
+    // A byte-array store shared by the upload/download stubs so a buffered result
+    // round-trips exactly the way it would through the hub File Manager.
+    private Map<String, byte[]> installFileStore() {
+        Map<String, byte[]> store = [:]
+        script.metaClass.uploadHubFile = { String name, byte[] content -> store[name] = content }
+        script.metaClass.downloadHubFile = { String name -> store[name] }
+        script.metaClass.deleteHubFile = { String name -> store.remove(name) }
+        return store
+    }
+
+    // ---------------- full-path dedup / replay / marker completion ----------------
+
+    def "a valid token on a write tool marks running then completes and buffers the result"() {
+        given:
+        settingsMap.enableWrite = true
+        def store = installFileStore()
+        def ran = 0
+        script.metaClass.toolCreateRoom = { a -> ran++; [success: true, roomId: 7, name: 'Den'] }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'abc12345'])
+
+        then: 'the write ran exactly once and the room result came back'
+        ran == 1
+        response.error == null
+        !response.result.isError
+        def inner = mcpDriver.parseInner(response)
+        inner.roomId == 7
+
+        and: 'the marker is completed (not left running) and names its buffer file'
+        def marker = atomicStateMap.opTokens['abc12345']
+        marker.state == 'complete'
+        marker.tool == 'hub_create_room'
+        marker.isError == false
+        marker.file == FILE_PREFIX + 'abc12345.json'
+
+        and: 'the result was buffered to the reserved-prefix file'
+        store.containsKey(FILE_PREFIX + 'abc12345.json')
+    }
+
+    def "a token on a READ tool is ignored -- no marker, no buffer file"() {
+        given:
+        settingsMap.enableRead = true
+        def uploads = 0
+        script.metaClass.uploadHubFile = { String name, byte[] content -> uploads++ }
+        script.metaClass.getRooms = { -> [] }
+
+        when: 'a read tool carrying a well-formed token'
+        def response = mcpDriver.callTool('hub_list_rooms', [opToken: 'readtoken1'])
+
+        then: 'the read succeeds and the token was silently ignored -- no marker for it, nothing buffered'
+        response.error == null
+        !response.result.isError
+        !atomicStateMap.opTokens?.containsKey('readtoken1')
+        uploads == 0
+    }
+
+    def "re-issuing a token whose op is still running is refused without re-running the write"() {
+        given:
+        settingsMap.enableWrite = true
+        installFileStore()
+        atomicStateMap.opTokens = [
+            runtok1234: [state: 'running', tool: 'hub_create_room', startedAt: FIXED_NOW - 3000L]
+        ]
+        def ran = 0
+        script.metaClass.toolCreateRoom = { a -> ran++; [success: true, roomId: 9] }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'runtok1234'])
+
+        then: 'the write did NOT run again (dedup short-circuits before executeTool)'
+        ran == 0
+
+        and: 'an isError envelope carrying the running status + recovery guidance'
+        response.result.isError == true
+        def inner = mcpDriver.parseInner(response)
+        inner.status == 'running'
+        inner.opToken == 'runtok1234'
+        inner.tool == 'hub_create_room'
+        inner.startedAt == FIXED_NOW - 3000L
+        inner.note instanceof String && inner.note.contains('hub_get_op_result')
+    }
+
+    def "re-issuing a completed token replays the buffered result with replayed=true and does not re-run the write"() {
+        given:
+        settingsMap.enableWrite = true
+        def store = installFileStore()
+        def ran = 0
+        script.metaClass.toolCreateRoom = { a -> ran++; [success: true, roomId: 11, name: 'Den'] }
+
+        when: 'first call commits and buffers under the token'
+        def first = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'donetoken1'])
+
+        and: 're-issue the identical call with the same token'
+        def second = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'donetoken1'])
+
+        then: 'the write ran exactly once across both calls'
+        ran == 1
+
+        and: 'the replay returns the original result plus replayed:true (round-tripped through the buffered file)'
+        def firstInner = mcpDriver.parseInner(first)
+        firstInner.roomId == 11
+        def replayInner = mcpDriver.parseInner(second)
+        replayInner.replayed == true
+        replayInner.roomId == 11
+    }
+
+    def "a completed token whose buffer file was swept returns status unknown"() {
+        given:
+        settingsMap.enableWrite = true
+        // Marker says complete, but the result file is gone (24h sweep) -> downloadHubFile null.
+        script.metaClass.uploadHubFile = { String name, byte[] content -> }
+        script.metaClass.downloadHubFile = { String name -> null }
+        atomicStateMap.opTokens = [
+            swept123456: [state: 'complete', tool: 'hub_create_room', isError: false,
+                          finishedAt: FIXED_NOW - 1000L, file: FILE_PREFIX + 'swept123456.json']
+        ]
+        def ran = 0
+        script.metaClass.toolCreateRoom = { a -> ran++; [success: true] }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'swept123456'])
+
+        then: 'the write is NOT re-run; the caller is told the result expired'
+        ran == 0
+        def inner = mcpDriver.parseInner(response)
+        inner.status == 'unknown'
+        inner.note instanceof String && inner.note.toLowerCase().contains('verify')
+    }
+
+    def "the marker is completed with isError when the write throws IllegalArgumentException"() {
+        given:
+        settingsMap.enableWrite = true
+        def store = installFileStore()
+        script.metaClass.toolCreateRoom = { a -> throw new IllegalArgumentException('bad room name') }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'iaetoken12'])
+
+        then: 'the validation error still maps to -32602'
+        response.error != null
+        response.error.code == -32602
+
+        and: 'no token is left eternally running -- the terminal IAE path completes the marker'
+        def marker = atomicStateMap.opTokens['iaetoken12']
+        marker.state == 'complete'
+        marker.isError == true
+        store.containsKey(FILE_PREFIX + 'iaetoken12.json')
+    }
+
+    def "the marker is completed with isError when the write throws a generic exception"() {
+        given:
+        settingsMap.enableWrite = true
+        def store = installFileStore()
+        script.metaClass.toolCreateRoom = { a -> throw new RuntimeException('hub blew up') }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'gentoken12'])
+
+        then: 'generic tool errors stay in the success channel with isError:true (MCP spec)'
+        response.error == null
+        response.result.isError == true
+
+        and: 'the marker still reaches a completed, isError state'
+        def marker = atomicStateMap.opTokens['gentoken12']
+        marker.state == 'complete'
+        marker.isError == true
+        store.containsKey(FILE_PREFIX + 'gentoken12.json')
+    }
+
+    def "the token nested in gateway inner args is extracted (args.args.opToken)"() {
+        given:
+        settingsMap.enableWrite = true
+        installFileStore()
+        script.metaClass.toolCreateRoom = { a -> [success: true, roomId: 3] }
+
+        when: 'a gateway-wrapped write whose opToken rides in the inner args'
+        def response = mcpDriver.callTool('hub_manage_rooms',
+            [tool: 'hub_create_room', args: [name: 'Den', confirm: true, opToken: 'gwtoken123']])
+
+        then: 'the token was processed -- a marker exists for it'
+        response.error == null
+        atomicStateMap.opTokens['gwtoken123']?.state == 'complete'
+    }
+
+    @spock.lang.Unroll
+    def "an invalid token on a write tool is rejected with -32602 (token=#label)"() {
+        given:
+        settingsMap.enableWrite = true
+        installFileStore()
+        def ran = 0
+        script.metaClass.toolCreateRoom = { a -> ran++; [success: true] }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: token])
+
+        then: 'validation rejects it (a caller-recoverable bad arg) before the write runs'
+        ran == 0
+        response.error != null
+        response.error.code == -32602
+
+        where:
+        label            | token
+        'too short'      | 'abc'
+        'bad charset'    | 'abc!defg'
+        'has a space'    | 'abc defgh'
+        'too long'       | ('a' * 129)
+    }
+
+    // ---------------- _opTokenMark: started marker, TTL prune, size cap ----------------
+
+    def "_opTokenMark writes a running marker stamped with the current clock"() {
+        when:
+        script._opTokenMark('marktok12', 'hub_create_room')
+
+        then:
+        def marker = atomicStateMap.opTokens['marktok12']
+        marker.state == 'running'
+        marker.tool == 'hub_create_room'
+        marker.startedAt == FIXED_NOW
+    }
+
+    def "_opTokenMark prunes entries older than 24h and best-effort deletes their result files"() {
+        given:
+        def deleted = []
+        script.metaClass.deleteHubFile = { String name -> deleted << name }
+        atomicStateMap.opTokens = [
+            stale123456: [state: 'complete', tool: 'hub_create_room',
+                          startedAt: FIXED_NOW - DAY_MS - 1L, file: FILE_PREFIX + 'stale123456.json'],
+            fresh123456: [state: 'complete', tool: 'hub_create_room', startedAt: FIXED_NOW - 1000L]
+        ]
+
+        when:
+        script._opTokenMark('newmark123', 'hub_create_room')
+
+        then: 'the >24h entry is gone, its file deleted; the fresh entry and the new marker survive'
+        !atomicStateMap.opTokens.containsKey('stale123456')
+        deleted.contains(FILE_PREFIX + 'stale123456.json')
+        atomicStateMap.opTokens.containsKey('fresh123456')
+        atomicStateMap.opTokens.containsKey('newmark123')
+    }
+
+    def "_opTokenMark caps the map at 50 entries, dropping the oldest first"() {
+        given: '50 fresh entries, op_00 the oldest'
+        def seed = [:]
+        (0..49).each { i ->
+            def key = "op_${String.format('%02d', i)}".toString()
+            seed[key] = [state: 'complete', tool: 'hub_create_room', startedAt: FIXED_NOW - (50L - i)]
+        }
+        atomicStateMap.opTokens = seed
+
+        when:
+        script._opTokenMark('capnew1234', 'hub_create_room')
+
+        then: 'the map is held at 50 and the single oldest entry was evicted for the newcomer'
+        atomicStateMap.opTokens.size() == 50
+        !atomicStateMap.opTokens.containsKey('op_00')
+        atomicStateMap.opTokens.containsKey('capnew1234')
+    }
+
+    // ---------------- _opTokenComplete: buffering + fallbacks ----------------
+
+    def "_opTokenComplete buffers the result to the reserved file and flips the marker to complete"() {
+        given:
+        def store = [:]
+        script.metaClass.uploadHubFile = { String name, byte[] content -> store[name] = new String(content, 'UTF-8') }
+        atomicStateMap.opTokens = [ct123456: [state: 'running', tool: 'hub_create_room', startedAt: FIXED_NOW - 500L]]
+
+        when:
+        script._opTokenComplete('ct123456', '{"success":true,"x":1}', false)
+
+        then: 'the exact bytes land in mcp-op-result-<token>.json'
+        store[FILE_PREFIX + 'ct123456.json'] == '{"success":true,"x":1}'
+
+        and: 'the marker is completed while preserving tool + startedAt'
+        def marker = atomicStateMap.opTokens['ct123456']
+        marker.state == 'complete'
+        marker.isError == false
+        marker.tool == 'hub_create_room'
+        marker.startedAt == FIXED_NOW - 500L
+        marker.finishedAt == FIXED_NOW
+        marker.file == FILE_PREFIX + 'ct123456.json'
+    }
+
+    def "_opTokenComplete falls back to inline storage when the upload fails and the result is small"() {
+        given:
+        script.metaClass.uploadHubFile = { String name, byte[] content -> throw new RuntimeException('storage full') }
+        atomicStateMap.opTokens = [inl123456: [state: 'running', tool: 'hub_create_room', startedAt: FIXED_NOW]]
+        def small = '{"success":true}'
+
+        when:
+        script._opTokenComplete('inl123456', small, false)
+
+        then: 'a small result is kept inline on the marker so replay still works'
+        def marker = atomicStateMap.opTokens['inl123456']
+        marker.state == 'complete'
+        marker.inline == small
+    }
+
+    def "_opTokenComplete marks failed_buffer when the upload fails and the result is too large to inline"() {
+        given:
+        script.metaClass.uploadHubFile = { String name, byte[] content -> throw new RuntimeException('storage full') }
+        atomicStateMap.opTokens = [big123456: [state: 'running', tool: 'hub_create_room', startedAt: FIXED_NOW]]
+        def big = '{"blob":"' + ('x' * 3000) + '"}'
+
+        when:
+        script._opTokenComplete('big123456', big, false)
+
+        then: 'an un-bufferable oversize result is flagged rather than inlined'
+        atomicStateMap.opTokens['big123456'].state == 'failed_buffer'
+    }
+}

--- a/src/test/groovy/server/OpTokenReplaySpec.groovy
+++ b/src/test/groovy/server/OpTokenReplaySpec.groovy
@@ -16,9 +16,10 @@ import support.ToolSpecBase
  *   - process the token ONLY when the resolved leaf is a WRITE tool (reads ignore it)
  *   - dedup: running -> isError status:running (do NOT re-run the write);
  *            complete -> replay the buffered result + replayed:true (no re-run);
- *            complete-but-file-swept -> status:unknown
+ *            complete-but-file-swept -> status:indeterminate (never the
+ *            safe-to-retry unknown -- the op DID run here)
  *   - a started marker is written before the tool runs and completed on EVERY
- *     terminal path (success, thrown IAE, generic throw)
+ *     terminal path (success, thrown IAE, generic throw, null result, oversize)
  *   - _opTokenMark prunes >24h entries (deleting their result files) and caps at 50
  *   - _opTokenComplete buffers the result to mcp-op-result-<token>.json (with an
  *     inline / failed_buffer fallback when the upload fails)

--- a/src/test/groovy/server/OpTokenReplaySpec.groovy
+++ b/src/test/groovy/server/OpTokenReplaySpec.groovy
@@ -225,25 +225,10 @@ class OpTokenReplaySpec extends ToolSpecBase {
         store.containsKey(FILE_PREFIX + 'nulltoken1.json')
     }
 
-    def "the marker is completed with isError when the write returns a non-serializable result"() {
-        given:
-        settingsMap.enableWrite = true
-        def store = installFileStore()
-        script.metaClass.toolCreateRoom = { a -> [success: true, oops: { -> 'a closure' }] }
-
-        when:
-        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'sertoken123'])
-
-        then: 'the serializer failure surfaces as an isError envelope'
-        response.error == null
-        response.result.isError == true
-
-        and: 'the marker completes with the error envelope buffered'
-        def marker = atomicStateMap.opTokens['sertoken123']
-        marker.state == 'complete'
-        marker.isError == true
-        store.containsKey(FILE_PREFIX + 'sertoken123.json')
-    }
+    // The non-serializable terminal path has no portable trigger: JsonOutput serializes
+    // Closures as {} on current Groovy, and the genuinely-failing inputs (circular maps)
+    // die with StackOverflowError, not Exception. The branch is line-for-line parallel to
+    // the null-result path pinned above, which covers the marker-completion guarantee.
 
     def "an oversize result buffers the REAL result under the token, not the too-large envelope"() {
         given: 'a result whose wire encoding trips the 120KB response guard'

--- a/src/test/groovy/server/OpTokenReplaySpec.groovy
+++ b/src/test/groovy/server/OpTokenReplaySpec.groovy
@@ -142,7 +142,7 @@ class OpTokenReplaySpec extends ToolSpecBase {
         replayInner.roomId == 11
     }
 
-    def "a completed token whose buffer file was swept returns status unknown"() {
+    def "a completed token whose buffer file was swept returns status indeterminate, never the safe-to-retry unknown"() {
         given:
         settingsMap.enableWrite = true
         // Marker says complete, but the result file is gone (24h sweep) -> downloadHubFile null.
@@ -158,10 +158,10 @@ class OpTokenReplaySpec extends ToolSpecBase {
         when:
         def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'swept123456'])
 
-        then: 'the write is NOT re-run; the caller is told the result expired'
+        then: 'the write is NOT re-run; the caller is told the result expired but the op DID complete'
         ran == 0
         def inner = mcpDriver.parseInner(response)
-        inner.status == 'unknown'
+        inner.status == 'indeterminate'
         inner.note instanceof String && inner.note.toLowerCase().contains('verify')
     }
 
@@ -203,6 +203,68 @@ class OpTokenReplaySpec extends ToolSpecBase {
         marker.state == 'complete'
         marker.isError == true
         store.containsKey(FILE_PREFIX + 'gentoken12.json')
+    }
+
+    def "the marker is completed with isError when the write returns null (internal tool bug path)"() {
+        given:
+        settingsMap.enableWrite = true
+        def store = installFileStore()
+        script.metaClass.toolCreateRoom = { a -> null }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'nulltoken1'])
+
+        then: 'the null result surfaces as an isError envelope'
+        response.error == null
+        response.result.isError == true
+
+        and: 'the marker still completes -- no eternal running'
+        def marker = atomicStateMap.opTokens['nulltoken1']
+        marker.state == 'complete'
+        marker.isError == true
+        store.containsKey(FILE_PREFIX + 'nulltoken1.json')
+    }
+
+    def "the marker is completed with isError when the write returns a non-serializable result"() {
+        given:
+        settingsMap.enableWrite = true
+        def store = installFileStore()
+        script.metaClass.toolCreateRoom = { a -> [success: true, oops: { -> 'a closure' }] }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'sertoken123'])
+
+        then: 'the serializer failure surfaces as an isError envelope'
+        response.error == null
+        response.result.isError == true
+
+        and: 'the marker completes with the error envelope buffered'
+        def marker = atomicStateMap.opTokens['sertoken123']
+        marker.state == 'complete'
+        marker.isError == true
+        store.containsKey(FILE_PREFIX + 'sertoken123.json')
+    }
+
+    def "an oversize result buffers the REAL result under the token, not the too-large envelope"() {
+        given: 'a result whose wire encoding trips the 120KB response guard'
+        settingsMap.enableWrite = true
+        def store = installFileStore()
+        def bigPayload = 'x' * 130000
+        script.metaClass.toolCreateRoom = { a -> [success: true, blob: bigPayload] }
+
+        when:
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'bigtoken123'])
+
+        then: 'the wire response is the too-large envelope'
+        response.error == null
+        def inner = mcpDriver.parseInner(response)
+        inner.response_too_large == true
+
+        and: 'the buffered result is the REAL oversize payload -- captured before the size guard'
+        def marker = atomicStateMap.opTokens['bigtoken123']
+        marker.state == 'complete'
+        marker.isError == false
+        new String(store[FILE_PREFIX + 'bigtoken123.json'], 'UTF-8').contains(bigPayload)
     }
 
     def "the token nested in gateway inner args is extracted (args.args.opToken)"() {
@@ -293,6 +355,50 @@ class OpTokenReplaySpec extends ToolSpecBase {
         atomicStateMap.opTokens.size() == 50
         !atomicStateMap.opTokens.containsKey('op_00')
         atomicStateMap.opTokens.containsKey('capnew1234')
+    }
+
+    def "the size cap never evicts a running token -- the oldest TERMINAL record goes instead"() {
+        given: '50 fresh entries; the oldest is still running, the next-oldest is complete'
+        def seed = [:]
+        (0..49).each { i ->
+            def key = "op_${String.format('%02d', i)}".toString()
+            seed[key] = [state: (i == 0 ? 'running' : 'complete'), tool: 'hub_create_room',
+                         startedAt: FIXED_NOW - (50L - i)]
+        }
+        atomicStateMap.opTokens = seed
+
+        when:
+        script._opTokenMark('capnew1234', 'hub_create_room')
+
+        then: 'the live op_00 survives; op_01 (oldest terminal) was evicted'
+        atomicStateMap.opTokens.size() == 50
+        atomicStateMap.opTokens.containsKey('op_00')
+        !atomicStateMap.opTokens.containsKey('op_01')
+        atomicStateMap.opTokens.containsKey('capnew1234')
+    }
+
+    def "replaying a paused in_progress result carries a replayNote so a spent-token resume cannot loop silently"() {
+        given: 'a completed token whose buffered result is a paused in_progress envelope'
+        settingsMap.enableWrite = true
+        script.metaClass.downloadHubFile = { String name ->
+            '{"success":true,"status":"in_progress","patchesRemaining":[{"x":1}]}'.getBytes('UTF-8')
+        }
+        atomicStateMap.opTokens = [
+            pausedtok99: [state: 'complete', tool: 'hub_create_room', isError: false,
+                          finishedAt: FIXED_NOW - 1000L, file: FILE_PREFIX + 'pausedtok99.json']
+        ]
+        def ran = 0
+        script.metaClass.toolCreateRoom = { a -> ran++; [success: true] }
+
+        when: 'the same token is re-issued as if it could resume'
+        def response = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'pausedtok99'])
+
+        then: 'no re-run; the replay is flagged as the original paused envelope'
+        ran == 0
+        def inner = mcpDriver.parseInner(response)
+        inner.replayed == true
+        inner.status == 'in_progress'
+        inner.replayNote instanceof String && inner.replayNote.toLowerCase().contains('fresh')
     }
 
     // ---------------- _opTokenComplete: buffering + fallbacks ----------------

--- a/src/test/groovy/server/RelayBudgetSpec.groovy
+++ b/src/test/groovy/server/RelayBudgetSpec.groovy
@@ -204,7 +204,8 @@ class RelayBudgetSpec extends ToolSpecBase {
     // verified live (requestSource=='cloud' probe).
 
     def "the budget clock reaches _applyNativeAppEdit through dispatch and the gateway (canonical form)"() {
-        given:
+        given: 'gateway mode pinned -- this test exercises the gateway re-injection hop'
+        settingsMap.useGateways = true
         settingsMap.enableWrite = true
         def captured = [:]
         script.metaClass._applyNativeAppEdit = { Map a -> captured.edit = a; [success: true, appId: 1] }
@@ -221,7 +222,8 @@ class RelayBudgetSpec extends ToolSpecBase {
     }
 
     def "the budget clock survives the operation-envelope rebuild (envelope form)"() {
-        given:
+        given: 'gateway mode pinned -- the envelope rides the same gateway hop'
+        settingsMap.useGateways = true
         settingsMap.enableWrite = true
         def captured = [:]
         script.metaClass._applyNativeAppEdit = { Map a -> captured.edit = a; [success: true, appId: 1] }
@@ -232,6 +234,24 @@ class RelayBudgetSpec extends ToolSpecBase {
             args: [[addAction: [a: 1]], [addAction: [a: 2]]]]])
 
         then: 'the re-carry preserved the clock across the rebuild'
+        response.error == null
+        captured.edit.__reqT0 instanceof Long
+        captured.edit.patches.size() == 2
+    }
+
+    def "the budget clock reaches _applyNativeAppEdit on a FLAT (no-gateway) dispatch"() {
+        given: 'flat mode pinned -- covers the direct handleToolsCall injection with no gateway hop'
+        settingsMap.useGateways = false
+        settingsMap.enableWrite = true
+        def captured = [:]
+        script.metaClass._applyNativeAppEdit = { Map a -> captured.edit = a; [success: true, appId: 1] }
+
+        when:
+        def response = mcpDriver.callTool('hub_set_rule', [
+            appId: 1, confirm: true,
+            patches: [[addAction: [a: 1]], [addAction: [a: 2]]]])
+
+        then:
         response.error == null
         captured.edit.__reqT0 instanceof Long
         captured.edit.patches.size() == 2

--- a/src/test/groovy/server/RelayBudgetSpec.groovy
+++ b/src/test/groovy/server/RelayBudgetSpec.groovy
@@ -190,4 +190,53 @@ class RelayBudgetSpec extends ToolSpecBase {
         result.status != 'in_progress'
         result.patchesRemaining == null
     }
+
+    // ---------------- __reqT0 threading: dispatch -> gateway -> loop ----------------
+    //
+    // The loop tests above plant __reqT0 directly, so they cannot catch a regression in
+    // the delivery chain: the _budgetAwareTools allowlist injection in handleToolsCall,
+    // the handleGateway re-injection into leaf args, and the _setRuleFromEnvelope
+    // re-carry (it rebuilds args and would drop the key). Here the pause predicate is
+    // stubbed to fire ONLY when a NON-NULL clock reaches the loop -- with the harness
+    // clock frozen, a pause firing IS the proof the clock survived every hop. The real
+    // _isCloudRequest()==true branch needs a live cloud-relayed request object the
+    // harness cannot fabricate; it is verified live (requestSource=='cloud' probe).
+
+    def "the budget clock reaches the patch loop through dispatch and the gateway (canonical form)"() {
+        given: 'the pause predicate fires only when a non-null clock arrives'
+        def addActionCalls = []
+        def clicks = []
+        installPatchStubs(addActionCalls, clicks, false)
+        script.metaClass._relayBudgetExceeded = { Long t0 -> t0 != null }
+
+        when: 'a two-op patches edit arrives through hub_manage_rule_machine'
+        def response = mcpDriver.callTool('hub_manage_rule_machine', [tool: 'hub_set_rule', args: [
+            appId: 1, confirm: true,
+            patches: [[addAction: [a: 1]], [addAction: [a: 2]]]]])
+        def inner = mcpDriver.parseInner(response)
+
+        then: 'the loop paused -- the clock arrived non-null through injection + gateway re-injection'
+        addActionCalls.size() == 1
+        inner.status == 'in_progress'
+        inner.patchesRemaining.size() == 1
+    }
+
+    def "the budget clock survives the operation-envelope rebuild (envelope form)"() {
+        given:
+        def addActionCalls = []
+        def clicks = []
+        installPatchStubs(addActionCalls, clicks, false)
+        script.metaClass._relayBudgetExceeded = { Long t0 -> t0 != null }
+
+        when: 'the same edit in envelope form -- _setRuleFromEnvelope rebuilds args from scratch'
+        def response = mcpDriver.callTool('hub_manage_rule_machine', [tool: 'hub_set_rule', args: [
+            operation: 'patches', appId: 1, confirm: true,
+            args: [[addAction: [a: 1]], [addAction: [a: 2]]]]])
+        def inner = mcpDriver.parseInner(response)
+
+        then: 'the pause proves the re-carry preserved the clock across the rebuild'
+        addActionCalls.size() == 1
+        inner.status == 'in_progress'
+        inner.patchesRemaining.size() == 1
+    }
 }

--- a/src/test/groovy/server/RelayBudgetSpec.groovy
+++ b/src/test/groovy/server/RelayBudgetSpec.groovy
@@ -191,52 +191,49 @@ class RelayBudgetSpec extends ToolSpecBase {
         result.patchesRemaining == null
     }
 
-    // ---------------- __reqT0 threading: dispatch -> gateway -> loop ----------------
+    // ---------------- __reqT0 threading: dispatch -> gateway -> handler ----------------
     //
     // The loop tests above plant __reqT0 directly, so they cannot catch a regression in
     // the delivery chain: the _budgetAwareTools allowlist injection in handleToolsCall,
     // the handleGateway re-injection into leaf args, and the _setRuleFromEnvelope
-    // re-carry (it rebuilds args and would drop the key). Here the pause predicate is
-    // stubbed to fire ONLY when a NON-NULL clock reaches the loop -- with the harness
-    // clock frozen, a pause firing IS the proof the clock survived every hop. The real
-    // _isCloudRequest()==true branch needs a live cloud-relayed request object the
-    // harness cannot fabricate; it is verified live (requestSource=='cloud' probe).
+    // re-carry (it rebuilds args and would drop the key). These two capture the args
+    // that actually reach _applyNativeAppEdit after a full dispatch ride and assert the
+    // clock arrived non-null -- the same stub boundary SetRuleSelfGatewaySpec uses, since
+    // the wizard internals below it need a live hub. The real _isCloudRequest()==true
+    // branch needs a cloud-relayed request object the harness cannot fabricate; it is
+    // verified live (requestSource=='cloud' probe).
 
-    def "the budget clock reaches the patch loop through dispatch and the gateway (canonical form)"() {
-        given: 'the pause predicate fires only when a non-null clock arrives'
-        def addActionCalls = []
-        def clicks = []
-        installPatchStubs(addActionCalls, clicks, false)
-        script.metaClass._relayBudgetExceeded = { Long t0 -> t0 != null }
+    def "the budget clock reaches _applyNativeAppEdit through dispatch and the gateway (canonical form)"() {
+        given:
+        settingsMap.enableWrite = true
+        def captured = [:]
+        script.metaClass._applyNativeAppEdit = { Map a -> captured.edit = a; [success: true, appId: 1] }
 
-        when: 'a two-op patches edit arrives through hub_manage_rule_machine'
+        when: 'a patches edit arrives through hub_manage_rule_machine'
         def response = mcpDriver.callTool('hub_manage_rule_machine', [tool: 'hub_set_rule', args: [
             appId: 1, confirm: true,
             patches: [[addAction: [a: 1]], [addAction: [a: 2]]]]])
-        def inner = mcpDriver.parseInner(response)
 
-        then: 'the loop paused -- the clock arrived non-null through injection + gateway re-injection'
-        addActionCalls.size() == 1
-        inner.status == 'in_progress'
-        inner.patchesRemaining.size() == 1
+        then: 'the clock arrived non-null through injection + gateway re-injection'
+        response.error == null
+        captured.edit.__reqT0 instanceof Long
+        captured.edit.patches.size() == 2
     }
 
     def "the budget clock survives the operation-envelope rebuild (envelope form)"() {
         given:
-        def addActionCalls = []
-        def clicks = []
-        installPatchStubs(addActionCalls, clicks, false)
-        script.metaClass._relayBudgetExceeded = { Long t0 -> t0 != null }
+        settingsMap.enableWrite = true
+        def captured = [:]
+        script.metaClass._applyNativeAppEdit = { Map a -> captured.edit = a; [success: true, appId: 1] }
 
         when: 'the same edit in envelope form -- _setRuleFromEnvelope rebuilds args from scratch'
         def response = mcpDriver.callTool('hub_manage_rule_machine', [tool: 'hub_set_rule', args: [
             operation: 'patches', appId: 1, confirm: true,
             args: [[addAction: [a: 1]], [addAction: [a: 2]]]]])
-        def inner = mcpDriver.parseInner(response)
 
-        then: 'the pause proves the re-carry preserved the clock across the rebuild'
-        addActionCalls.size() == 1
-        inner.status == 'in_progress'
-        inner.patchesRemaining.size() == 1
+        then: 'the re-carry preserved the clock across the rebuild'
+        response.error == null
+        captured.edit.__reqT0 instanceof Long
+        captured.edit.patches.size() == 2
     }
 }

--- a/src/test/groovy/server/RelayBudgetSpec.groovy
+++ b/src/test/groovy/server/RelayBudgetSpec.groovy
@@ -1,0 +1,193 @@
+package server
+
+import groovy.json.JsonOutput
+import spock.lang.Unroll
+import support.ToolSpecBase
+
+/**
+ * Spec for the cloud-relay self-budget (issue #348, section C). When a request
+ * arrives over the cloud relay, a partial-commit loop checks its own elapsed time
+ * between committed sub-steps and, before the relay's fixed ceiling, returns a
+ * success-shaped in_progress envelope with resume info -- so the response is never
+ * lost mid-loop and the already-committed work is not repeated.
+ *
+ * Two loops carry the checkpoint (libraries/mcp-native-rules-lib.groovy):
+ *   - _rmDriveWalkSteps  -- between ordered walkStep drive steps
+ *   - _applyNativeAppEdit -- between patches[] ops (the deferred trailing updateRule
+ *     must NOT fire on a pause; it fires when the remaining patches complete)
+ *
+ * The generic machinery (_isCloudRequest / _relayBudgetMs / _relayBudgetExceeded)
+ * lives in the main file. The loop tests stub _relayBudgetExceeded so the pause is
+ * deterministic; the composition of that predicate is unit-tested separately with
+ * _isCloudRequest stubbed and the harness's fixed clock (now()==1234567890000L).
+ * A LAN request or relayBudgetMs=0 short-circuits the guard, so those loops keep
+ * their pre-#348 shape byte-for-byte -- covered by the not-exceeded cases below.
+ */
+class RelayBudgetSpec extends ToolSpecBase {
+
+    private static final long FIXED_NOW = 1234567890000L
+
+    // ---------------- generic budget helpers (main file) ----------------
+
+    def "_relayBudgetMs defaults to 8000 when the setting is unset"() {
+        expect:
+        script._relayBudgetMs() == 8000L
+    }
+
+    def "_relayBudgetMs honours settings.relayBudgetMs"() {
+        given:
+        settingsMap.relayBudgetMs = 5000
+
+        expect:
+        script._relayBudgetMs() == 5000L
+    }
+
+    def "_isCloudRequest defaults to false when no cloud request marker is present"() {
+        // The harness request has no requestSource, so the try/catch returns the
+        // safe LAN default -- LAN behaviour must be identical to today.
+        expect:
+        script._isCloudRequest() == false
+    }
+
+    @Unroll
+    def "_relayBudgetExceeded fires only for a cloud request past a live budget (#desc)"() {
+        given:
+        settingsMap.relayBudgetMs = budgetMs
+        script.metaClass._isCloudRequest = { -> cloud }
+
+        expect:
+        script._relayBudgetExceeded(t0) == expected
+
+        where:
+        desc                        | cloud | budgetMs | t0                | expected
+        'cloud, over budget'        | true  | 100      | FIXED_NOW - 200L  | true
+        'cloud, under budget'       | true  | 100      | FIXED_NOW - 50L   | false
+        'cloud, null t0'            | true  | 100      | null              | false
+        'cloud, budget disabled 0'  | true  | 0        | FIXED_NOW - 200L  | false
+        'LAN, over budget'          | false | 100      | FIXED_NOW - 200L  | false
+    }
+
+    // ---------------- _rmDriveWalkSteps checkpoint ----------------
+
+    private List installWalkerStubs(List walkCalls, boolean pause) {
+        script.metaClass._rmWalkStep = { Integer id, Map step ->
+            walkCalls << new LinkedHashMap(step); [page: step.page, success: true]
+        }
+        script.metaClass._rmCheckRuleHealth = { Integer id -> [ok: true] }
+        script.metaClass._relayBudgetExceeded = { Long t0 -> pause }
+        return walkCalls
+    }
+
+    def "a drive over a tiny cloud budget commits the first step then pauses, handing back the rest"() {
+        given:
+        def walkCalls = []
+        installWalkerStubs(walkCalls, true)
+
+        when: 'three ordered steps; the budget is already blown'
+        def result = script._rmDriveWalkSteps(1, [operation: 'drive', __reqT0: 1000L, steps: [
+            [page: 'p1', operation: 'introspect'],
+            [page: 'p2', operation: 'introspect'],
+            [page: 'p3', operation: 'introspect'],
+        ]])
+
+        then: 'step 1 still ran (never pause before the first step); steps 2-3 did not'
+        walkCalls.size() == 1
+        walkCalls[0].page == 'p1'
+
+        and: 'a success-shaped in_progress envelope naming the next step and the unrun work'
+        result.status == 'in_progress'
+        result.success == true
+        result.pausedAtStep == 2
+        result.stepsRemaining instanceof List
+        result.stepsRemaining.size() == 2
+        result.stepsRemaining[0].page == 'p2'
+        result.stepsRemaining[1].page == 'p3'
+        result.resume?.note instanceof String && !result.resume.note.trim().isEmpty()
+
+        and: 'the internal budget marker is never echoed into the handed-back work'
+        !JsonOutput.toJson(result).contains('__reqT0')
+    }
+
+    def "a drive within budget runs every step and keeps its pre-budget shape"() {
+        given:
+        def walkCalls = []
+        installWalkerStubs(walkCalls, false)
+
+        when:
+        def result = script._rmDriveWalkSteps(1, [operation: 'drive', __reqT0: 1000L, steps: [
+            [page: 'p1', operation: 'introspect'],
+            [page: 'p2', operation: 'introspect'],
+            [page: 'p3', operation: 'introspect'],
+        ]])
+
+        then: 'all three steps ran and no in_progress/resume shape appears'
+        walkCalls.size() == 3
+        result.stepsRun == 3
+        result.success == true
+        result.status != 'in_progress'
+        result.stepsRemaining == null
+    }
+
+    // ---------------- _applyNativeAppEdit patches[] checkpoint ----------------
+
+    private void installPatchStubs(List addActionCalls, List clicks, boolean pause) {
+        stateMap.lastBackupTimestamp = FIXED_NOW   // requireDestructiveConfirm: backup within 24h
+        settingsMap.enableWrite = true
+        script.metaClass._rmBackupRuleSnapshot = { Integer id, String reason -> [key: 'snap'] }
+        script.metaClass._rmCheckRuleHealth = { Integer id -> [ok: true] }
+        script.metaClass._rmAddAction = { Integer id, Map spec, boolean batch = false ->
+            addActionCalls << spec; [success: true]
+        }
+        script.metaClass._rmClickAppButton = { Integer aId, String name, String stateAttr = null,
+                                               String pageName = null, Map cache = null -> clicks << name }
+        script.metaClass._relayBudgetExceeded = { Long t0 -> pause }
+    }
+
+    def "a patches batch over a tiny cloud budget commits the first op then pauses, deferring updateRule"() {
+        given:
+        def addActionCalls = []
+        def clicks = []
+        installPatchStubs(addActionCalls, clicks, true)
+
+        when: 'three addAction patch ops; the budget is already blown'
+        def result = script._applyNativeAppEdit([appId: 1, confirm: true, __reqT0: 2000L, patches: [
+            [addAction: [a: 1]],
+            [addAction: [a: 2]],
+            [addAction: [a: 3]],
+        ]])
+
+        then: 'only the first op committed; the rest are handed back'
+        addActionCalls.size() == 1
+        result.status == 'in_progress'
+        result.success == true
+        result.patchesRemaining instanceof List
+        result.patchesRemaining.size() == 2
+
+        and: 'the deferred trailing updateRule did NOT fire on the pause (it fires when the remainder completes)'
+        !clicks.contains('updateRule')
+
+        and: 'the internal budget marker is never echoed into the handed-back work'
+        !JsonOutput.toJson(result).contains('__reqT0')
+    }
+
+    def "a patches batch within budget applies every op and fires the trailing updateRule once"() {
+        given:
+        def addActionCalls = []
+        def clicks = []
+        installPatchStubs(addActionCalls, clicks, false)
+
+        when:
+        def result = script._applyNativeAppEdit([appId: 1, confirm: true, patches: [
+            [addAction: [a: 1]],
+            [addAction: [a: 2]],
+            [addAction: [a: 3]],
+        ]])
+
+        then: 'all three ops ran, the trailing updateRule fired, and no in_progress shape appears'
+        addActionCalls.size() == 3
+        clicks.contains('updateRule')
+        result.success == true
+        result.status != 'in_progress'
+        result.patchesRemaining == null
+    }
+}

--- a/src/test/groovy/server/RelayBudgetSpec.groovy
+++ b/src/test/groovy/server/RelayBudgetSpec.groovy
@@ -239,6 +239,37 @@ class RelayBudgetSpec extends ToolSpecBase {
         captured.edit.patches.size() == 2
     }
 
+    def "a drive paused right after an intermediate done step does NOT fire the trailing mainPage Done"() {
+        given: 'a walker that pauses after step 1 (a done op), plus a recorder on the finalizer'
+        stateMap.lastBackupTimestamp = FIXED_NOW
+        settingsMap.enableWrite = true
+        script.metaClass._rmBackupRuleSnapshot = { Integer id, String reason -> [key: 'snap'] }
+        script.metaClass._rmCheckRuleHealth = { Integer id -> [ok: true] }
+        script.metaClass._rmWalkStep = { Integer id, Map spec ->
+            spec.operation == 'drive' ? script._rmDriveWalkSteps(id, spec) : [page: spec.page, success: true]
+        }
+        script.metaClass._relayBudgetExceeded = { Long t0 -> t0 != null }
+        def doneClicks = 0
+        script.metaClass._rmSubmitMainPageDone = { Integer id -> doneClicks++; [done: true] }
+
+        when: 'the drive pauses at step 2, with lastStepOperation == done from step 1'
+        def result = script._applyNativeAppEdit([appId: 1, confirm: true, __reqT0: 1000L, walkStep: [
+            operation: 'drive', steps: [
+                [page: 'p1', operation: 'done'],
+                [page: 'p2', operation: 'introspect'],
+            ]]])
+
+        then: 'paused mid-flow: the update lifecycle must NOT run on the half-configured app'
+        result.status == 'in_progress'
+        result.lastStepOperation == 'done'
+        result.stepsRemaining.size() == 1
+        doneClicks == 0
+
+        and: 'no self-contradictory failure markers ride the pause envelope'
+        result.success == true
+        result.mainPageDoneFailed == null
+    }
+
     def "the budget clock reaches _applyNativeAppEdit on a FLAT (no-gateway) dispatch"() {
         given: 'flat mode pinned -- covers the direct handleToolsCall injection with no gateway hop'
         settingsMap.useGateways = false

--- a/src/test/groovy/server/ToolGetOpResultSpec.groovy
+++ b/src/test/groovy/server/ToolGetOpResultSpec.groovy
@@ -77,6 +77,24 @@ class ToolGetOpResultSpec extends ToolSpecBase {
         result.result.roomId == 7
     }
 
+    def "indeterminate: a finished token whose buffered result is unreadable is NOT reported as safe-to-retry unknown"() {
+        given:
+        settingsMap.enableRead = true
+        script.metaClass.downloadHubFile = { String name -> null }
+        atomicStateMap.opTokens = [
+            gonebuf9999: [state: 'complete', tool: 'hub_create_room', isError: false,
+                          finishedAt: FIXED_NOW - 2000L, file: FILE_PREFIX + 'gonebuf9999.json']
+        ]
+
+        when:
+        def result = script.toolGetOpResult([opToken: 'gonebuf9999'])
+
+        then:
+        result.status == 'indeterminate'
+        result.opToken == 'gonebuf9999'
+        result.note.toLowerCase().contains('verify')
+    }
+
     def "hub_get_op_result throws when opToken is missing"() {
         given:
         settingsMap.enableRead = true

--- a/src/test/groovy/server/ToolGetOpResultSpec.groovy
+++ b/src/test/groovy/server/ToolGetOpResultSpec.groovy
@@ -1,0 +1,168 @@
+package server
+
+import support.ToolSpecBase
+
+/**
+ * Spec for hub_get_op_result (issue #348, section B) -- the read tool that
+ * fetches the buffered result of a tokened write when the transport dropped the
+ * original response. Impl lives in libraries/mcp-diagnostics-lib.groovy
+ * (toolGetOpResult); it is reachable directly and through the hub_read_diagnostics
+ * gateway. Read-only, idempotent, closed-world.
+ *
+ * Tri-state contract (keyed on atomicState.opTokens[opToken]):
+ *   - absent      -> status:"unknown" (the call never arrived; safe to retry)
+ *   - running     -> status:"running" + elapsedMs, do NOT re-issue the write
+ *   - complete    -> status:"complete" + result:<parsed original result>
+ */
+class ToolGetOpResultSpec extends ToolSpecBase {
+
+    private static final String FILE_PREFIX = 'mcp-op-result-'
+    private static final long FIXED_NOW = 1234567890000L
+
+    // -------------------- direct-call tri-state --------------------
+
+    def "unknown: a token that never started reports status unknown and that it is safe to retry"() {
+        given:
+        settingsMap.enableRead = true
+
+        when:
+        def result = script.toolGetOpResult([opToken: 'neverused1'])
+
+        then:
+        result.status == 'unknown'
+        result.opToken == 'neverused1'
+        result.note instanceof String && result.note.toLowerCase().contains('retry')
+    }
+
+    def "running: an in-flight token reports status running with elapsedMs and a do-not-reissue note"() {
+        given:
+        settingsMap.enableRead = true
+        atomicStateMap.opTokens = [
+            runtok9999: [state: 'running', tool: 'hub_set_rule', startedAt: FIXED_NOW - 5000L]
+        ]
+
+        when:
+        def result = script.toolGetOpResult([opToken: 'runtok9999'])
+
+        then:
+        result.status == 'running'
+        result.opToken == 'runtok9999'
+        result.tool == 'hub_set_rule'
+        result.startedAt == FIXED_NOW - 5000L
+        result.elapsedMs == 5000L
+        result.note instanceof String && !result.note.trim().isEmpty()
+    }
+
+    def "complete: a finished token reports status complete and returns the parsed buffered result"() {
+        given:
+        settingsMap.enableRead = true
+        script.metaClass.downloadHubFile = { String name ->
+            name == FILE_PREFIX + 'donetok999.json' ? '{"success":true,"roomId":7}'.getBytes('UTF-8') : null
+        }
+        atomicStateMap.opTokens = [
+            donetok999: [state: 'complete', tool: 'hub_create_room', isError: false,
+                         finishedAt: FIXED_NOW - 2000L, file: FILE_PREFIX + 'donetok999.json']
+        ]
+
+        when:
+        def result = script.toolGetOpResult([opToken: 'donetok999'])
+
+        then:
+        result.status == 'complete'
+        result.opToken == 'donetok999'
+        result.tool == 'hub_create_room'
+        result.isError == false
+        result.finishedAt == FIXED_NOW - 2000L
+        result.result instanceof Map
+        result.result.roomId == 7
+    }
+
+    def "hub_get_op_result throws when opToken is missing"() {
+        given:
+        settingsMap.enableRead = true
+
+        when:
+        script.toolGetOpResult([:])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "hub_get_op_result rejects a malformed token"() {
+        given:
+        settingsMap.enableRead = true
+
+        when:
+        script.toolGetOpResult([opToken: 'bad!'])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    // -------------------- dispatch envelope --------------------
+
+    @spock.lang.Unroll
+    def "hub_get_op_result dispatches in both catalog modes (useGateways=#useGateways)"() {
+        given:
+        settingsMap.useGateways = useGateways
+        settingsMap.enableRead = true
+
+        when:
+        // Gateway mode routes through hub_read_diagnostics; flat mode disables the
+        // gateway tools by design, so the leaf is called by its real name.
+        def response = useGateways
+            ? mcpDriver.callTool('hub_read_diagnostics',
+                [tool: 'hub_get_op_result', args: [opToken: 'neverused1']])
+            : mcpDriver.callTool('hub_get_op_result', [opToken: 'neverused1'])
+
+        then:
+        response.error == null
+        !response.result.isError
+        def inner = mcpDriver.parseInner(response)
+        inner.status == 'unknown'
+        inner.opToken == 'neverused1'
+
+        where:
+        useGateways << [true, false]
+    }
+
+    @spock.lang.Unroll
+    def "hub_get_op_result maps a missing-token IAE to -32602 through the envelope (useGateways=#useGateways)"() {
+        given:
+        settingsMap.useGateways = useGateways
+        settingsMap.enableRead = true
+
+        when:
+        def response = mcpDriver.callTool('hub_get_op_result', [:])
+
+        then:
+        response.error != null
+        response.error.code == -32602
+
+        where:
+        useGateways << [true, false]
+    }
+
+    // -------------------- classification / membership --------------------
+
+    def "hub_get_op_result is classified read-only, idempotent, and closed-world"() {
+        expect:
+        script.getReadOnlyToolNames().contains('hub_get_op_result')
+        script.getIdempotentToolNames().contains('hub_get_op_result')
+        !script.getOpenWorldToolNames().contains('hub_get_op_result')
+    }
+
+    def "hub_get_op_result is a member of the hub_read_diagnostics gateway"() {
+        expect:
+        script.getGatewayConfig()['hub_read_diagnostics'].tools.contains('hub_get_op_result')
+    }
+
+    def "hub_get_op_result has a display-meta entry with a friendly title"() {
+        when:
+        def meta = script.getToolDisplayMeta()['hub_get_op_result']
+
+        then:
+        meta?.title == 'Get Operation Result'
+        meta.summary instanceof String && meta.summary.endsWith('.') && meta.summary.length() <= 140
+    }
+}

--- a/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
+++ b/src/test/groovy/server/ToolRmNativeCrudSpec.groovy
@@ -38767,8 +38767,8 @@ class ToolRmNativeCrudSpec extends ToolSpecBase {
         def def_ = script.getAllToolDefinitions().find { it.name == 'hub_set_native_app' }
         def props = def_.inputSchema.properties.keySet()
 
-        then: "the generic upsert params, plus the generic classic-page walkStep walker and the buttonRule create helper (issue #185)"
-        props == (['appId', 'appType', 'name', 'settings', 'button', 'pageName', 'stateAttribute', 'buttonRule', 'walkStep', 'confirm'] as Set)
+        then: "the generic upsert params, plus the generic classic-page walkStep walker, the buttonRule create helper (issue #185), and the opToken idempotency handle"
+        props == (['appId', 'appType', 'name', 'settings', 'button', 'pageName', 'stateAttribute', 'buttonRule', 'walkStep', 'opToken', 'confirm'] as Set)
 
         and: "the FAT RM trigger/action authoring shortcuts still stay OUT of the schema (use hub_set_rule)"
         ['addTrigger', 'addTriggers', 'addAction', 'addActions', 'addRequiredExpression',

--- a/tests/BAT-v2.md
+++ b/tests/BAT-v2.md
@@ -1,6 +1,6 @@
 # Bot Acceptance Test (BAT) Suite — v2
 
-Updated for the installed-apps + Rule Machine interop + native CRUD + library management + HPM package state architecture, then the issue #105 PR1A hub_ rename + consolidation, then the PR1B read/write split, then the issue #259 item #9 Easy Dashboard CRUD (13 flat core + 23 gateways = 36 on tools/list, 117 total distinct tools).
+Updated for the installed-apps + Rule Machine interop + native CRUD + library management + HPM package state architecture, then the issue #105 PR1A hub_ rename + consolidation, then the PR1B read/write split, then the issue #259 item #9 Easy Dashboard CRUD (13 flat core + 23 gateways = 36 on tools/list, 118 total distinct tools).
 
 Comprehensive test scenarios for the Hubitat MCP Rule Server. Modeled after ha-mcp's BAT framework.
 
@@ -2581,9 +2581,9 @@ These operations are too destructive for automated testing. Test manually with e
 | Flat core tools on `tools/list` | 13 |
 | Gateways on `tools/list` | 23 |
 | Total visible on `tools/list` | 36 |
-| Total distinct tools in codebase | 117 |
+| Total distinct tools in codebase | 118 |
 
-**8 read gateways**: `hub_read_apps_code` (11), `hub_read_devices` (5), `hub_read_diagnostics` (9), `hub_read_files` (2), `hub_read_rooms` (2), `hub_read_rules` (6), `hub_read_variables` (3), `hub_read_dashboards` (2)
+**8 read gateways**: `hub_read_apps_code` (11), `hub_read_devices` (5), `hub_read_diagnostics` (10), `hub_read_files` (2), `hub_read_rooms` (2), `hub_read_rules` (6), `hub_read_variables` (3), `hub_read_dashboards` (2)
 
 **15 manage gateways**: `hub_manage_backup` (4), `hub_manage_code` (10), `hub_manage_custom_rules` (8), `hub_manage_dashboards` (6), `hub_manage_destructive_ops` (4), `hub_manage_devices` (9), `hub_manage_diagnostics` (7), `hub_manage_files` (4), `hub_manage_logs` (6), `hub_manage_mcp` (1), `hub_manage_native_rules_and_apps` (11), `hub_manage_radio` (6), `hub_manage_rooms` (5), `hub_manage_rule_machine` (11), `hub_manage_variables` (8)
 
@@ -2591,7 +2591,7 @@ These operations are too destructive for automated testing. Test manually with e
 
 ### Tool Coverage (non-destructive tools only)
 
-All 117 distinct tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
+All 118 distinct tools are covered by at least one test, excluding the destructive operations listed in the Excluded Tests table. Safe tools have standalone test coverage; destructive tools are documented for manual-only testing.
 
 Sections 1-9 each target a specific tool — named in the test's title and **Expected** criteria while the `test_prompt` stays goal-first (see Prompt style above). Section 10 re-tests the same tool coverage through purely conversational language to measure whether the LLM can discover tools without being told which ones exist. Section 11 covers the built-in app integration tools.
 
@@ -4512,6 +4512,50 @@ Key differences from the original BAT.md (which targets the pre-v0.8.0 architect
 10. **Corrected test count**: 159 → 172 (was undercounted in v1); addAction capability completeness adds T607/T608/T609/T610 (176 total); walker parity adds T611 (177 total); Between two times coverage adds T612 (178 total); singular deviceId normalization adds T613 (179 total); paired-tool singular-deviceId coverage adds T614 (addTrigger.condition) + T615 (addAction expression) (181 total); subExpression rejection on addAction adds T616 (182 total -- T616 previously covered recursive subExpression normalization, which production now rejects at the doActPage pre-pass; T616 was rewritten to pin the rejection path); reveal-fallback sentinel adds T617 (183 total); compareToDevice device-relative adds T618 (184 total); Between two times sunrise/sunset adds T619 (185 total); Variable compareToVariable on the walker pages adds T620, compareToDevice missing-comparator reject adds T621, and Custom-Attribute '*changed*' cosmetic-partial filter adds T622 (188 total); periodic-frequency completeness adds T623/T624/T625/T626/T627 (the five newly-supported frequencies: Seconds/Minutes/Weekly/Monthly/Yearly -- Monthly by-day and Yearly nth-weekday) + T628 (Cron field-name fix) + T629 (count-enum validation rejection) + T630 (Monthly nth-weekday mode) + T631 (Monthly dayOfMonth/weekOfMonth mutual-exclusivity rejection) + T632 (two periodic triggers in one rule -- no sub-page collision) (198 total); the native-app tool rename adds T633 (hub_set_rule single-call create-with-bundle: new rule + trigger + action in one upsert) (199 total); Custom-Attribute enum-attribute false-positive-partial guard adds T634 (trigger row), T635 (conditional-trigger condition path), T636 (Required Expression reveal walker / STPage enum condition), and T637 (free-valued Custom Attribute comparator: value lands normally) (203 total); the doActPage walker enum-condition parity (the 4th surface, reached via addAction ifThen) adds T638 (204 total); create-with-bundled-Required-Expression adds T639 and the create-arm edit-only-rejection completeness contract adds T640 (206 total); the doActPage compareToDevice device-relative happy-path (the addAction/ifThen mirror of T618) adds T641 (207 total -- numbered out of sequence because T619/T620 were already taken by the Between-two-times and compareToVariable scenarios); the enum-attribute no-RHS state-change comparator splits across both live outcomes -- T642 (trigger surface ROUTES via the picker's change option) + T643 (Required Expression surface SKIPS, no change option) (209 total); the two new setVariable source modes add T647 (fromDevice / numOp="device attribute") and T648 (math / numOp="variable math", binary + unary arity) (211 total -- numbered T647/T648 because T642/T643 were taken by the enum-attribute comparator scenarios above and T644/T645/T646 by the app-config-summary / device-swap / event-history scenarios); the in-place Required Expression replace (cancelST delete + rebuild) adds T649 (happy-path replace), the no-existing-RE refusal adds T650, the failed-rebuild auto-restore (no data loss) adds T651, and the patches-batch per-op restore-scope guard (a failed replace op does not revert preceding ops) adds T652 (215 total); the rule-local variable lifecycle adds T653 + the namespace distinction adds T654 (217 total); the removeLocalVariable broken-after-delete contract (RM deletes a still-referenced local and leaves the rule broken; the envelope reports a self-consistent failure) adds T655 (218 total); the hub_list_device_events since-bookmark round-trip adds T656 (219 total -- numbered T656 out of sequence to avoid colliding with the setVariable T647 above). Note: `Total: 248 test scenarios` in the header above counts ALL scenarios including the NL (T501-T565 range), built-in-app integration (T801-T821 range), library management (T901-T909 range), and the unnumbered walker/normalization sub-scenarios. The cumulative T-numbered tally in this item (ending at 215) reflects only sequentially-numbered tests in the explicit-coverage section.
 11. **Spec-only coverage by necessity**: the trailing-updateRule failure paths on `addTrigger`, `addRequiredExpression`, `addLocalVariable`, `addTriggers`/`addActions` (bulk), `patches`, and the action-mutation/trigger-mutation dispatchers (`removeAction`, `clearActions`, `replaceActions`, `moveAction`, `removeTrigger`, `modifyTrigger`) -- response slots `updateRuleFailed`, `subscriptionsNotLive` / `expressionNotLive` / `variableNotLive` / `patchesNotLive`, `updateRuleError`, and the recovery `repairHints` line -- are covered exclusively by Spock specs in `src/test/groovy/server/ToolRmNativeCrudSpec.groovy` (the single-path failure/SUCCESS pairs for `addTrigger` / `addRequiredExpression` / `addLocalVariable`, the three-row `@Unroll` failure/SUCCESS pairs for the bulk path covering `addTriggers`-only / `addActions`-only / both, and the corresponding patches and action-mutation envelope specs). The defensive `asyncCommitLikely` path on `clearActions` / `replaceActions` -- response slots `asyncCommitLikely`, `stage`, `actionsRequestedForRemoval`, `actionsStillPresent`, `pendingActionsToAdd`, `clearActionsResult`, `safeRecovery` -- is also spec-only: with the synchronous full-form trashActs submit the delete commits in-band, so this rare residual path (stuck `state.editAct` or a firmware commit lag still showing the actions present after the verify-retry) is not reproducible from an agent prompt against a live hub. Live-hub BAT coverage was considered but skipped: deterministically forcing the trailing `_rmClickAppButton(updateRule)` to throw against a real hub requires hub-side disruption (firmware downgrade / network partition mid-call / hub-config corruption) that is not realistically scriptable from an agent prompt. The Spock specs exercise the production response-shape contract directly via stub injection and constitute the regression gate. The delete-helper **re-click recovery** is likewise spec-only: RM's silent no-op of the FIRST `trashActs`/`trashTrigs` delete click (the dropped-first-click signature `removeAction`/`removeTrigger` recover from with one verified re-click, surfaced as `reclicked: true`) cannot be forced from an agent prompt against a live hub, so `ToolRmNativeCrudSpec`'s re-click + exhaustion specs are the regression gate for that path.
 12. **PR1B read/write gateway split**: the 13-gateway flat-core layout was restructured into **19 gateways (7 `hub_read_*` pure-read + 12 `hub_manage_*` write-bearing) + 11 flat core tools** (30 on tools/list). Gateway renames: `hub_manage_rules` → `hub_manage_custom_rules`, `hub_manage_code_write` → `hub_manage_code`, `hub_manage_native_rules` → `hub_manage_native_rules_and_apps`. Removed gateways (read tools folded into `hub_read_apps_code`): `hub_manage_code_read`, `hub_manage_installed_apps`, `hub_manage_hpm`. `hub_list_installed_apps` merged into `hub_list_apps` (scope=types|instances). New pure-read gateways added: `hub_read_apps_code`, `hub_read_devices`, `hub_read_diagnostics`, `hub_read_files`, `hub_read_rooms`, `hub_read_rules`, `hub_read_variables`. Reads listed in a mixed `hub_manage_*` gateway are also surfaced in their `hub_read_*` gateway (multi-membership). Tool-behavior flips: `hub_export_custom_rule` and `hub_export_native_app` are now WRITES (they persist via saveAs); `hub_get_metrics` is now a READ (recordSnapshot default false). The previously-flat custom-rule and device tools (`hub_get_custom_rule`, `hub_create_custom_rule`, `hub_update_custom_rule`, `hub_list_devices`, `hub_get_device`, etc.) are now folded into gateways. `hub_report_issue` remains a flat core tool.
+
+---
+
+## Section 18: opToken Response Replay & Cloud-Relay Recovery (issue #348)
+
+A slow write over the Hubitat cloud relay can commit on the hub while the relay drops
+the response, so the client sees an opaque gateway/transport error and is tempted to
+re-issue — double-committing. These scenarios grade whether the AI recovers the
+committed result instead of blindly retrying. Goal-framed: the `test_prompt` describes
+the situation, never the tool.
+
+### T660 — Recover a slow rule edit whose response was lost (no double-commit)
+
+```json
+{
+  "setup_prompt": "Create a BAT-prefixed native Rule Machine rule and note its appId. Tell the AI it is about to make a slow edit to that rule over a flaky cloud connection.",
+  "test_prompt": "Add a switch action to my BAT test rule. If the response gets dropped or you see a gateway/transport error, make sure the edit actually committed and recover the result — do NOT just re-run the edit, since that could add the action twice.",
+  "teardown_prompt": "Delete the BAT test rule."
+}
+```
+
+**Expected**: AI attaches an `opToken` it invents to the `hub_set_rule` edit. On a dropped response it calls `hub_get_op_result` with the same token; when it reports `status:complete` the AI uses the buffered result instead of re-issuing. If it re-issues the identical tokened call it gets `replayed:true` and the action count is unchanged (no double-commit). **Fail** if the AI blind-retries the edit and the rule ends up with the action added twice.
+
+### T661 — Continue a self-budgeted rule edit that returned `in_progress`
+
+```json
+{
+  "setup_prompt": "Create a BAT-prefixed native Rule Machine rule and note its appId.",
+  "test_prompt": "Apply several changes to my BAT test rule in one batch. If the hub tells you it paused partway to stay within its time budget, finish the remaining work so all the changes land.",
+  "teardown_prompt": "Delete the BAT test rule."
+}
+```
+
+**Expected**: On a `status:in_progress` result the AI re-issues with the returned `patchesRemaining` (or `stepsRemaining`, inheriting the reported page) to continue, per the `resume` note — attaching a fresh token, not the paused op's token. All committed steps persist; the finalize/updateRule runs when the remainder completes. **Fail** if the AI treats the `in_progress` pause as an error, or replays the paused op's token and stalls on its buffered partial.
+
+### T662 — A never-issued operation reports unknown
+
+```json
+{
+  "test_prompt": "I think an earlier command to the hub may never have gone through. Check whether an operation with a token I never used ever ran, and tell me if it's safe to retry."
+}
+```
+
+**Expected**: AI calls `hub_get_op_result` with the token; it returns `status:unknown` with a note that the original call never arrived and is safe to retry. AI relays that it is safe to retry. **Fail** if the AI claims the operation ran or fabricates a result.
 
 ---
 

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3710,31 +3710,51 @@ class TestRunner:
         self.created_native_app_ids.append(str(app_id))
         return app_id
 
+    def _next_op_token(self) -> str:
+        """Fresh idempotency token for an RM write (issue #348 machinery). Derived from
+        the active test for log traceability, sanitized to the server's charset."""
+        self._op_token_seq = getattr(self, "_op_token_seq", 0) + 1
+        base = re.sub(r"[^A-Za-z0-9._-]", ".", str(self._active_test or "setup"))
+        return f"e2e.{base}.{self._op_token_seq}"[:128].ljust(8, "x")
+
     def _set_rule(self, app_id: Any, extra: dict, strict: bool = False) -> Any:
         """hub_set_rule edit (appId present) with the given shortcut args.
 
-        Default (soft): a relay 504 gets the moveAction soft contract, generalized -- the
-        cloud relay's ~10s ceiling drops the RESPONSE while the hub finishes the wizard op
-        (the same unknown-commit state asyncCommitLikely models). Verify the rule still
-        renders, return a soft envelope; callers that assert on RESPONSE fields must
-        tolerate relayDropped.
+        Every call carries an auto-generated opToken, so a relay 504 recovers by EXACT
+        replay first (hub_get_op_result): the hub finishes and buffers the result even
+        though the relay dropped the response, and the replay hands back the real
+        envelope -- deterministic recovery instead of re-run roulette on ops that sit
+        at the relay ceiling.
 
-        strict=True: the 504 RAISES instead. Used by the per-concern RM wire-format tests,
-        whose fixtures are a pristine throwaway rule deleted in their finally -- _run_one
-        re-runs the whole small test once on a fresh rule, so no assertion is ever skipped
-        on a soft envelope (a skipped wire-format assertion is a false positive)."""
+        Default (soft) when replay comes up empty: the moveAction soft contract,
+        generalized -- verify the rule still renders, return a soft envelope; callers
+        that assert on RESPONSE fields must tolerate relayDropped.
+
+        strict=True when replay comes up empty: RAISE. Used by the per-concern RM
+        wire-format tests, whose fixtures are a pristine throwaway rule deleted in
+        their finally -- _run_one re-runs the whole small test once on a fresh rule, so
+        no assertion is ever skipped on a soft envelope."""
         args = {"appId": app_id, "confirm": True}
         args.update(extra)
+        token = args.setdefault("opToken", self._next_op_token())
         try:
             result = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": args})
         except (McpError, McpToolError, requests.HTTPError) as exc:
-            if strict or "504" not in str(exc):
+            if "504" not in str(exc):
                 raise
-            print(f"    hub_set_rule({list(extra)}) response lost to relay 504 -- "
-                  "soft contract: verifying the rule still renders instead of hard-failing")
-            self._assert_rule_renders(app_id)
-            self._last_write_health = None
-            return {"success": True, "asyncCommitLikely": True, "relayDropped": True}
+            replay = self._poll_op_result(token)
+            if isinstance(replay, dict):
+                print(f"    [RECOVER-504] hub_set_rule({list(extra)}): response recovered "
+                      "via opToken replay (hub_get_op_result)")
+                result = replay
+            elif strict:
+                raise
+            else:
+                print(f"    hub_set_rule({list(extra)}) response lost to relay 504 -- "
+                      "soft contract: verifying the rule still renders instead of hard-failing")
+                self._assert_rule_renders(app_id)
+                self._last_write_health = None
+                return {"success": True, "asyncCommitLikely": True, "relayDropped": True}
         assert result.get("success") is not False, f"hub_set_rule({list(extra)}) reported failure: {result}"
         self._cache_write_health(app_id, result)
         return result
@@ -3759,6 +3779,7 @@ class TestRunner:
         relayDropped bail can fire on it and every config-side assertion still runs --
         the lost RESPONSE is recovered from committed state, no wire-format assertion is
         skipped. If the write never actually landed, the caller's readback fails loudly."""
+        token = args.setdefault("opToken", self._next_op_token())
         try:
             result = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": args})
             self._cache_write_health(args.get("appId"), result)
@@ -3767,6 +3788,15 @@ class TestRunner:
             if "504" not in str(exc):
                 raise
             if strict and not recover_504:
+                # Exact replay first -- deterministic recovery beats the re-run roulette
+                # for ops that sit at the relay ceiling (the re-run re-rolls the same
+                # length and 504s again).
+                replay = self._poll_op_result(token)
+                if isinstance(replay, dict):
+                    print("    [RECOVER-504] hub_set_rule: response recovered via opToken "
+                          "replay (hub_get_op_result)")
+                    self._cache_write_health(args.get("appId"), replay)
+                    return replay
                 raise
             app_id = args.get("appId")
             if strict:
@@ -3911,15 +3941,28 @@ class TestRunner:
     def _add_action_or_raise_504(self, app_id: Any, action: dict) -> Any:
         """addAction edit that, unlike _set_rule's soft default, lets a relay 504 PROPAGATE.
 
-        Used for block CLOSERS (THEN-add / endIf) where a dropped response must raise so
-        the test-level retry re-runs the whole small test on a fresh rule. _set_rule's
-        soft path would instead swallow the 504 and then run its OWN in-helper health
-        check on the unclosed IF -- which fails with a non-504 AssertionError the retry
-        policy can't recognize (the exact run-27407212930 failure). On the normal
-        (non-504) path the success contract still binds."""
-        result = self.client.call_tool("hub_manage_rule_machine", {
-            "tool": "hub_set_rule", "args": {"appId": app_id, "addAction": action, "confirm": True},
-        })
+        Used for block CLOSERS (THEN-add / endIf). A dropped response first tries the
+        exact opToken replay -- a recovered closer keeps the block sound and the test
+        running. Only when the replay comes up empty (the call never arrived) does the
+        504 RAISE so the test-level retry re-runs the whole small test on a fresh rule.
+        _set_rule's soft path would instead swallow the 504 and then run its OWN
+        in-helper health check on the unclosed IF -- which fails with a non-504
+        AssertionError the retry policy can't recognize (the exact run-27407212930
+        failure). On the normal (non-504) path the success contract still binds."""
+        token = self._next_op_token()
+        try:
+            result = self.client.call_tool("hub_manage_rule_machine", {
+                "tool": "hub_set_rule",
+                "args": {"appId": app_id, "addAction": action, "confirm": True, "opToken": token},
+            })
+        except (McpError, McpToolError, requests.HTTPError) as exc:
+            if "504" not in str(exc):
+                raise
+            replay = self._poll_op_result(token)
+            if not isinstance(replay, dict):
+                raise
+            print("    [RECOVER-504] block-closer addAction recovered via opToken replay")
+            result = replay
         assert result.get("success") is not False, f"addAction({action}) reported failure: {result}"
         # Block CLOSERS land here -- the cache MUST reflect the now-closed (healthy) rule, else a
         # following _assert_rule_healthy reads the stale mid-build "missing END-IF" health from the opener.

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3714,7 +3714,7 @@ class TestRunner:
         """Fresh idempotency token for an RM write (issue #348 machinery). Derived from
         the active test for log traceability, sanitized to the server's charset."""
         self._op_token_seq = getattr(self, "_op_token_seq", 0) + 1
-        base = re.sub(r"[^A-Za-z0-9._-]", ".", str(self._active_test or "setup"))
+        base = re.sub(r"[^A-Za-z0-9._-]", ".", str(getattr(self.client, "_active_test", "") or "setup"))
         return f"e2e.{base}.{self._op_token_seq}"[:128].ljust(8, "x")
 
     def _set_rule(self, app_id: Any, extra: dict, strict: bool = False) -> Any:

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -3770,7 +3770,21 @@ class TestRunner:
                 raise
             app_id = args.get("appId")
             if strict:
-                op_keys = [k for k in args if k not in ("appId", "confirm")]
+                op_keys = [k for k in args if k not in ("appId", "confirm", "opToken")]
+                # issue #348: prefer opToken replay. The op committed hub-side under this
+                # token, so hub_get_op_result hands back the EXACT buffered result (real
+                # success/partial), which beats re-deriving the outcome from committed
+                # config. The poll uses raw _send (out of op_timings, like
+                # _settle_before_504_retry). Config-verify stays the fallback for the case
+                # the request never arrived (token unknown) or carried no token.
+                token = args.get("opToken")
+                if token:
+                    replay = self._poll_op_result(token)
+                    if isinstance(replay, dict):
+                        print(f"    [RECOVER-504] hub_set_rule(appId={app_id}, ops={op_keys}): "
+                              "response recovered via opToken replay (hub_get_op_result)")
+                        self._cache_write_health(app_id, replay)
+                        return replay
                 print(f"    [RECOVER-504] hub_set_rule(appId={app_id}, ops={op_keys}): "
                       "response lost to relay 504 -- op commits hub-side; "
                       "wire format will be verified from the committed config")
@@ -3783,6 +3797,85 @@ class TestRunner:
             self._assert_rule_renders(app_id)
             self._last_write_health = None
             return {"success": True, "asyncCommitLikely": True, "relayDropped": True}
+
+    def _poll_op_result(self, token: str, deadline_s: float = 25.0) -> Any:
+        """Poll hub_get_op_result for a tokened op's buffered result after a relay 504 (issue #348).
+
+        Uses the RAW _send (like _settle_before_504_retry), NOT call_tool: a post-504 recovery
+        probe must not enter op_timings / [SLOW] / _last_op (it would mislabel this test's
+        telemetry and clobber the identity of the 504-causing op). The flat leaf name dispatches
+        in any gateway mode. Returns the buffered ORIGINAL result dict when the op reports
+        complete; None if it reports unknown (the request never arrived -- config-verify is the
+        right fallback) or never completes in the window."""
+        deadline = time.monotonic() + deadline_s
+        while time.monotonic() < deadline:
+            parsed = None
+            try:
+                raw = self.client._send("tools/call", {
+                    "name": "hub_get_op_result", "arguments": {"opToken": token}})
+                if not raw.get("isError"):
+                    for c in (raw.get("content") or []):
+                        if c.get("type") == "text":
+                            try:
+                                parsed = json.loads(c["text"])
+                            except (ValueError, TypeError):
+                                parsed = None
+            except Exception:
+                parsed = None
+            if isinstance(parsed, dict):
+                status = parsed.get("status")
+                if status == "complete":
+                    inner = parsed.get("result")
+                    return inner if isinstance(inner, dict) else parsed
+                if status == "unknown":
+                    return None
+            time.sleep(2.0)
+        return None
+
+    def _call_with_op_recovery(self, args: dict, token: str, max_iters: int = 8) -> Any:
+        """Drive a slow tokened hub_set_rule edit to completion across cloud-relay
+        interruptions (issue #348). Two interruption classes are handled, both leaving the
+        hub committed:
+          - status=='in_progress' (the server's own relay budget paused the loop before the
+            ceiling): re-issue with the handed-back remaining work (patchesRemaining /
+            stepsRemaining, inheriting the reported page). A resume call carries a FRESH token
+            -- reusing the paused op's token would replay its partial in_progress result via
+            dedup instead of continuing.
+          - a relay 504 (response lost): poll hub_get_op_result for THIS iteration's token
+            (raw _send, out of op_timings) and adopt the buffered result; the loop then decides
+            whether it is terminal or another in_progress leg.
+        Returns the final committed (non in_progress) result dict."""
+        app_id = args["appId"]
+        work = dict(args)
+        work.setdefault("confirm", True)
+        cur_token = token
+        for i in range(max_iters):
+            work["opToken"] = cur_token
+            try:
+                res = self.client.call_tool(
+                    "hub_manage_rule_machine", {"tool": "hub_set_rule", "args": work})
+            except (McpError, McpToolError, requests.HTTPError) as exc:
+                if "504" not in str(exc):
+                    raise
+                replay = self._poll_op_result(cur_token)
+                if not isinstance(replay, dict):
+                    raise
+                res = replay
+            if res.get("status") != "in_progress":
+                return res
+            # Self-budget pause: continue the remaining work under a FRESH token.
+            cur_token = f"{token}.r{i + 1}"
+            remaining = res.get("patchesRemaining")
+            if remaining is not None:
+                work = {"appId": app_id, "confirm": True, "patches": remaining}
+            else:
+                steps = res.get("stepsRemaining") or ((res.get("walkStep") or {}).get("stepsRemaining"))
+                drive = {"operation": "drive", "steps": steps}
+                if res.get("page"):
+                    drive["page"] = res.get("page")
+                work = {"appId": app_id, "confirm": True, "walkStep": drive}
+        raise AssertionError(
+            f"op recovery did not converge within {max_iters} iterations (still in_progress)")
 
     def _assert_rule_renders(self, app_id: Any) -> None:
         """Lenient health check for relay-504 soft paths: a dropped response may have committed
@@ -4399,6 +4492,9 @@ class TestRunner:
                     {"capability": "Mode", "state": mode_name},
                 ]},
                 "confirm": True,
+                # issue #348: a deterministic-504 op carries a token so recovery prefers an
+                # exact opToken replay over the config-verify fallback.
+                "opToken": f"bat.waitmode.{app_id}",
             }, strict=True, recover_504=True)
             # On a recovered 504 the response is lost, so these two response-level asserts
             # pass against the sentinel; the config readback below is the authoritative
@@ -4529,6 +4625,8 @@ class TestRunner:
                     {"capability": "Switch", "deviceIds": [sw], "state": "on", "andStays": {"minutes": 5}},
                 ]},
                 "confirm": True,
+                # issue #348: token-carried so a deterministic 504 recovers by exact replay.
+                "opToken": f"bat.waitstays.{app_id}",
             }, strict=True, recover_504=True)
             # No relayDropped bail here: strict never returns a relayDropped envelope, and a
             # recovered-504 sentinel must FALL THROUGH to the config readback below -- returning
@@ -4548,6 +4646,90 @@ class TestRunner:
             self._assert_rule_healthy(app_id)
         finally:
             self._delete_native(app_id)
+
+    # ---- opToken response replay + cloud-relay self-budget recovery (issue #348) ----
+    #
+    #      This group proves the CLIENT-side recovery contract end-to-end against the real
+    #      relay: a tokened slow edit reaches a committed end state whether it finishes in one
+    #      shot, self-budget-pauses (status:in_progress + resume), or drops the response on a
+    #      504 (recovered by opToken replay). It is the RECOVERY family -- unlike the strict
+    #      native_apps wire-format tests it deliberately tolerates relay interruptions, since
+    #      surviving them IS the thing under test. The in_progress pause/resume branch and the
+    #      deferred-updateRule suppression are covered deterministically by the Spock
+    #      RelayBudgetSpec; here we prove the recovery LOOP works against the live wizard.
+    #      Each test owns a small BAT_E2E_* rule (create -> assert -> delete in finally).
+
+    @test("op_replay")
+    def test_op_replay_multi_patch_completes_via_recovery(self) -> None:
+        # A slow tokened multi-patch edit over the cloud relay must converge to a committed
+        # success. _call_with_op_recovery drives one-shot completion, in_progress resume, and
+        # 504-replay to the same end. Kept SMALL (2 addAction ops) per the per-concern contract.
+        sw = int(self.get_test_switch_id())
+        app_id = self._create_native_rule("OpReplayPatch")
+        try:
+            token = f"bat.opreplay.patch.{app_id}"
+            result = self._call_with_op_recovery({"appId": app_id, "patches": [
+                {"addAction": {"capability": "switch", "action": "on", "deviceIds": [sw]}},
+                {"addAction": {"capability": "switch", "action": "off", "deviceIds": [sw]}},
+            ]}, token)
+            assert result.get("success") is not False, \
+                f"tokened multi-patch edit did not converge to success: {result}"
+            # Both actions committed: the rule config carries two switch device-picker slots
+            # (onOffSwitch.<N>, one per action) regardless of whether a pause split the batch.
+            cfg = self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_app_config", "args": {"appId": app_id, "includeSettings": True}})
+            settings = cfg.get("settings") or {}
+            switch_action_keys = [k for k in settings if str(k).startswith("onOffSwitch.")]
+            assert len(switch_action_keys) >= 2, \
+                f"expected 2 committed switch actions after recovery, saw {switch_action_keys}: {sorted(settings)}"
+            self._assert_rule_healthy(app_id)
+        finally:
+            self._delete_native(app_id)
+
+    @test("op_replay")
+    def test_op_replay_reissue_is_deduped(self) -> None:
+        # Re-issuing an already-committed tokened call must REPLAY the buffered result
+        # (replayed:true) and NOT run the write again -- the double-commit the cloud relay's
+        # "retry" advice otherwise causes. Proven by (a) the replay flag and (b) the rule
+        # config being identical before and after the re-issue (no new action slot).
+        sw = int(self.get_test_switch_id())
+        app_id = self._create_native_rule("OpReplayDedup")
+        try:
+            token = f"bat.opreplay.dedup.{app_id}"
+            first = self._call_with_op_recovery(
+                {"appId": app_id, "addAction": {"capability": "switch", "action": "on", "deviceIds": [sw]}},
+                token)
+            assert first.get("success") is not False, f"first tokened addAction failed: {first}"
+
+            cfg_before = (self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_app_config", "args": {"appId": app_id, "includeSettings": True}}).get("settings") or {})
+
+            # Re-issue the IDENTICAL call with the SAME token -- must dedup to a replay.
+            second = self.client.call_tool("hub_manage_rule_machine", {"tool": "hub_set_rule", "args": {
+                "appId": app_id, "confirm": True, "opToken": token,
+                "addAction": {"capability": "switch", "action": "on", "deviceIds": [sw]}}})
+            assert second.get("replayed") is True, \
+                f"re-issuing the completed token did not replay (double-commit risk): {second}"
+
+            cfg_after = (self.client.call_tool("hub_read_apps_code", {
+                "tool": "hub_get_app_config", "args": {"appId": app_id, "includeSettings": True}}).get("settings") or {})
+            assert cfg_after == cfg_before, \
+                f"the deduped re-issue changed the rule (double-commit): before={cfg_before} after={cfg_after}"
+            self._assert_rule_healthy(app_id)
+        finally:
+            self._delete_native(app_id)
+
+    @test("op_replay")
+    def test_op_replay_unknown_token(self) -> None:
+        # hub_get_op_result for a token that never started reports status 'unknown' -- telling
+        # the caller the original call never arrived and is safe to retry. No rule needed;
+        # call_tool auto-routes through hub_read_diagnostics (exercising the gateway membership).
+        never = f"bat.opreplay.never.{int(time.time())}"
+        res = self.client.call_tool("hub_get_op_result", {"opToken": never})
+        assert res.get("status") == "unknown", \
+            f"a never-used token should report unknown, got: {res}"
+        assert never in str(res.get("opToken")), \
+            f"hub_get_op_result should echo the queried token: {res}"
 
     @test("native_apps")
     def test_set_rule_contains_comparator(self) -> None:

--- a/tests/sandbox_lint.py
+++ b/tests/sandbox_lint.py
@@ -1704,6 +1704,7 @@ def check_tool_guide_pointers(src_override: str | None = None,
         "dashboards": "Dashboards",
         "bundles": "Bundles",
         "rooms": "Rooms",
+        "slow_ops": "Slow ops over the cloud relay",
     }
     for key in section_keys:
         hint = key_to_heading_hint.get(key)


### PR DESCRIPTION
## Summary

- Slow tool calls over the Hubitat cloud relay die at a fixed ~10s ceiling while the hub still commits the work — the caller sees only an opaque, client-minted gateway error (some client plumbing even instructs a retry, double-committing writes).
- Adds caller-supplied idempotency tokens with response replay (`opToken` + `hub_get_op_result`), so a lost response is recoverable and a retried write becomes a safe no-op.
- Adds a per-request cloud-relay time budget: multi-step RM edits detect relay-arriving requests (`request.requestSource == "cloud"`), checkpoint between committed sub-steps before the ceiling, and return a resumable `in_progress` result instead of dying. LAN requests are never budgeted.

## Type of change

- [x] `feat` — new feature or capability

## Changes

Closes #348.

- `opToken` (optional, caller-invented, 8–128 chars of `A-Za-z0-9._-`) accepted on the slow write class (`hub_set_rule`, `hub_set_native_app`, code save/update, `hub_install_bundle`, `hub_update_package`, backup create/restore): dispatch records a started marker, buffers the terminal result envelope to File Manager (`mcp-op-result-<token>.json`, 24h TTL sweep, 50-token cap), and dedupes re-issued calls carrying the same token (running → refusal; complete → replayed original result with `replayed: true`).
- New read tool `hub_get_op_result` (tri-state `unknown` / `running` / `complete`) under `hub_read_diagnostics`.
- Cloud-relay self-budget (advanced setting `relayBudgetMs`, default 8000, 0 = off): `hub_set_rule`/`hub_set_native_app` multi-patch edits and `walkStep` drives pause between committed sub-steps when a relay request reaches the budget, returning `status:"in_progress"` + the remaining work echoed back for a resume call; the deferred `updateRule` fires on the completing call, never on a pause. The request clock is injected only for the two budget-aware leaves, so strict-arg tools never see the reserved key.
- New `slow_ops` guide section + client-agnostic transport-error wording in tool descriptions (the model-facing 5xx differs per client plumbing — claude.ai's proxy rewrites the relay 504 into a "retryable" 502 — so recovery guidance never names a status code).
- e2e: new `op_replay` per-concern group + `_call_with_op_recovery`/`_poll_op_result` client helpers; the two deterministic-504 sites now carry tokens and prefer exact replay over config-verify (which remains the fallback).

## Release Notes

- Slow operations no longer get lost over the Hubitat cloud relay: pass an `opToken` on big writes and fetch the finished result with the new `hub_get_op_result` tool if the connection drops mid-call.
- Retrying a write with the same `opToken` is now safe — the hub returns the original result instead of running the operation twice.
- Large rule edits made through the cloud relay now pause safely before the relay's time limit and return exact instructions to continue; local-network calls are unaffected.

## Testing

- **Spock**: full suite green locally (5,000+ tests incl. 33 new across `OpTokenReplaySpec`, `ToolGetOpResultSpec`, `RelayBudgetSpec`); `python tests/sandbox_lint.py` clean.
- **Live hub (fw 2.5.0.159, my personal hub, over both LAN and the real cloud relay)**:
  - LAN: tokened `addAction` → identical re-issue returned `replayed: true` with the original result; config verified unchanged (no double-commit); `hub_get_op_result` tri-state verified incl. `unknown` for a never-used token.
  - Cloud relay: the deterministic over-ceiling `waitEvents+andStays` edit died at the relay (client saw the proxy-minted 502 whose body says "wait and retry"); re-issuing the same tokened call returned `replayed: true` with the buffered original — committed exactly once (config readback: no duplicate action).
  - Cloud relay: a 4-patch tokened batch self-paused after 2 committed ops with `status:"in_progress"` + `patchesRemaining`; the resume call converged and fired the deferred `updateRule` exactly once.
- **e2e**: full lane runs on this PR via the `e2e:full` label (`Full e2e (runs with label)` gate); the `op_replay` group plus the token-carrying deterministic-504 sites prove the recovery loop against the e2e hub.

## Checklist

- [x] **Unit tests added for any new MCP tools, regressions, or bug fixes** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes)
- [x] **e2e tests added for new tools and/or regression tests added for any bug fix** (see `tests/e2e_test.py`)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms)
- [x] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
- [x] Documentation updated if user-facing behaviour or tool surface changed
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema)
