### PR TITLE
chore: disable sunset Gemini Code Assist reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -4,6 +4,16 @@
 # All fields are optional; only listing what we override from defaults.
 
 code_review:
+  # Google sunset Gemini Code Assist's GitHub review activities; the app now
+  # only posts sunset-notice banners on PRs. Disable it fully so the lingering
+  # installation cannot post. The rest of this config (and styleguide.md) is
+  # kept for whichever review bot replaces it.
+  disable: true
+  pull_request_opened:
+    summary: false
+    code_review: false
+    include_drafts: false
+
   # Skip the .gemini/ directory in PR review diffs. The styleguide and this
   # config aren't code-under-review — letting Gemini comment on its own
   # config noise-pollutes reviews when this directory changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Conventions for AI coding agents working on this repo (OpenAI Codex, Cursor, Aider, Windsurf, Zed, etc.). Claude Code reads `CLAUDE.md`, which is kept byte-identical to this file — the PR Guard CI workflow flags drift. **AGENTS.md is the source of truth.** Edit it, then `cp AGENTS.md CLAUDE.md` before committing. (GitHub Copilot uses `.github/copilot-instructions.md`; Gemini Code Assist uses `.gemini/styleguide.md`.)
+Conventions for AI coding agents working on this repo (OpenAI Codex, Cursor, Aider, Windsurf, Zed, etc.). Claude Code reads `CLAUDE.md`, which is kept byte-identical to this file — the PR Guard CI workflow flags drift. **AGENTS.md is the source of truth.** Edit it, then `cp AGENTS.md CLAUDE.md` before committing. (GitHub Copilot uses `.github/copilot-instructions.md`; `.gemini/styleguide.md` drove Gemini Code Assist's reviews — that bot is sunset and disabled, its replacement TBD.)
 
 This file is for AI agents. Human contributors follow `.github/pull_request_template.md` and `.gemini/styleguide.md`.
 
@@ -329,6 +329,6 @@ All bookkeeping is bot-only. Communicate user-facing changes through your PR's `
 ## Reference
 
 - [`.github/pull_request_template.md`](.github/pull_request_template.md) — PR body structure (source of truth)
-- [`.gemini/styleguide.md`](.gemini/styleguide.md) — Gemini Code Assist's review checks
+- [`.gemini/styleguide.md`](.gemini/styleguide.md) — review checklist (drove the sunset Gemini Code Assist bot; kept for its future replacement)
 - [`docs/release-automation-design.md`](docs/release-automation-design.md) — full release-pipeline design and the bookkeeping rule
 - [`docs/testing.md`](docs/testing.md) — Spock + hubitat_ci harness, dispatch interception cheat sheet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Conventions for AI coding agents working on this repo (OpenAI Codex, Cursor, Aider, Windsurf, Zed, etc.). Claude Code reads `CLAUDE.md`, which is kept byte-identical to this file — the PR Guard CI workflow flags drift. **AGENTS.md is the source of truth.** Edit it, then `cp AGENTS.md CLAUDE.md` before committing. (GitHub Copilot uses `.github/copilot-instructions.md`; Gemini Code Assist uses `.gemini/styleguide.md`.)
+Conventions for AI coding agents working on this repo (OpenAI Codex, Cursor, Aider, Windsurf, Zed, etc.). Claude Code reads `CLAUDE.md`, which is kept byte-identical to this file — the PR Guard CI workflow flags drift. **AGENTS.md is the source of truth.** Edit it, then `cp AGENTS.md CLAUDE.md` before committing. (GitHub Copilot uses `.github/copilot-instructions.md`; `.gemini/styleguide.md` drove Gemini Code Assist's reviews — that bot is sunset and disabled, its replacement TBD.)
 
 This file is for AI agents. Human contributors follow `.github/pull_request_template.md` and `.gemini/styleguide.md`.
 
@@ -329,6 +329,6 @@ All bookkeeping is bot-only. Communicate user-facing changes through your PR's `
 ## Reference
 
 - [`.github/pull_request_template.md`](.github/pull_request_template.md) — PR body structure (source of truth)
-- [`.gemini/styleguide.md`](.gemini/styleguide.md) — Gemini Code Assist's review checks
+- [`.gemini/styleguide.md`](.gemini/styleguide.md) — review checklist (drove the sunset Gemini Code Assist bot; kept for its future replacement)
 - [`docs/release-automation-design.md`](docs/release-automation-design.md) — full release-pipeline design and the bookkeeping rule
 - [`docs/testing.md`](docs/testing.md) — Spock + hubitat_ci harness, dispatch interception cheat sheet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ The PR title must start with one of these, lowercase and colon-terminated:
 
 `build:` is reserved for Dependabot — contributors should not use it.
 
-Pick the prefix matching the diff and tick the matching `Type of change` box; Gemini Code Assist flags mismatches.
+Pick the prefix matching the diff and tick the matching `Type of change` box; reviewers flag mismatches.
 
 ### Release Notes section
 
@@ -94,7 +94,7 @@ If your PR changes tool behaviour, add or update the matching BAT scenarios in t
 
 ### PR review flow
 
-- [Gemini Code Assist](https://gemini.google.com/) auto-reviews using [`.gemini/styleguide.md`](.gemini/styleguide.md). Its first comment will always lead with "I am an AI and make mistakes…" — pushback is welcome and the maintainer treats Gemini's checks as suggestions, not blockers.
+- Gemini Code Assist's automated reviews are sunset (Google retired the bot's review activities; it is disabled in [`.gemini/config.yaml`](.gemini/config.yaml)). A replacement review bot is TBD; [`.gemini/styleguide.md`](.gemini/styleguide.md) remains the review checklist reviewers apply.
 - The three custom checks (Release Notes presence, title-prefix / Type-of-change agreement, prefix-matches-diff) are suggestions, not hard blocks.
 - The maintainer makes the final call on merge.
 


### PR DESCRIPTION
## Summary

- Google sunset Gemini Code Assist's GitHub review activities; disable the app in `.gemini/config.yaml` so the lingering installation cannot post sunset-notice banners on PRs
- Update AGENTS.md / CLAUDE.md / CONTRIBUTING.md to reflect the retirement; a replacement review bot is TBD
- The styleguide and existing config are kept for whichever review bot replaces it

## Type of change

- [x] `chore` — maintenance, dependency bump, or housekeeping

## Changes

- `.gemini/config.yaml`: `code_review.disable: true` plus `pull_request_opened` interactions off; existing `ignore_patterns` kept
- `AGENTS.md` + `CLAUDE.md` (byte-identical copy): header parenthetical and Reference entry updated
- `CONTRIBUTING.md`: PR review flow notes the sunset; prefix-mismatch flagging no longer attributed to Gemini

## Release Notes

## Testing

Docs and bot config only — no hub code touched; Spock/e2e not applicable.

## Checklist

- [ ] **Unit tests added for any new MCP tools, regressions, or bug fixes** (not applicable)
- [ ] **e2e tests added for new tools and/or regression tests added for any bug fix** (not applicable)
- [ ] Sandbox lint passes: `python tests/sandbox_lint.py` (not applicable)
- [ ] `./gradlew test` passes locally (or CI confirms) (not applicable)
- [ ] Live-hub BAT tests updated if tool behaviour changed (not applicable)
- [x] Documentation updated if user-facing behaviour or tool surface changed
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (not applicable)
