### PR TITLE
fix: backup gate and create-backup confirmation read the hub's real backup list

### DIFF
--- a/.github/scripts/mcp_arm_watchdog.sh
+++ b/.github/scripts/mcp_arm_watchdog.sh
@@ -42,10 +42,17 @@ APP_NAME="MCP Rule Server"
 WATCHDOG_NAME="E2E Dead-Man Watchdog v2"
 WATCHDOG_SOURCE_URL="${PR_RAW_BASE}/${PR_HEAD_SHA_RESOLVED}/e2e-deadman-watchdog-v2.groovy"
 FLAG_FILE="e2e-deadman-v2.json"
-ARM_WINDOW_MS=2100000   # 35 minutes -- deliberately > the 30-min job timeout-minutes, so the
-                        # watchdog can only fire AFTER GitHub has already killed a hung/dead job,
-                        # never mid-live-run. The always() disarm clears it in seconds on every
-                        # normal run, so the long window only matters when the session truly dies.
+ARM_WINDOW_MS=4500000   # 75 minutes -- deliberately > the longest LIVE window between this arm and
+                        # the always() disarm (full-lane deploy ~5 min + the whole suite ~40-50 min,
+                        # measured 49 min on run 30060370488), so the watchdog can only fire after a
+                        # run truly died, never mid-live-run. The original 35-min window was sized
+                        # against a 30-min job timeout that no longer exists (timeout-minutes is now
+                        # 270 to survive the approval/queue wait) and the dead-man fired MID-SUITE on
+                        # the first >35-min full lane: it silently restored canonical main while
+                        # tests were still running, so any test after the deadline exercised OLD
+                        # code (PR #362's protocol-group failure). The always() disarm clears the
+                        # flag in seconds on every normal run, so the wider window only delays
+                        # auto-recovery when the session truly dies.
 
 # Shared helpers (resolve_main_bundle_artifact_url -- the canonical-main bundle resolver this
 # script and the deploy's skip-compare both use). The lib's call wrappers are NOT used here;

--- a/.github/scripts/mcp_disarm_watchdog.sh
+++ b/.github/scripts/mcp_disarm_watchdog.sh
@@ -80,6 +80,16 @@ if ! CUR_TEXT=$(mcp_tool_call_text "hub_read_file (read armed flag for manifest)
   exit 1
 fi
 CUR_CONTENT=$(echo "$CUR_TEXT" | jq -r '.content // ""')
+# Surface the pre-disarm state BEFORE this script rewrites the flag: a dead-man that fired
+# mid-run (armed already false, fireAttempts > 0, restoreTrigger "deadline") is otherwise
+# invisible -- the disarm's rewrite erases the evidence and the run reads as inexplicably
+# testing OLD code past the deadline (how PR #362's mid-suite restore hid for a full run).
+PRE_STATE=$(printf '%s' "$CUR_CONTENT" | jq -c '{armed, fireAttempts, deadline, restoreTrigger, restoredAt}' 2>/dev/null || echo "{}")
+echo "Pre-disarm flag state: $PRE_STATE"
+PRE_FIRED=$(printf '%s' "$CUR_CONTENT" | jq -r '(.fireAttempts // 0) > 0 or ((.restoreTrigger // "") == "deadline")' 2>/dev/null || echo "false")
+if [ "$PRE_FIRED" = "true" ]; then
+  echo "::warning::The dead-man FIRED before this disarm (see pre-disarm flag state above) -- the hub was restored to canonical main MID-RUN, so any test executed after the deadline ran against OLD code. Treat this run's results as invalid and re-run."
+fi
 MANIFEST_JSON=$(printf '%s' "$CUR_CONTENT" | jq -c '.manifest // empty' 2>/dev/null || echo "")
 ARM_PR_SHA=$(printf '%s' "$CUR_CONTENT" | jq -r '.armPrSha // .mainSha // ""' 2>/dev/null || echo "")
 # The canonical-main SHA the hub was confirmed on at arm. Forwarded into the disarm flag so the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ Every MCP tool is gated. The layers, from broadest to narrowest:
 
 ### Error contracts
 
-- **Validation errors** (caller-recoverable, bad args): throw `IllegalArgumentException`. Caught by `handleToolsCall` and mapped to JSON-RPC `-32602`. Existing pattern; reaffirmed.
+- **Validation errors** (caller-recoverable, bad args): throw `IllegalArgumentException`. Caught by `handleToolsCall` and mapped to JSON-RPC `-32602`. Existing pattern; reaffirmed. **A validation throw MUST fire before any side effect** — the opToken machinery RELEASES a token on `-32602` (a corrected same-token re-issue executes fresh), which is only safe while nothing was committed; a tool that mutates state and then throws `IllegalArgumentException` would expose that work to a double-run.
 - **Runtime errors** (operation tried and failed for non-arg reasons): return `[success: false, error: <human-readable>, note: <actionable guidance>]`. Don't throw — the AI needs a structured error.
 - **`isError: true` envelope** for tool-execution errors per MCP spec 2025-06-18. Already adopted in v0.7.7+ (see SKILL.md § Version Management for the adoption note).
 - **Specific, actionable, recovery-oriented error text.** Tell the model how to recover. Anthropic recommends steering truncation errors toward recovery strategies like *"many small and targeted searches instead of a single, broad search."*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ Every MCP tool is gated. The layers, from broadest to narrowest:
 
 ### Error contracts
 
-- **Validation errors** (caller-recoverable, bad args): throw `IllegalArgumentException`. Caught by `handleToolsCall` and mapped to JSON-RPC `-32602`. Existing pattern; reaffirmed.
+- **Validation errors** (caller-recoverable, bad args): throw `IllegalArgumentException`. Caught by `handleToolsCall` and mapped to JSON-RPC `-32602`. Existing pattern; reaffirmed. **A validation throw MUST fire before any side effect** — the opToken machinery RELEASES a token on `-32602` (a corrected same-token re-issue executes fresh), which is only safe while nothing was committed; a tool that mutates state and then throws `IllegalArgumentException` would expose that work to a double-run.
 - **Runtime errors** (operation tried and failed for non-arg reasons): return `[success: false, error: <human-readable>, note: <actionable guidance>]`. Don't throw — the AI needs a structured error.
 - **`isError: true` envelope** for tool-execution errors per MCP spec 2025-06-18. Already adopted in v0.7.7+ (see SKILL.md § Version Management for the adoption note).
 - **Specific, actionable, recovery-oriented error text.** Tell the model how to recover. Anthropic recommends steering truncation errors toward recovery strategies like *"many small and targeted searches instead of a single, broad search."*

--- a/SKILL.md
+++ b/SKILL.md
@@ -296,7 +296,7 @@ Access control has a central master gate plus a destructive confirmation tier, w
 
 **`requireDestructiveConfirm(args.confirm)`** — runs in the handlers of the destructive/sensitive write tools, orthogonal to the masters (the Write master already gated them centrally). Two-layer check:
 1. `args.confirm` must be `true` (explicit confirmation parameter)
-2. `state.lastBackupTimestamp` must be within the last 24 hours
+2. A hub backup within the last 24 hours: `state.lastBackupTimestamp` first; when that stamp is stale/missing, the gate falls back to the hub's own local backup list (`GET /hub2/localBackups` via `_latestLocalHubBackupEpoch()`) — a scheduled/UI backup is a real recovery point — and caches a fresh find back into the stamp (issue #361)
 
 Exception: `toolCreateHubBackup` checks `confirm` directly without requiring a prior backup (it IS the backup operation).
 
@@ -408,7 +408,7 @@ The cookie is cached in `state.hubSecurityCookie` with expiry in `state.hubSecur
 | `debugLogs` | Map | `{entries: [], config: {logLevel, maxEntries}}` circular buffer |
 | `hubSecurityCookie` | String | Cached auth cookie |
 | `hubSecurityCookieExpiry` | Long | Cookie expiry epoch ms |
-| `lastBackupTimestamp` | Long | Last hub backup epoch ms (24-hour write safety gate) |
+| `lastBackupTimestamp` | Long | Newest known hub backup epoch ms (24-hour write safety gate; stamped by hub_create_backup or refreshed from the hub's local backup list on a gate fallback) |
 | `itemBackupManifest` | Map | Metadata for source code backups stored in File Manager, keyed by `"app_<id>"` / `"driver_<id>"` / `"library_<id>"`, max 20 entries |
 | `updateCheck` | Map | `{latestVersion, checkedAt, updateAvailable}` |
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -1167,7 +1167,7 @@ If the response is lost, do NOT re-run the operation and do NOT invent a fresh t
 - `status: "unknown"` (returned only to a token-only poll) — no RECORD of this token exists: the original call never arrived, OR the record aged out (records sweep ~24h after start, and past 100 stored records the oldest terminal records batch-evict down to 50). Poll promptly after a drop and it reliably means never-arrived: re-issue the ORIGINAL call (full arguments) with this same token. Do not trust day-old tokens.
 - `status: "indeterminate"` — the operation completed here but its buffered result cannot be read (buffering failed, or the result file is gone while the record survives). Do NOT re-issue blindly; verify current state via reads first.
 
-A token is SPENT once its operation completes — errors included; to retry with corrected arguments, invent a FRESH token. A replayed result whose `status` is `in_progress` carries `replayNote`: it is the original paused envelope, not new progress — a spent token cannot drive a resume; re-issue the remaining work with a fresh token.
+A token is SPENT once its operation completes — runtime errors included; to retry with corrected arguments after a RUNTIME failure, invent a FRESH token. Exception: a call rejected for invalid arguments (-32602) executed nothing and RELEASES its token — fix the arguments and re-issue with the SAME token. A replayed result whose `status` is `in_progress` carries `replayNote`: it is the original paused envelope, not new progress — a spent token cannot drive a resume; re-issue the remaining work with a fresh token.
 
 ### hub_update_package: never re-run on a timeout
 

--- a/TOOL_GUIDE.md
+++ b/TOOL_GUIDE.md
@@ -134,7 +134,7 @@ This is the consolidation target: best-practice content can move here from indiv
 
 All destructive write tools (the `confirm`+backup tier) require these steps:
 
-1. **Backup check**: Ensure `hub_create_backup` was called within the last 24 hours
+1. **Backup check**: Ensure a hub backup exists within the last 24 hours — `hub_create_backup`, or any backup already in `hub_list_backups` (scope=hub_local); the gate consults the hub's own backup list when this app's record is stale, so scheduled backups count
 2. **Inform user**: Tell them what you're about to do
 3. **Get confirmation**: Wait for explicit "yes", "confirm", or "proceed"
 4. **Set confirm=true**: Pass the confirm parameter

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -4233,9 +4233,54 @@ def requireDestructiveConfirm(Boolean confirmParam) {
     if (!confirmParam) {
         throw new IllegalArgumentException("SAFETY CHECK FAILED: You must set confirm=true to use this tool. Did you create a backup with hub_create_backup first? Review the tool description for the mandatory pre-flight checklist, or call hub_get_tool_guide for the tool's full reference.")
     }
-    // Check for recent hub backup (within 24 hours)
-    if (!state.lastBackupTimestamp || (now() - state.lastBackupTimestamp) > 86400000) {
-        throw new IllegalArgumentException("BACKUP REQUIRED: No hub backup found within the last 24 hours. You MUST call hub_create_backup FIRST and verify it succeeds before using this tool. Last backup: ${state.lastBackupTimestamp ? formatTimestamp(state.lastBackupTimestamp) : 'Never'}")
+    // Recent-backup check (within 24 hours): this app's own stamp first (cheap), then the
+    // hub's own local backup list -- a scheduled or UI-created backup is exactly as real a
+    // recovery point as an MCP-triggered one, and the stamp alone goes stale whenever a
+    // backup exists that this app never confirmed (issue #361: hub_update_firmware refused
+    // while hub_list_backups showed fresh backups).
+    if (state.lastBackupTimestamp && (now() - state.lastBackupTimestamp) <= 86400000) return
+    Long listEpoch = _latestLocalHubBackupEpoch()
+    if (listEpoch != null && (now() - listEpoch) <= 86400000) {
+        state.lastBackupTimestamp = listEpoch   // cache so later gated calls skip the list read
+        return
+    }
+    def lastKnown = [state.lastBackupTimestamp, listEpoch].findAll { it != null }.max()
+    throw new IllegalArgumentException("BACKUP REQUIRED: No hub backup found within the last 24 hours (checked this app's record and the hub's local backup list). You MUST call hub_create_backup FIRST and verify it succeeds before using this tool. Last backup: ${lastKnown ? formatTimestamp(lastKnown) : 'Never'}")
+}
+
+/**
+ * Newest local hub-DB backup's epoch millis from the hub's own list (GET /hub2/localBackups),
+ * or null when the list is unreachable, empty, or unparseable. Ground truth consulted by the
+ * destructive-confirm gate's fallback and hub_create_backup's completion check: the hub's
+ * list proves a backup file exists regardless of what this app's private stamp says.
+ */
+def _latestLocalHubBackupEpoch() {
+    try {
+        def raw = hubInternalGet("/hub2/localBackups", null, 10)
+        def parsed = raw ? new groovy.json.JsonSlurper().parseText(raw) : null
+        if (!(parsed instanceof List)) return null
+        Long newest = null
+        parsed.each { entry ->
+            def ts = (entry instanceof Map) ? entry.createTimeOrig?.toString() : null
+            if (!ts) return
+            Long epoch = null
+            // createTimeOrig carries an explicit numeric offset ("2026-04-23T07:01:24+0000");
+            // the offset-less shape is tolerated as UTC in case a firmware drops the suffix.
+            try { epoch = Date.parse("yyyy-MM-dd'T'HH:mm:ssZ", ts).time }
+            catch (Exception ignored) {
+                try {
+                    def sdf = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss")
+                    sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
+                    sdf.setLenient(false)
+                    epoch = sdf.parse(ts).time
+                } catch (Exception ignored2) { }
+            }
+            if (epoch != null && (newest == null || epoch > newest)) newest = epoch
+        }
+        return newest
+    } catch (Exception e) {
+        mcpLog("debug", "hub-admin", "local backup list unreadable (backup-gate fallback skipped): ${e.message}")
+        return null
     }
 }
 
@@ -5960,7 +6005,7 @@ This section covers the hub-admin and system tools (hub info, location modes, HS
 ### Destructive Write Tools - Pre-Flight Checklist
 
 All Write master tools require these steps:
-1. Backup check: Ensure hub_create_backup was called within the last 24 hours
+1. Backup check: Ensure a hub backup exists within the last 24 hours (hub_create_backup, or any backup in hub_list_backups scope=hub_local -- scheduled backups count; the gate checks the hub's own list when this app's record is stale)
 2. Inform user: Tell them what you're about to do
 3. Get confirmation: Wait for explicit "yes", "confirm", or "proceed"
 4. Set confirm=true: Pass the confirm parameter
@@ -6403,7 +6448,7 @@ Duplicates an existing MCP custom-engine rule into a new, independent rule with 
 
 ### Hub Backups
 - hub_create_backup creates full hub database backup
-- Required within 24 hours before any Write master operation
+- A hub backup within 24 hours is required before any Write master operation; the gate accepts this app's own record OR any backup in the hub's local backup list (scheduled/UI backups count)
 - Only write tool that doesn't require a prior backup
 
 ### Source Code Backups (Automatic)

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1180,8 +1180,16 @@ def handleToolsCall(msg) {
             }
         }
         if (opTokenActive) {
-            opCompletionText = groovy.json.JsonOutput.toJson([isError: true, error: "Invalid params: ${msgText}", tool: reactiveToolName])
-            opCompletionIsError = true
+            // A validation error means the leaf executed NOTHING, so the token must NOT be
+            // spent on it: buffering the -32602 made the documented recovery (re-issue with
+            // the SAME token) replay the stale rejection even after the caller fixed the
+            // arguments (the dedup gate cannot see that args changed -- issue #361 review).
+            // Release the record instead: a corrected re-issue executes fresh, and a
+            // lost-response re-poll answers "unknown -> re-issue the original call", which
+            // simply re-validates to the identical error. opCompletionText stays null, so
+            // the finally does not buffer.
+            try { _opTokenRelease(opToken) }
+            catch (Exception re) { mcpLog("warn", "op-token", "Releasing token ${opToken} after a validation error failed: ${re.message}") }
         }
         return jsonRpcError(msg.id, -32602, "Invalid params: ${msgText}")
     } catch (Exception e) {
@@ -1450,6 +1458,20 @@ def _opTokenPrune() {
 def _opTokenMark(String opToken, toolName) {
     _opTokenPut(opToken, [state: "running", tool: toolName?.toString(), startedAt: now()])
     _opTokenPrune()
+}
+
+// Remove a token's record entirely (the validation-error path: the leaf executed nothing,
+// so the token must stay spendable by a corrected re-issue). Whole-map remove -- the same
+// narrow concurrent-write window the prune accepts, self-healed by the TTL sweep. No result
+// file can exist on this path (only _opTokenComplete uploads, and completion never ran; a
+// prior record for the token would have short-circuited at the dedup gate before dispatch).
+def _opTokenRelease(String opToken) {
+    def stored = atomicState.opTokens
+    if (!(stored instanceof Map) || !stored.containsKey(opToken)) return
+    def tokens = [:]
+    tokens.putAll(stored)
+    tokens.remove(opToken)
+    atomicState.opTokens = tokens
 }
 
 // Buffer a token's terminal result (called once, on the request's terminal path).
@@ -7374,7 +7396,7 @@ If the response is lost, DO NOT re-run the operation and DO NOT invent a fresh t
 - `status: "unknown"` (returned only to a token-only poll) -- no RECORD of this token exists: the original call never arrived, OR the record aged out (records sweep ~24h after start, and past 100 stored records the oldest terminal records batch-evict down to 50). Poll promptly after a drop and it reliably means never-arrived: re-issue the ORIGINAL call (full arguments) with this same token. Do not trust day-old tokens.
 - `status: "indeterminate"` -- the operation completed here but its buffered result cannot be read (buffering failed, or the result file is gone while the record survives). Do NOT re-issue blindly; verify current state via reads first.
 
-A token is SPENT once its operation completes -- errors included. A replayed result carrying an error means that attempt failed; to retry with corrected arguments, invent a FRESH token. Never reuse a token for a different or corrected operation.
+A token is SPENT once its operation completes -- runtime errors included. A replayed result carrying an error means that attempt failed; to retry with corrected arguments after a RUNTIME failure, invent a FRESH token. Never reuse a token for a DIFFERENT operation. Exception: a call rejected for invalid arguments (-32602) executed nothing and RELEASES its token -- fix the arguments and re-issue with the SAME token.
 
 A replayed result whose `status` is "in_progress" carries `replayNote`: it is the ORIGINAL paused envelope, not new progress -- a spent token cannot drive a resume; re-issue the remaining work with a fresh token.
 

--- a/hubitat-mcp-server.groovy
+++ b/hubitat-mcp-server.groovy
@@ -1180,10 +1180,13 @@ def handleToolsCall(msg) {
             }
         }
         if (opTokenActive) {
-            // A validation error means the leaf executed NOTHING, so the token must NOT be
-            // spent on it: buffering the -32602 made the documented recovery (re-issue with
-            // the SAME token) replay the stale rejection even after the caller fixed the
-            // arguments (the dedup gate cannot see that args changed -- issue #361 review).
+            // A validation error means the leaf executed NOTHING (the error contract: an
+            // IllegalArgumentException is thrown up front, before any side effect -- the
+            // release below leans on that convention, so a tool must never throw IAE after
+            // partial work), so the token must NOT be spent on it: buffering the -32602 made
+            // the documented recovery (re-issue with the SAME token) replay the stale
+            // rejection even after the caller fixed the arguments (the dedup gate cannot see
+            // that args changed -- issue #361 review).
             // Release the record instead: a corrected re-issue executes fresh, and a
             // lost-response re-poll answers "unknown -> re-issue the original call", which
             // simply re-validates to the identical error. opCompletionText stays null, so
@@ -1460,18 +1463,21 @@ def _opTokenMark(String opToken, toolName) {
     _opTokenPrune()
 }
 
-// Remove a token's record entirely (the validation-error path: the leaf executed nothing,
-// so the token must stay spendable by a corrected re-issue). Whole-map remove -- the same
-// narrow concurrent-write window the prune accepts, self-healed by the TTL sweep. No result
-// file can exist on this path (only _opTokenComplete uploads, and completion never ran; a
-// prior record for the token would have short-circuited at the dedup gate before dispatch).
+// Release a token after a validation error (the leaf executed nothing, so the token must
+// stay spendable by a corrected re-issue). Written as a per-entry "released" sentinel that
+// the dedup gate treats as absent -- NOT a whole-map remove: atomicState has no per-key
+// remove, and a whole-map read-modify-write here could clobber a concurrent different-token
+// updateMapValue and silently lose a LIVE record's dedup protection (the prune stays the
+// only whole-map writer, and it only drops terminal records). The TTL sweep / size cap reap
+// released records like any other terminal entry. No result file from THIS request can
+// exist here (only _opTokenComplete uploads, and completion never ran; a prior record would
+// have short-circuited at the dedup gate before dispatch) -- at most a prune-orphaned file
+// from an earlier, already-pruned completion remains, which a later completion overwrites.
 def _opTokenRelease(String opToken) {
     def stored = atomicState.opTokens
-    if (!(stored instanceof Map) || !stored.containsKey(opToken)) return
-    def tokens = [:]
-    tokens.putAll(stored)
-    tokens.remove(opToken)
-    atomicState.opTokens = tokens
+    def prev = (stored instanceof Map && stored[opToken] instanceof Map) ? stored[opToken] : [:]
+    _opTokenPut(opToken, [state: "released", tool: prev.tool,
+                          startedAt: (prev.startedAt != null ? prev.startedAt : now())])
 }
 
 // Buffer a token's terminal result (called once, on the request's terminal path).
@@ -1518,6 +1524,9 @@ def _opTokenDedup(String opToken, origToolName) {
     def toks = atomicState.opTokens
     def rec = (toks instanceof Map && toks[opToken] instanceof Map) ? toks[opToken] : null
     if (rec == null) return null
+    // A released record means a validation error spent NOTHING: treat it as absent so the
+    // corrected re-issue dispatches fresh (it re-marks the token running on its way in).
+    if (rec.state == "released") return null
     if (rec.state == "running") {
         def started = (rec.startedAt != null) ? (rec.startedAt as Long) : null
         def runningNote = "An operation with this token is already executing on the hub. Do NOT re-run the operation; poll by re-issuing this call with the same opToken (the token alone is enough) until it replays the buffered result. See hub_get_tool_guide(section='slow_ops')."
@@ -4280,7 +4289,12 @@ def _latestLocalHubBackupEpoch() {
     try {
         def raw = hubInternalGet("/hub2/localBackups", null, 10)
         def parsed = raw ? new groovy.json.JsonSlurper().parseText(raw) : null
-        if (!(parsed instanceof List)) return null
+        if (!(parsed instanceof List)) {
+            // e.g. an auth-failure JSON object under Hub Security -- the fallback is out of
+            // service, which quietly regresses to the pre-#361 refusals; leave a trace.
+            mcpLog("debug", "hub-admin", "local backup list returned a ${parsed == null ? 'null/empty' : (parsed instanceof Map ? 'JSON-object' : 'non-list')} body -- backup-gate fallback skipped")
+            return null
+        }
         Long newest = null
         parsed.each { entry ->
             def ts = (entry instanceof Map) ? entry.createTimeOrig?.toString() : null
@@ -4288,6 +4302,8 @@ def _latestLocalHubBackupEpoch() {
             Long epoch = null
             // createTimeOrig carries an explicit numeric offset ("2026-04-23T07:01:24+0000");
             // the offset-less shape is tolerated as UTC in case a firmware drops the suffix.
+            // (If such a firmware emitted LOCAL time instead, a non-UTC hub would mis-age the
+            // backup by its offset -- accepted for a defensive path no real hub exercises.)
             try { epoch = Date.parse("yyyy-MM-dd'T'HH:mm:ssZ", ts).time }
             catch (Exception ignored) {
                 try {
@@ -4298,6 +4314,12 @@ def _latestLocalHubBackupEpoch() {
                 } catch (Exception ignored2) { }
             }
             if (epoch != null && (newest == null || epoch > newest)) newest = epoch
+        }
+        if (newest == null && !parsed.isEmpty()) {
+            // Backups exist but no createTimeOrig parsed -- a firmware format drift would
+            // silently re-break issue #361 (fallback dead, gate refusing beside real backups),
+            // so this one is loud.
+            mcpLog("warn", "hub-admin", "local backup list has ${parsed.size()} entries but no parseable createTimeOrig -- backup-gate fallback is blind (timestamp format drift?)")
         }
         return newest
     } catch (Exception e) {
@@ -6026,7 +6048,7 @@ This section covers the hub-admin and system tools (hub info, location modes, HS
 
 ### Destructive Write Tools - Pre-Flight Checklist
 
-All Write master tools require these steps:
+The destructive/confirm-tier write tools require these steps (ordinary writes need only the Write master):
 1. Backup check: Ensure a hub backup exists within the last 24 hours (hub_create_backup, or any backup in hub_list_backups scope=hub_local -- scheduled backups count; the gate checks the hub's own list when this app's record is stale)
 2. Inform user: Tell them what you're about to do
 3. Get confirmation: Wait for explicit "yes", "confirm", or "proceed"
@@ -6470,8 +6492,8 @@ Duplicates an existing MCP custom-engine rule into a new, independent rule with 
 
 ### Hub Backups
 - hub_create_backup creates full hub database backup
-- A hub backup within 24 hours is required before any Write master operation; the gate accepts this app's own record OR any backup in the hub's local backup list (scheduled/UI backups count)
-- Only write tool that doesn't require a prior backup
+- A hub backup within 24 hours is required by the destructive/confirm-tier write tools (ordinary writes need only the Write master); the gate accepts this app's own record OR any backup in the hub's local backup list (scheduled/UI backups count)
+- hub_create_backup itself is exempt from the prior-backup requirement (it IS the backup)
 
 ### Source Code Backups (Automatic)
 - Created when using hub_update_app, hub_update_driver, hub_update_library, hub_delete_item

--- a/libraries/mcp-item-backups-lib.groovy
+++ b/libraries/mcp-item-backups-lib.groovy
@@ -434,10 +434,12 @@ def toolCreateHubBackup(args) {
         // without performing any real backup -- the hub backup is a heavy operation the platform's
         // load limiter punishes, and e2e needs the GATED tools tested, not the backup itself.
         // Developer-mode-gated so a production client can't silently satisfy the gate with a lie.
+        // mockEpoch stamps an arbitrary epoch (e.g. a deliberately STALE one) so e2e can drive
+        // the gate's stale-stamp fallback path against the hub's real backup list.
         if (settings.enableDeveloperMode != true) {
             throw new IllegalArgumentException("hub_create_backup mock=true requires Developer Mode (it satisfies the destructive-confirm gate WITHOUT a real backup -- test environments only).")
         }
-        def backupTime = now()
+        def backupTime = (args.mockEpoch != null) ? (args.mockEpoch as Long) : now()
         state.lastBackupTimestamp = backupTime
         mcpLog("warn", "hub-admin", "MOCK backup recorded (no real backup performed; developer mode)")
         return [
@@ -462,27 +464,49 @@ def toolCreateHubBackup(args) {
         // did). So: fire the request asynchronously (the hub still creates the backup; the
         // async client's truncated body is discarded) and confirm completion via the hub's own
         // /hub/backup/statusJson instead of the binary response.
+        // Pre-trigger snapshot of the hub's newest local backup: completion is confirmed by a
+        // NEWER entry appearing in the hub's own list (ground truth), with statusJson quiet as
+        // the fast-path signal. statusJson ALONE wedged real hubs (issue #361): a Hub Protect
+        // cloud upload holds cloudBackupInProgress=true for minutes after the local .lzf is
+        // already written, so a real, listed backup read as unconfirmed and the 24h gate never
+        // stamped -- blocking every destructive tool despite a fresh recovery point.
+        Long preEpoch = _latestLocalHubBackupEpoch()
+        long confirmT0 = now()
         def asyncParams = [uri: hubBaseUri(), path: "/hub/backupDB", query: [fileName: "latest"], timeout: 300]
         def cookie = getHubSecurityCookie()
         if (cookie) asyncParams.headers = [Cookie: cookie]
         asynchttpGet("backupResponseSink", asyncParams)
 
-        // Confirm via statusJson: wait for an in-progress backup to finish (small JSON reads).
-        // A small-DB backup can finish before the first poll, so backupInProgress=false is
-        // treated as completion rather than requiring an observed true->false transition.
+        // Confirm via statusJson OR the backup list (small JSON reads). A small-DB backup can
+        // finish before the first poll, so backupInProgress=false is treated as completion
+        // rather than requiring an observed true->false transition. The loop is ALSO
+        // wall-clock-capped: with slow reads the 20 iterations could otherwise stretch to
+        // minutes of blocking (far past any transport ceiling) while pollers see "running".
         def confirmed = false
         def statusUnreadable = false
+        int unreadableRounds = 0
         for (int i = 0; i < 20; i++) {
             pauseExecution(3000)
             def statusText = null
-            try { statusText = hubInternalGet("/hub/backup/statusJson", null, 15) } catch (Exception ignored) { }
+            try { statusText = hubInternalGet("/hub/backup/statusJson", null, 10) } catch (Exception ignored) { }
             def parsed = null
             try { parsed = statusText ? new groovy.json.JsonSlurper().parseText(statusText) : null } catch (Exception ignored) { }
             if (parsed instanceof Map && parsed.backupInProgress == false && parsed.cloudBackupInProgress != true) {
                 confirmed = true
                 break
             }
-            if (parsed == null && i >= 2) { statusUnreadable = true; break }   // status endpoint unreadable; stop burning time
+            // Ground truth: a local backup entry newer than the pre-trigger snapshot means the
+            // backup file exists no matter what statusJson reports (an in-flight cloud upload
+            // must not un-confirm an already-written local backup). When the pre-trigger read
+            // failed, only an entry stamped since just before the trigger counts -- a stale
+            // list must not confirm.
+            Long newest = _latestLocalHubBackupEpoch()
+            if (newest != null && newest > (preEpoch != null ? preEpoch : confirmT0 - 60000L)) {
+                confirmed = true
+                break
+            }
+            if (parsed == null && newest == null && ++unreadableRounds >= 3) { statusUnreadable = true; break }   // both signals unreadable; stop burning time
+            if (now() - confirmT0 >= 57000L) break
         }
 
         if (!confirmed) {
@@ -490,17 +514,17 @@ def toolCreateHubBackup(args) {
             // state.lastBackupTimestamp here would let destructive ops proceed believing a recovery
             // point exists when it may not (a rejected/in-progress/failed backup) -- a silent failure.
             // Leave the gate unstamped and report failure so the caller blocks until a backup is real.
-            mcpLog("warn", "hub-admin", "Hub backup triggered but completion was NOT confirmed (${statusUnreadable ? '/hub/backup/statusJson unreadable' : 'still in progress after ~60s'}); destructive-confirm gate left unsatisfied")
+            mcpLog("warn", "hub-admin", "Hub backup triggered but completion was NOT confirmed (${statusUnreadable ? 'statusJson and the backup list were both unreadable' : 'no completion signal within ~60s'}); destructive-confirm gate left unsatisfied")
             return [
                 success: false,
                 confirmed: false,
                 scheduleUpdated: scheduleUpdated,
                 error: statusUnreadable
-                    ? "Hub backup was triggered but completion could not be confirmed (/hub/backup/statusJson was unreadable)."
-                    : "Hub backup was triggered but did not confirm complete within ~60s (it may still be running).",
+                    ? "Hub backup was triggered but completion could not be confirmed (/hub/backup/statusJson and the hub's backup list were both unreadable)."
+                    : "Hub backup was triggered but did not confirm complete within ~60s (no new entry in the hub's local backup list yet; it may still be running).",
                 note: "The 24h destructive-confirm gate was NOT satisfied -- do NOT run destructive ops yet. " +
-                      "A large backup can still be completing; verify in the Hubitat UI (Settings -> Backup and Restore), " +
-                      "or call hub_create_backup again once it finishes."
+                      "A large backup can still be completing; verify with hub_list_backups (scope=hub_local) or in the Hubitat UI (Settings -> Backup and Restore). " +
+                      "Once the backup file exists, destructive tools accept it directly from the hub's backup list -- no re-run of hub_create_backup needed."
             ]
         }
 
@@ -816,6 +840,7 @@ A transport drop (relay ceiling / client timeout) can lose the response while th
                 properties: [
                     confirm: [type: "boolean", description: "true to create a backup now (omit with scheduleOnly)."],
                     mock: [type: "boolean", description: "Developer Mode only: stamp the 24h gate record; no real backup (test envs)."],
+                    mockEpoch: [type: "integer", description: "Developer Mode only, with mock=true: stamp this epoch-millis instead of now (test envs; lets tests set a stale gate record)."],
                     schedule: [type: "object", description: "Optional: set the automatic-backup schedule. Omitted fields keep their current value (read-merged from the hub).[[FLAT_TRIM]] If cloud backup is enabled you MUST pass cloudBackupPassword (the hub doesn't expose it for read-back) or pass cloudBackupFrequency=0 to turn cloud backup off.[[/FLAT_TRIM]]", properties: [
                         hour: [type: "integer", description: "Hour 0-23 (kept if omitted)"],
                         minute: [type: "integer", description: "Minute 0-59 (kept if omitted)"],
@@ -832,7 +857,7 @@ A transport drop (relay ceiling / client timeout) can lose the response while th
                 type: "object",
                 properties: [
                     success: [type: "boolean", description: "Whether the operation succeeded"],
-                    confirmed: [type: "boolean", description: "Whether backup completion was confirmed via the hub's backup status (false = best-effort trigger)"],
+                    confirmed: [type: "boolean", description: "Whether backup completion was confirmed via the hub's backup status or a new entry in its backup list (false = best-effort trigger)"],
                     mocked: [type: "boolean", description: "true when mock=true stamped the gate record without a real backup"],
                     scheduleUpdated: [type: "boolean", description: "true when the automatic-backup schedule was set this call"],
                     message: [type: "string", description: "Human-readable result"],

--- a/libraries/mcp-system-lib.groovy
+++ b/libraries/mcp-system-lib.groovy
@@ -927,7 +927,7 @@ def _getAllToolDefinitions_partSystem() {
                     databaseSizeKB: [type: "string", description: "Database size in KB"],
                     databaseWarning: [type: "string", description: "Present when database is large"],
                     mcpServerVersion: [type: "string", description: "Installed MCP server version"],
-                    lastBackupEpoch: [type: "integer", description: "Epoch millis of the last hub_create_backup via this app; null if never. The destructive-confirm 24h gate reads the same record."],
+                    lastBackupEpoch: [type: "integer", description: "Epoch millis of the newest hub backup this app knows of (its own hub_create_backup stamp, or the hub's local backup list once a gated tool consulted it); null if never. The destructive-confirm 24h gate reads the same record and falls back to the hub's own backup list when it is stale."],
                     mcpDeviceCount: [type: "integer", description: "Selected device count"],
                     mcpRuleCount: [type: "integer", description: "MCP rule child-app count"],
                     mcpLogEntries: [type: "integer", description: "Buffered MCP log entry count"],

--- a/src/test/groovy/server/OpTokenReplaySpec.groovy
+++ b/src/test/groovy/server/OpTokenReplaySpec.groovy
@@ -186,8 +186,8 @@ class OpTokenReplaySpec extends ToolSpecBase {
         response.error != null
         response.error.code == -32602
 
-        and: 'the leaf executed nothing, so the token is released -- not left running, not spent on the stale rejection'
-        !atomicStateMap.opTokens?.containsKey('iaetoken12')
+        and: 'the leaf executed nothing, so the token is released (a per-entry sentinel the dedup gate treats as absent) -- not left running, not spent on the stale rejection'
+        atomicStateMap.opTokens['iaetoken12'].state == 'released'
         !store.containsKey(FILE_PREFIX + 'iaetoken12.json')
     }
 
@@ -562,7 +562,7 @@ class OpTokenReplaySpec extends ToolSpecBase {
         then: 'the leaf validation error surfaced (-32602), and the token was released for a corrected re-issue'
         response.error != null
         response.error.code == -32602
-        !atomicStateMap.opTokens?.containsKey('partial12345')
+        atomicStateMap.opTokens['partial12345'].state == 'released'
     }
 
     def "a token-only call naming a bare GATEWAY is a pure poll -- the token is never spent on a catalog listing"() {

--- a/src/test/groovy/server/OpTokenReplaySpec.groovy
+++ b/src/test/groovy/server/OpTokenReplaySpec.groovy
@@ -173,7 +173,7 @@ class OpTokenReplaySpec extends ToolSpecBase {
         inner.note instanceof String && inner.note.toLowerCase().contains('verify')
     }
 
-    def "the marker is completed with isError when the write throws IllegalArgumentException"() {
+    def "a validation error RELEASES the token instead of spending it (issue #361 review)"() {
         given:
         settingsMap.enableWrite = true
         def store = installFileStore()
@@ -186,11 +186,33 @@ class OpTokenReplaySpec extends ToolSpecBase {
         response.error != null
         response.error.code == -32602
 
-        and: 'no token is left eternally running -- the terminal IAE path completes the marker'
-        def marker = atomicStateMap.opTokens['iaetoken12']
-        marker.state == 'complete'
-        marker.isError == true
-        store.containsKey(FILE_PREFIX + 'iaetoken12.json')
+        and: 'the leaf executed nothing, so the token is released -- not left running, not spent on the stale rejection'
+        !atomicStateMap.opTokens?.containsKey('iaetoken12')
+        !store.containsKey(FILE_PREFIX + 'iaetoken12.json')
+    }
+
+    def "a corrected re-issue with the SAME token executes after a validation error"() {
+        given: 'the real-world footgun: first call rejected for bad args, caller fixes them and retries with the same token'
+        settingsMap.enableWrite = true
+        installFileStore()
+        def ran = 0
+        script.metaClass.toolCreateRoom = { a ->
+            if (a.confirm != true) throw new IllegalArgumentException('confirm required')
+            ran++; [success: true, roomId: 7]
+        }
+
+        when: 'first call fails validation (no confirm)'
+        def first = mcpDriver.callTool('hub_create_room', [name: 'Den', opToken: 'retrytok123'])
+
+        and: 'the corrected call reuses the SAME token'
+        def second = mcpDriver.callTool('hub_create_room', [name: 'Den', confirm: true, opToken: 'retrytok123'])
+
+        then: 'the rejection did not spend the token: the corrected call ran fresh (no stale -32602 replay)'
+        first.error?.code == -32602
+        ran == 1
+        mcpDriver.parseInner(second).success == true
+        atomicStateMap.opTokens['retrytok123'].state == 'complete'
+        atomicStateMap.opTokens['retrytok123'].isError == false
     }
 
     def "the marker is completed with isError when the write throws a generic exception"() {
@@ -525,7 +547,7 @@ class OpTokenReplaySpec extends ToolSpecBase {
         atomicStateMap.opTokens['freshtok1234'].state == 'running'
     }
 
-    def "a tokened call with PARTIAL args is NOT a poll -- it dispatches and burns the token on the leaf's own validation error"() {
+    def "a tokened call with PARTIAL args is NOT a poll -- it dispatches, and the leaf's validation error releases the token"() {
         given: 'negative-space pin: only a truly bare tokened call polls; partial args mean a real (malformed) execution attempt'
         settingsMap.enableWrite = true
         installFileStore()
@@ -537,11 +559,10 @@ class OpTokenReplaySpec extends ToolSpecBase {
         when: 'token + name but no confirm'
         def response = mcpDriver.callTool('hub_create_room', [opToken: 'partial12345', name: 'Den'])
 
-        then: 'the leaf validation error surfaced (-32602), and the token was marked and spent on it'
+        then: 'the leaf validation error surfaced (-32602), and the token was released for a corrected re-issue'
         response.error != null
         response.error.code == -32602
-        atomicStateMap.opTokens['partial12345'].state == 'complete'
-        atomicStateMap.opTokens['partial12345'].isError == true
+        !atomicStateMap.opTokens?.containsKey('partial12345')
     }
 
     def "a token-only call naming a bare GATEWAY is a pure poll -- the token is never spent on a catalog listing"() {

--- a/src/test/groovy/server/ToolBackupSpec.groovy
+++ b/src/test/groovy/server/ToolBackupSpec.groovy
@@ -509,13 +509,23 @@ class ToolBackupSpec extends ToolSpecBase {
         hubGet.calls.count { it.path == '/hub/backup/statusJson' } == 3
     }
 
+    // Virtual clock (mirrors ToolPollComparatorStableSpec): pauseExecution advances the clock by
+    // advanceMs (more than the requested pause = simulated slow rounds); now() reads it via the
+    // base mock's NOW_OVERRIDE holder, which HarnessSpec.setup() resets. Kept in a plain method
+    // body on purpose -- the groovy2x matrix leg cannot resolve the base-class static from
+    // inside a Spock feature block.
+    private List installVirtualClock(long start, long advanceMs) {
+        def clock = [start]
+        script.metaClass.pauseExecution = { long ms -> clock[0] = clock[0] + advanceMs }
+        NOW_OVERRIDE.set({ clock[0] })
+        return clock
+    }
+
     def "the confirm loop is wall-clock capped: slow rounds exit early instead of grinding all 20 iterations"() {
         given: 'a virtual clock where each round costs 30s (slow status/list reads on a loaded hub)'
         settingsMap.enableWrite = true
         stateMap.remove('lastBackupTimestamp')
-        def clock = [1234567890000L]
-        script.metaClass.pauseExecution = { long ms -> clock[0] = clock[0] + 30000L }
-        NOW_OVERRIDE.set({ clock[0] })
+        installVirtualClock(1234567890000L, 30000L)
         hubGet.register('/hub/backup/statusJson') { params -> '{"backupInProgress":true,"cloudBackupInProgress":false}' }
 
         when:

--- a/src/test/groovy/server/ToolBackupSpec.groovy
+++ b/src/test/groovy/server/ToolBackupSpec.groovy
@@ -511,9 +511,7 @@ class ToolBackupSpec extends ToolSpecBase {
 
     // Virtual clock (mirrors ToolPollComparatorStableSpec): pauseExecution advances the clock by
     // advanceMs (more than the requested pause = simulated slow rounds); now() reads it via the
-    // base mock's NOW_OVERRIDE holder, which HarnessSpec.setup() resets. Kept in a plain method
-    // body on purpose -- the groovy2x matrix leg cannot resolve the base-class static from
-    // inside a Spock feature block.
+    // base mock's NOW_OVERRIDE holder, which HarnessSpec.setup() resets.
     private List installVirtualClock(long start, long advanceMs) {
         def clock = [start]
         script.metaClass.pauseExecution = { long ms -> clock[0] = clock[0] + advanceMs }
@@ -521,6 +519,7 @@ class ToolBackupSpec extends ToolSpecBase {
         return clock
     }
 
+    @spock.lang.IgnoreIf({ System.getProperty('harnessStrictMetaClass') == 'true' })  // virtual clock needs the pauseExecution metaClass override + NOW_OVERRIDE, which the strict-metaClass groovy2x lane disallows; full coverage runs in the primary test lanes
     def "the confirm loop is wall-clock capped: slow rounds exit early instead of grinding all 20 iterations"() {
         given: 'a virtual clock where each round costs 30s (slow status/list reads on a loaded hub)'
         settingsMap.enableWrite = true

--- a/src/test/groovy/server/ToolBackupSpec.groovy
+++ b/src/test/groovy/server/ToolBackupSpec.groovy
@@ -435,7 +435,8 @@ class ToolBackupSpec extends ToolSpecBase {
         given:
         settingsMap.enableWrite = true            // Write master on, but NO prior backup stamp
         stateMap.remove('lastBackupTimestamp')
-        // statusJson never reports completion -> the backup is unverified
+        // statusJson never reports completion -> the backup is unverified (and the list fixture
+        // never gains a new entry, so the ground-truth signal stays silent too)
         hubGet.register('/hub/backup/statusJson') { params -> '{"backupInProgress":true,"cloudBackupInProgress":false}' }
 
         when:
@@ -446,6 +447,63 @@ class ToolBackupSpec extends ToolSpecBase {
         r.confirmed == false
         stateMap.lastBackupTimestamp == null      // the 24h gate is NOT satisfied by an unverified backup
         r.note.toLowerCase().contains('not')
+    }
+
+    // -------- issue #361: list-based completion + mockEpoch lever --------
+
+    def "a create confirms via a NEW entry in the hub's backup list even while cloudBackupInProgress stays true (issue #361)"() {
+        given:
+        settingsMap.enableWrite = true
+        stateMap.remove('lastBackupTimestamp')
+        // Hub Protect upload in progress: statusJson never settles (the pre-#361 wedge)
+        hubGet.register('/hub/backup/statusJson') { params -> '{"backupInProgress":false,"cloudBackupInProgress":true}' }
+        // First read = pre-trigger snapshot (old entry only); later reads show the new backup file
+        int listReads = 0
+        hubGet.register('/hub2/localBackups') { params ->
+            listReads++
+            listReads == 1 ? '[{"name":"old.lzf","createTimeOrig":"2026-06-01T00:00:00"}]'
+                           : '[{"name":"old.lzf","createTimeOrig":"2026-06-01T00:00:00"},{"name":"new.lzf","createTimeOrig":"2026-06-02T00:00:00+0000"}]'
+        }
+
+        when:
+        def r = script.toolCreateHubBackup([confirm: true])
+
+        then:
+        r.success == true
+        r.confirmed == true
+        stateMap.lastBackupTimestamp != null      // the 24h gate IS satisfied: the backup file exists
+    }
+
+    def "a create with an unsettled cloud upload and NO new list entry stays unconfirmed and unstamped"() {
+        given:
+        settingsMap.enableWrite = true
+        stateMap.remove('lastBackupTimestamp')
+        hubGet.register('/hub/backup/statusJson') { params -> '{"backupInProgress":false,"cloudBackupInProgress":true}' }
+        // the setup fixture list never changes -> no new entry appears
+
+        when:
+        def r = script.toolCreateHubBackup([confirm: true])
+
+        then:
+        r.success == false
+        r.confirmed == false
+        stateMap.lastBackupTimestamp == null
+        r.error.toLowerCase().contains('did not confirm')
+    }
+
+    def "mock=true with mockEpoch stamps the given epoch (developer-mode test lever)"() {
+        given:
+        settingsMap.enableWrite = true
+        settingsMap.enableDeveloperMode = true
+
+        when:
+        def r = script.toolCreateHubBackup([confirm: true, mock: true, mockEpoch: 1234000000000L])
+
+        then:
+        r.success == true
+        r.mocked == true
+        r.backupTimestampEpoch == 1234000000000L
+        stateMap.lastBackupTimestamp == 1234000000000L
     }
 
     // ---------- dispatch envelopes ----------

--- a/src/test/groovy/server/ToolBackupSpec.groovy
+++ b/src/test/groovy/server/ToolBackupSpec.groovy
@@ -491,6 +491,67 @@ class ToolBackupSpec extends ToolSpecBase {
         r.error.toLowerCase().contains('did not confirm')
     }
 
+    def "a create bails as statusUnreadable when statusJson AND the backup list are both unreadable"() {
+        given:
+        settingsMap.enableWrite = true
+        stateMap.remove('lastBackupTimestamp')
+        hubGet.register('/hub/backup/statusJson') { params -> '<html>login</html>' }
+        hubGet.register('/hub2/localBackups') { params -> '<html>login</html>' }
+
+        when:
+        def r = script.toolCreateHubBackup([confirm: true])
+
+        then: 'three consecutive both-signals-unreadable rounds end the loop with the distinct error'
+        r.success == false
+        r.confirmed == false
+        stateMap.lastBackupTimestamp == null
+        r.error.contains('both unreadable')
+        hubGet.calls.count { it.path == '/hub/backup/statusJson' } == 3
+    }
+
+    def "the confirm loop is wall-clock capped: slow rounds exit early instead of grinding all 20 iterations"() {
+        given: 'a virtual clock where each round costs 30s (slow status/list reads on a loaded hub)'
+        settingsMap.enableWrite = true
+        stateMap.remove('lastBackupTimestamp')
+        def clock = [1234567890000L]
+        script.metaClass.pauseExecution = { long ms -> clock[0] = clock[0] + 30000L }
+        NOW_OVERRIDE.set({ clock[0] })
+        hubGet.register('/hub/backup/statusJson') { params -> '{"backupInProgress":true,"cloudBackupInProgress":false}' }
+
+        when:
+        def r = script.toolCreateHubBackup([confirm: true])
+
+        then: 'the ~57s cap ends the loop on round 2 -- not the 20-iteration count'
+        r.success == false
+        r.confirmed == false
+        stateMap.lastBackupTimestamp == null
+        r.error.contains('did not confirm')
+        hubGet.calls.count { it.path == '/hub/backup/statusJson' } == 2
+    }
+
+    def "a create whose PRE-trigger list read failed only confirms on an entry newer than the trigger window"() {
+        given: 'preEpoch is null (unreadable pre-trigger list), so only a fresh-looking entry may confirm'
+        settingsMap.enableWrite = true
+        stateMap.remove('lastBackupTimestamp')
+        hubGet.register('/hub/backup/statusJson') { params -> '{"backupInProgress":false,"cloudBackupInProgress":true}' }
+        int listReads = 0
+        hubGet.register('/hub2/localBackups') { params ->
+            listReads++
+            // fixed harness now() = 1234567890000 (2009-02-13T23:31:30Z); this entry is 30s old --
+            // inside the confirmT0-60s window, so it confirms even with no pre-trigger baseline
+            listReads == 1 ? '<html>login</html>'
+                           : '[{"name":"new.lzf","createTimeOrig":"2009-02-13T23:31:00+0000"}]'
+        }
+
+        when:
+        def r = script.toolCreateHubBackup([confirm: true])
+
+        then:
+        r.success == true
+        r.confirmed == true
+        stateMap.lastBackupTimestamp != null
+    }
+
     def "mock=true with mockEpoch stamps the given epoch (developer-mode test lever)"() {
         given:
         settingsMap.enableWrite = true

--- a/src/test/groovy/server/ToolDestructiveHubOpsSpec.groovy
+++ b/src/test/groovy/server/ToolDestructiveHubOpsSpec.groovy
@@ -73,6 +73,7 @@ class ToolDestructiveHubOpsSpec extends ToolSpecBase {
         given:
         settingsMap.enableWrite = true
         // No stateMap.lastBackupTimestamp — requireDestructiveConfirm's 24h window fails
+        // (and /hub2/localBackups is unstubbed, so the list fallback degrades to null)
 
         when:
         script.toolRebootHub([confirm: true])
@@ -81,6 +82,72 @@ class ToolDestructiveHubOpsSpec extends ToolSpecBase {
         def ex = thrown(IllegalArgumentException)
         ex.message.contains('BACKUP REQUIRED')
         ex.message.contains('hub_create_backup')
+    }
+
+    // -------- requireDestructiveConfirm backup-list fallback (issue #361) --------
+    // The gate's private stamp goes stale whenever a backup exists that this app never
+    // confirmed (scheduled/UI backups, or a create whose completion check missed). The
+    // fallback reads the hub's own local backup list -- ground truth for recovery points.
+
+    def "gate accepts a fresh backup from the hub's local backup list when the app stamp is missing (issue #361)"() {
+        given:
+        settingsMap.enableWrite = true
+        // No stateMap.lastBackupTimestamp. Fixed harness now() = 1234567890000 (2009-02-13T23:31:30Z);
+        // this entry is ~3.5h old -- within the 24h window.
+        hubGet.register('/hub2/localBackups') { params -> '[{"name":"2009-02-13~2.5.0.159.lzf","createTimeOrig":"2009-02-13T20:00:00+0000"}]' }
+        def postedPath = null
+        script.metaClass.hubInternalPost = { String path, Map body = null -> postedPath = path; 'ok' }
+
+        when:
+        def result = script.toolRebootHub([confirm: true])
+
+        then:
+        postedPath == '/hub/reboot'
+        result.success == true
+        stateMap.lastBackupTimestamp == 1234555200000L   // the list's epoch is cached into the stamp
+    }
+
+    def "gate caches the list find, so a second gated call skips the list read"() {
+        given:
+        settingsMap.enableWrite = true
+        hubGet.register('/hub2/localBackups') { params -> '[{"name":"a.lzf","createTimeOrig":"2009-02-13T20:00:00+0000"}]' }
+        script.metaClass.hubInternalPost = { String path, Map body = null -> 'ok' }
+
+        when:
+        script.toolRebootHub([confirm: true])
+        script.toolRebootHub([confirm: true])
+
+        then:
+        hubGet.calls.count { it.path == '/hub2/localBackups' } == 1
+    }
+
+    def "the backup-list fallback ignores backups older than 24h"() {
+        given:
+        settingsMap.enableWrite = true
+        // ~3.98 days before the fixed harness now() -- outside the 24h window.
+        hubGet.register('/hub2/localBackups') { params -> '[{"name":"old.lzf","createTimeOrig":"2009-02-10T00:00:00+0000"}]' }
+
+        when:
+        script.toolRebootHub([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('BACKUP REQUIRED')
+        ex.message.contains('backup list')
+        stateMap.lastBackupTimestamp == null      // a stale list entry must NOT stamp the gate
+    }
+
+    def "a malformed backup list leaves the gate closed"() {
+        given:
+        settingsMap.enableWrite = true
+        hubGet.register('/hub2/localBackups') { params -> '<html>login required</html>' }
+
+        when:
+        script.toolRebootHub([confirm: true])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains('BACKUP REQUIRED')
     }
 
     // -------- toolCreateHubBackup (async trigger; never slurps the .lzf) --------

--- a/src/test/groovy/server/ToolDestructiveHubOpsSpec.groovy
+++ b/src/test/groovy/server/ToolDestructiveHubOpsSpec.groovy
@@ -137,6 +137,22 @@ class ToolDestructiveHubOpsSpec extends ToolSpecBase {
         stateMap.lastBackupTimestamp == null      // a stale list entry must NOT stamp the gate
     }
 
+    def "the fallback parses an offset-less createTimeOrig as UTC and skips entries without one"() {
+        given:
+        settingsMap.enableWrite = true
+        // First entry has no createTimeOrig (skipped); the second is suffix-less -- the
+        // SimpleDateFormat UTC fallback must resolve it to the same epoch as the +0000 form.
+        hubGet.register('/hub2/localBackups') { params -> '[{"name":"junk.lzf"},{"name":"a.lzf","createTimeOrig":"2009-02-13T20:00:00"}]' }
+        script.metaClass.hubInternalPost = { String path, Map body = null -> 'ok' }
+
+        when:
+        def result = script.toolRebootHub([confirm: true])
+
+        then:
+        result.success == true
+        stateMap.lastBackupTimestamp == 1234555200000L   // == the +0000 parse of the same instant
+    }
+
     def "a malformed backup list leaves the gate closed"() {
         given:
         settingsMap.enableWrite = true

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -9800,6 +9800,36 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             f"Expected HTTP 202 for a notification, got {resp.status_code}: {resp.text[:200]!r}"
         assert resp.text.strip() == "", f"Expected empty body for 202, got: {resp.text[:200]!r}"
 
+    @test("protocol")
+    def test_op_token_released_on_validation_error(self) -> None:
+        """A tokened call rejected for invalid arguments (-32602) executed nothing, so it
+        must RELEASE the token: a corrected re-issue with the SAME token executes fresh
+        instead of replaying the stale rejection (issue #361 review finding — the old
+        behaviour buffered the -32602 under the token, wedging every fix-and-retry)."""
+        token = self._next_op_token()
+        room_name = f"{PREFIX}TokRelease"
+        try:
+            self.client.call_tool("hub_manage_rooms", {
+                "tool": "hub_create_room", "args": {"name": room_name, "opToken": token}})
+            raise AssertionError("hub_create_room without confirm should have been rejected (-32602)")
+        except McpError as exc:
+            assert "confirm" in str(exc).lower(), f"expected the missing-confirm validation error, got: {exc}"
+        created = None
+        try:
+            created = self.client.call_tool("hub_manage_rooms", {
+                "tool": "hub_create_room", "args": {"name": room_name, "confirm": True, "opToken": token}})
+            assert isinstance(created, dict) and created.get("success") is True, \
+                f"corrected re-issue with the SAME token should execute, not replay the rejection: {created}"
+            assert created.get("replayed") is not True, \
+                f"corrected re-issue was served a REPLAY -- the validation error spent the token: {created}"
+        finally:
+            if isinstance(created, dict) and created.get("success") is True:
+                try:
+                    self.client.call_tool("hub_manage_rooms", {
+                        "tool": "hub_delete_room", "args": {"room": room_name, "confirm": True}})
+                except Exception as exc:
+                    print(f"    [WARN] could not delete {room_name} (prefix sweep will reap it): {exc}")
+
     # -----------------------------------------------------------------------
     # Cleanup
     # -----------------------------------------------------------------------

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -7565,7 +7565,7 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         self._delete_rule_safe(rule_id)
 
     # -----------------------------------------------------------------------
-    # GROUP 9: system_tools (5 tests)
+    # GROUP 9: system_tools
     # -----------------------------------------------------------------------
 
     @test("system_tools")
@@ -7601,6 +7601,76 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         src = self.client.call_tool("hub_manage_backup", {"tool": "hub_list_backups", "args": {}})
         assert isinstance(src, dict) and "backups" in src, \
             f"default scope=source missing 'backups': {sorted(src.keys()) if isinstance(src, dict) else type(src).__name__}"
+
+    @test("system_tools")
+    def test_backup_gate_list_fallback(self) -> None:
+        # Issue #361: the destructive-confirm gate must accept a real backup from the hub's OWN
+        # local backup list when this app's private stamp is stale (a scheduled/UI backup is a
+        # real recovery point the stamp knows nothing about). Live proof, driven by the
+        # developer-mode mock lever's mockEpoch (stamps an arbitrarily STALE record):
+        #   1. snapshot the newest local backup entry + parse its epoch
+        #   2. stamp a >24h-old record via hub_create_backup(mock=true, mockEpoch)
+        #   3. run a gated write (hub_write_file):
+        #        list has a <24h backup -> the gate PASSES via the fallback and re-stamps
+        #                                  lastBackupEpoch to the list's newest epoch
+        #        no <24h backup listed  -> the gate throws BACKUP REQUIRED naming the list
+        #   4. finally: restore a fresh mock stamp (and remove the probe file) so later gated
+        #      tests see the standard state
+        from datetime import datetime as _dt
+        stale_epoch = int(time.time() * 1000) - 30 * 3600 * 1000   # 30h ago: outside the 24h window
+        loc = self.client.call_tool("hub_manage_backup", {"tool": "hub_list_backups", "args": {"scope": "hub_local"}})
+        newest_ms = None
+        for entry in (loc.get("hubLocalBackups") or []) if isinstance(loc, dict) else []:
+            ts = entry.get("createTimeOrig")
+            if not ts:
+                continue
+            try:
+                ms = int(_dt.strptime(ts, "%Y-%m-%dT%H:%M:%S%z").timestamp() * 1000)
+            except ValueError:
+                continue
+            newest_ms = ms if newest_ms is None else max(newest_ms, ms)
+        probe = f"{PREFIX}361_gate_probe.txt"
+        try:
+            mock = self.client.call_tool("hub_create_backup", {"confirm": True, "mock": True, "mockEpoch": stale_epoch})
+            assert isinstance(mock, dict) and mock.get("mocked") is True, f"mockEpoch stamp failed: {mock}"
+            info = self.client.call_tool("hub_get_info")
+            assert isinstance(info, dict) and info.get("lastBackupEpoch") == stale_epoch, \
+                f"mockEpoch did not land: {info.get('lastBackupEpoch') if isinstance(info, dict) else info} != {stale_epoch}"
+            fresh_in_list = newest_ms is not None and (time.time() * 1000 - newest_ms) <= 24 * 3600 * 1000
+            if fresh_in_list:
+                assert newest_ms is not None  # narrowed by fresh_in_list; keeps type checkers happy
+                wr = self.client.call_tool("hub_manage_files", {
+                    "tool": "hub_write_file",
+                    "args": {"fileName": probe, "content": "issue-361 gate probe", "confirm": True}})
+                assert isinstance(wr, dict) and wr.get("success") is True, \
+                    f"gated write should PASS via the backup-list fallback " \
+                    f"(list has a {(time.time() * 1000 - newest_ms) / 3600000.0:.1f}h-old backup): {wr}"
+                info2 = self.client.call_tool("hub_get_info")
+                restamped = info2.get("lastBackupEpoch") if isinstance(info2, dict) else None
+                assert restamped is not None and restamped != stale_epoch, \
+                    "gate fallback must re-stamp lastBackupEpoch from the hub's backup list"
+                assert abs(float(restamped) - newest_ms) < 60000, \
+                    f"re-stamped epoch should match the list's newest entry: {restamped} vs {newest_ms}"
+            else:
+                print("    [E2E-NOTE] no <24h local backup on the hub -- proving the REFUSAL side of the fallback")
+                try:
+                    self.client.call_tool("hub_manage_files", {
+                        "tool": "hub_write_file",
+                        "args": {"fileName": probe, "content": "issue-361 gate probe", "confirm": True}})
+                    raise AssertionError("gated write should have been refused: stale stamp AND no <24h backup in the hub's list")
+                except McpError as exc:
+                    assert "BACKUP REQUIRED" in str(exc), f"expected BACKUP REQUIRED, got: {exc}"
+                    assert "backup list" in str(exc), f"the refusal should say the hub's backup list was checked: {exc}"
+        finally:
+            # Restore a fresh stamp FIRST (later gated calls, including the probe delete, need it).
+            try:
+                self.client.call_tool("hub_create_backup", {"confirm": True, "mock": True})
+            except Exception as exc:
+                print(f"    [WARN] could not restore a fresh mock backup stamp: {exc}")
+            try:
+                self.client.call_tool("hub_manage_files", {"tool": "hub_delete_file", "args": {"fileName": probe, "confirm": True}})
+            except Exception:
+                pass  # refusal branch never wrote the probe file
 
     @test("system_tools")
     def test_mode_lifecycle(self) -> None:


### PR DESCRIPTION
## Summary

- The destructive-confirm gate now falls back to the hub's own local backup list (`GET /hub2/localBackups`) when this app's private stamp is stale — a scheduled/UI backup is a real recovery point, so gated tools no longer refuse while `hub_list_backups` shows fresh backups (the issue #361 headline, reproduced live on release code).
- `hub_create_backup` confirms completion by a NEW entry appearing in the hub's backup list as well as by statusJson, so a Hub Protect cloud upload holding `cloudBackupInProgress=true` can no longer un-confirm an already-written backup; the confirm loop is also wall-clock-capped (~60s instead of a ~6-minute worst case).
- A call rejected for invalid arguments (-32602) now RELEASES its opToken instead of spending it, so a corrected re-issue with the same token executes instead of replaying the stale rejection (footgun hit twice during the live reproduction).

## Type of change

- [ ] `feat` — new feature or capability
- [x] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

Closes #361.

- `requireDestructiveConfirm`: stamp-first check, then a backup-list fallback via the new `_latestLocalHubBackupEpoch()` helper; a fresh find is cached back into `state.lastBackupTimestamp`; the refusal message now names both sources checked.
- `toolCreateHubBackup`: pre-trigger snapshot of the newest local backup; the confirm loop treats a NEWER list entry as ground-truth completion (statusJson quiet stays as the fast path), bails when both signals are unreadable, and is wall-clock-capped at ~57s.
- `hub_create_backup` mock lever gains developer-mode-only `mockEpoch` so e2e can stamp a deliberately stale gate record and drive the fallback live.
- opToken: the IllegalArgumentException path calls the new `_opTokenRelease()` instead of buffering the -32602 under the token; slow_ops guide updated to document the release semantics.
- Docs: SKILL.md (gate pattern + state table), TOOL_GUIDE.md and the served guide sections' pre-flight checklist, `lastBackupEpoch` schema description.

## Release Notes

- Destructive tools no longer refuse with "BACKUP REQUIRED" when a real hub backup exists: the safety gate now also accepts any backup in the hub's own local backup list (scheduled backups count), not just backups created through hub_create_backup.
- hub_create_backup now recognizes completion as soon as the backup file appears, even while a Hub Protect cloud upload is still running, instead of failing after a minute of waiting.
- A call rejected for invalid arguments no longer burns its opToken — fix the arguments and re-issue with the same token.

## Testing

- **Live reproduction on untouched release 3.4.2 (cloud endpoint, Hub Protect hub):** `hub_create_backup(confirm=true, opToken)` during a cloud-backup upload → relay 504 at 10s, token polls answered `running` while `cloudBackupInProgress=true`, terminal result `success:false / confirmed:false` at ~70s, `lastBackupEpoch` unchanged — while the backup file it created was visible in `hub_list_backups`. With a stale stamp, a gated write then refused with `BACKUP REQUIRED … Last backup: 2026-07-22 14:53` while the list showed a backup from 35 minutes earlier.
- **Live green on this branch (same hub, same scenarios):** the stale-stamp gated write passed via the list fallback and re-stamped `lastBackupEpoch` to the newest entry's exact `createTimeOrig`; the cloud-upload wedge run confirmed `success:true / confirmed:true` on the first poll (~36s) while the upload was still in progress; a corrected re-issue with the same opToken executed after a -32602 instead of replaying it.
- Spock: gate fallback (pass/cache/stale-list/malformed-list), list-based create confirmation under a stuck cloud upload, no-new-entry stays unstamped, mockEpoch, opToken release + corrected same-token re-issue.
- e2e: `test_backup_gate_list_fallback` (system_tools; branch-adaptive on the hub's real backup list via `mockEpoch`) and `test_op_token_released_on_validation_error` (protocol).

## Checklist

- [x] **Unit tests added for any new MCP tools, regressions, or bug fixes** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes)
- [x] **e2e tests added for new tools and/or regression tests added for any bug fix** (see `tests/e2e_test.py`)
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
- [x] Documentation updated if user-facing behaviour or tool surface changed
- [x] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema)
