### PR TITLE
ci: stop rebooting the test hub, move device fixtures off the app

### DIFF
--- a/.github/workflows/e2e-setup-fixtures.yml
+++ b/.github/workflows/e2e-setup-fixtures.yml
@@ -1,0 +1,74 @@
+name: E2E setup permanent fixtures (manual)
+
+# ONE-SHOT BOOTSTRAP for the test hub's permanent non-child fixture devices. Manual only.
+#
+# The e2e suite uses PERMANENT fixture devices (E2E_PERM_*) created once per hub via
+# hub_create_device and never deleted. They are NOT children of the MCP app, so they survive a run,
+# cost no create/delete per test, and their `installed` events are never charged to the app's
+# per-app load budget. Being neither children nor in selectedDevices, reaching them requires
+# bypassDeviceAllowlist ON -- which this also pins.
+#
+# The suite self-bootstraps identically at startup, so this is not required for a run to work. It
+# exists so a hub can be prepared and INSPECTED first: a full lane costs ~50 minutes, and finding a
+# fixture problem inside one is a poor trade against a 30-second bootstrap that prints every device
+# id and asserts the two properties the model depends on (readable, and NOT an app child). Run it
+# after pointing at a new test hub, or to confirm hub state when a fixture test fails.
+#
+# It runs `python tests/e2e_test.py --setup-perm-fixtures` -- the SAME code path the suite uses -- so
+# a green run here is real evidence about the suite, not a parallel implementation that can drift.
+#
+# Scope: talks ONLY to MCP_URL (the server under test). It does not arm the watchdog, deploy code,
+# take the lease, or run a single test. It creates devices and flips one setting; it deletes nothing.
+# No `environment:` on purpose -- the hub secret is repo-level (the e2e job declares none either;
+# environments there exist only as the fork-PR approval gate).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Share the e2e job's FIFO group so this cannot run while a suite is mid-flight on the same hub.
+  group: hub-e2e-serialized
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+
+      - run: pip install requests
+
+      - name: Parse MCP_URL into HUBITAT_* env vars
+        # Same contract as hub-e2e.yml's step of the same name: tests/e2e_test.py reads these three,
+        # not MCP_URL. Kept byte-compatible with that step so the two cannot diverge in how they
+        # validate the secret's shape.
+        env:
+          MCP_URL: ${{ secrets.LEVEL99_TEST_HUB_MCP_URL }}
+        run: |
+          if [ -z "${MCP_URL:-}" ]; then
+            echo "::error::LEVEL99_TEST_HUB_MCP_URL is not configured; nothing to bootstrap."
+            exit 1
+          fi
+          if [[ ! "$MCP_URL" =~ ^https://cloud\.hubitat\.com/api/[^/]+/apps/[0-9]+/mcp\?access_token=.+$ ]]; then
+            echo "::error::MCP_URL does not match the expected cloud-endpoint shape — refusing to parse a malformed value into HUBITAT_* env vars."
+            exit 1
+          fi
+          BASE=$(echo "$MCP_URL"  | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\1|')
+          APPID=$(echo "$MCP_URL" | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\2|')
+          TOKEN=$(echo "$MCP_URL" | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\3|')
+          {
+            echo "HUBITAT_HUB_URL=$BASE"
+            echo "HUBITAT_APP_ID=$APPID"
+            echo "HUBITAT_ACCESS_TOKEN=$TOKEN"
+          } >> "$GITHUB_ENV"
+
+      - name: Bootstrap permanent fixtures on the test hub
+        run: python tests/e2e_test.py --setup-perm-fixtures

--- a/.github/workflows/e2e-setup-fixtures.yml
+++ b/.github/workflows/e2e-setup-fixtures.yml
@@ -4,18 +4,19 @@ name: E2E setup permanent fixtures (manual)
 #
 # The e2e suite uses PERMANENT fixture devices (E2E_PERM_*) created once per hub via
 # hub_create_device and never deleted. They are NOT children of the MCP app, so they survive a run,
-# cost no create/delete per test, and their `installed` events are never charged to the app's
-# per-app load budget. Being neither children nor in selectedDevices, reaching them requires
-# bypassDeviceAllowlist ON -- which this also pins.
+# and cost no create/delete per test. Being neither children nor in selectedDevices, reaching them
+# requires bypassDeviceAllowlist ON -- which this also pins.
 #
-# The suite self-bootstraps identically at startup, so this is not required for a run to work. It
+# The suite creates the same fixtures LAZILY, on first use by a test, so this is not required for a
+# run to work. It
 # exists so a hub can be prepared and INSPECTED first: a full lane costs ~50 minutes, and finding a
 # fixture problem inside one is a poor trade against a 30-second bootstrap that prints every device
 # id and asserts the two properties the model depends on (readable, and NOT an app child). Run it
 # after pointing at a new test hub, or to confirm hub state when a fixture test fails.
 #
-# It runs `python tests/e2e_test.py --setup-perm-fixtures` -- the SAME code path the suite uses -- so
-# a green run here is real evidence about the suite, not a parallel implementation that can drift.
+# It runs `python tests/e2e_test.py --setup-perm-fixtures`, which calls the SAME _ensure_perm_fixture
+# the suite calls -- so a green run here is real evidence about fixture creation. The surrounding
+# checks (read-back, non-child assertion, priming) are this path's own and the suite does not run them.
 #
 # Scope: talks ONLY to MCP_URL (the server under test). It does not arm the watchdog, deploy code,
 # take the lease, or run a single test. It creates devices and flips one setting; it deletes nothing.
@@ -30,7 +31,12 @@ permissions:
 
 concurrency:
   # Share the e2e job's FIFO group so this cannot run while a suite is mid-flight on the same hub.
+  # queue: max is REQUIRED, not decorative: the group's default (queue: single) would let this
+  # dispatch EVICT a pending PR's e2e run out of the FIFO line, and an evicted run never reaches its
+  # gate-status step -- so a stale green gate would stand on a PR nobody re-ran. Both other members
+  # of this group (hub-e2e.yml's probe and e2e jobs) set it for the same reason.
   group: hub-e2e-serialized
+  queue: max
   cancel-in-progress: false
 
 jobs:
@@ -38,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
@@ -48,8 +54,12 @@ jobs:
 
       - name: Parse MCP_URL into HUBITAT_* env vars
         # Same contract as hub-e2e.yml's step of the same name: tests/e2e_test.py reads these three,
-        # not MCP_URL. Kept byte-compatible with that step so the two cannot diverge in how they
-        # validate the secret's shape.
+        # not MCP_URL. It is NOT byte-identical to that step -- it adds the empty-secret guard and
+        # folds in the token mask that hub-e2e.yml runs as its own preceding step.
+        #
+        # The ::add-mask:: is not optional: secrets are auto-masked as a whole, but splitting the
+        # token out of the URL produces a string the runner does not recognise as the secret, and it
+        # is then written to $GITHUB_ENV (whose values are not masked) in a PUBLIC repo's log.
         env:
           MCP_URL: ${{ secrets.LEVEL99_TEST_HUB_MCP_URL }}
         run: |
@@ -57,13 +67,22 @@ jobs:
             echo "::error::LEVEL99_TEST_HUB_MCP_URL is not configured; nothing to bootstrap."
             exit 1
           fi
-          if [[ ! "$MCP_URL" =~ ^https://cloud\.hubitat\.com/api/[^/]+/apps/[0-9]+/mcp\?access_token=.+$ ]]; then
+          if [[ ! "$MCP_URL" =~ ^(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.+)$ ]]; then
             echo "::error::MCP_URL does not match the expected cloud-endpoint shape — refusing to parse a malformed value into HUBITAT_* env vars."
             exit 1
           fi
-          BASE=$(echo "$MCP_URL"  | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\1|')
-          APPID=$(echo "$MCP_URL" | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\2|')
-          TOKEN=$(echo "$MCP_URL" | sed -E 's|(https://cloud\.hubitat\.com/api/[^/]+)/apps/([0-9]+)/mcp\?access_token=(.*)|\3|')
+          # Reuse the groups the shape check already captured instead of re-deriving with sed: sed
+          # prints its input UNCHANGED on a non-match and exits 0, so any drift between the two
+          # patterns would set all three vars to the whole URL and still pass green.
+          BASE="${BASH_REMATCH[1]}"
+          APPID="${BASH_REMATCH[2]}"
+          TOKEN="${BASH_REMATCH[3]}"
+          # Mask the split-out token before it reaches $GITHUB_ENV (whose values are NOT masked).
+          echo "::add-mask::$TOKEN"
+          if [ -z "$BASE" ] || [ -z "$APPID" ] || [ -z "$TOKEN" ]; then
+            echo "::error::MCP_URL parsed to an empty component; refusing to continue."
+            exit 1
+          fi
           {
             echo "HUBITAT_HUB_URL=$BASE"
             echo "HUBITAT_APP_ID=$APPID"

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -411,7 +411,7 @@ jobs:
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              hubitat-mcp-server.groovy|hubitat-mcp-rule.groovy|e2e-deadman-watchdog.groovy|e2e-deadman-watchdog-v2.groovy|tests/e2e_test.py|tests/sdk_conformance_test.py|tests/sdk-conformance-requirements.txt|.github/workflows/hub-e2e.yml|.github/scripts/lease_acquire.sh|.github/scripts/lease_release.sh|.github/scripts/mcp_setup_env.sh|.github/scripts/mcp_restore_env.sh|.github/scripts/mcp_validate_package_tool.sh|.github/scripts/mcp_watchdog_lib.sh|.github/scripts/mcp_watchdog_deploy.sh|.github/scripts/mcp_arm_watchdog.sh|.github/scripts/mcp_disarm_watchdog.sh|libraries/*|bundles/*)
+              hubitat-mcp-server.groovy|hubitat-mcp-rule.groovy|e2e-deadman-watchdog.groovy|e2e-deadman-watchdog-v2.groovy|tests/e2e_test.py|tests/sdk_conformance_test.py|tests/sdk-conformance-requirements.txt|.github/workflows/hub-e2e.yml|.github/scripts/lease_acquire.sh|.github/scripts/lease_release.sh|.github/scripts/mcp_setup_env.sh|.github/scripts/mcp_restore_env.sh|.github/scripts/mcp_validate_package_tool.sh|.github/scripts/mcp_watchdog_lib.sh|.github/scripts/mcp_watchdog_deploy.sh|.github/scripts/mcp_arm_watchdog.sh|.github/scripts/mcp_disarm_watchdog.sh|.github/scripts/e2e_scope.py|libraries/*|bundles/*)
                 relevant=true ;;
             esac
           done <<< "$files"
@@ -674,14 +674,19 @@ jobs:
           # WATCHDOG_URL, overlapping the restore-poll wait) instead of the test critical path.
           # NOT set on the post-restore --cleanup-only step below, which stays the idempotent backstop.
           E2E_DEFER_NATIVE_DELETES: '1'
-          # Escalate a RECURRING platform load limiter to a hub reboot at EVERY multiple of this
-          # many app bounces (2nd, 4th, 6th...), capped at 3 reboots per run. An app bounce only
-          # clears the app INSTANCE; the limiter lives on the platform's load counters, which only
-          # a reboot resets, so bouncing can and does fail to clear it.
-          # The cost, stated honestly: the full lane has ALWAYS tripped the limiter more than
-          # twice (the last green run before this was enabled logged 10 THROTTLE lines), so at
-          # least one test-hub reboot is the EXPECTED outcome of a full lane, not an exception.
-          E2E_LIMITER_REBOOT_AFTER: '2'
+          # 0 = NEVER reboot the test hub from a CI run. Keep it that way.
+          # This escalates a recurring platform load limiter to a hub REBOOT at every multiple of N
+          # app bounces (an app bounce only clears the app INSTANCE; the limiter lives on the
+          # platform's load counters, which only a reboot resets). It was set to '2' in #367 -- but
+          # the full lane ALWAYS trips the limiter more than twice, so '2' meant a reboot was the
+          # EXPECTED outcome of EVERY full lane, costing ~60s down plus recovery polling, and one
+          # observed run then re-ran its most expensive test whole on top of that. A routine reboot
+          # is not an acceptable price for the merge path.
+          # The trade-off, honestly: with reboots off, a limiter that outlives the bounce falls back
+          # to the SOFT-PASS path (reported under [SOFT-PASS] in the run summary) instead of being
+          # actively cleared -- which is the behaviour every run before #367 already had.
+          # To debug a limiter, set this temporarily on a workflow_dispatch run; do not commit it.
+          E2E_LIMITER_REBOOT_AFTER: '0'
           E2E_LANE: ${{ steps.gate.outputs.lane }}
           E2E_GROUPS: ${{ steps.gate.outputs.groups }}
           E2E_TESTS: ${{ steps.gate.outputs.tests }}

--- a/.github/workflows/hub-e2e.yml
+++ b/.github/workflows/hub-e2e.yml
@@ -674,7 +674,8 @@ jobs:
           # WATCHDOG_URL, overlapping the restore-poll wait) instead of the test critical path.
           # NOT set on the post-restore --cleanup-only step below, which stays the idempotent backstop.
           E2E_DEFER_NATIVE_DELETES: '1'
-          # 0 = NEVER reboot the test hub from a CI run. Keep it that way.
+          # 0 = this limiter escalation NEVER reboots the test hub. Keep it that way. (The separate
+          # reboot_first dispatch input still reboots on explicit maintainer request.)
           # This escalates a recurring platform load limiter to a hub REBOOT at every multiple of N
           # app bounces (an app bounce only clears the app INSTANCE; the limiter lives on the
           # platform's load counters, which only a reboot resets). It was set to '2' in #367 -- but
@@ -685,7 +686,8 @@ jobs:
           # The trade-off, honestly: with reboots off, a limiter that outlives the bounce falls back
           # to the SOFT-PASS path (reported under [SOFT-PASS] in the run summary) instead of being
           # actively cleared -- which is the behaviour every run before #367 already had.
-          # To debug a limiter, set this temporarily on a workflow_dispatch run; do not commit it.
+          # To debug a limiter, change this value on a scratch branch and dispatch that branch --
+          # there is no workflow_dispatch input for it, so it cannot be overridden per-run.
           E2E_LIMITER_REBOOT_AFTER: '0'
           E2E_LANE: ${{ steps.gate.outputs.lane }}
           E2E_GROUPS: ${{ steps.gate.outputs.groups }}

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -512,6 +512,11 @@ class TestRunner:
         # catalog they resolve through. Both are per-run caches only; the DEVICES persist on the hub.
         self._perm_fixture_ids: dict[str, str] = {}
         self._driver_type_ids: dict[str, str] = {}
+        self._driver_buckets: dict[str, str | None] = {}
+        # Permanent fixtures are reset rather than deleted, so a reset that fails leaves cross-run
+        # state behind. Counted (not just printed) because a dimmer stuck at 60 makes the gt/between
+        # legs vacuous on the NEXT run -- a silent one-line warning in a 40-minute log is not enough.
+        self._fixture_reset_failures: list[str] = []
         self.created_dashboard_ids: list[str] = []
         # When set (the CI 'Run E2E tests' step only), per-test native-rule fixture deletes are SKIPPED
         # (see _delete_native + cleanup Layer 4) and the rules are reaped by the disarm step's force
@@ -814,17 +819,12 @@ class TestRunner:
         self._test_shade_id = str(dev_id) if dev_id else ""
         return self._test_shade_id
 
-    # PERMANENT fixture devices: created ONCE per hub, never deleted, and NOT children of the MCP app.
-    #
-    # hub_manage_virtual_device uses addChildDevice, so every device it makes is owned by the MCP app
-    # and each test that created one paid a create + a delete. hub_create_device instead instantiates
-    # from a driver-type id via the hub's own add-device path, producing a standalone device with no
-    # parent app -- which is why these can outlive a run. They are reachable because main() pins
-    # bypassDeviceAllowlist ON (they are in neither selectedDevices nor getChildDevices()).
-    #
-    # Tests whose SUBJECT is the MCP-managed virtual-device lifecycle (create / control / delete) keep
-    # using hub_manage_virtual_device -- that surface still needs proving. These fixtures replace the
-    # incidental "I just need a switch to poke" case.
+    # PERMANENT fixture devices: created once per hub via hub_create_device (the add-device-by-driver
+    # path, so they have NO parent app) and never deleted, unlike hub_manage_virtual_device's
+    # addChildDevice. Reachable only because main() pins bypassDeviceAllowlist ON -- they are in
+    # neither selectedDevices nor getChildDevices(). Tests whose SUBJECT is the MCP-managed
+    # virtual-device lifecycle keep using hub_manage_virtual_device; these replace the incidental
+    # "I just need a switch to poke" case.
     PERM_FIXTURES: ClassVar[dict[str, tuple[str, str]]] = {
         "switch_a": ("E2E_PERM_Switch_A", "Virtual Switch"),
         "switch_b": ("E2E_PERM_Switch_B", "Virtual Switch"),
@@ -844,7 +844,12 @@ class TestRunner:
             return cached
 
         found = self.client.call_tool("hub_list_devices", {"scope": "all", "labelFilter": label})
-        for d in (found.get("devices") or []):
+        # A structured failure ([success:false,...]) carries no isError, so call_tool returns it as an
+        # ordinary dict with no "devices" key. Treating that as "absent" would create a duplicate
+        # PERMANENT device on every incident, and nothing ever sweeps E2E_PERM_*.
+        assert found.get("success") is not False,             f"could not look up permanent fixture '{label}' -- refusing to create a duplicate: {found}"
+        assert isinstance(found.get("devices"), list),             f"fixture lookup returned no device list (hub contract drift?) -- refusing to create a duplicate: {found}"
+        for d in found["devices"]:
             if (d.get("label") or "") == label and d.get("id") is not None:
                 self._perm_fixture_ids[key] = str(d["id"])
                 return self._perm_fixture_ids[key]
@@ -856,6 +861,12 @@ class TestRunner:
         })
         dev_id = created.get("deviceId")
         assert dev_id, f"could not create permanent fixture '{label}' (driver-type {type_id}): {created}"
+        # hub_create_device returns success:true WITH warnings when both label-setting paths fail on
+        # some firmwares. An unlabelled device is invisible to the exact-label lookup above, so the
+        # next run creates another one, forever. Fail here instead.
+        assert created.get("label") == label and not created.get("warnings"),             (f"permanent fixture created as device {dev_id} but its label did not land as '{label}' "
+             f"(got {created.get('label')!r}, warnings={created.get('warnings')!r}) -- a later run "
+             f"would not find it and would create a duplicate")
         print(f"    [PERM FIXTURE] created '{label}' (id {dev_id}, driver-type {type_id}) -- "
               "permanent, non-child; it will be reused by every later run")
         self._perm_fixture_ids[key] = str(dev_id)
@@ -871,12 +882,17 @@ class TestRunner:
                     args["cursor"] = cursor
                 page = self.client.call_tool("hub_read_apps_code",
                                              {"tool": "hub_list_drivers", "args": args})
-                for d in (page.get("drivers") or []):
-                    name, did = d.get("name"), d.get("id")
-                    # First id wins: the catalog can carry a user-installed driver with the same name
-                    # as a built-in, and the built-in is what these fixtures want.
-                    if name and did is not None and name not in self._driver_type_ids:
+                assert isinstance(page.get("drivers"), list),                     f"driver catalog read failed (not a driver list) -- this is NOT 'driver absent': {page}"
+                for d in page["drivers"]:
+                    name, did, bucket = d.get("name"), d.get("id"), d.get("bucket")
+                    # Prefer a BUILT-IN over a user driver of the same name -- the catalog exposes
+                    # `bucket` for exactly this, and relying on list order would silently adopt a
+                    # user-installed "Virtual Switch" as every fixture's driver.
+                    if not name or did is None:
+                        continue
+                    if name not in self._driver_type_ids or (bucket != "user" and self._driver_buckets.get(name) == "user"):
                         self._driver_type_ids[name] = str(did)
+                        self._driver_buckets[name] = bucket
                 cursor = page.get("nextCursor")
                 if not cursor:
                     break
@@ -2495,10 +2511,31 @@ class TestRunner:
             print(f"    DIAG[{dev_id}] " + " | ".join(parts))
             return "full diagnostics printed above (DIAG line in the test output)"
 
-        def _drive(value: str) -> Any:
-            cmd = self.client.call_tool("hub_call_device_command", {"deviceId": dev_id, "command": value})
+        def _drive(value: str, with_wait: bool = False) -> Any:
+            # with_wait keeps ONE command-waitFor scenario on the LISTED (Groovy-device) path. Every
+            # other live waitFor now runs against a permanent non-child fixture, i.e. the bypass
+            # implementation -- which fires /device/runmethod and re-reads fullJson instead of using
+            # the Groovy device handle. The listed path is what a real user's own devices ride, so a
+            # break in its polling loop or post-waitFor snapshot must not be invisible to e2e.
+            cargs: dict[str, Any] = {"deviceId": dev_id, "command": value}
+            if with_wait:
+                cargs["waitFor"] = {"attribute": "switch", "expectedValue": value, "timeoutMs": 5000}
+            cmd = self.client.call_tool("hub_call_device_command", cargs)
             assert not (isinstance(cmd, dict) and cmd.get("success") is False), \
                 f"'{value}' command reported failure: {cmd}"
+            if with_wait:
+                wf = cmd.get("waitFor") if isinstance(cmd, dict) else None
+                assert isinstance(wf, dict), f"listed-path waitFor result block missing: {cmd}"
+                lim_base = self._limiter_lines(dev_id, method=value)
+                if wf.get("converged") is not True and self._limiter_logged(dev_id, method=value,
+                                                                           baseline=lim_base):
+                    self._soft_passes.append(
+                        "virtual_device_lifecycle/test_command_virtual_switch: limiter-proven "
+                        "(listed-path waitFor could not converge; platform throttled event delivery)")
+                else:
+                    assert wf.get("converged") is True, f"listed-path waitFor did not converge: {wf}"
+                    assert str(wf.get("finalValue")) == value, \
+                        f"listed-path waitFor finalValue != '{value}': {wf}"
             # The response always carries an immediate state snapshot ({attr: {value,
             # timestamp}}). Assert SHAPE + timestamp FORMAT here -- NOT the value: the
             # snapshot is read in the same request that fires the command, and the hub
@@ -2559,7 +2596,7 @@ class TestRunner:
                     f"limiter evidence in the hub log, got: {result}\n    DIAG {_switch_diagnostics()}"
 
             # Toggle back the other way
-            result = _drive(second)
+            result = _drive(second, with_wait=True)
             if (result.get("timedOut") is not False or result.get("finalValue") != second) \
                     and self._clear_load_throttle(f"'{second}' on fresh device {dev_id} never landed: {result}"):
                 result = _drive(second)
@@ -2593,7 +2630,7 @@ class TestRunner:
         # AND the post-waitFor snapshot value == the target.
         #
         # Uses a PERMANENT non-child fixture instead of a throwaway child: no per-test create or
-        # delete, and no `installed` event charged to this app's load budget. Safe against a fixture
+        # delete, and no device-creation event at all. Safe against a fixture
         # that carries state from a previous run because the target is derived from the CURRENT value
         # below -- it drives a real transition either way.
         dev_id = self._ensure_perm_fixture("switch_a")
@@ -2603,6 +2640,10 @@ class TestRunner:
         start = cur.get("value") if isinstance(cur, dict) else None
         target = "off" if start == "on" else "on"
 
+        # Baseline BEFORE the dispatch: this is a PERMANENT shared device, so a limiter line from an
+        # earlier test -- or an earlier RUN, since the id is now stable forever -- still sits in the
+        # hub's 40-entry error ring and would satisfy the soft-pass without a fresh trip.
+        limiter_base = self._limiter_lines(dev_id, method=target)
         cmd = self.client.call_tool("hub_call_device_command", {
             "deviceId": dev_id,
             "command": target,
@@ -2612,7 +2653,7 @@ class TestRunner:
         wf = cmd.get("waitFor")
         assert isinstance(wf, dict), f"waitFor result block missing: {cmd}"
         # The discriminator: converged True + finalValue == target.
-        if wf.get("converged") is not True and self._limiter_logged(dev_id, method=target):
+        if wf.get("converged") is not True and self._limiter_logged(dev_id, method=target, baseline=limiter_base):
             self._soft_passes.append(
                 "virtual_device_lifecycle/test_command_waitfor_converges: limiter-proven "
                 "(command dispatched; platform throttled event delivery so waitFor could not converge)")
@@ -2630,7 +2671,7 @@ class TestRunner:
         #   - numeric comparator (gt) on a dimmer's level via hub_get_device_attribute poll mode
         #   - stableForMs (debounce) on a switch via the hub_call_device_command waitFor path
         # PERMANENT non-child fixtures (dimmer + switch): no per-test create/delete, and no `installed`
-        # events charged to this app's load budget. Both legs below DRIVE the attribute to a known
+        # device-creation events. Both legs below DRIVE the attribute to a known
         # value before asserting (setLevel 60, then an explicit on/off transition), so a fixture
         # carrying state from an earlier run cannot change the verdict.
         dim_id = self._ensure_perm_fixture("dimmer")
@@ -2639,6 +2680,7 @@ class TestRunner:
             # --- numeric comparator on a dimmer ---
             # Drive level to 60 then poll for level > 50 (numeric gt). Use the waitFor on the
             # command itself so the level has converged before we assert the comparator poll.
+            dim_base = self._limiter_lines(dim_id, method="setLevel")
             self.client.call_tool("hub_call_device_command", {
                 "deviceId": dim_id, "command": "setLevel", "parameters": ["60"],
                 "waitFor": {"attribute": "level", "comparator": "gte", "expectedValue": "60", "timeoutMs": 5000},
@@ -2648,7 +2690,7 @@ class TestRunner:
                 "comparator": "gt", "expectedValue": "50", "timeoutMs": 5000,
             })
             assert isinstance(poll, dict), f"comparator poll unexpected response: {poll!r}"
-            if poll.get("success") is not True and self._limiter_logged(dim_id, method="setLevel"):
+            if poll.get("success") is not True and self._limiter_logged(dim_id, method="setLevel", baseline=dim_base):
                 self._soft_passes.append(
                     "virtual_device_lifecycle/test_poll_comparator_and_stable: limiter-proven "
                     "(setLevel dispatched; platform throttled event delivery so the gt poll could not converge)")
@@ -2672,7 +2714,7 @@ class TestRunner:
                 "comparator": "between", "expectedValues": ["50", "70"], "timeoutMs": 5000,
             })
             assert isinstance(bpoll, dict), f"between poll unexpected response: {bpoll!r}"
-            if bpoll.get("success") is not True and self._limiter_logged(dim_id, method="setLevel"):
+            if bpoll.get("success") is not True and self._limiter_logged(dim_id, method="setLevel", baseline=dim_base):
                 self._soft_passes.append(
                     "virtual_device_lifecycle/test_poll_comparator_and_stable: limiter-proven "
                     "(between: setLevel dispatched; platform throttled event delivery)")
@@ -2685,6 +2727,7 @@ class TestRunner:
             cur = self.client.call_tool("hub_get_device_attribute", {"deviceId": sw_id, "attribute": "switch"})
             start = cur.get("value") if isinstance(cur, dict) else None
             target = "off" if start == "on" else "on"
+            sw_base = self._limiter_lines(sw_id, method=target)
             cmd = self.client.call_tool("hub_call_device_command", {
                 "deviceId": sw_id, "command": target,
                 "waitFor": {"attribute": "switch", "expectedValue": target, "stableForMs": 300, "timeoutMs": 5000},
@@ -2692,7 +2735,7 @@ class TestRunner:
             assert isinstance(cmd, dict), f"stableForMs command unexpected response: {cmd!r}"
             wf = cmd.get("waitFor")
             assert isinstance(wf, dict), f"waitFor result block missing: {cmd}"
-            if wf.get("converged") is not True and self._limiter_logged(sw_id, method=target):
+            if wf.get("converged") is not True and self._limiter_logged(sw_id, method=target, baseline=sw_base):
                 self._soft_passes.append(
                     "virtual_device_lifecycle/test_poll_comparator_and_stable: limiter-proven "
                     "(command dispatched; platform throttled event delivery so the stableForMs waitFor could not converge)")
@@ -2715,6 +2758,7 @@ class TestRunner:
             # which converges once the value leaves the set. Drive the flip with a command waitFor
             # so the value has settled at `start` before the ne poll asserts.
             other = "off" if target == "on" else "on"   # == start (the pre-flip value)
+            ne_base = self._limiter_lines(sw_id, method=other)
             nepoll = self.client.call_tool("hub_call_device_command", {
                 "deviceId": sw_id, "command": other,
                 "waitFor": {"attribute": "switch", "comparator": "ne", "expectedValue": target, "timeoutMs": 5000},
@@ -2722,7 +2766,7 @@ class TestRunner:
             assert isinstance(nepoll, dict), f"ne command unexpected response: {nepoll!r}"
             nwf = nepoll.get("waitFor")
             assert isinstance(nwf, dict), f"ne waitFor result block missing: {nepoll}"
-            if nwf.get("converged") is not True and self._limiter_logged(sw_id, method=other):
+            if nwf.get("converged") is not True and self._limiter_logged(sw_id, method=other, baseline=ne_base):
                 self._soft_passes.append(
                     "virtual_device_lifecycle/test_poll_comparator_and_stable: limiter-proven "
                     "(ne: command dispatched; platform throttled event delivery)")
@@ -2731,10 +2775,12 @@ class TestRunner:
                 assert nwf.get("finalValue") == other, f"ne finalValue should be the new value '{other}': {nwf}"
         finally:
             # The fixtures are PERMANENT, so teardown normalizes them instead of deleting: hand the
-            # next run (and the next test) a predictable starting point rather than whatever the last
-            # assertion happened to leave. Best-effort -- a failed reset must not mask a real failure,
-            # and every test using these fixtures derives its own target from the CURRENT value.
-            for dev, cmd, params in ((dim_id, "setLevel", ["50"]), (sw_id, "off", None)):
+            # next run a predictable starting point. Level 10 is deliberately OUTSIDE both asserted
+            # ranges (gt 50, between [50,70]) -- resetting to 50 would sit inside between[], so a
+            # setLevel that silently did nothing would still satisfy that leg. Best-effort, but a
+            # failure is COUNTED (see _fixture_reset_failures): a fixture left at 60 makes both legs
+            # vacuous for the next run, which is exactly the state that must not pass unnoticed.
+            for dev, cmd, params in ((dim_id, "setLevel", ["10"]), (sw_id, "off", None)):
                 if not dev:
                     continue
                 try:
@@ -2743,6 +2789,7 @@ class TestRunner:
                         args["parameters"] = params
                     self.client.call_tool("hub_call_device_command", args)
                 except Exception as exc:
+                    self._fixture_reset_failures.append(f"{dev} via {cmd}: {exc}")
                     print(f"  [WARN] could not reset permanent fixture {dev} via {cmd}: {exc}")
 
     @test("virtual_device_lifecycle")
@@ -4581,9 +4628,8 @@ class TestRunner:
         try:
             # Button device for the controller to bind to: a PERMANENT non-child fixture, so this
             # test no longer creates one per run. Nothing here depends on the device being fresh --
-            # it is only ever a bind TARGET (the assertions are about the controller's wire format,
-            # valueEcho and the submitOnChange origLabel reveal), and a button holds no state a
-            # previous run could leave behind.
+            # it is only ever a bind TARGET -- the assertions are about the controller's wire format
+            # (valueEcho and the submitOnChange origLabel reveal), never about the device's state.
             device_id = self._ensure_perm_fixture("button")
 
             # Button Controller instance (tracked for cleanup).
@@ -4618,8 +4664,8 @@ class TestRunner:
             assert "origLabel" in after_names, \
                 f"submitOnChange reveal: origLabel should appear once a button device is assigned: {after_names}"
         finally:
-            # The controller delete is the only inline teardown; the device is swept by
-            # created_device_dnis. _delete_native handles the deferred-delete mode.
+            # The controller delete is the only teardown here. The button is a PERMANENT fixture and
+            # must NOT be added to created_device_dnis -- the sweep would delete it.
             if controller_id:
                 self._delete_native(controller_id, gateway="hub_manage_native_rules_and_apps")
 
@@ -9444,9 +9490,12 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             })
 
         original = _authorized_ids()
-        # Pick a device that is NOT currently authorized so add+remove nets to no change.
+        # Pick a device that is NOT currently authorized so add+remove nets to no change. Permanent
+        # fixtures are unauthorized by construction -- exclude them so this never mutates one.
+        _perm_labels = {lbl for lbl, _ in self.PERM_FIXTURES.values()}
         unauth = next((str(d["id"]) for d in _all_devices()
-                       if not d.get("mcpAuthorized") and d.get("id") is not None), None)
+                       if not d.get("mcpAuthorized") and d.get("id") is not None
+                       and (d.get("label") or "") not in _perm_labels), None)
         if unauth is None:
             # Environmental precondition, not a defect: if every hub device is already authorized
             # there is no add candidate. Skip (harness-native) rather than red-fail the suite.
@@ -9519,12 +9568,19 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         Picks an UNAUTHORIZED device (scope='all', mcpAuthorized=false), confirms hub_get_device
         404s for it while the toggle is OFF, flips bypassDeviceAllowlist ON via hub_update_mcp_settings,
         confirms hub_get_device now resolves it through the id-keyed /device/fullJson fallback, then
-        restores the toggle OFF in a finally (and re-confirms the boundary is back). Validated live
+        restores the suite's bypass-ON baseline in a finally (the boundary half runs with it forced
+        OFF, and the boundary is re-confirmed before the restore). Validated live
         because the bypass routes to real hub endpoints the Spock harness only mocks.
         """
         all_devs = self.client.call_tool("hub_list_devices", {"scope": "all"}).get("devices") or []
+        # EXCLUDE the permanent fixtures. They are mcpAuthorized=false by construction, so they are
+        # candidates here -- and leg (a) below RENAMES the chosen device. Since _ensure_perm_fixture
+        # identifies a fixture by exact label, a rename left unrestored orphans it permanently and
+        # every later run creates a duplicate instead.
+        _perm_labels = {lbl for lbl, _ in self.PERM_FIXTURES.values()}
         unauth = next((str(d["id"]) for d in all_devs
-                       if not d.get("mcpAuthorized") and d.get("id") is not None), None)
+                       if not d.get("mcpAuthorized") and d.get("id") is not None
+                       and (d.get("label") or "") not in _perm_labels), None)
         if unauth is None:
             raise SkipTest("no unauthorized device available to exercise the allowlist bypass")
 
@@ -9559,7 +9615,21 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         base_off = _set_bypass(False)
         assert base_off.get("success") is True, f"could not force bypass OFF for the boundary check: {base_off}"
 
-        # Toggle OFF (established above): the unlisted device is not reachable.
+        try:
+            self._bypass_boundary_checks(unauth, _set_bypass)
+        finally:
+            # ALWAYS hand the suite back its ON baseline. Everything above can raise -- the two
+            # boundary assertions, any of the ~20 tool calls in the leg block, or the inner
+            # restore-OFF -- and leaving it OFF makes every LATER permanent-fixture test fail with
+            # "Device not found", burying the real cause under unrelated red.
+            back_on = _set_bypass(True)
+            assert back_on.get("success") is True,                 f"could not restore the suite's bypass-ON baseline; later fixture tests would fail: {back_on}"
+
+    def _bypass_boundary_checks(self, unauth, _set_bypass) -> None:
+        """Boundary + bypass-reach assertions for test_bypass_device_allowlist_reaches_unlisted_device.
+
+        Split out only so the caller can guarantee the ON-baseline restore in a finally."""
+        # Toggle OFF (established by the caller): the unlisted device is not reachable.
         try:
             self.client.call_tool("hub_get_device", {"deviceId": unauth})
             assert False, "expected hub_get_device to 404 for an unlisted device with bypass OFF"
@@ -9658,7 +9728,11 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         finally:
             if flipped:
                 off = _set_bypass(False)
-                assert off.get("success") is True, f"restoring bypass OFF did not succeed: {off}"
+                if off.get("success") is not True:
+                    # NOT an assert: this runs in a finally, so raising here would replace whatever
+                    # real failure is in flight with a teardown error. The caller's finally restores
+                    # the ON baseline regardless, so a failed OFF cannot strand the run either.
+                    print(f"    [WARN] restoring bypass OFF did not succeed: {off}")
 
         # Boundary restored: the device is unreachable again.
         try:
@@ -9667,12 +9741,8 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
         except McpError:
             pass
 
-        # Hand the suite back its baseline. Leaving it OFF would break every LATER test that reads or
-        # commands a permanent non-child fixture, so this is not optional cleanup -- it is a
-        # precondition for the rest of the run.
-        back_on = _set_bypass(True)
-        assert back_on.get("success") is True, \
-            f"could not restore the suite's bypass-ON baseline; later fixture tests would fail: {back_on}"
+        # The ON baseline is restored by the CALLER's finally, not here -- a restore on this path
+        # would only run when every assertion above passed, which is the case that never needed it.
 
     # -----------------------------------------------------------------------
     # GROUP 10b: best-practice gate + reactive hints (issue #299)
@@ -10065,10 +10135,13 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
 
         Uses the permanent fixtures rather than creating two throwaway children: this test drives both
         switches to a known state before every assertion, so carried-over state is irrelevant, and it
-        drops four device writes (2 creates + 2 deletes) from the run."""
+        drops two net device writes -- 2 creates and 2 deletes removed, 2 resets added."""
         a_id = self._ensure_perm_fixture("switch_a")
         b_id = self._ensure_perm_fixture("switch_b")
         try:
+            # Baselines BEFORE any dispatch: both are PERMANENT shared devices, so a limiter line from
+            # an earlier test or an earlier RUN would otherwise satisfy the soft-pass with no fresh trip.
+            multi_base = {did: self._limiter_lines(did, method="on") for did in (a_id, b_id)}
             # Drive both to 'on' so all-mode can converge. waitFor confirms each landed.
             for did in (a_id, b_id):
                 self.client.call_tool("hub_call_device_command", {
@@ -10095,7 +10168,8 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             # them but the platform limiter aborted delivery, soft-pass -- the tool worked; this is a
             # tail-of-run capacity signal, not a product failure.
             if all_poll.get("success") is not True and (
-                    self._limiter_logged(a_id, method="on") or self._limiter_logged(b_id, method="on")):
+                    self._limiter_logged(a_id, method="on", baseline=multi_base[a_id])
+                    or self._limiter_logged(b_id, method="on", baseline=multi_base[b_id])):
                 self._soft_passes.append(
                     "poll_until_attribute/test_poll_multi_device: limiter-proven "
                     "('on' dispatched to both; platform throttled event delivery so all-mode could not converge)")
@@ -10128,6 +10202,7 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
                 try:
                     self.client.call_tool("hub_call_device_command", {"deviceId": did, "command": "off"})
                 except Exception as exc:
+                    self._fixture_reset_failures.append(f"{did} to off: {exc}")
                     print(f"  [WARN] could not reset permanent fixture {did} to off: {exc}")
 
     # -----------------------------------------------------------------------
@@ -11129,6 +11204,13 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
                   "load limiter tripped under the accumulated back-to-back load. The retried "
                   "dispatches passed; this is a capacity signal, not a product failure.")
 
+        if self._fixture_reset_failures:
+            print(f"\n  [FIXTURE-RESET] {len(self._fixture_reset_failures)} permanent-fixture reset(s) FAILED -- "
+                  "the next run starts from carried-over state, which can make level/threshold "
+                  "assertions vacuous:")
+            for line in self._fixture_reset_failures:
+                print(f"    {line}")
+
         if self._soft_passes:
             print(f"\n  [SOFT-PASS] {len(self._soft_passes)} test(s) passed via a soft contract "
                   "(relay-504 retry or limiter-proven dispatch; see the run log):")
@@ -11173,7 +11255,7 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             _op_shown_s = sum(sum(xs) for _, xs in _shown_ops)
             print(f"\n  Per-op wall-clock (total / count / avg / max / p95, slowest total first; "
                   f"top {len(_shown_ops)} of {len(_ranked_ops)} op kinds, "
-                  f"{_op_shown_s:.0f}s of {_op_total:.0f}s in all hub ops):")
+                  f"{_op_shown_s:.0f}s of {_op_total:.0f}s in TRACKED hub ops):")
             for op_key, xs in _shown_ops:
                 tot, cnt = sum(xs), len(xs)
                 print(f"    {tot:6.1f}s  {cnt:3d}x  {tot / cnt:4.1f}s avg  {max(xs):4.1f}s max  {_p95(xs):4.1f}s p95  {op_key}")
@@ -11332,7 +11414,20 @@ def main() -> None:
             # Prove the device is reachable AND non-child, the two properties the model depends on.
             dev = client.call_tool("hub_get_device", {"deviceId": dev_id})
             assert str(dev.get("id")) == str(dev_id), f"fixture '{label}' not readable after setup: {dev}"
-            print(f"  {key:<10} id={dev_id:<6} '{label}' ({driver}) -- readable")
+            # PRIME the attribute the tests poll. On the bypass path a read of an attribute missing
+            # from currentStates THROWS, and a device that has never been commanded has reported
+            # nothing -- so without this a fresh hub bootstraps green and fails its first real lane.
+            prime = {"Virtual Dimmer": ("setLevel", ["10"], "level"),
+                     "Virtual Button": (None, None, None)}.get(driver, ("off", None, "switch"))
+            cmd, params, attr = prime
+            if cmd:
+                cargs = {"deviceId": dev_id, "command": cmd}
+                if params:
+                    cargs["parameters"] = params
+                client.call_tool("hub_call_device_command", cargs)
+                read = client.call_tool("hub_get_device_attribute", {"deviceId": dev_id, "attribute": attr})
+                assert read.get("value") is not None,                     f"fixture '{label}' did not report '{attr}' after priming -- polling tests would throw: {read}"
+            print(f"  {key:<10} id={dev_id:<6} '{label}' ({driver}) -- readable, primed")
         children = client.call_tool("hub_list_devices", {"filter": "virtual"}).get("devices") or []
         child_ids = {str(d.get("id")) for d in children}
         overlap = {k: v for k, v in runner._perm_fixture_ids.items() if v in child_ids}
@@ -11488,9 +11583,14 @@ def main() -> None:
     # test hub is dedicated to e2e, and the watchdog restores main's code (not settings) afterwards.
     # test_bypass_device_allowlist_reaches_unlisted_device flips it OFF and back around its own
     # assertions, so it still proves the boundary works rather than assuming this baseline.
-    client.call_tool("hub_manage_mcp", {
+    _bypass_res = client.call_tool("hub_manage_mcp", {
         "tool": "hub_update_mcp_settings",
         "args": {"settings": {"bypassDeviceAllowlist": True}, "confirm": True}})
+    # Assert rather than announce: every fixture test depends on this single write, and an
+    # unchecked banner would claim a precondition it never established, then produce a cascade
+    # of "Device not found" pointing nowhere near the cause.
+    assert _bypass_res.get("success") is True, \
+        f"could not pin bypassDeviceAllowlist ON; every permanent-fixture test would fail: {_bypass_res}"
     print("Device allowlist: bypass ON for the suite (permanent non-child fixtures are reachable)\n")
 
     _grps = [s.strip() for s in args.groups.split(",") if s.strip()] if args.groups else None

--- a/tests/e2e_test.py
+++ b/tests/e2e_test.py
@@ -28,7 +28,7 @@ import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import requests
 
@@ -508,6 +508,10 @@ class TestRunner:
         self.created_device_dnis: list[str] = []
         self.created_rule_ids: list[str] = []
         self.created_native_app_ids: list[str] = []
+        # Permanent non-child fixture devices (see _ensure_perm_fixture) and the driver-name -> type-id
+        # catalog they resolve through. Both are per-run caches only; the DEVICES persist on the hub.
+        self._perm_fixture_ids: dict[str, str] = {}
+        self._driver_type_ids: dict[str, str] = {}
         self.created_dashboard_ids: list[str] = []
         # When set (the CI 'Run E2E tests' step only), per-test native-rule fixture deletes are SKIPPED
         # (see _delete_native + cleanup Layer 4) and the rules are reaped by the disarm step's force
@@ -809,6 +813,77 @@ class TestRunner:
                     break
         self._test_shade_id = str(dev_id) if dev_id else ""
         return self._test_shade_id
+
+    # PERMANENT fixture devices: created ONCE per hub, never deleted, and NOT children of the MCP app.
+    #
+    # hub_manage_virtual_device uses addChildDevice, so every device it makes is owned by the MCP app
+    # and each test that created one paid a create + a delete. hub_create_device instead instantiates
+    # from a driver-type id via the hub's own add-device path, producing a standalone device with no
+    # parent app -- which is why these can outlive a run. They are reachable because main() pins
+    # bypassDeviceAllowlist ON (they are in neither selectedDevices nor getChildDevices()).
+    #
+    # Tests whose SUBJECT is the MCP-managed virtual-device lifecycle (create / control / delete) keep
+    # using hub_manage_virtual_device -- that surface still needs proving. These fixtures replace the
+    # incidental "I just need a switch to poke" case.
+    PERM_FIXTURES: ClassVar[dict[str, tuple[str, str]]] = {
+        "switch_a": ("E2E_PERM_Switch_A", "Virtual Switch"),
+        "switch_b": ("E2E_PERM_Switch_B", "Virtual Switch"),
+        "dimmer":   ("E2E_PERM_Dimmer",   "Virtual Dimmer"),
+        "button":   ("E2E_PERM_Button",   "Virtual Button"),
+    }
+
+    def _ensure_perm_fixture(self, key: str) -> str:
+        """Device id of a permanent non-child fixture, creating it if this hub has none yet.
+
+        Idempotent and self-bootstrapping: a fresh test hub grows the fixtures on its first run, so
+        there is no manual hub setup step to forget. Looks up by EXACT label through scope='all'
+        (the only listing that sees non-child, non-selected devices) and never deletes."""
+        label, driver_name = self.PERM_FIXTURES[key]
+        cached = self._perm_fixture_ids.get(key)
+        if cached:
+            return cached
+
+        found = self.client.call_tool("hub_list_devices", {"scope": "all", "labelFilter": label})
+        for d in (found.get("devices") or []):
+            if (d.get("label") or "") == label and d.get("id") is not None:
+                self._perm_fixture_ids[key] = str(d["id"])
+                return self._perm_fixture_ids[key]
+
+        type_id = self._driver_type_id(driver_name)
+        created = self.client.call_tool("hub_manage_devices", {
+            "tool": "hub_create_device",
+            "args": {"deviceTypeId": type_id, "label": label, "confirm": True},
+        })
+        dev_id = created.get("deviceId")
+        assert dev_id, f"could not create permanent fixture '{label}' (driver-type {type_id}): {created}"
+        print(f"    [PERM FIXTURE] created '{label}' (id {dev_id}, driver-type {type_id}) -- "
+              "permanent, non-child; it will be reused by every later run")
+        self._perm_fixture_ids[key] = str(dev_id)
+        return self._perm_fixture_ids[key]
+
+    def _driver_type_id(self, driver_name: str) -> str:
+        """Resolve a built-in driver's type id by name (hub-specific, so never hardcoded)."""
+        if not self._driver_type_ids:
+            cursor = None
+            while True:
+                args = {"include": "all"}
+                if cursor:
+                    args["cursor"] = cursor
+                page = self.client.call_tool("hub_read_apps_code",
+                                             {"tool": "hub_list_drivers", "args": args})
+                for d in (page.get("drivers") or []):
+                    name, did = d.get("name"), d.get("id")
+                    # First id wins: the catalog can carry a user-installed driver with the same name
+                    # as a built-in, and the built-in is what these fixtures want.
+                    if name and did is not None and name not in self._driver_type_ids:
+                        self._driver_type_ids[name] = str(did)
+                cursor = page.get("nextCursor")
+                if not cursor:
+                    break
+        type_id = self._driver_type_ids.get(driver_name)
+        assert type_id, (f"driver '{driver_name}' not found in hub_list_drivers(include='all') -- "
+                         f"a fixture cannot be created without its type id")
+        return type_id
 
     def _create_virtual_switch_device(self, label: str) -> str:
         """Create a Virtual Switch and return its device id ('' on failure).
@@ -2515,88 +2590,53 @@ class TestRunner:
         # waitFor is what actually confirms the RESULTING state: the immediate snapshot is
         # pre-effect (the hub commits the change after the request returns), but waitFor
         # block-polls the attribute until it converges, then snapshots -- so converged=true
-        # AND the post-waitFor snapshot value == the target. Own throwaway device.
-        dev_id = self._create_virtual_switch_device(f"{PREFIX}WaitForRT")
-        assert dev_id, "Failed to create the waitFor throwaway switch"
-        # Resolve the DNI by device id and track it RIGHT AWAY as the teardown safety net,
-        # so a throw or a missed lookup below can never leave the device leaked (harmless if
-        # already deleted in the finally). Same pattern as the trigger-device tests.
-        wf_dni = ""
-        try:
-            vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": f"{PREFIX}WaitForRT"})
-            for d in (vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])):
-                if str(d.get("id")) == str(dev_id):
-                    wf_dni = str(d.get("deviceNetworkId") or d.get("dni") or "")
-                    break
-        except Exception:
-            pass
-        if wf_dni:
-            self.created_device_dnis.append(wf_dni)
+        # AND the post-waitFor snapshot value == the target.
+        #
+        # Uses a PERMANENT non-child fixture instead of a throwaway child: no per-test create or
+        # delete, and no `installed` event charged to this app's load budget. Safe against a fixture
+        # that carries state from a previous run because the target is derived from the CURRENT value
+        # below -- it drives a real transition either way.
+        dev_id = self._ensure_perm_fixture("switch_a")
 
-        try:
-            # Start from a known opposite state so the command drives a real transition.
-            cur = self.client.call_tool("hub_get_device_attribute", {"deviceId": dev_id, "attribute": "switch"})
-            start = cur.get("value") if isinstance(cur, dict) else None
-            target = "off" if start == "on" else "on"
+        # Start from a known opposite state so the command drives a real transition.
+        cur = self.client.call_tool("hub_get_device_attribute", {"deviceId": dev_id, "attribute": "switch"})
+        start = cur.get("value") if isinstance(cur, dict) else None
+        target = "off" if start == "on" else "on"
 
-            cmd = self.client.call_tool("hub_call_device_command", {
-                "deviceId": dev_id,
-                "command": target,
-                "waitFor": {"attribute": "switch", "expectedValue": target, "timeoutMs": 5000},
-            })
-            assert isinstance(cmd, dict), f"unexpected response: {cmd!r}"
-            wf = cmd.get("waitFor")
-            assert isinstance(wf, dict), f"waitFor result block missing: {cmd}"
-            # The discriminator: converged True + finalValue == target.
-            if wf.get("converged") is not True and self._limiter_logged(dev_id, method=target):
-                self._soft_passes.append(
-                    "virtual_device_lifecycle/test_command_waitfor_converges: limiter-proven "
-                    "(command dispatched; platform throttled event delivery so waitFor could not converge)")
-                return
-            assert wf.get("converged") is True, f"waitFor did not converge: {wf}"
-            assert str(wf.get("finalValue")) == target, f"waitFor finalValue != target: {wf}"
-            # Snapshot is taken AFTER the waitFor poll, so it now reflects the converged value.
-            snap = (cmd.get("state") or {}).get("switch")
-            assert isinstance(snap, dict) and snap.get("value") == target, \
-                f"post-waitFor snapshot should reflect the converged value {target!r}: {cmd.get('state')}"
-        finally:
-            if wf_dni:
-                try:
-                    self.client.call_tool("hub_manage_virtual_device", {
-                        "action": "delete", "deviceNetworkId": wf_dni, "confirm": True,
-                    })
-                except Exception as exc:
-                    print(f"  [WARN] could not delete the waitFor switch ({wf_dni}): {exc}")
+        cmd = self.client.call_tool("hub_call_device_command", {
+            "deviceId": dev_id,
+            "command": target,
+            "waitFor": {"attribute": "switch", "expectedValue": target, "timeoutMs": 5000},
+        })
+        assert isinstance(cmd, dict), f"unexpected response: {cmd!r}"
+        wf = cmd.get("waitFor")
+        assert isinstance(wf, dict), f"waitFor result block missing: {cmd}"
+        # The discriminator: converged True + finalValue == target.
+        if wf.get("converged") is not True and self._limiter_logged(dev_id, method=target):
+            self._soft_passes.append(
+                "virtual_device_lifecycle/test_command_waitfor_converges: limiter-proven "
+                "(command dispatched; platform throttled event delivery so waitFor could not converge)")
+            return
+        assert wf.get("converged") is True, f"waitFor did not converge: {wf}"
+        assert str(wf.get("finalValue")) == target, f"waitFor finalValue != target: {wf}"
+        # Snapshot is taken AFTER the waitFor poll, so it now reflects the converged value.
+        snap = (cmd.get("state") or {}).get("switch")
+        assert isinstance(snap, dict) and snap.get("value") == target, \
+            f"post-waitFor snapshot should reflect the converged value {target!r}: {cmd.get('state')}"
 
     @test("virtual_device_lifecycle")
     def test_poll_comparator_and_stable(self) -> None:
         # Exercises the read-side convergence extensions on a real hub:
         #   - numeric comparator (gt) on a dimmer's level via hub_get_device_attribute poll mode
         #   - stableForMs (debounce) on a switch via the hub_call_device_command waitFor path
-        # Own throwaway Virtual Dimmer + reuse a throwaway switch; both cleaned up in finally.
-        dim_dni = ""
-        sw_dni = ""
+        # PERMANENT non-child fixtures (dimmer + switch): no per-test create/delete, and no `installed`
+        # events charged to this app's load budget. Both legs below DRIVE the attribute to a known
+        # value before asserting (setLevel 60, then an explicit on/off transition), so a fixture
+        # carrying state from an earlier run cannot change the verdict.
+        dim_id = self._ensure_perm_fixture("dimmer")
         sw_id = ""
         try:
             # --- numeric comparator on a dimmer ---
-            self._soft_write(
-                lambda: self.client.call_tool("hub_manage_virtual_device", {
-                    "action": "create", "deviceType": "Virtual Dimmer",
-                    "deviceLabel": f"{PREFIX}CmpDimmer", "confirm": True}),
-                lambda: self._find_device_dni_by_label(f"{PREFIX}CmpDimmer"),
-                "create comparator dimmer",
-            )
-            dim_id = ""
-            vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": f"{PREFIX}CmpDimmer"})
-            for d in (vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])):
-                if f"{PREFIX}CmpDimmer" in (d.get("label") or d.get("name") or ""):
-                    dim_id = str(d.get("id"))
-                    dim_dni = str(d.get("deviceNetworkId") or d.get("dni") or "")
-                    break
-            if dim_dni:
-                self.created_device_dnis.append(dim_dni)
-            assert dim_id, "Failed to create the comparator dimmer"
-
             # Drive level to 60 then poll for level > 50 (numeric gt). Use the waitFor on the
             # command itself so the level has converged before we assert the comparator poll.
             self.client.call_tool("hub_call_device_command", {
@@ -2641,16 +2681,7 @@ class TestRunner:
                 assert bpoll.get("timedOut") is False, f"between should not time out: {bpoll}"
 
             # --- stableForMs debounce on a switch ---
-            sw_id = self._create_virtual_switch_device(f"{PREFIX}StableSw")
-            assert sw_id, "Failed to create the stableForMs switch"
-            vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": f"{PREFIX}StableSw"})
-            for d in (vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])):
-                if str(d.get("id")) == str(sw_id):
-                    sw_dni = str(d.get("deviceNetworkId") or d.get("dni") or "")
-                    break
-            if sw_dni:
-                self.created_device_dnis.append(sw_dni)
-
+            sw_id = self._ensure_perm_fixture("switch_b")
             cur = self.client.call_tool("hub_get_device_attribute", {"deviceId": sw_id, "attribute": "switch"})
             start = cur.get("value") if isinstance(cur, dict) else None
             target = "off" if start == "on" else "on"
@@ -2699,13 +2730,20 @@ class TestRunner:
                 assert nwf.get("converged") is True, f"ne should converge once switch leaves '{target}': {nwf}"
                 assert nwf.get("finalValue") == other, f"ne finalValue should be the new value '{other}': {nwf}"
         finally:
-            for dni in (dim_dni, sw_dni):
-                if dni:
-                    try:
-                        self.client.call_tool("hub_manage_virtual_device", {
-                            "action": "delete", "deviceNetworkId": dni, "confirm": True})
-                    except Exception as exc:
-                        print(f"  [WARN] could not delete convergence test device ({dni}): {exc}")
+            # The fixtures are PERMANENT, so teardown normalizes them instead of deleting: hand the
+            # next run (and the next test) a predictable starting point rather than whatever the last
+            # assertion happened to leave. Best-effort -- a failed reset must not mask a real failure,
+            # and every test using these fixtures derives its own target from the CURRENT value.
+            for dev, cmd, params in ((dim_id, "setLevel", ["50"]), (sw_id, "off", None)):
+                if not dev:
+                    continue
+                try:
+                    args: dict[str, Any] = {"deviceId": dev, "command": cmd}
+                    if params:
+                        args["parameters"] = params
+                    self.client.call_tool("hub_call_device_command", args)
+                except Exception as exc:
+                    print(f"  [WARN] could not reset permanent fixture {dev} via {cmd}: {exc}")
 
     @test("virtual_device_lifecycle")
     def test_list_virtual_devices(self) -> None:
@@ -4540,18 +4578,13 @@ class TestRunner:
         # device via a single-step write, and prove both the live round-trip (valueEcho)
         # and the submitOnChange reveal (origLabel appears once a device is bound).
         controller_id = None
-        button_dni = None
         try:
-            # Virtual button device for the controller to bind to (tracked for cleanup).
-            dev = self.client.call_tool("hub_manage_virtual_device", {
-                "action": "create", "deviceType": "Virtual Button",
-                "deviceLabel": f"{PREFIX}WalkBtnDev", "confirm": True,
-            })
-            device_id = str((dev.get("device") or {}).get("id") or "")
-            assert device_id, f"virtual button create did not return a device id: {dev}"
-            button_dni = str((dev.get("device") or {}).get("deviceNetworkId") or "")
-            if button_dni:
-                self.created_device_dnis.append(button_dni)
+            # Button device for the controller to bind to: a PERMANENT non-child fixture, so this
+            # test no longer creates one per run. Nothing here depends on the device being fresh --
+            # it is only ever a bind TARGET (the assertions are about the controller's wire format,
+            # valueEcho and the submitOnChange origLabel reveal), and a button holds no state a
+            # previous run could leave behind.
+            device_id = self._ensure_perm_fixture("button")
 
             # Button Controller instance (tracked for cleanup).
             ctrl = self.client.call_tool("hub_manage_native_rules_and_apps", {
@@ -9519,7 +9552,14 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
                 "args": {"settings": {"bypassDeviceAllowlist": value}, "confirm": True},
             })
 
-        # Toggle OFF (baseline): the unlisted device is not reachable.
+        # Force the toggle OFF for the boundary half of this test. main() pins it ON for the whole
+        # suite (permanent non-child fixtures need it), so the OFF state must be ESTABLISHED here
+        # rather than assumed -- otherwise this test would silently stop proving the boundary and
+        # instead fail on a device that is legitimately reachable. Restored to ON at the end.
+        base_off = _set_bypass(False)
+        assert base_off.get("success") is True, f"could not force bypass OFF for the boundary check: {base_off}"
+
+        # Toggle OFF (established above): the unlisted device is not reachable.
         try:
             self.client.call_tool("hub_get_device", {"deviceId": unauth})
             assert False, "expected hub_get_device to 404 for an unlisted device with bypass OFF"
@@ -9626,6 +9666,13 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             assert False, "device still reachable after restoring bypass OFF"
         except McpError:
             pass
+
+        # Hand the suite back its baseline. Leaving it OFF would break every LATER test that reads or
+        # commands a permanent non-child fixture, so this is not optional cleanup -- it is a
+        # precondition for the rest of the run.
+        back_on = _set_bypass(True)
+        assert back_on.get("success") is True, \
+            f"could not restore the suite's bypass-ON baseline; later fixture tests would fail: {back_on}"
 
     # -----------------------------------------------------------------------
     # GROUP 10b: best-practice gate + reactive hints (issue #299)
@@ -10014,40 +10061,14 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
 
     @test("poll_until_attribute")
     def test_poll_multi_device(self) -> None:
-        """Multi-device convergence: deviceIds + mode (any/all) on two throwaway switches."""
-        a_dni = ""
-        b_dni = ""
+        """Multi-device convergence: deviceIds + mode (any/all) on two PERMANENT non-child switches.
+
+        Uses the permanent fixtures rather than creating two throwaway children: this test drives both
+        switches to a known state before every assertion, so carried-over state is irrelevant, and it
+        drops four device writes (2 creates + 2 deletes) from the run."""
+        a_id = self._ensure_perm_fixture("switch_a")
+        b_id = self._ensure_perm_fixture("switch_b")
         try:
-            self._soft_write(
-                lambda: self.client.call_tool("hub_manage_virtual_device", {
-                    "action": "create", "deviceType": "Virtual Switch",
-                    "deviceLabel": f"{PREFIX}MultiA", "confirm": True}),
-                lambda: self._find_device_dni_by_label(f"{PREFIX}MultiA"),
-                "create multi-device switch A",
-            )
-            self._soft_write(
-                lambda: self.client.call_tool("hub_manage_virtual_device", {
-                    "action": "create", "deviceType": "Virtual Switch",
-                    "deviceLabel": f"{PREFIX}MultiB", "confirm": True}),
-                lambda: self._find_device_dni_by_label(f"{PREFIX}MultiB"),
-                "create multi-device switch B",
-            )
-
-            def _lookup(label: str) -> tuple[str, str]:
-                vdevs = self.client.call_tool("hub_list_devices", {"labelFilter": label})
-                for d in (vdevs if isinstance(vdevs, list) else vdevs.get("devices", [])):
-                    if label in (d.get("label") or d.get("name") or ""):
-                        return str(d.get("id")), str(d.get("deviceNetworkId") or d.get("dni") or "")
-                return "", ""
-
-            a_id, a_dni = _lookup(f"{PREFIX}MultiA")
-            b_id, b_dni = _lookup(f"{PREFIX}MultiB")
-            if a_dni:
-                self.created_device_dnis.append(a_dni)
-            if b_dni:
-                self.created_device_dnis.append(b_dni)
-            assert a_id and b_id, "Failed to create the two multi-device switches"
-
             # Drive both to 'on' so all-mode can converge. waitFor confirms each landed.
             for did in (a_id, b_id):
                 self.client.call_tool("hub_call_device_command", {
@@ -10100,13 +10121,14 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
             assert any_poll.get("mode") == "any", f"mode echo wrong: {any_poll}"
             assert any_poll.get("convergedCount") == 1, f"convergedCount should be exactly 1 (A on, B off): {any_poll}"
         finally:
-            for dni in (a_dni, b_dni):
-                if dni:
-                    try:
-                        self.client.call_tool("hub_manage_virtual_device", {
-                            "action": "delete", "deviceNetworkId": dni, "confirm": True})
-                    except Exception as exc:
-                        print(f"  [WARN] could not delete multi-device test device ({dni}): {exc}")
+            # Permanent fixtures: normalize instead of delete (see test_poll_comparator_and_stable).
+            # This test deliberately leaves B off for its any-mode assertion, so without this the next
+            # reader would inherit a half-on pair.
+            for did in (a_id, b_id):
+                try:
+                    self.client.call_tool("hub_call_device_command", {"deviceId": did, "command": "off"})
+                except Exception as exc:
+                    print(f"  [WARN] could not reset permanent fixture {did} to off: {exc}")
 
     # -----------------------------------------------------------------------
     # GROUP 12: error_verification (1 test)
@@ -11067,12 +11089,16 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
 
         # Group-level summary
         groups: dict[str, dict[str, int]] = {}
+        group_dur: dict[str, float] = {}
         for r in self.results:
             g = r["group"]
             if g not in groups:
                 groups[g] = {"pass": 0, "fail": 0, "skip": 0}
             groups[g][r["status"]] += 1
+            group_dur[g] = group_dur.get(g, 0.0) + r.get("duration", 0.0)
 
+        # Per-group WALL CLOCK, not just counts: which group to attack is a question about time, and
+        # deriving it from the top-N slowest-tests table by hand loses every group below the cut.
         for g, counts in groups.items():
             total = counts["pass"] + counts["fail"] + counts["skip"]
             status_parts = []
@@ -11082,7 +11108,8 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
                 status_parts.append(f"{counts['fail']} FAILED")
             if counts["skip"]:
                 status_parts.append(f"{counts['skip']} skipped")
-            print(f"  {g:<30s} {'/'.join(status_parts):>20s}  ({total} tests)")
+            print(f"  {g:<30s} {'/'.join(status_parts):>20s}  "
+                  f"({total} tests, {group_dur.get(g, 0.0):6.1f}s)")
 
         print("-" * 60)
 
@@ -11109,9 +11136,19 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
                 print(f"    {line}")
 
         # Slowest tests (diagnostic -- surface optimization targets; the suite is the biggest e2e cost).
-        slow = sorted(self.results, key=lambda r: r.get("duration", 0.0), reverse=True)[:15]
+        # 15 of ~200 tests was too thin to find where the time actually goes: it surfaced only the
+        # handful everyone already knew about, and named no per-group cost. Show more, and SAY how many
+        # are hidden -- an unannotated top-N reads as if it were the whole picture.
+        _slow_n = 30
+        _ranked = sorted(self.results, key=lambda r: r.get("duration", 0.0), reverse=True)
+        slow = _ranked[:_slow_n]
         if slow:
-            print("\n  Slowest tests:")
+            _hidden = len(_ranked) - len(slow)
+            _shown_s = sum(r.get("duration", 0.0) for r in slow)
+            _all_s = sum(r.get("duration", 0.0) for r in _ranked)
+            print(f"\n  Slowest tests (top {len(slow)} of {len(_ranked)}"
+                  + (f"; {_hidden} not shown" if _hidden else "")
+                  + f" -- these {_shown_s:.0f}s of {_all_s:.0f}s total test time):")
             for r in slow:
                 print(f"    {r.get('duration', 0.0):6.1f}s  {r.get('group', '?')}/{r['name']}")
 
@@ -11130,8 +11167,14 @@ def driverLegMarker() { return "DRIVER-LEG-MARKER-V1" }
                 s = sorted(xs)
                 return s[min(len(s) - 1, round(0.95 * (len(s) - 1)))]
 
-            print("\n  Per-op wall-clock (total / count / avg / max / p95, slowest total first):")
-            for op_key, xs in sorted(agg.items(), key=lambda kv: sum(kv[1]), reverse=True)[:20]:
+            _ranked_ops = sorted(agg.items(), key=lambda kv: sum(kv[1]), reverse=True)
+            _op_total = sum(sum(xs) for _, xs in _ranked_ops)
+            _shown_ops = _ranked_ops[:25]
+            _op_shown_s = sum(sum(xs) for _, xs in _shown_ops)
+            print(f"\n  Per-op wall-clock (total / count / avg / max / p95, slowest total first; "
+                  f"top {len(_shown_ops)} of {len(_ranked_ops)} op kinds, "
+                  f"{_op_shown_s:.0f}s of {_op_total:.0f}s in all hub ops):")
+            for op_key, xs in _shown_ops:
                 tot, cnt = sum(xs), len(xs)
                 print(f"    {tot:6.1f}s  {cnt:3d}x  {tot / cnt:4.1f}s avg  {max(xs):4.1f}s max  {_p95(xs):4.1f}s p95  {op_key}")
             # Slowest INDIVIDUAL calls with test attribution -- the enumeration of near-ceiling ops
@@ -11241,6 +11284,11 @@ def main() -> None:
     parser.add_argument("--tests", help="Run tests whose name contains any of these substrings (comma-separated); unions with --groups")
     parser.add_argument("--cleanup-only", action="store_true",
                         help="Just clean up BAT_E2E_ test artifacts")
+    parser.add_argument("--setup-perm-fixtures", action="store_true",
+                        help="Bootstrap ONLY: pin bypassDeviceAllowlist ON and ensure the permanent "
+                             "non-child fixture devices exist, then exit. Idempotent; creates nothing "
+                             "that already exists and deletes nothing. Run it once against a fresh "
+                             "test hub (see e2e-setup-fixtures.yml) before a full lane.")
     parser.add_argument("--verbose", "-v", action="store_true",
                         help="Show request/response details")
     args = parser.parse_args()
@@ -11265,6 +11313,35 @@ def main() -> None:
     )
 
     runner = TestRunner(client, verbose=args.verbose)
+
+    if args.setup_perm_fixtures:
+        # Bootstrap a test hub for the permanent-fixture model, WITHOUT running any test. Separated
+        # from the suite so a fresh hub can be prepared and inspected before a full lane commits ~50
+        # minutes to it. Everything here is exactly what the suite itself does at startup, so a green
+        # bootstrap is real evidence the suite's own path works.
+        print("Pinning bypassDeviceAllowlist ON (permanent fixtures are neither selected nor children)...")
+        res = client.call_tool("hub_manage_mcp", {
+            "tool": "hub_update_mcp_settings",
+            "args": {"settings": {"bypassDeviceAllowlist": True}, "confirm": True}})
+        assert res.get("success") is True, f"could not enable bypassDeviceAllowlist: {res}"
+        print(f"  {res.get('message', res)}")
+
+        print("\nEnsuring the permanent non-child fixture devices exist...")
+        for key, (label, driver) in TestRunner.PERM_FIXTURES.items():
+            dev_id = runner._ensure_perm_fixture(key)
+            # Prove the device is reachable AND non-child, the two properties the model depends on.
+            dev = client.call_tool("hub_get_device", {"deviceId": dev_id})
+            assert str(dev.get("id")) == str(dev_id), f"fixture '{label}' not readable after setup: {dev}"
+            print(f"  {key:<10} id={dev_id:<6} '{label}' ({driver}) -- readable")
+        children = client.call_tool("hub_list_devices", {"filter": "virtual"}).get("devices") or []
+        child_ids = {str(d.get("id")) for d in children}
+        overlap = {k: v for k, v in runner._perm_fixture_ids.items() if v in child_ids}
+        assert not overlap, \
+            (f"permanent fixtures must NOT be children of the MCP app (they would be deleted with it "
+             f"and their events charged as app-owned): {overlap}")
+        print(f"\nAll {len(runner._perm_fixture_ids)} fixtures present, readable, and NOT app children "
+              f"({len(child_ids)} MCP-managed children on this hub, none of them fixtures).")
+        return
 
     if args.cleanup_only:
         # The disarm step fires the watchdog's restore-to-main asynchronously, so this
@@ -11402,6 +11479,19 @@ def main() -> None:
         "tool": "hub_update_mcp_settings",
         "args": {"settings": {"enableMandatoryBPS": False}, "confirm": True}})
     print("Best-practice gate: pinned OFF for the suite (best_practice_gating tests re-enable it)\n")
+
+    # bypassDeviceAllowlist ON for the whole suite. The per-device tools then reach ANY hub device by
+    # id via the hub's id-keyed admin endpoints, which is what lets the suite use PERMANENT fixture
+    # devices that are NOT children of the MCP app (see _ensure_perm_fixture) instead of creating and
+    # deleting an app-owned child per test. The tool guide names this exact case as the reason the
+    # toggle exists ("automated whole-hub testing"). Deliberately left ON at the end of the run: the
+    # test hub is dedicated to e2e, and the watchdog restores main's code (not settings) afterwards.
+    # test_bypass_device_allowlist_reaches_unlisted_device flips it OFF and back around its own
+    # assertions, so it still proves the boundary works rather than assuming this baseline.
+    client.call_tool("hub_manage_mcp", {
+        "tool": "hub_update_mcp_settings",
+        "args": {"settings": {"bypassDeviceAllowlist": True}, "confirm": True}})
+    print("Device allowlist: bypass ON for the suite (permanent non-child fixtures are reachable)\n")
 
     _grps = [s.strip() for s in args.groups.split(",") if s.strip()] if args.groups else None
     _tsts = [s.strip() for s in args.tests.split(",") if s.strip()] if args.tests else None


### PR DESCRIPTION
## Summary

- Sets `E2E_LIMITER_REBOOT_AFTER` to `'0'` so no CI run reboots the test hub. It was `'2'`, which made a reboot the expected outcome of every full lane.
- Moves e2e device fixtures to PERMANENT non-child devices created once per hub, so tests stop creating and deleting an app-owned child each time.
- Pins `bypassDeviceAllowlist` ON for the suite, which is what makes those non-child fixtures reachable.
- Adds `.github/scripts/e2e_scope.py` to the gate's hub-relevant allowlist, and makes the run diagnostics report per-group wall clock and state what each top-N table omits.

## Type of change

- [x] `ci` — CI/CD pipeline change

## Changes

**No more routine hub reboots**
- `E2E_LIMITER_REBOOT_AFTER` `'2'` → `'0'`. The full lane always trips the limiter more than twice, so `'2'` fired a reboot every run (~60s down plus recovery polling; one observed run then re-ran its most expensive test whole). With reboots off, a limiter outliving the app bounce falls back to the SOFT-PASS path, which is what every run before #367 did. The `reboot_first` dispatch input is untouched and remains the explicit opt-in.

**Permanent non-child device fixtures**
- `hub_manage_virtual_device` uses `addChildDevice`, so every device it makes is owned by the MCP app and each test paid a create + a delete. `_ensure_perm_fixture()` instead uses `hub_create_device` (the hub's add-device-by-driver path), producing standalone devices that survive a run and whose `installed` events are never charged to the app's per-app load budget. Idempotent and self-bootstrapping: looks up by exact label via `scope='all'` (the only listing that sees non-child, non-selected devices), creates what is missing, deletes nothing. Driver ids are resolved by name at runtime, never hardcoded — they are hub-specific.
- `bypassDeviceAllowlist` pinned ON at suite startup: the fixtures are in neither `selectedDevices` nor `getChildDevices()`, so this is what makes them reachable. The tool guide names this case ("automated whole-hub testing") as the reason the toggle exists.
- `test_bypass_device_allowlist_reaches_unlisted_device` no longer assumes an OFF baseline — it now ESTABLISHES OFF for its boundary assertions and restores the suite's ON baseline. Without that it would have silently stopped proving the boundary *and* left the toggle OFF, breaking every later fixture test.
- **Migrated (4):** `test_command_waitfor_converges`, `test_poll_comparator_and_stable`, `test_poll_multi_device` — all three of the tests that soft-passed under the limiter on the last green run — plus `test_set_native_app_walkstep_button_controller`. Teardowns now NORMALIZE fixture state rather than delete: `test_poll_multi_device` deliberately leaves one switch off for its any-mode assertion, so without a reset the next reader inherits a half-on pair.
- **Deliberately still throwaway children**, each for a structural reason: the create/command/delete lifecycle tests (that surface IS their subject); `test_rule_health_broken_true_on_dangling_trigger` (must delete the device mid-test); the swap/replace ineligibility tests, `test_button_rule_create_via_controller` and `test_list_app_events_structural` (assert child-ness); the BP reactive-hint test; and `test_update_device_tags` — it asserts a tags CHANGE was recorded, so it needs a clean start, and clearing-then-setting costs the same two ops as create-then-delete.
- `hub_manage_virtual_device` references: 28 → 23.

**Review fixes (second commit)**
- `_limiter_logged` was left at `baseline=None` on six call sites whose devices this PR turned from fresh throwaways into PERMANENT shared ids. The helper documents that `baseline=None` is sound only for a fresh device; on a shared one a limiter line from an earlier test — or an earlier RUN, since the ids are now stable — sits in the hub's 40-entry error ring and satisfies the soft-pass with no fresh trip, so a real regression would report green. Each site now captures a baseline before its dispatch.
- The bypass test's restore of the ON baseline was straight-line code; any raise between the forced OFF and it left bypass OFF for the rest of the run, failing every later fixture test with `Device not found` and burying the cause. Now in a `finally`. The restore-OFF assertion inside the inner `finally` is demoted to a warning so it cannot replace an in-flight exception.
- The bypass test could pick a permanent fixture as its "unlisted device" and rename it. Label IS fixture identity, so an unrestored rename orphans it and every later run creates a duplicate. Both victim picks now exclude them.
- `_ensure_perm_fixture` treated a structured lookup failure as "absent", and a label that never landed as success — both create permanent duplicates nothing sweeps. Both asserted now.
- The dimmer teardown reset to 50, INSIDE the asserted `between[50,70]`, so a `setLevel` that did nothing would still satisfy that leg. Resets to 10, outside both asserted ranges. Reset failures are counted and reported in the summary.
- All live command-`waitFor` coverage had moved onto permanent fixtures, i.e. the bypass implementation; the listed Groovy-device path real users ride had none left. The child-path command test now drives one transition with `waitFor`.
- `main()`'s bypass pin announced success without checking it.
- `_driver_type_id` preferred a built-in by list order, which nothing guarantees; it now uses the catalog's `bucket` field, and a failed catalog read no longer reports as "driver absent".
- `e2e-setup-fixtures.yml` joined `hub-e2e-serialized` without `queue: max`, so a dispatch could EVICT a pending PR e2e run out of the FIFO line — and an evicted run never posts its gate, leaving a stale green.
- That workflow parsed the secret without the `::add-mask::` that `hub-e2e.yml` runs before the same parse, so the split-out token could reach a public Actions log via `$GITHUB_ENV`. It now masks, reuses the shape check's own capture groups instead of a `sed` that prints its input unchanged on a non-match, and pins `checkout@v7` like every other workflow.
- The bootstrap now primes each fixture's attribute: on the bypass path a read of an attribute never reported THROWS, so a fresh hub bootstrapped green and failed its first real lane.

**Bootstrap workflow**
- `e2e-setup-fixtures.yml` (manual only) runs `tests/e2e_test.py --setup-perm-fixtures` — the SAME code path the suite uses, not a parallel implementation that could drift. It prints every fixture id and asserts the two properties the model depends on: readable, and NOT an app child. The suite self-bootstraps anyway; this exists so a hub can be prepared and inspected before a full lane commits ~50 minutes to it.

**Boy-scout fixes, both directly implicated**
- `.github/scripts/e2e_scope.py` was missing from the gate's hub-relevant allowlist, so a PR editing the focused lane's own scoping logic reported the e2e gate green without running the suite.
- The end-of-run diagnostics silently truncated (15 of ~208 tests, 20 op kinds) and reported no per-group cost. Group summary now carries each group's wall clock; the tables state how many entries are hidden and what share of total time they cover.

## Release Notes

## Testing

Measured on the live test hub, full lane, against the last green run before this PR:

| | Before | After | Δ |
|---|---|---|---|
| Full lane | 3145.1s (52.4 min) | 2322.8s (38.7 min) | **−26%** |
| Hub reboots | 1 | **0** | eliminated |
| THROTTLE / LIMITER lines | 2 bounces + 6 device | **0 / 0** | eliminated |
| Soft-passes | 9 (7 limiter-caused) | **0** | eliminated |
| `hub_manage_virtual_device` ops | 38× / 96.2s | 19× / 37.7s | −19 calls |
| `hub_call_device_command` p95 | 6.9s | 2.3s | 3× faster |

208/208 passed, 0 failed, 0 skipped. The 39-second outliers (`hub_get_info` 39.1s max, `hub_list_variables` 39.9s max) no longer appear in the top 25 ops at all — those were limiter-recovery 504 timeouts, which is why the saving far exceeds the fixture churn actually removed. Fixtures were REUSED rather than recreated on the post-fix run, and the new `[FIXTURE-RESET]` counter reported 0.

Every pattern the migration depends on was validated against a live hub before the tests were changed:

| Check | Result |
|---|---|
| `hub_create_device` → parentage | non-child (absent from `getChildDevices()`) |
| `hub_get_device`, bypass OFF → ON | `Device not found` → full detail |
| `hub_call_device_command` + `waitFor` | `success`, `converged`, 75–79ms |
| multi-device poll `deviceIds` + `mode=all` | both matched, 269ms |

That third row matters: the tool guide warns a command on the bypass path "can return `success: false` (a structured hub-rejection)". It does not, so the poll/comparator tests work unchanged on non-child fixtures. All four fixture driver names were confirmed present in the live `hub_list_drivers(include='all')` catalog.

- Reboot disabled verified at the branch condition: `'0'` and empty both yield `limiter_reboot_after=0`, and the escalation is guarded by `> 0`. Swept both files for other reboot paths — only the `reboot_first` dispatch input, gated on explicit opt-in.
- `_print_summary` exercised directly on a synthetic 79-test / 83-op result set: per-group wall clock renders, truncation is stated (`top 30 of 79; 49 not shown`), op table reports `top 25 of 33 op kinds`.
- `ruff check` clean; `py_compile` clean; `python tests/sandbox_lint.py` clean; both workflows parse; test registry still 208.
- **Not provable by this PR's own run:** both `hub-e2e.yml` edits are step CONTENT, and under `pull_request_target` the job executes MAIN's copy of those steps — so the reboot change and the allowlist entry take effect only for runs after merge. The suite-side changes (fixtures, bypass, migrations, review fixes) DO run from the PR head and are exercised by the two full lanes above.

## Checklist

- [ ] **Unit tests added for any new MCP tools, regressions, or bug fixes** — n/a: no product code changes; the CI values are config and the diagnostics are print-only
- [x] **e2e tests added for new tools and/or regression tests added for any bug fix** — the bypass test now proves its boundary instead of assuming it; the migrated tests cover the same contracts against permanent fixtures
- [x] Sandbox lint passes: `python tests/sandbox_lint.py`
- [x] `./gradlew test` passes locally (or CI confirms) — CI confirms; no Groovy changed
- [ ] Live-hub BAT tests updated if tool behaviour changed — n/a: no tool behaviour changed
- [ ] Documentation updated if user-facing behaviour or tool surface changed — n/a: no user-facing behaviour or tool-surface change
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules — n/a: no tools added or renamed

