### PR TITLE
docs: pin mcp SDK <2.0.0 in the Claude Desktop mcp-proxy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Add the block for your OS — use your **local** URL (`http://YOUR_HUB_IP/apps/a
     "hubitat": {
       "command": "uvx",
       "args": [
+        "--with",
+        "mcp<2.0.0",
         "mcp-proxy",
         "--transport",
         "streamablehttp",
@@ -162,6 +164,8 @@ Add the block for your OS — use your **local** URL (`http://YOUR_HUB_IP/apps/a
   }
 }
 ```
+
+> **The `--with "mcp<2.0.0"` lines are required** (and must come *before* `mcp-proxy` — `--with` is a `uv` option, not an `mcp-proxy` one): the `mcp` Python SDK 2.0.0 release (28 July 2026) removed an API that `mcp-proxy` 0.12.0 imports, and `mcp-proxy` sets no upper bound on the dependency, so an unpinned `uvx mcp-proxy` crashes on startup (`ImportError: cannot import name 'request_ctx'`) and the server never connects. Tracked upstream at [sparfenyuk/mcp-proxy#235](https://github.com/sparfenyuk/mcp-proxy/issues/235); once a fixed `mcp-proxy` release ships, the pin becomes unnecessary but is harmless to leave in place. If your previously working config broke around that date, this is why — add the two lines and fully restart Claude Desktop.
 
 **macOS — [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) (via `npx`).** Add `--allow-http` for a **local** (plain-HTTP) URL; omit it for the **cloud** (HTTPS) URL:
 ```json


### PR DESCRIPTION
## Summary

- Adds `--with "mcp<2.0.0"` to the Windows Claude Desktop `uvx mcp-proxy` config in the README, with a callout explaining why the pin is needed.

## Type of change

- [x] `docs` — documentation only

## Changes

- README Claude Desktop section: the Windows `mcp-proxy` block now pins the `mcp` SDK below 2.0.0 (`--with` placed before the package name, where `uv` requires it), plus a note covering the breakage (`mcp` SDK 2.0.0 removed `request_ctx`; `mcp-proxy` 0.12.0 has no upper bound, so an unpinned `uvx mcp-proxy` crashes on import), the ImportError signature, and the upstream tracking link (sparfenyuk/mcp-proxy#235). Companion to the pinned known-issue announcement (#373).

## Release Notes

## Testing

- Docs-only. Verified upstream state: mcp-proxy's latest release is still v0.12.0 with the unbounded `mcp>=1.17.0` dependency; the upstream fix PR is open and unmerged.

## Checklist

- [ ] **Unit tests added for any new MCP tools, regressions, or bug fixes** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes)
- [ ] **e2e tests added for new tools and/or regression tests added for any bug fix** (see `tests/e2e_test.py`)
- [ ] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
- [x] Documentation updated if user-facing behaviour or tool surface changed
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema)
