### PR TITLE
chore: Create Code Review Style Guide for Hubitat MCP Server

### DIFF
--- a/REVIEW.MD
+++ b/REVIEW.MD
@@ -8,9 +8,6 @@ The very first review comment you post on any PR must begin with this exact sent
 
 This is a hard requirement. Authors should know up front that pushback is welcome and respected.
 
-## Dependabot exemption
-
-PRs authored by `dependabot[bot]` are automatic dependency bumps. They use a `build:` title prefix, do not use this repo's PR template, and do not have a `## Release Notes` section by design. **Skip the three custom checks below** for those PRs. Continue to apply your standard code-quality review.
 
 ## Repository conventions to refer to
 

--- a/REVIEW.MD
+++ b/REVIEW.MD
@@ -1,0 +1,78 @@
+# Code Review Style Guide — Hubitat MCP Server
+
+## How to start every PR review
+
+The very first review comment you post on any PR must begin with this exact sentence, verbatim:
+
+> I am an AI and make mistakes. If you feel that any of my review items are incorrect, please don't hesitate to push back.
+
+This is a hard requirement. Authors should know up front that pushback is welcome and respected.
+
+## Dependabot exemption
+
+PRs authored by `dependabot[bot]` are automatic dependency bumps. They use a `build:` title prefix, do not use this repo's PR template, and do not have a `## Release Notes` section by design. **Skip the three custom checks below** for those PRs. Continue to apply your standard code-quality review.
+
+## Repository conventions to refer to
+
+When reviewing code, refer to (do not duplicate or quote) these existing repo docs for project conventions, conventions for tool design, testing patterns, and release automation:
+
+- [AGENTS.md](../AGENTS.md) — conventions for AI coding agents working on this repo (sandbox rules, PR workflow, boundaries)
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — human-contributor guide (local dev setup, PR template walkthrough, prefix conventions, release-notes expectations)
+- [README.md](../README.md) — project overview and feature catalog
+- [SKILL.md](../SKILL.md) — tool reference and usage patterns
+- [TOOL_GUIDE.md](../TOOL_GUIDE.md) — detailed per-tool documentation
+- [docs/testing.md](../docs/testing.md) — Spock test harness conventions, including the rule that every new MCP tool must ship with unit tests
+- [docs/release-automation-design.md](../docs/release-automation-design.md) — how the release bot consumes PR metadata
+
+Link to these docs from your review comments when relevant; do not paste their content.
+
+## Custom review checks
+
+The three checks below are **soft requests**, not blockers. Phrase them as suggestions in your review ("Consider adding…", "Could you clarify…"). Do not mark a PR as blocked, do not use a "Request changes" review state, and do not lower the overall review verdict solely because of one of these. The author may push back; if they do, defer to them.
+
+### 1. Release Notes section presence
+
+Every non-Dependabot PR description should contain a `## Release Notes` heading followed by at least one bulleted item (`-` or `*`). The matcher is lenient: the heading match is case-insensitive ("release notes", "Release Notes", "RELEASE NOTES" all valid), an optional trailing colon is fine, and any markdown heading level (h1–h6) counts.
+
+If the section is missing, empty, or contains only prose with no bullets, ask the author to add bulleted release notes. In your comment, explain why this matters: **these bullets are what HPM users see in the update prompt when they upgrade the rule app**. They should be written for end users, not developers — short, scannable, free of internal jargon. Sub-bullets are supported (nest with any leading whitespace) for grouping related details under one top-level point.
+
+### 2. Title prefix matches the "Type of change" checkbox
+
+Every non-Dependabot PR title should start with one of these prefixes (lowercase, trailing colon):
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `chore:` — maintenance / non-feature work
+- `refactor:` — code restructuring with no behavior change
+- `docs:` — documentation only
+- `test:` — tests only
+- `ci:` — CI / workflow changes only
+
+(`build:` is reserved for Dependabot — contributors are instructed not to use it.)
+
+The PR template has a "Type of change" checkbox section. The prefix the author chose for the PR title and the box they ticked must agree. If they disagree (for example, the title is `feat:` but the `fix` box is ticked), call it out as a suggestion and ask the author to correct one of them so the metadata is consistent.
+
+### 3. Prefix and checkbox match what the PR actually does
+
+Best-effort judgment: read the diff and decide whether the prefix and ticked checkbox accurately describe the change.
+
+- If the title says `feat:` but the diff is purely an internal refactor with no new user-visible capability, suggest a `refactor:` reclassification.
+- If the title says `fix:` but the diff adds a new tool or new behavior, suggest `feat:`.
+- If the title says `docs:` but the diff edits Groovy logic, suggest the appropriate code prefix.
+
+This check is judgmental and you may misread the diff. That is expected and acceptable. Raise it as a suggestion only ("This looks more like a refactor than a feature — would you consider relabeling?"), not as a hard finding. Author pushback ends the discussion.
+
+### 4. New MCP tools follow `AGENTS.md` Tool Design Rules
+
+When a PR adds or renames an MCP tool, best-effort judgement: does the tool follow the conventions in `AGENTS.md` § Tool design rules? Eight broad areas to look at:
+
+1. **Naming** — `hub_` prefix present; verb from the allowed vocabulary; `manage_` used only for gateways (or the documented flat-multi-action exception).
+2. **Parameter names** — unambiguous (e.g. `device_id` not `id`); semantic over wired.
+3. **Annotations** — all four hints (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`) set explicitly.
+4. **Description quality** — concise first line; usage guidance; write-tool safety warnings present; semantic IDs over opaque UUIDs.
+5. **Consolidation candidates** — verb-pair tools (enable/disable, pause/resume, etc.) suggested for merge into a single `set_<noun>_<attribute>` tool; always-called-in-sequence tools flagged.
+6. **Schema design** — `enum` for fixed-set free-text params; `required` only when applicable; `outputSchema` present for structured returns.
+7. **Error contracts** — validation throws `IllegalArgumentException`; runtime returns `[success: false, error, note]`; `isError: true` for tool-execution errors; error text is recovery-oriented.
+8. **Pagination** — cursor support on any tool that can return a long list.
+
+Raise mismatches as suggestions only (e.g. "Consider `hub_get_room_health` instead of `check_room_health` — `check` folds into `get` in the verb vocabulary"). Don't mark as blocking, don't lower the verdict for naming nits. Author pushback ends the discussion.

--- a/REVIEW.MD
+++ b/REVIEW.MD
@@ -13,13 +13,13 @@ This is a hard requirement. Authors should know up front that pushback is welcom
 
 When reviewing code, refer to (do not duplicate or quote) these existing repo docs for project conventions, conventions for tool design, testing patterns, and release automation:
 
-- [AGENTS.md](../AGENTS.md) — conventions for AI coding agents working on this repo (sandbox rules, PR workflow, boundaries)
-- [CONTRIBUTING.md](../CONTRIBUTING.md) — human-contributor guide (local dev setup, PR template walkthrough, prefix conventions, release-notes expectations)
-- [README.md](../README.md) — project overview and feature catalog
-- [SKILL.md](../SKILL.md) — tool reference and usage patterns
-- [TOOL_GUIDE.md](../TOOL_GUIDE.md) — detailed per-tool documentation
-- [docs/testing.md](../docs/testing.md) — Spock test harness conventions, including the rule that every new MCP tool must ship with unit tests
-- [docs/release-automation-design.md](../docs/release-automation-design.md) — how the release bot consumes PR metadata
+- [AGENTS.md](AGENTS.md) — conventions for AI coding agents working on this repo (sandbox rules, PR workflow, boundaries)
+- [CONTRIBUTING.md](CONTRIBUTING.md) — human-contributor guide (local dev setup, PR template walkthrough, prefix conventions, release-notes expectations)
+- [README.md](README.md) — project overview and feature catalog
+- [SKILL.md](SKILL.md) — tool reference and usage patterns
+- [TOOL_GUIDE.md](TOOL_GUIDE.md) — detailed per-tool documentation
+- [docs/testing.md](docs/testing.md) — Spock test harness conventions, including the rule that every new MCP tool must ship with unit tests
+- [docs/release-automation-design.md](docs/release-automation-design.md) — how the release bot consumes PR metadata
 
 Link to these docs from your review comments when relevant; do not paste their content.
 


### PR DESCRIPTION

<!-- Prefix your PR title with the type that matches what you tick below.
     Valid prefixes: feat: | fix: | chore: | refactor: | docs: | test: | ci:
     Example: "feat: add device health polling tool"
     Note: build: is reserved for Dependabot — contributors should not use it. -->

## Summary

Added a Code Review Style Guide for the Hubitat MCP Server, detailing review processes, conventions, and custom checks for PRs. This is meant to work for coderabbit and any other future bot reviewers since Gemini was deprecated. Literally just copied and pasted the old Gemini styleguide over so that coderabbit would use it. 


## Type of change

<!-- Tick exactly one. -->

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [x] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `ci` — CI/CD pipeline change

## Changes

Copied and pasted Gemini styleguide to review.md

## Release Notes

<!-- These bullets are what HPM users will see when prompted to update — write for end users, not developers.
     Sub-bullets are supported (nest with 2-space indent).
     If you skip this section, the release entry will fall back to just the PR title.
     LEAVE COMPLETELY BLANK IF THERE ARE NO RELEASE NOTES — typing "None" in here will LITERALLY
     give a release note that says "None". -->



## Testing

N/A

## Checklist

- [ ] **Unit tests added for any new MCP tools, regressions, or bug fixes** (required — see [docs/testing.md](docs/testing.md) for the harness + recipes)
- [ ] **e2e tests added for new tools and/or regression tests added for any bug fix** (see `tests/e2e_test.py`)
- [ ] Sandbox lint passes: `python tests/sandbox_lint.py`
- [ ] `./gradlew test` passes locally (or CI confirms)
- [ ] Live-hub BAT tests updated if tool behaviour changed (see `tests/BAT-v2.md`)
- [ ] Documentation updated if user-facing behaviour or tool surface changed
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules (naming, annotations, schema)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a review style guide for the Hubitat MCP Server.
  * Documented review expectations for release notes, pull request titles, checklist consistency, change classification, and MCP tool design.
  * Added guidance for tool naming, parameters, descriptions, schemas, errors, pagination, and constructive suggestions.
  * Included standard opening disclaimer requirements, Dependabot metadata-check exemptions, and references to repository documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->