### PR TITLE
ci: dispatchable fast lanes, and promote Groovy 2.5 Spock to a required gate

### DIFF
--- a/.github/workflows/groovy24-parse.yml
+++ b/.github/workflows/groovy24-parse.yml
@@ -17,6 +17,9 @@ name: Groovy 2.4 Parse Check
 # It is fully standalone: a separate build under ci/groovy24-parse/ that never touches the
 # root build.gradle or the existing 3.0 unit-test lane.
 on:
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e. Path filters don't gate a dispatch.
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/groovy2x-spock.yml
+++ b/.github/workflows/groovy2x-spock.yml
@@ -9,32 +9,28 @@ name: Groovy 2.5 Spock (additive)
 # Fully standalone: a separate build under ci/groovy2x-spock/ that never touches the root
 # build.gradle or the existing 3.0 unit-test lane. The shared spec corpus is referenced read-only.
 #
-# ALLOW-FAILURE: continue-on-error keeps this lane informational until the 2.5 corpus is fully green.
-# It is NOT the repo ruleset's required `test` check, so it never blocks merge.
+# GATE: the 2.5 corpus has a track record now, so this lane is a required status check
+# (`groovy2x-spock` in the `main-required-checks` ruleset) rather than an informational one.
+# NO `paths:` filter, deliberately: a path-filtered workflow does not trigger at all when nothing
+# matches, so no check is ever created and a required check that never reports leaves the PR
+# waiting on it forever -- a docs-only PR would wedge. The sibling required lanes (`test`, `guard`)
+# omit their filters for the same reason. The whole corpus runs in ~2 min, so it is cheap to
+# always run.
 on:
-  # Manual runs: lets the fast Spock lanes be driven on ANY branch with no PR open,
-  # so a spec change can be verified without opening a pull request -- which would
-  # also start the hub e2e lane and take the shared test hub for an hour.
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e.
   workflow_dispatch:
   pull_request:
     branches: [main]
-    paths:
-      - '*.groovy'
-      - 'libraries/**'
-      - 'src/test/groovy/**'
-      - 'src/main/groovy/**'
-      - 'ci/groovy2x-spock/**'
-      - '.github/workflows/groovy2x-spock.yml'
 
 permissions:
   contents: read
 
 jobs:
   groovy2x-spock:
-    name: groovy2x-spock (allow-failure)
+    # The ruleset gates on this job name — renaming it silently un-gates the lane.
+    name: groovy2x-spock
     runs-on: ubuntu-latest
-    # Informational lane — a 2.5 spec failure must not fail the workflow or gate merge.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5

--- a/.github/workflows/groovy2x-spock.yml
+++ b/.github/workflows/groovy2x-spock.yml
@@ -12,6 +12,10 @@ name: Groovy 2.5 Spock (additive)
 # ALLOW-FAILURE: continue-on-error keeps this lane informational until the 2.5 corpus is fully green.
 # It is NOT the repo ruleset's required `test` check, so it never blocks merge.
 on:
+  # Manual runs: lets the fast Spock lanes be driven on ANY branch with no PR open,
+  # so a spec change can be verified without opening a pull request -- which would
+  # also start the hub e2e lane and take the shared test hub for an hour.
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/lane-gate-test.yml
+++ b/.github/workflows/lane-gate-test.yml
@@ -5,6 +5,9 @@ name: lane-gate-test
 # gate or double-book the single shared test hub, so the pure decision is unit-tested here. Pure
 # node; no hub, no secrets.
 on:
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e. Path filters don't gate a dispatch.
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/scripts/lane_gate.js'

--- a/.github/workflows/lease-scripts-test.yml
+++ b/.github/workflows/lease-scripts-test.yml
@@ -5,6 +5,9 @@ name: lease-scripts-test
 # false-empty read that double-booked the test hub cannot quietly come back. No hub, no
 # secrets -- just bash + jq on the runner.
 on:
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e. Path filters don't gate a dispatch.
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/scripts/lease_acquire.sh'

--- a/.github/workflows/pr-guard.yml
+++ b/.github/workflows/pr-guard.yml
@@ -1,5 +1,8 @@
 name: PR Guard
 on:
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e.
+  workflow_dispatch:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
@@ -11,16 +14,21 @@ permissions:
 jobs:
   guard:
     runs-on: ubuntu-latest
+    env:
+      # A dispatch has no PR to read a base off, so fall back to the default branch --
+      # the same diff the PR run would take. Kept out of `run:`/`with:` interpolation so
+      # a ref name can never be spliced into the shell.
+      BASE_BRANCH: ${{ github.event.pull_request.base.ref || github.event.repository.default_branch }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+        run: git fetch origin "$BASE_BRANCH"
       - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
       - name: Run PR guard
         env:
-          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          BASE_REF: origin/${{ env.BASE_BRANCH }}
         run: python .github/scripts/pr_guard.py

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,5 +1,8 @@
 name: Python Tests
 on:
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e. Path filters don't gate a dispatch.
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,8 @@
 name: Ruff
 on:
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e. Path filters don't gate a dispatch.
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/sandbox-lint.yml
+++ b/.github/workflows/sandbox-lint.yml
@@ -1,5 +1,8 @@
 name: Sandbox Lint
 on:
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e. Path filters don't gate a dispatch.
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/self-deploy-recovery.yml
+++ b/.github/workflows/self-deploy-recovery.yml
@@ -8,6 +8,9 @@ name: Self-deploy recovery (hub-less)
 # running PR code is a cache-poisoning / untrusted-execution vector (CodeQL critical/high).
 
 on:
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e. Path filters don't gate a dispatch.
+  workflow_dispatch:
   pull_request:
     branches: [main]
     # The extraction logic under test lives in the deploy scripts, so guard that surface.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,8 +1,7 @@
 name: Unit Tests
 on:
-  # Manual runs: lets the fast Spock lanes be driven on ANY branch with no PR open,
-  # so a spec change can be verified without opening a pull request -- which would
-  # also start the hub e2e lane and take the shared test hub for an hour.
+  # Manual run on any ref, no PR needed -- opening a PR just to exercise a lane also
+  # books the single shared test hub for an hour of e2e.
   workflow_dispatch:
   pull_request:
     branches: [main]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,9 @@
 name: Unit Tests
 on:
+  # Manual runs: lets the fast Spock lanes be driven on ANY branch with no PR open,
+  # so a spec change can be verified without opening a pull request -- which would
+  # also start the hub e2e lane and take the shared test hub for an hour.
+  workflow_dispatch:
   pull_request:
     branches: [main]
   push:

--- a/docs/groovy2x-spock-lane.md
+++ b/docs/groovy2x-spock-lane.md
@@ -29,7 +29,7 @@ so it is a strict superset of the parse concern.
 |---|---|---|---|---|
 | Unit Tests (`unit-tests.yml`) | 3.0 | eighty20results | full behaviour on 3.0 | **required** (`test`) |
 | Groovy 2.4 Parse (`groovy24-parse.yml`) | 2.4.21 | none (parse only) | load-time/syntax (#227) | required-adjacent |
-| **Groovy 2.5 Spock (`groovy2x-spock.yml`)** | 2.5 | joelwetzel | **runtime divergence (#230)** + parse | **allow-failure** |
+| **Groovy 2.5 Spock (`groovy2x-spock.yml`)** | 2.5 | joelwetzel | **runtime divergence (#230)** + parse | **required** (`groovy2x-spock`) |
 
 ## Why joelwetzel/hubitat_ci on Groovy 2.5
 
@@ -84,8 +84,11 @@ scaffold, and all existing workflows stay **byte-untouched**.
   `childAppResolver:` option that joelwetzel's `sandbox.run()` rejects (its self-test value — that
   sandbox-loaded `hubitat.helper.RMUtils` calls reach `RMUtilsMock` — is instead proven by the RM
   tool specs passing).
-- **Allow-failure** — `continue-on-error: true`; the lane is informational until the 2.5 corpus is
-  fully green and is **not** the ruleset's required `test` check, so it never blocks merge.
+- **Gating** — the lane is a required status check (`groovy2x-spock`) in the `main-required-checks`
+  ruleset, so a 2.5 failure blocks merge. It carries **no `paths:` filter**: a path-filtered workflow
+  does not trigger when nothing matches, so no check is created, and a required check that never
+  reports leaves the PR waiting on it forever. The sibling required lanes (`test`, `guard`) omit
+  their filters for the same reason.
 
 ## Running locally
 
@@ -105,7 +108,9 @@ only tracks the root build's eighty20results *tag* (joelwetzel cuts no tags), so
 lane, it is a real 2.x-vs-3.0 runtime divergence (or a hub-relevant fork-behaviour gap) — investigate
 before dismissing.
 
-The corpus already passes fully under Groovy 2.5 (locally and in the lane's first CI run); the lane is
-kept on `continue-on-error` deliberately, since Actions runners differ from a dev box and the fork's
-stability there is young. Once it has a track record, flip `continue-on-error` off to promote it to a
-gate.
+The lane shipped on `continue-on-error` while the fork's stability on Actions runners was still
+unproven. It has since built that track record, so the flag is gone and the lane is a gate — a red
+2.5 run now blocks merge instead of merely reporting. The job name is the ruleset's status-check
+context, so **renaming the job silently un-gates the lane**; rename the ruleset context in the same
+change, and land the workflow rename on `main` before adding the new context, or every open PR waits
+on a check name that does not exist yet.

--- a/docs/issue-209-smoke-test-game-plan.md
+++ b/docs/issue-209-smoke-test-game-plan.md
@@ -131,7 +131,7 @@ library is registered in the `#include`→path map (dev tool) and in `LIBS` (bun
   Dev mode must be ON on the test hub (`mcp_setup_env.sh` checks). 30-min lease (`lease_acquire.sh`).
 - **CI lanes:** unit-tests (Spock 2×2 matrix normal/strict × gateway/flat, eighty20results hubitat_ci,
   JDK 11, ~2min — **rerun only the changed spec locally, let CI do the full matrix**), groovy24-parse,
-  groovy2x-spock (allow-failure), sandbox-lint (python), pr-guard (bot-only: version/`currentVersion()`/
+  groovy2x-spock (required), sandbox-lint (python), pr-guard (bot-only: version/`currentVersion()`/
   header version strings/`releaseNotes`/`dateReleased`/CHANGELOG/README `## Version History`).
 - **`#include` facts (from recon):** no lane resolves `#include` today (`HubitatAppSandbox` has no
   include hook). No `@Field static` in the file; closures are method-scoped (extract whole methods).


### PR DESCRIPTION
## Summary

- Every fast CI lane gains `workflow_dispatch`, so a change can be verified against any ref
  without opening a PR — which would also start the hub e2e lane and take the shared test hub
  for roughly an hour.
- Promotes the Groovy 2.5 Spock lane from allow-failure to a required gate. It has the track
  record `docs/groovy2x-spock-lane.md` set as the condition for the flip.

## Type of change

- [ ] `feat` — new feature or capability
- [ ] `fix` — bug fix
- [ ] `chore` — maintenance, dependency bump, or housekeeping
- [ ] `refactor` — code restructure with no behaviour change
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `ci` — CI/CD pipeline change

## Changes

Added `workflow_dispatch:` to every fast lane, leaving existing `pull_request` / `push`
triggers byte-for-byte unchanged: `unit-tests.yml`, `groovy2x-spock.yml`, `groovy24-parse.yml`,
`python-tests.yml`, `ruff.yml`, `sandbox-lint.yml`, `lane-gate-test.yml`,
`lease-scripts-test.yml`, `self-deploy-recovery.yml`.

- `pr-guard.yml` — additionally falls back to the repository default branch for `BASE_REF`
  when there is no PR to read a base off, so a manual run makes the same diff a PR run does.
  The ref moved out of `run:` interpolation into a job-level env var. On a `pull_request`
  event the value still resolves to the PR's base, so the required `guard` check is unchanged.
- `groovy2x-spock.yml` — dropped `continue-on-error: true` and renamed the job from
  `groovy2x-spock (allow-failure)` to `groovy2x-spock`. Also **removed the `paths:` filter**:
  a path-filtered workflow does not trigger when nothing matches, so no check is created, and
  a required check that never reports leaves the PR waiting on it forever (PR #379, which
  touched only `REVIEW.MD`, produced no `groovy2x-spock` check at all). The sibling required
  lanes `test` and `guard` omit their filters for the same reason. The corpus runs in ~2 min.
- `docs/groovy2x-spock-lane.md`, `docs/issue-209-smoke-test-game-plan.md` — gating tables and
  the maintenance note updated to match, including the warning that the job name *is* the
  ruleset's status-check context, so renaming the job silently un-gates the lane.

`release.yml` is deliberately excluded from the dispatch change — it is the post-merge release
bot, not a test lane. `hub-e2e.yml`, `hubitat-ci-version-check.yml`, `publish-bundle-artifact.yml`
and `e2e-setup-fixtures.yml` were already dispatchable.

## Release Notes

## Testing

All 15 workflow files parse as valid YAML with the expected trigger sets. `groovy2x-spock.yml`
verified to carry no `continue-on-error` and no `paths:` filter, with the job name
`groovy2x-spock`.

Every changed lane was then dispatched against this branch with `gh workflow run <lane> --ref
ci/manual-fast-lane-dispatch` — the feature is exercised here, not merely asserted. All ten pass:

| Lane | Run |
|---|---|
| Unit Tests | 31398417372 |
| Groovy 2.5 Spock (additive) | 31398423068 |
| Groovy 2.4 Parse Check | 31398428568 |
| Python Tests | 31398434621 |
| Ruff | 31398439963 |
| Sandbox Lint | 31398362433 |
| lane-gate-test | 31398446153 |
| lease-scripts-test | 31398451780 |
| Self-deploy recovery (hub-less) | 31398457655 |
| PR Guard | 31398463195 |

Two are worth calling out. `Sandbox Lint` is not reached by the `pull_request` trigger on this PR
at all — its `paths:` list deliberately omits its own workflow file, since nothing in that file can
change the lint's verdict — so dispatch is the only way it self-checks here. `PR Guard` exercises
the new no-PR `BASE_REF` fallback: its log confirms `BASE_BRANCH: main`, a successful
`git fetch origin "main"`, and `pr_guard.py` running against it.

The Groovy 2.5 run is the first whose conclusion is load-bearing, now that `continue-on-error` is
gone — verified genuine at every level: job `groovy2x-spock` success, the Spock step itself
success, and `BUILD SUCCESSFUL in 2m` in the log.

`groovy2x-spock` has been added to the `main-required-checks` ruleset, so the gate is live. The
ruleset change was surgical — name, target, enforcement, conditions, bypass actors and rule types
are unchanged; only the required-check list gained the new context.

## Checklist

- [ ] **Unit tests added for any new MCP tools, regressions, or bug fixes** — n/a, no product code
- [ ] **e2e tests added for new tools and/or regression tests added for any bug fix** — n/a, no hub-facing change
- [ ] Sandbox lint passes: `python tests/sandbox_lint.py` — n/a, no `.groovy` touched
- [ ] `./gradlew test` passes locally (or CI confirms) — CI confirms
- [ ] Live-hub BAT tests updated if tool behaviour changed — n/a, no tool behaviour change
- [x] Documentation updated if user-facing behaviour or tool surface changed
- [ ] New/renamed MCP tools follow `AGENTS.md` Tool Design Rules — n/a, no tools touched
